### PR TITLE
feat(orochi): agent_meta oauth email + subscription state (todo#265)

### DIFF
--- a/hub/registry.py
+++ b/hub/registry.py
@@ -87,6 +87,28 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
                 if isinstance(info.get("mcp_servers"), (list, tuple))
                 else prev.get("mcp_servers") or []
             ),
+            # todo#265: Claude Code OAuth account public metadata pushed
+            # by agent_meta.py --push so the Agents/Activity tab can show
+            # which account each agent is running under, detect
+            # out_of_credits state, and support fleet load-balancing.
+            # Strict whitelist — no tokens, secrets, or credentials.
+            "oauth_email": info.get("oauth_email") or prev.get("oauth_email") or "",
+            "oauth_org_name": info.get("oauth_org_name") or prev.get("oauth_org_name") or "",
+            "oauth_account_uuid": info.get("oauth_account_uuid") or prev.get("oauth_account_uuid") or "",
+            "oauth_display_name": info.get("oauth_display_name") or prev.get("oauth_display_name") or "",
+            "billing_type": info.get("billing_type") or prev.get("billing_type") or "",
+            "has_available_subscription": (
+                info.get("has_available_subscription")
+                if info.get("has_available_subscription") is not None
+                else prev.get("has_available_subscription")
+            ),
+            "usage_disabled_reason": info.get("usage_disabled_reason") or prev.get("usage_disabled_reason") or "",
+            "has_extra_usage_enabled": (
+                info.get("has_extra_usage_enabled")
+                if info.get("has_extra_usage_enabled") is not None
+                else prev.get("has_extra_usage_enabled")
+            ),
+            "subscription_created_at": info.get("subscription_created_at") or prev.get("subscription_created_at") or "",
         }
 
 
@@ -375,6 +397,18 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "pane_tail_block": a.get("pane_tail_block", ""),
                 "claude_md_head": a.get("claude_md_head", ""),
                 "mcp_servers": list(a.get("mcp_servers") or []),
+                # todo#265: OAuth account public metadata. Whitelist
+                # only — no tokens, credentials, or secrets are ever
+                # stored or surfaced.
+                "oauth_email": a.get("oauth_email", ""),
+                "oauth_org_name": a.get("oauth_org_name", ""),
+                "oauth_account_uuid": a.get("oauth_account_uuid", ""),
+                "oauth_display_name": a.get("oauth_display_name", ""),
+                "billing_type": a.get("billing_type", ""),
+                "has_available_subscription": a.get("has_available_subscription"),
+                "usage_disabled_reason": a.get("usage_disabled_reason", ""),
+                "has_extra_usage_enabled": a.get("has_extra_usage_enabled"),
+                "subscription_created_at": a.get("subscription_created_at", ""),
             }
         )
     return result

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -1215,3 +1215,291 @@ class PushFanoutTest(TestCase):
                 )
                 self.assertEqual(n, 0)
                 mock_wp.assert_not_called()
