### PR TITLE
feat: add basic CI workflow (pytest + ruff)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run tests
+        run: pytest tests/ -v
+
+  lint:
+    runs-on: ubuntu-latest
+    # Advisory only until existing ruff errors are cleaned up.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff check
+        run: ruff check src/ tests/


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI for scitex-orochi (was missing entirely)
- Runs `pytest tests/` on Python 3.11 and 3.12 for push/PR to main/develop
- Runs `ruff check src/ tests/` as **advisory** (continue-on-error) until 23 existing ruff errors are cleaned up

## Why
scitex-orochi had 0 workflows configured — no test enforcement on PRs. This is a first step; follow-ups can tighten lint once existing errors are fixed.

## Test plan
- [x] `pytest tests/` passes locally (30 tests)
- [x] `ruff check` surfaces existing errors (F401, F821, etc.) but is advisory
- [ ] CI runs green on this PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)