### PR TITLE
fix(hub/sidebar): cursor: pointer on clickable items (todo#331)

### DIFF
--- a/hub/static/hub/style.css
+++ b/hub/static/hub/style.css
@@ -305,6 +305,11 @@ body {
   padding: 4px 8px;
   border-radius: 4px;
   transition: background 0.15s;
+  cursor: pointer;
+}
+.agent-card,
+.machine-item {
+  cursor: pointer;
 }
 .channel-item:hover {
   background: #1a1a1a;


### PR DESCRIPTION
Sidebar channel-item / agent-card / machine-item now show the hand cursor on hover. 5 lines of CSS, no JS change.