### PR TITLE
fix: declare aiosqlite, aiohttp, websockets as runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "django-allauth[socialaccount]>=65.0",
     "click>=8.0",
     "pyyaml>=6.0",
+    "aiohttp>=3.9",
+    "aiosqlite>=0.20",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- CI tests fail at collection with `ModuleNotFoundError: No module named 'aiosqlite'`
- `scitex_orochi._store` imports aiosqlite unconditionally; `__init__.py` re-exports `OrochiServer` which pulls in `_store`; so every test module tripping through `scitex_orochi` blows up
- `aiohttp` and `websockets` have the same smell (runtime code paths, missing from base deps)
- Move/add all three to the base `dependencies` list

Three recent PRs all hit this same collection error:
- #54 long-press reply
- #203 thread close button
- fix/settings-header-and-password-change (PR #84)

None of them actually broke tests — they just triggered the unrelated missing-dep landmine.

## Test plan
- [x] Local `pip install -e .` installs aiosqlite/aiohttp/websockets
- [ ] CI green on this PR
- [ ] Re-run failed PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)