### PR TITLE
feat(hub): DM UI + MCP tools (todo#60 PR 4 / final)

### DIFF
--- a/hub/static/hub/dms.js
+++ b/hub/static/hub/dms.js
@@ -1,0 +1,312 @@
+/* Direct messages sidebar + new-DM picker (todo#60 PR 4)
+ *
+ * Renders a "Direct messages" sidebar section below #channels by polling
+ * GET /api/dms/. Each row sets currentChannel = "dm:<a>|<b>" on click and
+ * routes through the existing loadChannelHistory + draft/filter pipeline.
+ *
+ * Per spec v3.1 §4.1, agents must use the WS `reply` tool with the
+ * dm:<a>|<b> channel name for sending — the REST POST path is not the
+ * write path. This module only consumes GET /api/dms/ (list) and
+ * POST /api/dms/ (create), never POST /api/messages/ for DMs.
+ */
+/* globals apiUrl, orochiHeaders, currentChannel, setCurrentChannel,
+   loadChannelHistory, loadHistory, addTag, fetchStats, escapeHtml */
+
+(function () {
+  var lastDmJson = "";
+  var memberCache = null;
+  var agentCache = null;
+
+  function selfPrincipalKey() {
+    var u = window.__orochiUserName || "";
+    return u ? "human:" + u : "";
+  }
+
+  function dmDisplayName(row) {
+    var others = (row && row.other_participants) || [];
+    if (others.length === 0) return row && row.name ? row.name : "(empty DM)";
+    return others
+      .map(function (p) {
+        return p.identity_name || "?";
+      })
+      .join(", ");
+  }
+
+  function dmBadgeHtml(row) {
+    var others = (row && row.other_participants) || [];
+    if (others.length === 0) return "";
+    var t = others[0].type === "agent" ? "agent" : "human";
+    var label = t === "agent" ? "AI" : "U";
+    return (
+      '<span class="dm-principal-badge ' + t + '">' + label + "</span>"
+    );
+  }
+
+  function renderDms(rows) {
+    var container = document.getElementById("dms");
+    if (!container) return;
+    if (!rows || rows.length === 0) {
+      container.innerHTML = '<div class="dm-empty">No direct messages</div>';
+    } else {
+      container.innerHTML = rows
+        .map(function (row) {
+          var ch = row.name;
+          var active =
+            typeof currentChannel !== "undefined" && currentChannel === ch
+              ? " active"
+              : "";
+          return (
+            '<div class="dm-item' +
+            active +
+            '" data-channel="' +
+            escapeHtml(ch) +
+            '" title="' +
+            escapeHtml(ch) +
+            '">' +
+            dmBadgeHtml(row) +
+            escapeHtml(dmDisplayName(row)) +
+            "</div>"
+          );
+        })
+        .join("");
+      container.querySelectorAll(".dm-item").forEach(function (el) {
+        el.addEventListener("click", function () {
+          var ch = el.getAttribute("data-channel");
+          if (!ch) return;
+          /* Mirror the channel-link pattern from chat.js:1547 and the
+           * #channels click handler in app.js:920. */
+          if (
+            typeof currentChannel !== "undefined" &&
+            currentChannel === ch
+          ) {
+            if (typeof setCurrentChannel === "function")
+              setCurrentChannel(null);
+            if (typeof loadHistory === "function") loadHistory();
+          } else {
+            if (typeof setCurrentChannel === "function")
+              setCurrentChannel(ch);
+            if (typeof loadChannelHistory === "function")
+              loadChannelHistory(ch);
+          }
+          if (typeof addTag === "function") addTag("channel", ch);
+          fetchDms();
+          if (typeof fetchStats === "function") fetchStats();
+        });
+      });
+    }
+    var countEl = document.getElementById("sidebar-count-dms");
+    if (countEl) countEl.textContent = "(" + (rows ? rows.length : 0) + ")";
+  }
+
+  async function fetchDms() {
+    try {
+      var res = await fetch(apiUrl("/api/dms/"), {
+        credentials: "same-origin",
+      });
+      if (!res.ok) {
+        /* 401/403/404 — silently render empty so we don't pollute the UI */
+        if (res.status === 404 || res.status === 401 || res.status === 403) {
+          renderDms([]);
+        }
+        return;
+      }
+      var data = await res.json();
+      var rows = (data && data.dms) || [];
+      var json = JSON.stringify(rows);
+      if (json === lastDmJson) return;
+      lastDmJson = json;
+      renderDms(rows);
+    } catch (e) {
+      /* network error — leave UI alone */
+    }
+  }
+  window.fetchDms = fetchDms;
+
+  /* ---------------- New-DM picker modal ---------------- */
+
+  async function loadCandidates() {
+    var candidates = [];
+    var selfKey = selfPrincipalKey();
+    var seen = {};
+    /* Humans via /api/members/ */
+    try {
+      if (memberCache === null) {
+        var r1 = await fetch(apiUrl("/api/members/"), {
+          credentials: "same-origin",
+        });
+        memberCache = r1.ok ? await r1.json() : [];
+      }
+      (memberCache || []).forEach(function (m) {
+        var name = m && m.username;
+        if (!name) return;
+        var key, label, type;
+        if (name.indexOf("agent-") === 0) {
+          type = "agent";
+          label = name.slice("agent-".length);
+          key = "agent:" + label;
+        } else {
+          type = "human";
+          label = name;
+          key = "human:" + name;
+        }
+        if (key === selfKey) return;
+        if (seen[key]) return;
+        seen[key] = true;
+        candidates.push({ key: key, label: label, type: type });
+      });
+    } catch (_) {}
+    /* Live agents via /api/agents to surface ones not yet in members table */
+    try {
+      if (agentCache === null) {
+        var r2 = await fetch(apiUrl("/api/agents"), {
+          credentials: "same-origin",
+        });
+        agentCache = r2.ok ? await r2.json() : [];
+      }
+      (agentCache || []).forEach(function (a) {
+        var n = a && a.name ? String(a.name).split("@")[0] : "";
+        if (!n) return;
+        var key = "agent:" + n;
+        if (seen[key]) return;
+        seen[key] = true;
+        candidates.push({ key: key, label: n, type: "agent" });
+      });
+    } catch (_) {}
+    candidates.sort(function (a, b) {
+      return a.label.localeCompare(b.label);
+    });
+    return candidates;
+  }
+
+  function renderPickerResults(candidates, query) {
+    var container = document.getElementById("new-dm-results");
+    if (!container) return;
+    var q = (query || "").toLowerCase();
+    var filtered = candidates.filter(function (c) {
+      if (!q) return true;
+      return c.label.toLowerCase().indexOf(q) !== -1;
+    });
+    if (filtered.length === 0) {
+      container.innerHTML =
+        '<div class="dm-modal-empty">No matches</div>';
+      return;
+    }
+    container.innerHTML = filtered
+      .map(function (c) {
+        var badge =
+          '<span class="dm-principal-badge ' +
+          c.type +
+          '">' +
+          (c.type === "agent" ? "AI" : "U") +
+          "</span>";
+        return (
+          '<div class="dm-modal-result" data-key="' +
+          escapeHtml(c.key) +
+          '">' +
+          badge +
+          escapeHtml(c.label) +
+          "</div>"
+        );
+      })
+      .join("");
+    container.querySelectorAll(".dm-modal-result").forEach(function (el) {
+      el.addEventListener("click", function () {
+        var key = el.getAttribute("data-key");
+        if (key) openDmWith(key);
+      });
+    });
+  }
+
+  async function openDmWith(principalKey) {
+    try {
+      var headers = { "Content-Type": "application/json" };
+      var token = window.__orochiCsrfToken || "";
+      if (token) headers["X-CSRFToken"] = token;
+      var res = await fetch(apiUrl("/api/dms/"), {
+        method: "POST",
+        headers: headers,
+        credentials: "same-origin",
+        body: JSON.stringify({ recipient: principalKey }),
+      });
+      if (!res.ok) {
+        var t = await res.text();
+        console.error("Create DM failed:", res.status, t);
+        return;
+      }
+      var row = await res.json();
+      closeModal();
+      lastDmJson = "";
+      await fetchDms();
+      var ch = row && row.name;
+      if (ch) {
+        if (typeof setCurrentChannel === "function") setCurrentChannel(ch);
+        if (typeof loadChannelHistory === "function")
+          loadChannelHistory(ch);
+        if (typeof addTag === "function") addTag("channel", ch);
+        if (typeof fetchStats === "function") fetchStats();
+      }
+    } catch (e) {
+      console.error("openDmWith error:", e);
+    }
+  }
+
+  function openModal() {
+    var modal = document.getElementById("new-dm-modal");
+    if (!modal) return;
+    modal.hidden = false;
+    var search = document.getElementById("new-dm-search");
+    if (search) {
+      search.value = "";
+      search.focus();
+    }
+    /* Force refresh on open so newly-onboarded members appear. */
+    memberCache = null;
+    agentCache = null;
+    loadCandidates().then(function (cands) {
+      renderPickerResults(cands, "");
+      if (search) {
+        search.oninput = function () {
+          renderPickerResults(cands, search.value);
+        };
+      }
+    });
+  }
+
+  function closeModal() {
+    var modal = document.getElementById("new-dm-modal");
+    if (modal) modal.hidden = true;
+  }
+
+  function wireModal() {
+    var btn = document.getElementById("new-dm-btn");
+    if (btn) {
+      btn.addEventListener("click", function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        openModal();
+      });
+    }
+    var close = document.getElementById("new-dm-close");
+    if (close) close.addEventListener("click", closeModal);
+    var modal = document.getElementById("new-dm-modal");
+    if (modal) {
+      var bd = modal.querySelector(".dm-modal-backdrop");
+      if (bd) bd.addEventListener("click", closeModal);
+    }
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") closeModal();
+    });
+  }
+
+  function init() {
+    wireModal();
+    fetchDms();
+    setInterval(fetchDms, 10000);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/hub/static/hub/style.css
+++ b/hub/static/hub/style.css
@@ -1276,3 +1276,152 @@ body {
   transform: translateX(-20px);
   transition: opacity 0.3s, transform 0.3s;
 }
+
+/* ---------------- Direct messages (todo#60 PR 4) ---------------- */
+.dm-heading {
+  display: flex;
+  align-items: center;
+}
+.dm-heading .sidebar-count {
+  flex: 1;
+}
+.new-dm-btn {
+  background: transparent;
+  color: #888;
+  border: 1px solid #333;
+  border-radius: 4px;
+  width: 22px;
+  height: 22px;
+  line-height: 18px;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0;
+}
+.new-dm-btn:hover {
+  background: #1a1a1a;
+  color: #fff;
+}
+.dm-item {
+  font-size: 12px;
+  color: #aaa;
+  margin-bottom: 8px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.dm-item:hover {
+  background: #1a1a1a;
+}
+.dm-item.active {
+  background: #1a1a1a;
+  font-weight: bold;
+  color: #fff;
+}
+.dm-item .dm-principal-badge {
+  display: inline-block;
+  font-size: 9px;
+  padding: 1px 4px;
+  border-radius: 2px;
+  margin-right: 4px;
+  background: #333;
+  color: #ccc;
+}
+.dm-item .dm-principal-badge.agent {
+  background: #2a4a6a;
+  color: #b8d4e3;
+}
+.dm-item .dm-principal-badge.human {
+  background: #4a2a4a;
+  color: #e8a6c8;
+}
+.dm-empty {
+  font-size: 12px;
+  color: #555;
+  font-style: italic;
+  padding: 4px 8px;
+}
+/* New DM modal */
+.dm-modal[hidden] {
+  display: none;
+}
+.dm-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.dm-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+.dm-modal-card {
+  position: relative;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 6px;
+  padding: 16px;
+  width: 360px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
+}
+.dm-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  color: #ddd;
+  margin-bottom: 12px;
+}
+.dm-modal-close {
+  background: transparent;
+  border: none;
+  color: #888;
+  font-size: 22px;
+  cursor: pointer;
+}
+.dm-modal-close:hover {
+  color: #fff;
+}
+#new-dm-search {
+  background: #0d0d0d;
+  color: #eee;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-size: 13px;
+  margin-bottom: 10px;
+  outline: none;
+}
+#new-dm-search:focus {
+  border-color: #555;
+}
+.dm-modal-results {
+  overflow-y: auto;
+  flex: 1;
+}
+.dm-modal-result {
+  padding: 8px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #ccc;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.dm-modal-result:hover {
+  background: #2a2a2a;
+}
+.dm-modal-empty {
+  padding: 12px;
+  color: #666;
+  font-size: 12px;
+  font-style: italic;
+  text-align: center;
+}

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -8,7 +8,7 @@
           content="black-translucent">
     <link rel="manifest" href="{% static 'hub/manifest.json' %}">
     <link rel="apple-touch-icon" href="{% static 'hub/orochi-icon.png' %}">
