### PR TITLE
test(hub/consumers): regression guard for channel-subscription filter (todo#257)

### DIFF
--- a/tests/test_consumers_channel_filter.py
+++ b/tests/test_consumers_channel_filter.py
@@ -1,0 +1,74 @@
+"""Tests for AgentConsumer.chat_message channel filtering (todo#257).
+
+Regression guard: chat messages are broadcast both to per-channel groups
+and to the workspace group (for dashboard observers). Agents join the
+workspace group on connect, so without filtering they receive every
+message in the workspace regardless of SCITEX_OROCHI_CHANNELS. The
+filter in chat_message drops events whose channel is not in the agent's
+registered subscription set.
+"""
+
+import os
+from unittest.mock import AsyncMock
+
+import pytest
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "orochi.settings")
+django = pytest.importorskip("django")
+django.setup()
+
+from hub.consumers import AgentConsumer  # noqa: E402
+
+
+def _make_consumer(subscribed):
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_meta = {"channels": subscribed}
+    consumer.send_json = AsyncMock()
+    return consumer
+
+
+def _event(channel):
+    return {
+        "id": 1,
+        "sender": "peer-agent",
+        "sender_type": "agent",
+        "channel": channel,
+        "text": "hi",
+        "ts": "2026-04-13T00:00:00Z",
+        "metadata": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_drops_unsubscribed_channel():
+    consumer = _make_consumer(["#agent", "#progress"])
+    await consumer.chat_message(_event("#ywatanabe"))
+    consumer.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_forwards_subscribed_channel():
+    consumer = _make_consumer(["#agent", "#progress"])
+    await consumer.chat_message(_event("#agent"))
+    consumer.send_json.assert_awaited_once()
+    forwarded = consumer.send_json.await_args.args[0]
+    assert forwarded["channel"] == "#agent"
+    assert forwarded["type"] == "message"
+
+
+@pytest.mark.asyncio
+async def test_forwards_when_no_subscription_metadata():
+    # Before register() arrives, agent_meta may be missing or empty.
+    # Fail-open preserves pre-fix behavior during that window rather
+    # than silently dropping early messages.
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.send_json = AsyncMock()
+    await consumer.chat_message(_event("#agent"))
+    consumer.send_json.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_forwards_when_empty_subscription_list():
+    consumer = _make_consumer([])
+    await consumer.chat_message(_event("#agent"))
+    consumer.send_json.assert_awaited_once()


### PR DESCRIPTION
## Summary
Tests-only PR. The fix (4 lines in `AgentConsumer.chat_message`) already landed on develop as 90158bc — this adds the regression guard so the fix can't silently evaporate under future refactors.

Context: todo#257 — `SCITEX_OROCHI_CHANNELS` was effectively a no-op as a receive filter because `consumers.py:309-322` broadcasts every chat message to the workspace group in addition to the per-channel group, and every connected agent joins the workspace group at `consumers.py:62`. 90158bc filters by `agent_meta["channels"]` in `chat_message`; this PR guards that behavior.

## Test cases (4)
- `test_drops_unsubscribed_channel` — subscribed to `#agent,#progress`, event on `#ywatanabe` → no forward
- `test_forwards_subscribed_channel` — subscribed to `#agent,#progress`, event on `#agent` → forwarded with correct payload
- `test_forwards_when_no_subscription_metadata` — `agent_meta` attribute absent (pre-register window) → fail-open
- `test_forwards_when_empty_subscription_list` — empty channels list → fail-open

Uses `AgentConsumer.__new__` to avoid Django Channels scope/session setup; only the filter branch is exercised. `DJANGO_SETTINGS_MODULE=orochi.settings` is set at import time with `pytest.importorskip("django")` as a guard. All 4 pass locally against current develop in 0.61s.

## Background
Race-condition writeup: PR #99 landed the fix+tests together, but ywatanabe's 90158bc landed the same fix directly on develop ~1 minute earlier. #99 was closed as superseded; this PR preserves only the regression guard, rebased cleanly on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)