### PR TITLE
fix(hub): honor SCITEX_OROCHI_CHANNELS in AgentConsumer.chat_message (todo#257)

### DIFF
--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -322,7 +322,17 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             )
 
     async def chat_message(self, event):
-        """Handle chat.message from channel layer — forward to WebSocket client."""
+        """Handle chat.message from channel layer — forward to WebSocket client.
+
+        Honor the agent's SCITEX_OROCHI_CHANNELS subscription: chat messages
+        are broadcast to both the per-channel group and the workspace group
+        (the latter for dashboard observers), so every connected agent
+        receives every message via the workspace fanout. Filter here so the
+        agent only sees channels it explicitly registered for.
+        """
+        agent_channels = getattr(self, "agent_meta", {}).get("channels") or []
+        if agent_channels and event.get("channel") not in agent_channels:
+            return
         await self.send_json(
             {
                 "type": "message",

--- a/tests/test_consumers_channel_filter.py
+++ b/tests/test_consumers_channel_filter.py
@@ -1,0 +1,74 @@
+"""Tests for AgentConsumer.chat_message channel filtering (todo#257).
+
+Regression guard: chat messages are broadcast both to per-channel groups
+and to the workspace group (for dashboard observers). Agents join the
+workspace group on connect, so without filtering they receive every
+message in the workspace regardless of SCITEX_OROCHI_CHANNELS. The
+filter in chat_message drops events whose channel is not in the agent's
+registered subscription set.
+"""
+
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "orochi.settings")
+django = pytest.importorskip("django")
+django.setup()
+
+from hub.consumers import AgentConsumer  # noqa: E402
+
+
+def _make_consumer(subscribed):
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_meta = {"channels": subscribed}
+    consumer.send_json = AsyncMock()
+    return consumer
+
+
+def _event(channel):
+    return {
+        "id": 1,
+        "sender": "peer-agent",
+        "sender_type": "agent",
+        "channel": channel,
+        "text": "hi",
+        "ts": "2026-04-13T00:00:00Z",
+        "metadata": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_drops_unsubscribed_channel():
+    consumer = _make_consumer(["#agent", "#progress"])
+    await consumer.chat_message(_event("#ywatanabe"))
+    consumer.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_forwards_subscribed_channel():
+    consumer = _make_consumer(["#agent", "#progress"])
+    await consumer.chat_message(_event("#agent"))
+    consumer.send_json.assert_awaited_once()
+    forwarded = consumer.send_json.await_args.args[0]
+    assert forwarded["channel"] == "#agent"
+    assert forwarded["type"] == "message"
+
+
+@pytest.mark.asyncio
+async def test_forwards_when_no_subscription_metadata():
+    # Before register() arrives, agent_meta may be missing or empty.
+    # Fail-open preserves pre-fix behavior during that window rather
+    # than silently dropping early messages.
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.send_json = AsyncMock()
+    await consumer.chat_message(_event("#agent"))
+    consumer.send_json.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forwards_when_empty_subscription_list():
+    consumer = _make_consumer([])
+    await consumer.chat_message(_event("#agent"))
+    consumer.send_json.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Fixes todo#257: per-role channel subscription optimization was a no-op because every connected agent joins `workspace_<id>` group on connect (`consumers.py:62`) and every chat message is broadcast to that workspace group (`consumers.py:309-322`), bypassing the per-channel group filter wired up at `consumers.py:115-117` during register.
- Adds a 1-condition filter in `AgentConsumer.chat_message` that drops events whose `channel` is not in `self.agent_meta["channels"]`. Fail-open when metadata is absent (pre-register window) to preserve prior behavior.
- Dashboard observers still receive via the workspace-group broadcast path — no change for browser clients.

## Fleet diagnosis trail
Fleet initially blamed `--dangerously-load-development-channels server:scitex-orochi` (Claude Code MCP dev-load flag) and proposed stripping it from every agent yaml. Code trace invalidated that: the flag is unrelated to scitex-orochi channel subscription. `ts/src/config.ts:11-15` correctly honors `SCITEX_OROCHI_CHANNELS`; `src_mcp.json` carries exactly the configured channels; register only joins the configured per-channel groups. Root cause is the workspace-group fanout in `chat_message`, not any agent-side config.

## Test plan
- [x] `tests/test_consumers_channel_filter.py` — 4 cases: drop unsubscribed, forward subscribed, fail-open when `agent_meta` missing, fail-open when channels list empty. All passing locally (0.71s).
- [ ] Post-merge (healer): restart hub on MBA, smoke-test with a narrow-subscription agent (e.g. mamba-auth-manager-mba with `#agent,#escalation` only) and verify it no longer receives `#ywatanabe` broadcast.
- [ ] Post-merge (verifier): confirm no broadcast-to-all regression via live observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)