-    <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=118">
+    <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=119">
     <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/todo-tab.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/attachments.css' %}?v=99">
@@ -72,6 +72,11 @@
                 Channels <span class="sidebar-count" id="sidebar-count-channels"></span>
             </h2>
             <div id="channels" class="sidebar-section"></div>
+            <h2 class="collapsible-heading channels-heading dm-heading">
+                Direct messages <span class="sidebar-count" id="sidebar-count-dms"></span>
+                <button type="button" id="new-dm-btn" class="new-dm-btn" title="Start a new DM">+</button>
+            </h2>
+            <div id="dms" class="sidebar-section"></div>
             <h2 class="collapsible-heading channels-heading">
                 Machines <span class="sidebar-count" id="sidebar-count-machines"></span>
             </h2>
@@ -162,6 +167,17 @@
             <div class="stats-bar"></div>
         </div>
     </div>
+    <div id="new-dm-modal" class="dm-modal" hidden>
+      <div class="dm-modal-backdrop"></div>
+      <div class="dm-modal-card">
+        <div class="dm-modal-header">
+          <span>New direct message</span>
+          <button type="button" id="new-dm-close" class="dm-modal-close" aria-label="Close">&times;</button>
+        </div>
+        <input type="text" id="new-dm-search" placeholder="Search agents and people…" autocomplete="off">
+        <div id="new-dm-results" class="dm-modal-results"></div>
+      </div>
+    </div>
 {% endblock %}
 {% block extra_js %}
     <!-- hook-bypass: inline-script — Django template vars must be injected server-side -->
