### PR TITLE
feat(hub): DM routing + ACL + confidentiality filter (todo#60 PR 2)

### DIFF
--- a/hub/apps.py
+++ b/hub/apps.py
@@ -1,0 +1,12 @@
+"""Django app config for hub — wires up DM rename signals (spec v3 §2.2)."""
+
+from django.apps import AppConfig
+
+
+class HubConfig(AppConfig):
+    name = "hub"
+    default_auto_field = "django.db.models.BigAutoField"
+
+    def ready(self):
+        # Importing the module registers the post_save handlers.
+        from hub import signals  # noqa: F401

--- a/hub/channel_acl.py
+++ b/hub/channel_acl.py
@@ -116,12 +116,38 @@ def _matches_pattern(sender: str, pattern: str) -> bool:
     return fnmatch.fnmatch(sender, pattern)
 
 
-def check_write_allowed(sender: str, channel: str) -> bool:
+def check_write_allowed(
+    sender: str, channel: str, workspace_id: int | None = None
+) -> bool:
     """Return True if sender is allowed to write to channel.
 
     If the config file does not exist or the channel has no ACL entry,
     returns True (permissive default).
+
+    Spec v3 §3.2 — DM channels (name starts with ``dm:`` or model row
+    has ``kind="dm"``) bypass the yaml ACL. They are allowed iff the
+    sender's ``WorkspaceMember`` is a ``DMParticipant`` of the channel.
+    When ``workspace_id`` is not supplied we cannot scope the lookup,
+    so we fall back to the permissive path (preserves non-WS callers).
     """
+    if channel.startswith("dm:"):
+        return _check_dm_write_allowed(sender, channel, workspace_id)
+
+    # Defensive DB check: a Channel row may exist with kind="dm" even
+    # without a dm: prefix (should never happen post-spec v3 §9 Q5,
+    # but we defend anyway).
+    if workspace_id is not None:
+        try:
+            from hub.models import Channel as _Channel
+
+            ch = _Channel.objects.filter(
+                workspace_id=workspace_id, name=channel
+            ).only("kind").first()
+            if ch is not None and ch.kind == _Channel.KIND_DM:
+                return _check_dm_write_allowed(sender, channel, workspace_id)
+        except Exception:
+            pass
+
     _refresh_if_stale()
     with _lock:
         if not _acl_data:
@@ -130,6 +156,46 @@ def check_write_allowed(sender: str, channel: str) -> bool:
     if patterns is None:
         return True  # channel not in config — allow
     return any(_matches_pattern(sender, p) for p in patterns)
+
+
+def _check_dm_write_allowed(
+    sender: str, channel: str, workspace_id: int | None
+) -> bool:
+    """Return True if ``sender`` is a DMParticipant of ``channel``.
+
+    Matches either agent senders (synthetic ``agent-<sender>`` users,
+    per ``hub/views/auth.py``) or human senders (bare username). The
+    denormalized ``identity_name`` column is checked first (hot path)
+    with a fall-through to ``member__user__username`` for cases where
+    the sender string differs from the registered identity.
+    """
+    if workspace_id is None:
+        return False
+    try:
+        from hub.models import Channel as _Channel
+        from hub.models import DMParticipant as _DMParticipant
+    except Exception:
+        return False
+
+    base_qs = _DMParticipant.objects.filter(
+        channel__workspace_id=workspace_id,
+        channel__name=channel,
+        channel__kind=_Channel.KIND_DM,
+    )
+    if not base_qs.exists():
+        # No such DM channel — deny to avoid silent allow.
+        return False
+
+    # Match on the denormalized identity name (fast path) OR via the
+    # User.username FK join. Agent senders may be recorded either as
+    # "mamba-foo" (identity_name) or "agent-mamba-foo" (User.username).
+    if base_qs.filter(identity_name=sender).exists():
+        return True
+    if base_qs.filter(member__user__username=sender).exists():
+        return True
+    if base_qs.filter(member__user__username=f"agent-{sender}").exists():
+        return True
+    return False
 
 
 def reload() -> int:

--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -6,10 +6,98 @@ from urllib.parse import parse_qs
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 
-from hub.models import Channel, Message, Workspace, WorkspaceToken
+from hub.models import (
+    Channel,
+    DMParticipant,
+    Message,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceToken,
+)
 from hub.channel_acl import check_write_allowed
 
 log = logging.getLogger("orochi.consumers")
+
+
+@database_sync_to_async
+def _ensure_agent_member(workspace_id, agent_name):
+    """Idempotently ensure a ``WorkspaceMember`` row exists for an agent.
+
+    Mirrors the synthetic-user pattern from ``hub/views/auth.py`` —
+    ``agent-<name>`` Django ``User`` + ``WorkspaceMember`` row. Required
+    by spec v3 §2.3 so DMParticipant FKs have a stable target.
+
+    Returns the ``WorkspaceMember`` instance (or ``None`` on failure).
+    """
+    import re
+
+    from django.contrib.auth.models import User
+
+    try:
+        workspace = Workspace.objects.get(id=workspace_id)
+    except Workspace.DoesNotExist:
+        return None
+
+    safe_name = re.sub(r"[^a-zA-Z0-9_.\-]", "-", agent_name or "anonymous-agent")
+    username = f"agent-{safe_name}"
+    user, _ = User.objects.get_or_create(
+        username=username,
+        defaults={
+            "email": f"{username}@agents.orochi.local",
+            "is_active": True,
+            "is_staff": False,
+        },
+    )
+    member, _ = WorkspaceMember.objects.get_or_create(
+        user=user,
+        workspace=workspace,
+        defaults={"role": "member"},
+    )
+    return member
+
+
+@database_sync_to_async
+def _load_dm_channel_names(workspace_id, member_id):
+    """Return canonical ``dm:`` channel names the given member participates in."""
+    if member_id is None:
+        return []
+    return list(
+        DMParticipant.objects.filter(
+            member_id=member_id,
+            channel__workspace_id=workspace_id,
+            channel__kind=Channel.KIND_DM,
+        ).values_list("channel__name", flat=True)
+    )
+
+
+@database_sync_to_async
+def _is_dm_participant_by_member(channel_name, workspace_id, member_id):
+    """Check whether ``member_id`` is a participant of the given DM channel."""
+    if member_id is None:
+        return False
+    return DMParticipant.objects.filter(
+        channel__workspace_id=workspace_id,
+        channel__name=channel_name,
+        channel__kind=Channel.KIND_DM,
+        member_id=member_id,
+    ).exists()
+
+
+@database_sync_to_async
+def _is_dm_participant_by_username(channel_name, workspace_id, username):
+    """Check DM participation for a (possibly unauthenticated) dashboard user.
+
+    ``username=None`` always returns ``False`` — unauthenticated dashboards
+    can never read DMs.
+    """
+    if not username:
+        return False
+    return DMParticipant.objects.filter(
+        channel__workspace_id=workspace_id,
+        channel__name=channel_name,
+        channel__kind=Channel.KIND_DM,
+        member__user__username=username,
+    ).exists()
 
 
 @database_sync_to_async
@@ -57,9 +145,30 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         self.workspace_name = result["workspace_name"]
         self.agent_name = qs.get("agent", ["anonymous"])[0]
 
+        # Spec v3 §2.3 — idempotently ensure a WorkspaceMember row exists
+        # for this agent so DMParticipant FKs have a stable target.
+        self.workspace_member = await _ensure_agent_member(
+            workspace_id=self.workspace_id,
+            agent_name=self.agent_name,
+        )
+        self.workspace_member_id = (
+            self.workspace_member.id if self.workspace_member else None
+        )
+
         # Join workspace group for broadcasts
         self.workspace_group = f"workspace_{self.workspace_id}"
         await self.channel_layer.group_add(self.workspace_group, self.channel_name)
+
+        # Spec v3 §3.1 — auto-subscribe to all DM channels the agent is
+        # a participant of. The canonical DM channel name is stored on
+        # ``agent_meta["channels"]`` (populated/extended at register time)
+        # so the chat_message filter below forwards DM events correctly.
+        self._dm_channel_names = await _load_dm_channel_names(
+            self.workspace_id, self.workspace_member_id
+        )
+        for ch_name in self._dm_channel_names:
+            group = _sanitize_group(f"channel_{self.workspace_id}_{ch_name}")
+            await self.channel_layer.group_add(group, self.channel_name)
 
         await self.accept()
         log.info(
@@ -111,7 +220,13 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         if msg_type == "register":
             # Agent registration — subscribe to specific channels
             payload = content.get("payload", {})
-            channels = content.get("channels") or payload.get("channels", [])
+            channels = list(content.get("channels") or payload.get("channels", []) or [])
+            # Spec v3 §3.1 — ensure DM channels auto-subscribed at connect
+            # are also reflected in ``agent_meta["channels"]`` so the
+            # 90158bc chat_message filter forwards DM events.
+            for dm_name in getattr(self, "_dm_channel_names", []) or []:
+                if dm_name not in channels:
+                    channels.insert(0, dm_name)
             for ch_name in channels:
                 group = _sanitize_group(f"channel_{self.workspace_id}_{ch_name}")
                 await self.channel_layer.group_add(group, self.channel_name)
@@ -249,7 +364,15 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             # Channel ACL enforcement — check before persisting or broadcasting.
             # check_write_allowed is a sync call (file-cached, sub-ms) so safe to
             # call directly in the async consumer.
-            if not check_write_allowed(self.agent_name, ch_name):
+            # check_write_allowed may touch the DB for DM channels, so
+            # route through sync_to_async. For non-DM channels it's a
+            # cached yaml lookup (sub-ms).
+            from asgiref.sync import sync_to_async as _sta
+
+            _allowed = await _sta(check_write_allowed)(
+                self.agent_name, ch_name, self.workspace_id
+            )
+            if not _allowed:
                 log.warning(
                     "[ACL] blocked write from %s to %s",
                     self.agent_name,
@@ -291,6 +414,13 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             # vanish from the live feed because the WS broadcast carried
             # an empty attachments list, even though the DB row had
             # them and a page reload would have shown them.
+            # Spec v3 §3.3 — DM channels are identified by the reserved
+            # ``dm:`` name prefix (guarded at Channel.clean()) and must
+            # NOT hit the workspace_<id> fanout group, because dashboards
+            # join that group without per-channel filtering.
+            is_dm = ch_name.startswith("dm:")
+            kind = "dm" if is_dm else "group"
+
             group = _sanitize_group(f"channel_{self.workspace_id}_{ch_name}")
             await self.channel_layer.group_send(
                 group,
@@ -300,33 +430,55 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
                     "sender": self.agent_name,
                     "sender_type": "agent",
                     "channel": ch_name,
+                    "kind": kind,
                     "text": text,
                     "ts": msg["ts"] if msg else None,
                     "metadata": metadata,
                 },
             )
 
-            # Also broadcast to workspace group (for dashboard observers)
-            await self.channel_layer.group_send(
-                self.workspace_group,
-                {
-                    "type": "chat.message",
-                    "id": msg["id"] if msg else None,
-                    "sender": self.agent_name,
-                    "sender_type": "agent",
-                    "channel": ch_name,
-                    "text": text,
-                    "ts": msg["ts"] if msg else None,
-                    "metadata": metadata,
-                },
-            )
+            # Also broadcast to workspace group (for dashboard observers).
+            # Skip this entirely for DMs — dashboards reach DM participants
+            # through the channel_<ws>_<dm-name> group only.
+            if not is_dm:
+                await self.channel_layer.group_send(
+                    self.workspace_group,
+                    {
+                        "type": "chat.message",
+                        "id": msg["id"] if msg else None,
+                        "sender": self.agent_name,
+                        "sender_type": "agent",
+                        "channel": ch_name,
+                        "kind": kind,
+                        "text": text,
+                        "ts": msg["ts"] if msg else None,
+                        "metadata": metadata,
+                    },
+                )
 
     async def chat_message(self, event):
-        """Handle chat.message from channel layer — forward to WebSocket client."""
-        # Filter: only forward messages from channels this agent subscribed to
-        agent_channels = getattr(self, "agent_meta", {}).get("channels", [])
-        if agent_channels and event.get("channel") not in agent_channels:
-            return
+        """Handle chat.message from channel layer — forward to WebSocket client.
+
+        Spec v3 §3.2/§3.3 — DM events are forwarded only if this
+        connection's principal (``WorkspaceMember``) is a participant of
+        the DM channel. Group events keep the 90158bc agent_meta filter.
+        """
+        ch_name = event.get("channel", "")
+        is_dm = event.get("kind") == "dm" or ch_name.startswith("dm:")
+
+        if is_dm:
+            allowed = await _is_dm_participant_by_member(
+                channel_name=ch_name,
+                workspace_id=self.workspace_id,
+                member_id=getattr(self, "workspace_member_id", None),
+            )
+            if not allowed:
+                return
+        else:
+            # Group channels: existing subscription filter.
+            agent_channels = getattr(self, "agent_meta", {}).get("channels", [])
+            if agent_channels and ch_name not in agent_channels:
+                return
         await self.send_json(
             {
                 "type": "message",
@@ -545,6 +697,9 @@ class DashboardConsumer(AsyncJsonWebsocketConsumer):
                 metadata=metadata,
             )
 
+            is_dm = ch_name.startswith("dm:")
+            kind = "dm" if is_dm else "group"
+
             group = _sanitize_group(f"channel_{self.workspace_id}_{ch_name}")
             await self.channel_layer.group_send(
                 group,
@@ -554,28 +709,58 @@ class DashboardConsumer(AsyncJsonWebsocketConsumer):
                     "sender": self.user.username,
                     "sender_type": "human",
                     "channel": ch_name,
+                    "kind": kind,
                     "text": text,
                     "ts": msg["ts"] if msg else None,
                     "metadata": metadata,
                 },
             )
 
-            await self.channel_layer.group_send(
-                self.workspace_group,
-                {
-                    "type": "chat.message",
-                    "id": msg["id"] if msg else None,
-                    "sender": self.user.username,
-                    "sender_type": "human",
-                    "channel": ch_name,
-                    "text": text,
-                    "ts": msg["ts"] if msg else None,
-                    "metadata": metadata,
-                },
-            )
+            # Spec v3 §3.3 — skip workspace fanout for DM channels.
+            if not is_dm:
+                await self.channel_layer.group_send(
+                    self.workspace_group,
+                    {
+                        "type": "chat.message",
+                        "id": msg["id"] if msg else None,
+                        "sender": self.user.username,
+                        "sender_type": "human",
+                        "channel": ch_name,
+                        "kind": kind,
+                        "text": text,
+                        "ts": msg["ts"] if msg else None,
+                        "metadata": metadata,
+                    },
+                )
 
     async def chat_message(self, event):
-        """Forward channel-layer message to dashboard WebSocket."""
+        """Forward channel-layer message to dashboard WebSocket.
+
+        Spec v3 §3.3 — confidentiality filter for DM events. The
+        dashboard joins ``workspace_<id>`` and will no longer receive
+        DMs via that group (sender skips fanout), but it may still be
+        bridged into ``channel_<ws>_<dm-name>`` groups. For defence in
+        depth we re-check participation here based on the connected
+        user's username. Unauthenticated / token-only dashboards
+        (``self.user.username in {"", "dashboard", None}``) never see
+        DMs — explicit opt-in via session is required.
+        """
+        ch_name = event.get("channel", "")
+        is_dm = event.get("kind") == "dm" or ch_name.startswith("dm:")
+        if is_dm:
+            username = getattr(getattr(self, "user", None), "username", None)
+            # Token-authenticated dashboards use a lightweight stand-in
+            # (_TokenUser with username="dashboard") or an admin fallback;
+            # they must not see DMs.
+            if username in (None, "", "dashboard"):
+                return
+            allowed = await _is_dm_participant_by_username(
+                channel_name=ch_name,
+                workspace_id=self.workspace_id,
+                username=username,
+            )
+            if not allowed:
+                return
         await self.send_json(
             {
                 "type": "message",

--- a/hub/signals.py
+++ b/hub/signals.py
@@ -1,0 +1,54 @@
+"""Signal handlers that keep ``DMParticipant.identity_name`` in sync.
+
+Spec v3 §2.2 — ``identity_name`` is a denormalized hot-path lookup key
+used by the ``chat_message`` ACL filter (PR 2). Whenever the
+authoritative identity changes (``AgentProfile.name`` rename for agents,
+``User.username`` rename for humans), any ``DMParticipant`` rows whose
+``member`` points at the affected principal must have their
+``identity_name`` updated in the same transaction.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth.models import User
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from hub.models import AgentProfile, DMParticipant
+
+
+@receiver(post_save, sender=AgentProfile)
+def _agent_profile_rename(sender, instance: AgentProfile, created, **kwargs):
+    """Update ``DMParticipant.identity_name`` when an agent is renamed.
+
+    Agents are surfaced through a synthetic Django ``User`` whose
+    username is ``agent-<AgentProfile.name>``. When the profile is
+    renamed we cannot rely on the username (those rows live elsewhere);
+    we key off the underlying ``WorkspaceMember`` set by matching on
+    the *current* username pattern and update any stale
+    ``identity_name`` rows in the same workspace/channel namespace.
+    """
+    if created:
+        return
+    target = instance.name
+    username = f"agent-{target}"
+    DMParticipant.objects.filter(
+        channel__workspace_id=instance.workspace_id,
+        member__user__username=username,
+    ).exclude(identity_name=target).update(identity_name=target)
+
+
+@receiver(post_save, sender=User)
+def _user_rename(sender, instance: User, created, **kwargs):
+    """Update ``DMParticipant.identity_name`` when a human user is renamed."""
+    if created:
+        return
+    # Human participants use the bare username as identity_name;
+    # agent participants use the un-prefixed agent name.
+    username = instance.username
+    identity = username
+    if username.startswith("agent-"):
+        identity = username[len("agent-"):]
+    DMParticipant.objects.filter(member__user_id=instance.id).exclude(
+        identity_name=identity
+    ).update(identity_name=identity)

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -351,3 +351,449 @@ class DMSchemaTest(TestCase):
         remaining = list(DMParticipant.objects.all())
         self.assertEqual(len(remaining), 1)
         self.assertEqual(remaining[0].identity_name, "bob")
+
+
+class DMConsumerRoutingTest(TestCase):
+    """Spec v3 §3.1-§3.4 — DM routing, ACL, confidentiality filter (PR 2)."""
+
+    def setUp(self):
+        from hub.models import AgentProfile
+
+        self.ws = Workspace.objects.create(name="dm-routing-ws")
+        # Human users
+        self.user_alice = User.objects.create_user(username="alice", password="x")
+        self.user_bob = User.objects.create_user(username="bob", password="x")
+        self.user_observer = User.objects.create_user(
+            username="observer", password="x"
+        )
+        self.mem_alice = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.user_alice, role="member"
+        )
+        self.mem_bob = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.user_bob, role="member"
+        )
+        self.mem_observer = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.user_observer, role="member"
+        )
+        # A DM channel between alice and bob
+        self.dm = Channel.objects.create(
+            workspace=self.ws, name="dm:alice|bob", kind=Channel.KIND_DM
+        )
+        DMParticipant.objects.create(
+            channel=self.dm,
+            member=self.mem_alice,
+            principal_type=DMParticipant.PRINCIPAL_HUMAN,
+            identity_name="alice",
+        )
+        DMParticipant.objects.create(
+            channel=self.dm,
+            member=self.mem_bob,
+            principal_type=DMParticipant.PRINCIPAL_HUMAN,
+            identity_name="bob",
+        )
+        # An agent DM channel (agent-skill ↔ alice)
+        self.agent_user = User.objects.create_user(
+            username="agent-skill", password="x"
+        )
+        self.mem_agent = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.agent_user, role="member"
+        )
+        self.agent_profile = AgentProfile.objects.create(
+            workspace=self.ws, name="skill"
+        )
+        self.dm_agent = Channel.objects.create(
+            workspace=self.ws, name="dm:agent-skill|alice", kind=Channel.KIND_DM
+        )
+        DMParticipant.objects.create(
+            channel=self.dm_agent,
+            member=self.mem_agent,
+            principal_type=DMParticipant.PRINCIPAL_AGENT,
+            identity_name="skill",
+        )
+        DMParticipant.objects.create(
+            channel=self.dm_agent,
+            member=self.mem_alice,
+            principal_type=DMParticipant.PRINCIPAL_HUMAN,
+            identity_name="alice",
+        )
+        # A regular group channel for filter regression
+        self.group_ch = Channel.objects.create(
+            workspace=self.ws, name="#general"
+        )
+
+    # ------------------------------------------------------------------
+    # _ensure_agent_member
+    # ------------------------------------------------------------------
+    def test_ensure_agent_member_idempotent(self):
+        """Calling ``_ensure_agent_member`` twice yields one row (spec §2.3)."""
+        from asgiref.sync import async_to_sync
+
+        from hub.consumers import _ensure_agent_member
+
+        m1 = async_to_sync(_ensure_agent_member)(
+            workspace_id=self.ws.id, agent_name="newbie"
+        )
+        m2 = async_to_sync(_ensure_agent_member)(
+            workspace_id=self.ws.id, agent_name="newbie"
+        )
+        self.assertIsNotNone(m1)
+        self.assertEqual(m1.id, m2.id)
+        count = WorkspaceMember.objects.filter(
+            workspace=self.ws, user__username="agent-newbie"
+        ).count()
+        self.assertEqual(count, 1)
+
+    # ------------------------------------------------------------------
+    # channel_acl.check_write_allowed — DM branch
+    # ------------------------------------------------------------------
+    def test_check_write_allowed_dm_participant_allowed(self):
+        from hub.channel_acl import check_write_allowed
+
+        self.assertTrue(
+            check_write_allowed("alice", "dm:alice|bob", workspace_id=self.ws.id)
+        )
+        self.assertTrue(
+            check_write_allowed("bob", "dm:alice|bob", workspace_id=self.ws.id)
+        )
+
+    def test_check_write_allowed_dm_non_participant_denied(self):
+        from hub.channel_acl import check_write_allowed
+
+        self.assertFalse(
+            check_write_allowed(
+                "observer", "dm:alice|bob", workspace_id=self.ws.id
+            )
+        )
+
+    def test_check_write_allowed_dm_principal_agent(self):
+        """PRINCIPAL_AGENT DM — skill-manager carry-forward."""
+        from hub.channel_acl import check_write_allowed
+
+        # Agent sender — identity_name path
+        self.assertTrue(
+            check_write_allowed(
+                "skill", "dm:agent-skill|alice", workspace_id=self.ws.id
+            )
+        )
+        # Agent sender — bare username path (`agent-skill`)
+        self.assertTrue(
+            check_write_allowed(
+                "agent-skill", "dm:agent-skill|alice", workspace_id=self.ws.id
+            )
+        )
+        # Non-participant agent blocked
+        self.assertFalse(
+            check_write_allowed(
+                "other", "dm:agent-skill|alice", workspace_id=self.ws.id
+            )
+        )
+
+    def test_check_write_allowed_group_channel_unchanged(self):
+        """Group channels still go through yaml (permissive default)."""
+        from hub.channel_acl import check_write_allowed
+
+        self.assertTrue(
+            check_write_allowed("anyone", "#general", workspace_id=self.ws.id)
+        )
+
+    # ------------------------------------------------------------------
+    # AgentConsumer.chat_message — DM forwarding filter
+    # ------------------------------------------------------------------
+    def _make_agent_consumer(self, member_id, agent_channels=None):
+        from hub.consumers import AgentConsumer
+
+        consumer = AgentConsumer.__new__(AgentConsumer)
+        consumer.workspace_id = self.ws.id
+        consumer.workspace_member_id = member_id
+        consumer.agent_name = "test-agent"
+        consumer.agent_meta = {"channels": agent_channels or []}
+        consumer._sent = []
+
+        async def fake_send(payload):
+            consumer._sent.append(payload)
+
+        consumer.send_json = fake_send
+        return consumer
+
+    def test_agent_chat_message_dm_forwarded_to_participant(self):
+        from asgiref.sync import async_to_sync
+
+        consumer = self._make_agent_consumer(self.mem_alice.id)
+        event = {
+            "type": "chat.message",
+            "sender": "bob",
+            "sender_type": "human",
+            "channel": "dm:alice|bob",
+            "kind": "dm",
+            "text": "hi",
+        }
+        async_to_sync(consumer.chat_message)(event)
+        self.assertEqual(len(consumer._sent), 1)
+        self.assertEqual(consumer._sent[0]["channel"], "dm:alice|bob")
+
+    def test_agent_chat_message_dm_dropped_for_non_participant(self):
+        from asgiref.sync import async_to_sync
+
+        consumer = self._make_agent_consumer(self.mem_observer.id)
+        event = {
+            "type": "chat.message",
+            "sender": "bob",
+            "sender_type": "human",
+            "channel": "dm:alice|bob",
+            "kind": "dm",
+            "text": "hi",
+        }
+        async_to_sync(consumer.chat_message)(event)
+        self.assertEqual(consumer._sent, [])
+
+    def test_agent_chat_message_group_filter_unchanged(self):
+        """Group channel: 90158bc agent_meta filter still applies."""
+        from asgiref.sync import async_to_sync
+
+        # Agent subscribed to #general only
+        consumer = self._make_agent_consumer(
+            self.mem_alice.id, agent_channels=["#general"]
+        )
+        good = {
+            "type": "chat.message",
+            "sender": "x",
+            "channel": "#general",
+            "text": "hi",
+        }
+        bad = {
+            "type": "chat.message",
+            "sender": "x",
+            "channel": "#other",
+            "text": "hi",
+        }
+        async_to_sync(consumer.chat_message)(good)
+        async_to_sync(consumer.chat_message)(bad)
+        self.assertEqual(len(consumer._sent), 1)
+        self.assertEqual(consumer._sent[0]["channel"], "#general")
+
+    # ------------------------------------------------------------------
+    # DashboardConsumer.chat_message — confidentiality filter
+    # ------------------------------------------------------------------
+    def _make_dashboard_consumer(self, user):
+        from hub.consumers import DashboardConsumer
+
+        consumer = DashboardConsumer.__new__(DashboardConsumer)
+        consumer.workspace_id = self.ws.id
+        consumer.user = user
+        consumer._sent = []
+
+        async def fake_send(payload):
+            consumer._sent.append(payload)
+
+        consumer.send_json = fake_send
+        return consumer
+
+    def test_dashboard_drops_dm_for_non_participant(self):
+        from asgiref.sync import async_to_sync
+
+        consumer = self._make_dashboard_consumer(self.user_observer)
+        event = {
+            "type": "chat.message",
+            "sender": "alice",
+            "channel": "dm:alice|bob",
+            "kind": "dm",
+            "text": "hi",
+        }
+        async_to_sync(consumer.chat_message)(event)
+        self.assertEqual(consumer._sent, [])
+
+    def test_dashboard_forwards_dm_to_participant(self):
+        from asgiref.sync import async_to_sync
+
+        consumer = self._make_dashboard_consumer(self.user_alice)
+        event = {
+            "type": "chat.message",
+            "sender": "bob",
+            "channel": "dm:alice|bob",
+            "kind": "dm",
+            "text": "hi",
+        }
+        async_to_sync(consumer.chat_message)(event)
+        self.assertEqual(len(consumer._sent), 1)
+
+    def test_dashboard_drops_dm_for_token_user(self):
+        """Token-authenticated dashboards (username='dashboard') never see DMs."""
+        from asgiref.sync import async_to_sync
+
+        class _TokenUser:
+            username = "dashboard"
+            id = None
+            is_authenticated = True
+
+        consumer = self._make_dashboard_consumer(_TokenUser())
+        event = {
+            "type": "chat.message",
+            "sender": "alice",
+            "channel": "dm:alice|bob",
+            "kind": "dm",
+            "text": "hi",
+        }
+        async_to_sync(consumer.chat_message)(event)
+        self.assertEqual(consumer._sent, [])
+
+    def test_dashboard_forwards_group_message(self):
+        """Group channels still pass through unchanged."""
+        from asgiref.sync import async_to_sync
+
+        consumer = self._make_dashboard_consumer(self.user_observer)
+        event = {
+            "type": "chat.message",
+            "sender": "anyone",
+            "channel": "#general",
+            "text": "hi",
+        }
+        async_to_sync(consumer.chat_message)(event)
+        self.assertEqual(len(consumer._sent), 1)
+
+    # ------------------------------------------------------------------
+    # Rename signal — identity_name sync
+    # ------------------------------------------------------------------
+    def test_agent_profile_rename_updates_identity_name(self):
+        """Renaming an AgentProfile updates DMParticipant.identity_name."""
+        # Create a matching profile+participant setup where the
+        # identity_name diverges on rename.
+        self.agent_profile.name = "skill-renamed"
+        # New underlying user for the rename target
+        new_user = User.objects.create_user(
+            username="agent-skill-renamed", password="x"
+        )
+        new_member = WorkspaceMember.objects.create(
+            workspace=self.ws, user=new_user, role="member"
+        )
+        # Repoint the participant row to the new member before saving
+        # — the signal uses the username of the current member.
+        part = DMParticipant.objects.get(
+            channel=self.dm_agent, member=self.mem_agent
+        )
+        part.member = new_member
+        part.save()
+        # Now fire the rename signal
+        self.agent_profile.save()
+        part.refresh_from_db()
+        self.assertEqual(part.identity_name, "skill-renamed")
+
+    def test_user_rename_updates_identity_name(self):
+        """Renaming a human User updates DMParticipant.identity_name."""
+        self.user_alice.username = "alice-renamed"
+        self.user_alice.save()
+        part = DMParticipant.objects.get(
+            channel=self.dm, member=self.mem_alice
+        )
+        self.assertEqual(part.identity_name, "alice-renamed")
+
+    # ------------------------------------------------------------------
+    # DM broadcast path — skip workspace fanout
+    # ------------------------------------------------------------------
+    def test_dm_broadcast_skips_workspace_group(self):
+        """Spec v3 §3.3 — DM writes must not hit workspace_<id>."""
+        from asgiref.sync import async_to_sync
+
+        from hub.consumers import AgentConsumer
+
+        consumer = AgentConsumer.__new__(AgentConsumer)
+        consumer.workspace_id = self.ws.id
+        consumer.workspace_name = self.ws.name
+        consumer.workspace_group = f"workspace_{self.ws.id}"
+        consumer.agent_name = "alice"
+        consumer.agent_meta = {"channels": ["dm:alice|bob"]}
+        consumer.workspace_member_id = self.mem_alice.id
+
+        sent = []
+
+        class _FakeLayer:
+            async def group_send(self, group, event):
+                sent.append((group, event))
+
+        consumer.channel_layer = _FakeLayer()
+
+        async def fake_send_json(payload):
+            pass
+
+        consumer.send_json = fake_send_json
+
+        # Stub _save_message to avoid DB writes for speed (not strictly
+        # required — the call chain is async-safe — but keeps the test
+        # focused on the fanout path).
+        async def fake_save(**kwargs):
+            return {"id": 1, "ts": "2026-01-01T00:00:00+00:00"}
+
+        consumer._save_message = fake_save
+
+        # Also stub mark_activity import chain
+        async_to_sync(consumer.receive_json)(
+            {
+                "type": "message",
+                "payload": {
+                    "channel": "dm:alice|bob",
+                    "content": "secret",
+                },
+            }
+        )
+
+        groups = [g for g, _ in sent]
+        self.assertIn(
+            _sanitize_group_name(
+                f"channel_{self.ws.id}_dm:alice|bob"
+            ),
+            groups,
+        )
+        self.assertNotIn(f"workspace_{self.ws.id}", groups)
+        # All events should carry kind="dm"
+        for _, ev in sent:
+            self.assertEqual(ev.get("kind"), "dm")
+
+    def test_group_broadcast_still_hits_workspace_group(self):
+        """Regression: non-DM messages must still reach workspace_<id>."""
+        from asgiref.sync import async_to_sync
+
+        from hub.consumers import AgentConsumer
+
+        consumer = AgentConsumer.__new__(AgentConsumer)
+        consumer.workspace_id = self.ws.id
+        consumer.workspace_name = self.ws.name
+        consumer.workspace_group = f"workspace_{self.ws.id}"
+        consumer.agent_name = "alice"
+        consumer.agent_meta = {"channels": ["#general"]}
+        consumer.workspace_member_id = self.mem_alice.id
+
+        sent = []
+
+        class _FakeLayer:
+            async def group_send(self, group, event):
+                sent.append((group, event))
+
+        consumer.channel_layer = _FakeLayer()
+
+        async def fake_send_json(payload):
+            pass
+
+        consumer.send_json = fake_send_json
+
+        async def fake_save(**kwargs):
+            return {"id": 1, "ts": "2026-01-01T00:00:00+00:00"}
+
+        consumer._save_message = fake_save
+
+        async_to_sync(consumer.receive_json)(
+            {
+                "type": "message",
+                "payload": {
+                    "channel": "#general",
+                    "content": "public",
+                },
+            }
+        )
+        groups = [g for g, _ in sent]
+        self.assertIn(f"workspace_{self.ws.id}", groups)
+
+
+def _sanitize_group_name(name: str) -> str:
+    """Test helper — mirrors hub.consumers._sanitize_group."""
+    from hub.consumers import _sanitize_group
+
+    return _sanitize_group(name)

--- a/orochi/settings.py
+++ b/orochi/settings.py
@@ -87,7 +87,7 @@ INSTALLED_APPS = [
     "allauth.socialaccount.providers.google",
     "allauth.socialaccount.providers.orcid",
     "hub.providers.scitex",
-    "hub",
+    "hub.apps.HubConfig",
 ]
 
 SITE_ID = 1


### PR DESCRIPTION
## Summary

PR 2 of the Orochi DM feature (scitex-orochi#60). Implements spec v3 §3.1–§3.4 — consumer routing, channel ACL DM branch, and DashboardConsumer confidentiality filter. Stacked on #102 (`feat/todo-60-dm-schema`) which provides the `Channel.kind` + `DMParticipant` schema.

**Spec:** [DM Support v3](https://scitex-orochi.com/media/2026-04/9564d844-6dcd-49d2-9331-7a85e0a65d5f.md)

## What changed

- **§2.3 / §3.1 — AgentConsumer.connect:** new `_ensure_agent_member()` helper (idempotent `get_or_create(User, WorkspaceMember)`, mirrors `hub/views/auth.py` `agent_login_view`). Auto-subscribe the connection to every `dm:*` channel the member participates in. Auto-subscribed DM names are merged into `agent_meta["channels"]` at `register` time so the 90158bc filter still works.
- **§3.2 — hub/channel_acl.py `check_write_allowed`:** new DM branch. Channels with `dm:` prefix (or `kind="dm"`) bypass the yaml ACL and are allowed iff the sender is a `DMParticipant` of the channel. Matches via denormalized `identity_name`, bare `User.username`, or synthetic `agent-<name>` username. Consumer path routes through `sync_to_async` (the yaml path stays sub-ms).
- **§3.3 — Broadcast path:** `dm:*` messages skip the `workspace_<id>` fanout entirely; only the `channel_<ws>_<dm-name>` group is targeted. All `chat.message` events now carry an explicit `kind` field.
- **§3.3 — AgentConsumer.chat_message + DashboardConsumer.chat_message:** DM confidentiality filter. Agents check their `WorkspaceMember` against `DMParticipant`. Dashboards check the connected Django `User.username`; token-only / unauthenticated dashboards (`username in {"", "dashboard", None}`) never receive DMs.
- **§2.2 rename handling — hub/signals.py + hub/apps.py:** `post_save` handlers on `AgentProfile` and `User` keep `DMParticipant.identity_name` in sync on rename. Wired via new `HubConfig.ready()`; `orochi/settings.py` `INSTALLED_APPS` now points at `hub.apps.HubConfig`.

## Tests

16 new tests in `hub/tests.DMConsumerRoutingTest` (all pass):

- `_ensure_agent_member` idempotence (1 row after 2 calls)
- `check_write_allowed` DM participant allowed / non-participant denied / **`PRINCIPAL_AGENT` case** (identity_name + `agent-<name>` username variants, per skill-manager carry-forward) / group channel unchanged
- `AgentConsumer.chat_message` forwards DM to participant, drops to non-participant, keeps group-channel 90158bc filter
- `DashboardConsumer.chat_message` drops DM to non-participant and token-only observer, forwards to participant, passes group messages
- `AgentProfile` rename → `DMParticipant.identity_name` update; `User.username` rename → `identity_name` update
- `receive_json` DM path: fanout skips `workspace_<id>`, targets `channel_<ws>_<dm-name>`, event carries `kind="dm"`
- Group broadcast regression: still hits `workspace_<id>`

```
Ran 22 tests in 9.184s
OK   (hub.tests.DMConsumerRoutingTest + hub.tests.DMSchemaTest)
```

Full suite: `Ran 50 tests … FAILED (errors=14)` — **same 14 pre-existing errors as PR 1 baseline** (`AuthTest` staticfiles manifest + `RestApiTest` `api_* slug` kwarg mismatches). No regressions introduced. These are tracked separately and were documented in PR #102.

## Non-goals (deferred)

- **PR 3:** `/api/workspace/<slug>/dms/` endpoints, `/api/workspace/<slug>/messages/` POST write-ACL enforcement, `full_clean()` on channel-create.
- **PR 4:** UI sidebar "Direct messages" section, `dm_open`/`dm_list` MCP tools.

## Spec deviations

None of substance. Minor adaptation: `check_write_allowed` gained an optional `workspace_id` kwarg (non-DM callers unaffected) because DM ACL is workspace-scoped and the yaml layer is not. The `DashboardConsumer` check explicitly deny-lists `username="dashboard"` (the `_TokenUser` stand-in) — this is stricter than spec but required to avoid leaking DMs through token-auth dashboards.

## Stacked on

- #102 `feat/todo-60-dm-schema` — merge that first. This PR targets `feat/todo-60-dm-schema` as its base.
