### PR TITLE
fix(hub): two P0 UI urgents — feed selection + sidebar badges (todo#315, #274)

### DIFF
--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -741,7 +741,13 @@ async function fetchAgents() {
               });
             if (!isOpen) popup.classList.add("open");
           }
-          addTag("agent", el.getAttribute("data-agent-name"));
+          /* todo#274 Part 1: no longer creates a filter badge. Pure
+           * visual highlight — clicked card gains .selected, siblings
+           * dim via CSS. Toggle off on second click. */
+          var cards = container.querySelectorAll(".agent-card[data-agent-name]");
+          var wasSelected = el.classList.contains("selected");
+          cards.forEach(function (c) { c.classList.remove("selected"); });
+          if (!wasSelected) el.classList.add("selected");
         });
       });
     container
@@ -927,7 +933,15 @@ async function fetchStats() {
           setCurrentChannel(ch);
           loadChannelHistory(ch);
         }
-        addTag("channel", ch);
+        /* todo#274 Part 1: no longer creates a filter badge. Pure
+         * visual highlight — clicked item gains .selected, siblings
+         * dim via CSS. Reset on second click (toggle). */
+        var items = chContainer.querySelectorAll(".channel-item");
+        var wasSelected = el.classList.contains("selected");
+        items.forEach(function (it) { it.classList.remove("selected"); });
+        if (!wasSelected && currentChannel === ch) {
+          el.classList.add("selected");
+        }
         fetchStats();
       });
     });

--- a/hub/static/hub/chat.js
+++ b/hub/static/hub/chat.js
@@ -1075,6 +1075,20 @@ document.addEventListener("mousedown", function (e) {
         if (stn === "TEXTAREA" || stn === "INPUT" || stn === "SELECT") return;
         if (still.isContentEditable) return;
       }
+      /* todo#315: don't snap focus back if the user is actively
+       * selecting text inside the message feed — refocusing would
+       * collapse the selection and make copy impossible. */
+      try {
+        var sel = window.getSelection && window.getSelection();
+        if (sel && sel.toString().length > 0) {
+          var anchor = sel.anchorNode;
+          if (anchor && anchor.nodeType === 3) anchor = anchor.parentElement;
+          if (anchor && anchor.closest &&
+              anchor.closest("#messages, .msg, .thread-panel")) {
+            return;
+          }
+        }
+      } catch (_) {}
       try {
         msgInput.focus();
         msgInput.setSelectionRange(savedStart, savedEnd);

--- a/hub/static/hub/style.css
+++ b/hub/static/hub/style.css
@@ -554,6 +554,22 @@ body {
   border-left: 3px solid #4ecdc4;
 }
 
+/* todo#274 Part 1: pure visual selection in sidebar — clicking a
+ * channel or agent highlights just that item and dims siblings.
+ * Replaces the previous badge-filter UX. */
+.sidebar .channel-item.selected {
+  background: rgba(126, 200, 227, 0.20);
+  border-left: 3px solid #7ec8e3;
+}
+.sidebar .agent-card.selected {
+  background: rgba(78, 205, 196, 0.20);
+  border-left: 3px solid #4ecdc4;
+}
+.sidebar #channels:has(.channel-item.selected) .channel-item:not(.selected),
+.sidebar #agents:has(.agent-card.selected) .agent-card:not(.selected) {
+  opacity: 0.6;
+}
+
 /* Blockers sidebar section */
 .blockers-heading {
   color: #ef4444 !important;


### PR DESCRIPTION
## Summary

Two P0 UI urgents blocking ywatanabe in the Orochi hub dashboard.

### todo#315 — feed text selection/copy
The defensive blur watchdog in `chat.js` (~line 1069) re-focused `#msg-input` via `requestAnimationFrame` whenever it lost focus. When the user mouse-dragged to select message text, that refocus collapsed the active selection, making copy impossible. Fix: inside the rAF callback, bail out early if `window.getSelection().toString()` is non-empty and the anchor node lives under `#messages / .msg / .thread-panel`. Minimal belt-and-suspenders patch — the surrounding watchdog logic is unchanged, and `__userIsSelecting` is not referenced on `origin/develop`, so no additional port is needed.

### todo#274 Part 1 — sidebar badge removal
Clicking a sidebar channel or agent card used to call `addTag()`, which created a filter badge at the top of the page AND hid all sibling items via `runFilter → filterSidebarElements`. Dismissing the badge did not always restore the sidebar visually, forcing a hard reload. Fix: the two sidebar click handlers in `app.js` (channel list and agent cards) no longer call `addTag`. Instead they toggle a `.selected` class, and CSS dims sibling items via `:has()`. The existing `setCurrentChannel` + `loadChannelHistory` channel-switch path is unchanged — only the badge side-effect is removed. Second-click toggle restores the list to its full, undimmed state.

**Out of scope (deferred to Parts 2-3 of #274):**
- Ctrl/Cmd-click multi-select
- Removing the broken filter-input area entirely
- The dedicated `Agents` / `Resources` tab row clicks (not sidebar)

Typed filter tags (`agent:foo` in the filter-input) still work and still render badges in `#filter-tags` — only sidebar clicks were changed.

## Files touched

- `hub/static/hub/chat.js` (+14, blur watchdog guard)
- `hub/static/hub/app.js` (+16/-2, two sidebar click handlers)
- `hub/static/hub/style.css` (+16, `.selected` + sibling dim via `:has()`)

## Test plan

- [ ] Open the hub dashboard in desktop Chrome/Safari
- [ ] In the message feed, mouse-drag across a message body → selection should stay highlighted; Cmd-C should copy the text
- [ ] Selection inside `.thread-panel` messages should also persist
- [ ] Typing into `#msg-input` and then clicking a feed button/link should still not steal selection (watchdog still protects the typed cursor — existing behavior)
- [ ] Click a channel in the sidebar → that channel should gain a highlighted background, siblings dim; the page should NOT gain a filter badge at the top
- [ ] Click the same channel again → selection clears, siblings return to full opacity (toggle)
- [ ] Click a different channel → selection moves, no reload needed
- [ ] Click an agent card in the sidebar → same highlight behavior
- [ ] Typed filter (e.g. type `agent:head-mba` in the filter input) should still create a badge in `#filter-tags` and still filter messages — unaffected

## Notes

- Mobile long-press copy in `responsive.css` untouched.
- Broader in-progress WIP on this repo was stashed (`wip-before-ui-urgent`) before branching; restored after commit.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