+
+
+class AgentMetaOAuthRegisterTest(TestCase):
+    """todo#265: /api/agents/register/ accepts OAuth public metadata fields.
+
+    The agent_meta.py --push heartbeat surfaces the authenticated
+    Claude Code OAuth account's PUBLIC metadata (email, org,
+    subscription state) so the Agents/Activity tab can show which
+    account each agent is running under and detect out_of_credits.
+
+    Strict security contract: the 9 whitelisted fields are read only
+    from ``~/.claude.json`` via a whitelist extractor. No tokens,
+    refresh tokens, credentials, or secrets are ever read or accepted.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="oauth-test-ws")
+        self.token = WorkspaceToken.objects.create(
+            workspace=self.ws, label="oauth-test"
+        )
+
+    def _post(self, payload):
+        return self.client.post(
+            "/api/agents/register/",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+
+    def test_register_accepts_oauth_fields(self):
+        from hub.registry import _agents as _reg_agents
+        from hub.registry import get_agents
+
+        _reg_agents.clear()
+        payload = {
+            "token": self.token.token,
+            "name": "oauth-agent-1",
+            "machine": "MBA",
+            "oauth_email": "alice@example.org",
+            "oauth_org_name": "Acme Research",
+            "oauth_account_uuid": "uuid-111",
+            "oauth_display_name": "Alice",
+            "billing_type": "subscription",
+            "has_available_subscription": True,
+            "usage_disabled_reason": "",
+            "has_extra_usage_enabled": False,
+            "subscription_created_at": "2025-01-01T00:00:00Z",
+        }
+        resp = self._post(payload)
+        self.assertEqual(resp.status_code, 200)
+        agents = get_agents(workspace_id=self.ws.id)
+        match = [a for a in agents if a["name"] == "oauth-agent-1"]
+        self.assertEqual(len(match), 1)
+        a = match[0]
+        self.assertEqual(a["oauth_email"], "alice@example.org")
+        self.assertEqual(a["oauth_org_name"], "Acme Research")
+        self.assertEqual(a["oauth_account_uuid"], "uuid-111")
+        self.assertEqual(a["oauth_display_name"], "Alice")
+        self.assertEqual(a["billing_type"], "subscription")
+        self.assertEqual(a["has_available_subscription"], True)
+        self.assertEqual(a["has_extra_usage_enabled"], False)
+        self.assertEqual(a["subscription_created_at"], "2025-01-01T00:00:00Z")
+
+    def test_register_out_of_credits_flag(self):
+        """usage_disabled_reason='out_of_credits' is persisted for UI."""
+        from hub.registry import _agents as _reg_agents
+        from hub.registry import get_agents
+
+        _reg_agents.clear()
+        resp = self._post({
+            "token": self.token.token,
+            "name": "oauth-agent-2",
+            "usage_disabled_reason": "out_of_credits",
+        })
+        self.assertEqual(resp.status_code, 200)
+        a = [x for x in get_agents(workspace_id=self.ws.id)
+             if x["name"] == "oauth-agent-2"][0]
+        self.assertEqual(a["usage_disabled_reason"], "out_of_credits")
+
+    def test_register_missing_oauth_fields_defaults(self):
+        """Legacy agents without oauth fields still register cleanly."""
+        from hub.registry import _agents as _reg_agents
+        from hub.registry import get_agents
+
+        _reg_agents.clear()
+        resp = self._post({
+            "token": self.token.token,
+            "name": "legacy-agent",
+        })
+        self.assertEqual(resp.status_code, 200)
+        a = [x for x in get_agents(workspace_id=self.ws.id)
+             if x["name"] == "legacy-agent"][0]
+        self.assertEqual(a["oauth_email"], "")
+        self.assertEqual(a["oauth_org_name"], "")
+        self.assertIsNone(a["has_available_subscription"])
+
+    def test_register_does_not_echo_tokens(self):
+        """Even if a client tries to POST token-like fields under
+        arbitrary keys, the registry's strict whitelist drops them.
+
+        This is the server-side belt to the client-side braces
+        (read_oauth_metadata's whitelist extractor + assert).
+        """
+        from hub.registry import _agents as _reg_agents
+        from hub.registry import get_agents
+
+        _reg_agents.clear()
+        resp = self._post({
+            "token": self.token.token,
+            "name": "leak-test",
+            "oauth_email": "bob@example.org",
+            # Hostile fields — must NOT end up in the registry.
+            "accessToken": "sk-ant-oat01-leaked",
+            "refreshToken": "sk-ant-ort01-leaked",
+            "apiKey": "sk-ant-api03-leaked",
+            "claudeAiOauth": {"accessToken": "sk-ant-oat01-leaked"},
+            "credentials": "bearer leaked",
+        })
+        self.assertEqual(resp.status_code, 200)
+        a = [x for x in get_agents(workspace_id=self.ws.id)
+             if x["name"] == "leak-test"][0]
+        flat = json.dumps(a).lower()
+        for forbidden in (
+            "sk-ant-oat01-leaked",
+            "sk-ant-ort01-leaked",
+            "sk-ant-api03-leaked",
+            "bearer leaked",
+        ):
+            self.assertNotIn(forbidden, flat,
+                             f"leaked token material {forbidden!r} in registry entry")
+        # And no forbidden keys in the registry row.
+        for k in a.keys():
+            kl = k.lower()
+            self.assertNotIn("token", kl)
+            self.assertNotIn("secret", kl)
+            self.assertFalse(kl.endswith("key"), f"key-like field: {k}")
+
+
+class ReadOauthMetadataHelperTest(TestCase):
+    """todo#265: unit tests for the read_oauth_metadata() helper.
+
+    The helper lives in the canonical agent_meta.py shipped from
+    ``.dotfiles/src/.scitex/orochi/scripts/agent_meta.py`` (see PR
+    body for dotfiles sync notes). This test imports it directly
+    from that path so the scitex-orochi hub test suite guards the
+    token-leak regression even though the helper lives upstream.
+    """
+
+    DOTFILES_AGENT_META = (
+        "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py"
+    )
+
+    def _import_helper(self):
+        import importlib.util
+        import os
+
+        if not os.path.isfile(self.DOTFILES_AGENT_META):
+            self.skipTest("dotfiles agent_meta.py not present on this host")
+        spec = importlib.util.spec_from_file_location(
+            "agent_meta_under_test", self.DOTFILES_AGENT_META
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # type: ignore[union-attr]
+        return mod
+
+    def test_missing_file_returns_empty(self):
+        mod = self._import_helper()
+        from pathlib import Path
+        result = mod.read_oauth_metadata(Path("/nonexistent/.claude.json"))
+        self.assertEqual(result, {})
+
+    def test_all_nine_keys_extracted(self):
+        import tempfile
+        from pathlib import Path
+        mod = self._import_helper()
+        doc = {
+            "hasAvailableSubscription": True,
+            "cachedExtraUsageDisabledReason": "out_of_credits",
+            "oauthAccount": {
+                "accountUuid": "uuid-abc",
+                "emailAddress": "alice@example.org",
+                "organizationUuid": "org-uuid",
+                "organizationName": "Acme",
+                "hasExtraUsageEnabled": False,
+                "billingType": "subscription",
+                "accountCreatedAt": "2024-01-01",
+                "subscriptionCreatedAt": "2025-01-01T00:00:00Z",
+                "displayName": "Alice",
+                "organizationRole": "admin",
+                "workspaceRole": "member",
+            },
+            # Hostile fields — must not appear in output.
+            "accessToken": "sk-ant-oat01-should-not-leak",
+            "refreshToken": "sk-ant-ort01-should-not-leak",
+            "claudeAiOauth": {"accessToken": "sk-ant-oat01-nested-leak"},
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(doc, f)
+            path = Path(f.name)
+        try:
+            result = mod.read_oauth_metadata(path)
+            expected_keys = {
+                "oauth_email",
+                "oauth_org_name",
+                "oauth_account_uuid",
+                "oauth_display_name",
+                "billing_type",
+                "has_available_subscription",
+                "usage_disabled_reason",
+                "has_extra_usage_enabled",
+                "subscription_created_at",
+            }
+            self.assertEqual(set(result.keys()), expected_keys)
+            self.assertEqual(result["oauth_email"], "alice@example.org")
+            self.assertEqual(result["oauth_org_name"], "Acme")
+            self.assertEqual(result["oauth_account_uuid"], "uuid-abc")
+            self.assertEqual(result["oauth_display_name"], "Alice")
+            self.assertEqual(result["billing_type"], "subscription")
+            self.assertEqual(result["has_available_subscription"], True)
+            self.assertEqual(result["usage_disabled_reason"], "out_of_credits")
+            self.assertEqual(result["has_extra_usage_enabled"], False)
+            self.assertEqual(
+                result["subscription_created_at"], "2025-01-01T00:00:00Z"
+            )
+        finally:
+            path.unlink()
+
+    def test_token_leak_regression(self):
+        """CRITICAL: hostile top-level fields must never appear in output.
+
+        This is the primary security invariant for todo#265. If a
+        future edit blacklist-converts the extractor, or adds a new
+        whitelist key, this test catches leakage of any substring
+        that looks like a Claude Code token/credential.
+        """
+        import tempfile
+        from pathlib import Path
+        mod = self._import_helper()
+        hostile = {
+            "oauthAccount": {
+                "emailAddress": "eve@example.org",
+                # Hostile nested field — still must not leak.
+                "accessToken": "sk-ant-oat01-nested-should-not-leak",
+            },
+            "accessToken": "sk-ant-oat01-top-should-not-leak",
+            "refreshToken": "sk-ant-ort01-top-should-not-leak",
+            "apiKey": "sk-ant-api03-top-should-not-leak",
+            "bearer": "Bearer should-not-leak",
+            "credentials": {"apiKey": "sk-ant-api03-inner-should-not-leak"},
+            "claudeAiOauth": {
+                "accessToken": "sk-ant-oat01-claudeai-should-not-leak",
+                "refreshToken": "sk-ant-ort01-claudeai-should-not-leak",
+            },
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump(hostile, f)
+            path = Path(f.name)
+        try:
+            result = mod.read_oauth_metadata(path)
+            # Whitelist: no key name should contain token/secret/key.
+            for k in result.keys():
+                kl = k.lower()
+                self.assertNotIn("token", kl)
+                self.assertNotIn("secret", kl)
+                # "key" substring is too broad (would trip "oauth_email"
+                # if we were sloppy); use endswith instead.
+                self.assertFalse(
+                    kl.endswith("key"), f"forbidden key-like field: {k}"
+                )
+            # And no value should contain the leaked substrings.
+            flat = json.dumps(result).lower()
+            forbidden_substrings = (
+                "sk-ant-oat01",
+                "sk-ant-ort01",
+                "sk-ant-api03",
+                "should-not-leak",
+                "bearer",
+            )
+            for s in forbidden_substrings:
+                self.assertNotIn(
+                    s, flat, f"token material {s!r} leaked into output"
+                )
+        finally:
+            path.unlink()

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -1329,6 +1329,18 @@ def api_agents_register(request):
             "pane_tail_block": body.get("pane_tail_block", ""),
             "claude_md_head": body.get("claude_md_head", ""),
             "mcp_servers": body.get("mcp_servers") or [],
+            # todo#265: Claude Code OAuth account public metadata
+            # (email, org, subscription state). Strict whitelist —
+            # never accept access/refresh tokens or credentials.
+            "oauth_email": body.get("oauth_email", ""),
+            "oauth_org_name": body.get("oauth_org_name", ""),
+            "oauth_account_uuid": body.get("oauth_account_uuid", ""),
+            "oauth_display_name": body.get("oauth_display_name", ""),
+            "billing_type": body.get("billing_type", ""),
+            "has_available_subscription": body.get("has_available_subscription"),
+            "usage_disabled_reason": body.get("usage_disabled_reason", ""),
+            "has_extra_usage_enabled": body.get("has_extra_usage_enabled"),
+            "subscription_created_at": body.get("subscription_created_at", ""),
         },
     )
     # Persist subagent_count separately — register_agent() preserves prev


### PR DESCRIPTION
## Summary

Implements todo#265: surface the authenticated Claude Code OAuth account's PUBLIC metadata (email, org, subscription state) from ``agent_meta.py --push`` to the Orochi hub's agent registry. This lets the Agents/Activity tab show which account each agent is running under, detect ``out_of_credits`` state, and support fleet load-balancing.

## The 9 whitelisted fields

All sourced from ``~/.claude.json`` public sections. **NEVER** from ``~/.claude/.credentials.json``.

| Payload key | Source in ~/.claude.json |
|---|---|
| ``oauth_email`` | ``oauthAccount.emailAddress`` |
| ``oauth_org_name`` | ``oauthAccount.organizationName`` |
| ``oauth_account_uuid`` | ``oauthAccount.accountUuid`` |
| ``oauth_display_name`` | ``oauthAccount.displayName`` |
| ``billing_type`` | ``oauthAccount.billingType`` |
| ``has_available_subscription`` | top-level ``hasAvailableSubscription`` |
| ``usage_disabled_reason`` | top-level ``cachedExtraUsageDisabledReason`` |
| ``has_extra_usage_enabled`` | ``oauthAccount.hasExtraUsageEnabled`` |
| ``subscription_created_at`` | ``oauthAccount.subscriptionCreatedAt`` |

## Security contract

**NO token/secret material is read or emitted** at any layer.

1. **Client** (``read_oauth_metadata()`` in dotfiles ``agent_meta.py``): whitelist-only extractor. Never opens ``.credentials.json``. Ends with an assertion that no output key contains ``token``/``secret``/``key``.
2. **Server** (``api_agents_register`` → ``registry.register_agent`` → ``get_agents``): strict whitelist projection. Hostile keys in the POST body are dropped.

Both layers are covered by regression tests that feed hostile payloads (``accessToken``/``refreshToken``/``apiKey``/``claudeAiOauth``/``credentials``/``Bearer``) and assert none of the substrings survive into output.

## Server-side acceptance path

**In-memory registry extension** (NOT a new DB migration). Matches the existing pattern for ``context_pct``, ``pane_tail``, ``recent_actions`` etc., which all live in the ``hub/registry.py`` in-memory dict. No ``AgentProfile`` schema change — OAuth metadata is ephemeral heartbeat state and recomputed on every push cycle. A future follow-up can persist a hash/last-seen timestamp if needed.

Changes:
- ``hub/views/api.py``: ``api_agents_register`` accepts the 9 new keys into the ``register_agent()`` info dict.
- ``hub/registry.py``: ``register_agent()`` stores them (with prev-fallback for missed heartbeats); ``get_agents()`` projects them into the public API output so the Agents dashboard can read them.

## Client-side (``agent_meta.py``) — dotfiles sync

``agent_meta.py`` is NOT checked into ``scitex-orochi``. It lives upstream in the ``.dotfiles`` repo at two real (non-symlinked) locations:

- ``~/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py`` — canonical base
- ``~/.dotfiles/src/.scitex/orochi/agents/mamba-healer-mba/scripts/agent_meta.py`` — healer variant (adds liveness tracking)

Both files got the same ``read_oauth_metadata()`` helper + ``push_all()`` merge. These will be committed to ``.dotfiles`` as a follow-up (the DEPRECATED header in the scripts/ copy notes that new callers should use the scitex-agent-container CLI, so this is the last extension before retirement). **Cleanup follow-up**: consolidate the two copies — the healer variant could ``from agent_meta import read_oauth_metadata`` once layout allows.

## Tests

New classes in ``hub/tests.py``:
- ``AgentMetaOAuthRegisterTest`` (4 tests) — server accepts the 9 fields; ``out_of_credits`` flag persists; legacy agents without oauth fields still register; hostile token fields are dropped by the whitelist projection.
- ``ReadOauthMetadataHelperTest`` (3 tests) — imports the helper from dotfiles via ``importlib``; missing-file returns ``{}``; all 9 keys extracted; **token-leak regression test** with hostile top-level + nested input.

```
$ python manage.py test hub.tests.AgentMetaOAuthRegisterTest hub.tests.ReadOauthMetadataHelperTest
Ran 7 tests in 0.013s — OK
```

Full ``python manage.py test hub`` shows the 12 pre-existing staticfiles/``api_stats(slug=...)`` errors (baseline, not touched by this PR). No new failures.

## Non-goals (separate follow-ups)

- Fetching live quota from ``/api/oauth/usage`` (needs refresh-token rotation)
- Agents/Activity tab UI changes (todo#253)
- Color-coding out_of_credits agents in the dashboard
- Installing claude-hud on fleet hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)