### PR TITLE
fix(hub/ui): include currentChannel in fetchStats guard key (todo#246 reopened)

### DIFF
--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -895,7 +895,13 @@ async function fetchStats() {
     var res = await fetch(apiUrl("/api/stats"));
     var stats = await res.json();
     var chContainer = document.getElementById("channels");
-    var newStatsJson = JSON.stringify(stats.channels);
+    /* Guard key must include currentChannel: otherwise a channel click that
+     * leaves the stats payload unchanged (same channel list, same counts)
+     * skips the rerender and the .active highlight fails to update — making
+     * it look like the active channel "jumped" or disappeared on the next
+     * unrelated stats refresh (todo#246 reopened). */
+    var newStatsJson =
+      JSON.stringify(stats.channels) + "|" + (currentChannel || "__all__");
     if (chContainer._lastStatsJson === newStatsJson) return;
     chContainer._lastStatsJson = newStatsJson;
     var msgInput = document.getElementById("msg-input");


### PR DESCRIPTION
## Summary
- Sidebar active-channel highlight stayed stale after click because `fetchStats()` short-circuited on `_lastStatsJson` when the API payload was byte-identical, skipping the rerender that would have applied the new `.active` class.
- Fix: include `currentChannel` in the guard key so any selection change forces a rerender.

## Root cause
`hub/static/hub/app.js:898` — click handler calls `setCurrentChannel(ch)` + `fetchStats()` specifically to rerender the sidebar. If stats didn't change, the early return skipped the rerender. The next unrelated stats refresh (new message / presence_change / 10s interval) then DID rerender, making the highlight appear to "jump" at the moment a new message arrived.

## Test plan
- [x] Reproduced via playwright (headed Chrome) on scitex-lab.scitex-orochi.com
- [x] Verified fix via live monkey-patch
- [ ] Re-verify against deployed build after merge

Generated with Claude Code