@@ -178,7 +194,8 @@
     </script>
     <script src="{% static 'hub/config.js' %}?v=117"></script>
     <script src="{% static 'hub/agent-icons.js' %}?v=99"></script>
-    <script src="{% static 'hub/app.js' %}?v=118"></script>
+    <script src="{% static 'hub/app.js' %}?v=119"></script>
+    <script src="{% static 'hub/dms.js' %}?v=1"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
     <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>
     <script src="{% static 'hub/todo-tab.js' %}?v=100"></script>

--- a/ts/mcp_channel.ts
+++ b/ts/mcp_channel.ts
@@ -26,6 +26,8 @@ import { addMessage } from "./src/message_buffer.js";
 import { spawnSync } from "child_process";
 import {
   handleContext,
+  handleDmList,
+  handleDmOpen,
   handleDownloadMedia,
   handleHealth,
   handleReply,
@@ -576,6 +578,8 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (name === "rsync_media") return handleRsyncMedia(args as any);
   if (name === "rsync_status") return handleRsyncStatus(args as any);
   if (name === "self_command") return handleSelfCommand(args as any);
+  if (name === "dm_list") return handleDmList(args as any);
+  if (name === "dm_open") return handleDmOpen(args as any);
   throw new Error(`Unknown tool: ${name}`);
 });
 

