### PR TITLE
feat(hub): DM REST API + /messages/ write-ACL fix (todo#60 PR 3)

### DIFF
--- a/hub/tests.py
+++ b/hub/tests.py
@@ -797,3 +797,209 @@ def _sanitize_group_name(name: str) -> str:
     from hub.consumers import _sanitize_group
 
     return _sanitize_group(name)
+
+
+# ---------------------------------------------------------------------------
+# DM REST API + write-ACL tests (todo#60 PR 3, spec v3 §4 + §8)
+# ---------------------------------------------------------------------------
+
+
+class DmRestApiTest(TestCase):
+    """Coverage for /api/workspace/<slug>/dms/ and the /messages/ ACL fix."""
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="dm-ws")
+
+        # Two human callers + one synthetic agent user, all members.
+        self.alice = User.objects.create_user(username="alice", password="x")
+        self.bob = User.objects.create_user(username="bob", password="x")
+        self.carol = User.objects.create_user(username="carol", password="x")
+        self.agent_user = User.objects.create_user(
+            username="agent-mamba-foo", password="x"
+        )
+        self.alice_m = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.alice
+        )
+        self.bob_m = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.bob
+        )
+        self.carol_m = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.carol
+        )
+        self.agent_m = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.agent_user
+        )
+
+    def _login(self, user):
+        self.client.force_login(user)
+
+    # ---- POST /dms/ ----------------------------------------------------
+
+    def test_post_dms_creates_canonical_channel(self):
+        self._login(self.alice)
+        resp = self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        # Canonical name is dm:<sorted principal keys>
+        expected = "dm:" + "|".join(sorted(["human:alice", "human:bob"]))
+        self.assertEqual(data["name"], expected)
+        self.assertEqual(data["kind"], "dm")
+        self.assertEqual(len(data["other_participants"]), 1)
+        self.assertEqual(data["other_participants"][0]["identity_name"], "bob")
+
+        ch = Channel.objects.get(workspace=self.ws, name=expected)
+        self.assertEqual(ch.kind, "dm")
+        self.assertEqual(ch.dm_participants.count(), 2)
+
+    def test_post_dms_is_idempotent(self):
+        self._login(self.alice)
+        url = "/api/workspace/dm-ws/dms/"
+        body = json.dumps({"recipient": "human:bob"})
+        r1 = self.client.post(url, data=body, content_type="application/json")
+        r2 = self.client.post(url, data=body, content_type="application/json")
+        self.assertEqual(r1.status_code, 200)
+        self.assertEqual(r2.status_code, 200)
+        self.assertEqual(r1.json()["name"], r2.json()["name"])
+        self.assertEqual(
+            Channel.objects.filter(
+                workspace=self.ws, kind="dm", name=r1.json()["name"]
+            ).count(),
+            1,
+        )
+        self.assertEqual(DMParticipant.objects.filter(channel__name=r1.json()["name"]).count(), 2)
+
+    def test_post_dms_rejects_non_member(self):
+        self._login(self.alice)
+        resp = self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "human:nobody"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_post_dms_routes_through_channel_clean(self):
+        """The dm: prefix guard in Channel.clean() must run on create.
+
+        Indirect test: create a DM, then try to create a *group* channel
+        with the same dm: name — clean() must reject it. This proves the
+        full_clean() path is wired up.
+        """
+        self._login(self.alice)
+        resp = self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200)
+        canonical = resp.json()["name"]
+        # Now build a group Channel with the same name and confirm
+        # full_clean() rejects it (PR 1 guard).
+        bad = Channel(
+            workspace=self.ws, name=canonical, kind=Channel.KIND_GROUP
+        )
+        with self.assertRaises(ValidationError):
+            bad.full_clean()
+
+    def test_post_dms_agent_recipient(self):
+        self._login(self.alice)
+        resp = self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "agent:mamba-foo"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        self.assertIn("agent:mamba-foo", data["name"])
+        self.assertEqual(data["other_participants"][0]["type"], "agent")
+        self.assertEqual(
+            data["other_participants"][0]["identity_name"], "mamba-foo"
+        )
+
+    # ---- GET /dms/ -----------------------------------------------------
+
+    def test_get_dms_only_returns_callers_dms(self):
+        # alice <-> bob
+        self._login(self.alice)
+        self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        # carol <-> bob (alice should NOT see this one)
+        self.client.logout()
+        self._login(self.carol)
+        self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+
+        # Alice's view
+        self.client.logout()
+        self._login(self.alice)
+        resp = self.client.get("/api/workspace/dm-ws/dms/")
+        self.assertEqual(resp.status_code, 200)
+        rows = resp.json()["dms"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0]["other_participants"][0]["identity_name"], "bob"
+        )
+
+    # ---- /messages/ write-ACL fix (§8 / todo#258) ----------------------
+
+    def test_messages_post_dm_non_participant_forbidden(self):
+        # Create a DM between alice <-> bob
+        self._login(self.alice)
+        r = self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        dm_name = r.json()["name"]
+        self.client.logout()
+
+        # Carol (not a participant) tries to post into the DM channel.
+        self._login(self.carol)
+        resp = self.client.post(
+            "/api/workspace/dm-ws/messages/",
+            data=json.dumps({"channel": dm_name, "text": "sneaky"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.assertEqual(
+            Message.objects.filter(channel__name=dm_name).count(), 0
+        )
+
+    def test_messages_post_dm_participant_allowed(self):
+        self._login(self.alice)
+        r = self.client.post(
+            "/api/workspace/dm-ws/dms/",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        dm_name = r.json()["name"]
+
+        resp = self.client.post(
+            "/api/workspace/dm-ws/messages/",
+            data=json.dumps({"channel": dm_name, "text": "hi bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.content)
+        self.assertEqual(
+            Message.objects.filter(channel__name=dm_name).count(), 1
+        )
+
+    def test_messages_post_group_channel_unaffected(self):
+        Channel.objects.create(workspace=self.ws, name="#general")
+        self._login(self.alice)
+        resp = self.client.post(
+            "/api/workspace/dm-ws/messages/",
+            data=json.dumps({"channel": "#general", "text": "hello"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.content)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -60,6 +60,9 @@ urlpatterns = [
         "api/workspace/<slug:slug>/messages/", views.api_messages, name="api-messages"
     ),
     path(
+        "api/workspace/<slug:slug>/dms/", views.api_dms, name="api-dms"
+    ),
+    path(
         "api/workspace/<slug:slug>/history/<str:channel_name>/",
         views.api_history,
         name="api-history",

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -49,6 +49,7 @@ urlpatterns = [
     # REST API — no slug needed, workspace from subdomain
     path("api/channels/", views.api_channels, name="api-channels"),
     path("api/messages/", views.api_messages, name="api-messages"),
+    path("api/dms/", views.api_dms, name="api-dms"),
     path("api/history/<str:channel_name>/", views.api_history, name="api-history"),
     path("api/stats/", views.api_stats, name="api-stats"),
     path("api/workspaces/", views.api_workspaces, name="api-workspaces"),

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -14,6 +14,7 @@ from hub.views.api import (  # noqa: F401
     api_channels,
     api_config,
     api_connectivity,
+    api_dms,
     api_event_tool_use,
     api_history,
     api_media,

--- a/hub/views/_helpers.py
+++ b/hub/views/_helpers.py
@@ -18,9 +18,23 @@ def bare_url(path="/"):
     return f"{scheme}://{base}{path}"
 
 
-def get_workspace(request):
-    """Get workspace from middleware (subdomain) or raise 404."""
+def get_workspace(request, slug=None):
+    """Get workspace from middleware (subdomain) or by ``slug`` kwarg.
+
+    The subdomain middleware sets ``request.workspace`` for hosts of the
+    form ``<slug>.scitex-orochi.com``. For test clients (default
+    ``testserver`` host) and the path-based ``/api/workspace/<slug>/...``
+    routes in :mod:`hub.urls`, the URL kwarg ``slug`` is used as a
+    fallback so the same view function works in both contexts.
+    """
     workspace = getattr(request, "workspace", None)
-    if not workspace:
-        raise Http404("No workspace context")
-    return workspace
+    if workspace:
+        return workspace
+    if slug:
+        from hub.models import Workspace
+
+        try:
+            return Workspace.objects.get(name=slug)
+        except Workspace.DoesNotExist:
+            raise Http404(f"Workspace {slug!r} not found")
+    raise Http404("No workspace context")

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -18,8 +18,10 @@ from django.views.decorators.http import require_GET, require_http_methods
 _server_start_time = time.time()
 
 
+from hub.channel_acl import check_write_allowed
 from hub.models import (
     Channel,
+    DMParticipant,
     Message,
     MessageReaction,
     MessageThread,
@@ -68,9 +70,9 @@ def api_channels(request):
 
 @login_required
 @require_http_methods(["GET", "POST"])
-def api_messages(request):
+def api_messages(request, slug=None):
     """GET/POST /api/messages/ — recent messages or send one."""
-    workspace = get_workspace(request)
+    workspace = get_workspace(request, slug=slug)
 
     if request.method == "GET":
         from django.db.models import Count, Exists, OuterRef
@@ -114,6 +116,20 @@ def api_messages(request):
         metadata = {**metadata, "attachments": attachments}
     if not text and not attachments:
         return JsonResponse({"error": "text or attachments required"}, status=400)
+
+    # Spec v3 §8 / todo#258: REST POST /messages/ previously bypassed
+    # the channel write-ACL that AgentConsumer.receive_json enforces.
+    # Mirror the same check here so DM confidentiality (and any
+    # channels.yaml ACL) is enforced regardless of transport.
+    sender_identity = request.user.username
+    if not check_write_allowed(
+        sender=sender_identity,
+        channel=ch_name,
+        workspace_id=workspace.id,
+    ):
+        return JsonResponse(
+            {"error": "not allowed to write to this channel"}, status=403
+        )
 
     channel, _ = Channel.objects.get_or_create(workspace=workspace, name=ch_name)
     msg = Message.objects.create(
@@ -1758,3 +1774,178 @@ def api_resources(request):
                 machines[machine]["last_heartbeat"] = a["last_heartbeat"]
 
     return JsonResponse(machines, safe=False)
+
+
+# ---------------------------------------------------------------------------
+# Direct Messages (spec v3 §4) — todo#60 PR 3
+# ---------------------------------------------------------------------------
+
+
+def _dm_canonical_name(principal_keys):
+    """Return the canonical ``dm:<a>|<b>`` channel name for a sorted pair.
+
+    Spec v3 §2.3: DM channel names are ``dm:`` + ``|``-joined sorted
+    list of ``<type>:<identity>`` principal keys. Sorting makes the
+    name independent of who initiated the DM, so ``get_or_create``
+    is naturally idempotent.
+    """
+    return "dm:" + "|".join(sorted(principal_keys))
+
+
+def _principal_key_for_member(member):
+    """Return ``"agent:<name>"`` or ``"human:<username>"`` for a member."""
+    username = member.user.username or ""
+    if username.startswith("agent-"):
+        return f"agent:{username[len('agent-'):]}"
+    return f"human:{username}"
+
+
+def _resolve_recipient_member(workspace, recipient):
+    """Resolve a ``"agent:<name>"`` or ``"human:<username>"`` recipient
+    string to a :class:`WorkspaceMember`. Returns ``None`` if the
+    recipient is not a member of ``workspace`` or the form is invalid.
+    """
+    if not recipient or ":" not in recipient:
+        return None
+    kind, _, identity = recipient.partition(":")
+    identity = identity.strip()
+    if not identity:
+        return None
+    if kind == "agent":
+        username = f"agent-{identity}"
+    elif kind == "human":
+        username = identity
+    else:
+        return None
+    return (
+        WorkspaceMember.objects.filter(
+            workspace=workspace, user__username=username
+        )
+        .select_related("user")
+        .first()
+    )
+
+
+def _dm_row(channel, current_member):
+    """Build the row dict returned by GET/POST /dms/."""
+    others = []
+    for p in channel.dm_participants.select_related("member__user"):
+        if p.member_id == current_member.id:
+            continue
+        others.append(
+            {"type": p.principal_type, "identity_name": p.identity_name}
+        )
+    last_msg = (
+        Message.objects.filter(channel=channel).order_by("-ts").only("ts").first()
+    )
+    return {
+        "name": channel.name,
+        "kind": channel.kind,
+        "other_participants": others,
+        "last_message_ts": last_msg.ts.isoformat() if last_msg else None,
+    }
+
+
+@login_required
+@csrf_exempt
+@require_http_methods(["GET", "POST"])
+def api_dms(request, slug=None):
+    """GET/POST /api/workspace/<slug>/dms/ — list or create 1:1 DMs.
+
+    Spec v3 §4. The current authenticated principal is resolved via
+    ``WorkspaceMember`` for ``request.user`` in the active workspace.
+    """
+    workspace = get_workspace(request, slug=slug)
+
+    current_member = (
+        WorkspaceMember.objects.filter(workspace=workspace, user=request.user)
+        .select_related("user")
+        .first()
+    )
+    if current_member is None:
+        return JsonResponse(
+            {"error": "not a workspace member"}, status=403
+        )
+
+    if request.method == "GET":
+        my_dm_channel_ids = DMParticipant.objects.filter(
+            member=current_member,
+            channel__workspace=workspace,
+            channel__kind=Channel.KIND_DM,
+        ).values_list("channel_id", flat=True)
+        channels = Channel.objects.filter(id__in=list(my_dm_channel_ids)).order_by(
+            "name"
+        )
+        rows = [_dm_row(ch, current_member) for ch in channels]
+        return JsonResponse({"dms": rows}, safe=False)
+
+    # POST — get-or-create a 1:1 DM
+    try:
+        body = json.loads(request.body or b"{}")
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "invalid json"}, status=400)
+    recipient = (body.get("recipient") or body.get("peer") or "").strip()
+    if not recipient:
+        return JsonResponse({"error": "recipient required"}, status=400)
+
+    other_member = _resolve_recipient_member(workspace, recipient)
+    if other_member is None:
+        return JsonResponse(
+            {"error": f"recipient {recipient!r} is not a workspace member"},
+            status=404,
+        )
+    if other_member.id == current_member.id:
+        return JsonResponse(
+            {"error": "cannot DM yourself"}, status=400
+        )
+
+    me_key = _principal_key_for_member(current_member)
+    other_key = _principal_key_for_member(other_member)
+    canonical_name = _dm_canonical_name([me_key, other_key])
+
+    # Idempotent get-or-create. We do NOT use Channel.objects.get_or_create
+    # because we need full_clean() (PR 1 dm: prefix guard) to run on
+    # the create path.
+    channel = Channel.objects.filter(
+        workspace=workspace, name=canonical_name
+    ).first()
+    if channel is None:
+        channel = Channel(
+            workspace=workspace,
+            name=canonical_name,
+            kind=Channel.KIND_DM,
+        )
+        channel.full_clean()
+        channel.save()
+
+    def _principal_type(member):
+        return (
+            DMParticipant.PRINCIPAL_AGENT
+            if (member.user.username or "").startswith("agent-")
+            else DMParticipant.PRINCIPAL_HUMAN
+        )
+
+    def _identity_name(member):
+        username = member.user.username or ""
+        if username.startswith("agent-"):
+            return username[len("agent-"):]
+        return username
+
+    DMParticipant.objects.get_or_create(
+        channel=channel,
+        member=current_member,
+        defaults={
+            "principal_type": _principal_type(current_member),
+            "identity_name": _identity_name(current_member),
+        },
+    )
+    DMParticipant.objects.get_or_create(
+        channel=channel,
+        member=other_member,
+        defaults={
+            "principal_type": _principal_type(other_member),
+            "identity_name": _identity_name(other_member),
+        },
+    )
+
+    return JsonResponse(_dm_row(channel, current_member), status=200)


### PR DESCRIPTION
## Summary

PR 3 of the Orochi DM feature (scitex-orochi#60). Implements the REST API surface for direct messages and closes the latent write-ACL bypass on the existing `/messages/` POST handler.

Spec v3 (canonical): https://scitex-orochi.com/media/2026-04/9564d844-6dcd-49d2-9331-7a85e0a65d5f.md

**Depends on #103 (PR 2 — DM consumers + ACL) and transitively on #102 (PR 1 — model + migration).**

## Spec sections implemented

### Section 4 — REST API
- `GET /api/workspace/<slug>/dms/` — list current authenticated principal's DM channels with `{name, kind, other_participants:[{type,identity_name}], last_message_ts}`.
- `POST /api/workspace/<slug>/dms/` body `{"recipient": "agent:<name>" | "human:<username>"}` — get-or-create a 1:1 DM channel. Builds the canonical `dm:<sorted-principal-keys>` name, creates two `DMParticipant` rows, and is idempotent (second POST returns the existing channel).
- Recipient resolution rejects callers that pass a principal which is not a `WorkspaceMember`.
- `Channel.full_clean()` is called on the create path so the PR 1 `dm:`-prefix guard runs end-to-end. There is currently no group-channel-create REST endpoint, so the carry-forward fix lives entirely on the DM create path. Indirectly tested by constructing a `Channel(name=<canonical>, kind=group)` and asserting `full_clean()` raises.

### Section 8 — `/messages/` write-ACL fix (todo#258)
- `POST /api/workspace/<slug>/messages/` now calls `channel_acl.check_write_allowed(sender, channel, workspace_id)` before persisting the message, mirroring the check `AgentConsumer.receive_json` already performs in PR 2. This closes the REST bypass that allowed any logged-in workspace member to write into a DM they were not a participant of (DM confidentiality is now enforced regardless of transport).

### Infrastructure side fix
- `_helpers.get_workspace` gained an optional `slug` fallback so the path-based `/api/workspace/<slug>/...` routes resolve a workspace under the test client, where the subdomain middleware does not run (`testserver` host). This unblocks both the new tests and 2 pre-existing `api_messages` tests.

## Non-goals (PR 4)
- `hub/static/hub/*.js` sidebar DM section, DM picker
- MCP `dm_open` / `dm_list` tools
- Per-agent token hardening
- Any UI changes

## Files touched
- `hub/views/api.py` — `api_dms`, ACL check on `api_messages`, slug-fallback signature
- `hub/views/_helpers.py` — `get_workspace(request, slug=None)`
- `hub/views/__init__.py` — re-export `api_dms`
- `hub/urls.py` + `hub/urls_workspace.py` — wire `/api/workspace/<slug>/dms/` (path) and `/api/dms/` (subdomain)
- `hub/tests.py` — new `DmRestApiTest` class

## Test plan

`python manage.py test hub`

- 9/9 new tests in `DmRestApiTest` PASS:
  - `test_post_dms_creates_canonical_channel`
  - `test_post_dms_is_idempotent`
  - `test_post_dms_rejects_non_member`
  - `test_post_dms_routes_through_channel_clean`
  - `test_post_dms_agent_recipient`
  - `test_get_dms_only_returns_callers_dms`
  - `test_messages_post_dm_non_participant_forbidden`
  - `test_messages_post_dm_participant_allowed`
  - `test_messages_post_group_channel_unaffected`
- Total: 59 tests, 12 errors (down from 50/14 on parent branch). Net: +9 tests added, +2 pre-existing tests fixed as a side effect of the `get_workspace` slug-fallback.
- Remaining 12 errors are the pre-existing staticfiles-manifest / `slug` kwarg failures in `api_channels`/`api_history`/`api_stats`/etc., identical to the PR 1/2 baseline. Out of scope for this PR.

## Closes
- todo#258 (REST `/messages/` write-ACL bypass)