--- a/ts/src/tool_defs.ts
+++ b/ts/src/tool_defs.ts
@@ -240,6 +240,45 @@ export const TOOL_DEFS = [
     },
   },
   {
+    name: "dm_list",
+    description:
+      "List 1:1 direct-message channels the current agent participates in (todo#60). Returns rows with name, kind, other_participants, last_message_ts. Read-only — does not send messages.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workspace: {
+          type: "string",
+          description:
+            "Workspace slug. Defaults to env SCITEX_OROCHI_WORKSPACE if set.",
+        },
+      },
+    },
+  },
+  {
+    name: "dm_open",
+    description:
+      "Get-or-create a 1:1 DM channel between the caller and `recipient` (todo#60). Recipient is a principal key like 'agent:mamba-healer-mba' or 'human:ywatanabe'. Returns the DM row {name, kind, other_participants, ...}; the caller must use the existing `reply` tool with chat_id=<returned name> to actually send a message (the WS reply path is the sole agent write path per spec v3.1 §4.1).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        recipient: {
+          type: "string",
+          description:
+            "Principal key: 'agent:<name>' or 'human:<username>'. Alias: peer.",
+        },
+        peer: {
+          type: "string",
+          description: "Alias for recipient.",
+        },
+        workspace: {
+          type: "string",
+          description:
+            "Workspace slug. Defaults to env SCITEX_OROCHI_WORKSPACE if set.",
+        },
+      },
+    },
+  },
+  {
     name: "self_command",
     description:
       "Send an arbitrary slash command (e.g. /compact, /clear) to the agent's own screen/tmux session. Returns immediately; the command fires after delay_ms when the agent is idle at its prompt. Destructive commands (/clear, /kill, /exit, /quit) require confirm=true.",

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -548,6 +548,119 @@ export async function handleUploadMedia(args: {
 }
 
 // ---------------------------------------------------------------------------
+// Direct messages — dm_list / dm_open (todo#60 PR 4)
+//
+// These tools wrap the REST endpoints `/api/workspace/<slug>/dms/`. They are
+// READ / CREATE only — actual message sending stays on the WS `reply` path
+// (spec v3.1 §4.1: REST sender-identity for token-auth agents is unreliable;
+// `reply` is the sole agent write path).
+// ---------------------------------------------------------------------------
+
+function resolveWorkspaceSlug(arg?: string): string | null {
+  return (arg || process.env.SCITEX_OROCHI_WORKSPACE || "").trim() || null;
+}
+
+function dmsUrl(slug: string): string {
+  return `${httpBase}/api/workspace/${encodeURIComponent(slug)}/dms/${tokenParam("?")}`;
+}
+
+export async function handleDmList(args: {
+  workspace?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const slug = resolveWorkspaceSlug(args.workspace);
+  if (!slug) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "Error: workspace slug required. Pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE.",
+        },
+      ],
+    };
+  }
+  try {
+    const resp = await fetch(dmsUrl(slug), {
+      method: "GET",
+      headers: buildFetchHeaders(),
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: HTTP ${resp.status} — ${body.slice(0, 300)}`,
+          },
+        ],
+      };
+    }
+    const out = await resp.json();
+    return { content: [{ type: "text", text: JSON.stringify(out) }] };
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
+    };
+  }
+}
+
+export async function handleDmOpen(args: {
+  recipient?: string;
+  peer?: string;
+  workspace?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const slug = resolveWorkspaceSlug(args.workspace);
+  if (!slug) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "Error: workspace slug required. Pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE.",
+        },
+      ],
+    };
+  }
+  const recipient = (args.recipient || args.peer || "").trim();
+  if (!recipient) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "Error: recipient required (e.g. 'agent:mamba-healer-mba' or 'human:ywatanabe').",
+        },
+      ],
+    };
+  }
+  try {
+    const resp = await fetch(dmsUrl(slug), {
+      method: "POST",
+      headers: buildFetchHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ recipient }),
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: HTTP ${resp.status} — ${body.slice(0, 300)}`,
+          },
+        ],
+      };
+    }
+    const out = await resp.json();
+    /* Caller chains `reply` with chat_id=out.name to actually send. */
+    return { content: [{ type: "text", text: JSON.stringify(out) }] };
+  } catch (err) {
+    return {
+      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // rsync_media / rsync_status: background file transfer over SSH mesh.
 //
 // Each job:


### PR DESCRIPTION
## Summary

Final PR (4/4) of the Direct Messages feature chain (scitex-orochi#60).

Implements spec [v3.1](https://scitex-orochi.com/media/2026-04/56cef814-aa2b-49ce-926d-5950f5e75d5f.md) sections 5 (UI) and 6 (MCP tools).

**Depends on #102 / #103 / #104.** Base branch is `feat/todo-60-dm-api` (PR #104).

### Frontend (spec section 5)
- New "Direct messages" sidebar section below `#channels`, polled from `GET /api/dms/` every 10s.
- Each row shows `other_participants[].identity_name` with an agent/human badge -- never the raw `dm:<a>|<b>` string.
- Click handler reuses the existing channel-link pattern (`setCurrentChannel` + `loadChannelHistory` + `addTag`); no `#`-prefix assumptions broken.
- "+ New DM" button opens a modal listing workspace members (`/api/members/`) and live agents (`/api/agents`) minus self, then `POST /api/dms/` with `{recipient: "<principal_key>"}` and selects the resulting DM.
- All new markup lives in `dashboard.html` with no inline `<script>` or `<style>`; styles in `style.css`; logic in a new `hub/static/hub/dms.js` module (clean for the pre-tool-use hooks).
- Cache busters bumped: `app.js` v118 -> v119, `style.css` v118 -> v119, new `dms.js?v=1`.

### MCP client (spec section 6)
- `dm_list({workspace?})` -- `GET /api/workspace/<slug>/dms/`, returns the parsed JSON.
- `dm_open({recipient|peer, workspace?})` -- `POST /api/workspace/<slug>/dms/`, returns the created/existing DM row. Accepts `peer` as an alias per spec section 4.
- Both tools take the workspace slug as an arg or fall back to `SCITEX_OROCHI_WORKSPACE`.
- Wired into the dispatch table in `ts/mcp_channel.ts` alongside the existing `react`/`status`/`history` tools.

### Caveat -- agent write path (spec section 4.1)
Per the v3.1 caveat, REST sender-identity is unreliable for token-auth agents, so **`dm_open` does NOT send a message**. Callers chain the existing WS `reply` tool with `chat_id=<returned name>` for the actual write. Tool descriptions document this explicitly. No REST-based send path was added.

## Files touched
- `hub/templates/hub/dashboard.html` -- DM sidebar markup, modal, cache busters
- `hub/static/hub/dms.js` -- new module (sidebar render + picker)
- `hub/static/hub/style.css` -- DM section + modal styles
- `ts/src/tool_defs.ts` -- new tool schemas
- `ts/src/tools.ts` -- `handleDmList` / `handleDmOpen`
- `ts/mcp_channel.ts` -- dispatch wiring

## Test plan
- [x] `python manage.py test hub` -- 59 tests, 12 errors. **Identical to PR 3 baseline** (all pre-existing `api_stats` / url-kwarg failures, none new from PR 4).
- [x] `bunx tsc --noEmit ts/mcp_channel.ts` -- 6 pre-existing errors in `src/tools.ts` (`status`/`reconnectAttempts` typing); zero new errors introduced by PR 4.
- [ ] No JS or TS test infra in this repo (`tests/js/` and `ts/tests/` do not exist), so frontend / MCP tools rely on the Python API tests landed in PR 3 for backend coverage and on manual verification for the UI.
- [ ] Manual smoke after merge: open dashboard, see "Direct messages" section, click "+ New DM", pick an agent, verify DM channel appears and `reply` from the sidecar lands in it.

## Strictly out of scope (deferred to v2)
Per-agent token hardening, group DMs, typing indicators, read receipts, unread badges, DM notifications, mute, ACL UI, search, threading, file upload, E2E encryption.

Generated with Claude Code.
