### PR TITLE
fix(hub): write-side channel-name normalize + dedup migration (#326)

### DIFF
--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -13,6 +13,7 @@ from hub.models import (
     Workspace,
     WorkspaceMember,
     WorkspaceToken,
+    normalize_channel_name,
 )
 from hub.channel_acl import check_write_allowed
 
@@ -589,7 +590,7 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         try:
             workspace = Workspace.objects.get(id=self.workspace_id)
             channel, _ = Channel.objects.get_or_create(
-                workspace=workspace, name=channel_name
+                workspace=workspace, name=normalize_channel_name(channel_name)
             )
             msg = Message.objects.create(
                 workspace=workspace,
@@ -958,7 +959,7 @@ class DashboardConsumer(AsyncJsonWebsocketConsumer):
         try:
             workspace = Workspace.objects.get(id=self.workspace_id)
             channel, _ = Channel.objects.get_or_create(
-                workspace=workspace, name=channel_name
+                workspace=workspace, name=normalize_channel_name(channel_name)
             )
             msg = Message.objects.create(
                 workspace=workspace,

--- a/hub/migrations/0015_dedupe_unhashed_channels.py
+++ b/hub/migrations/0015_dedupe_unhashed_channels.py
@@ -1,0 +1,86 @@
+"""Backfill: dedupe legacy bare-name group channels into ``#name`` canonical.
+
+Why this exists
+---------------
+Prior to todo#326 the hub had no normalization on the write path, so any
+client posting to ``general`` (or ``progress``, ``escalation`` …) created
+a separate ``Channel`` row alongside the canonical ``#general``. The
+read-side normalization (2f4e073) hid this in the sidebar but the
+duplicate rows still hold messages — so clicking ``#general`` shows only
+one of the two histories and the other becomes invisible.
+
+What this migration does
+------------------------
+For every workspace, walk all group-kind channels whose name is neither
+``#``-prefixed nor ``dm:``-prefixed. For each such legacy row:
+
+  1. compute the canonical name (``#<name>``);
+  2. find or create the canonical Channel row (using ``Channel.objects``
+     so the model save() normalizer also runs);
+  3. reassign every Message FK from the legacy row to the canonical row;
+  4. delete the legacy row.
+
+Idempotent: re-running is a no-op once all rows are normalized.
+Reverse: not supported — there is no record of which messages came from
+which legacy bucket. ``RunPython.noop`` is used so the migration is
+forward-only but Django still recognises a reverse step exists.
+"""
+from django.db import migrations
+
+
+def merge_unhashed_channels(apps, schema_editor):
+    Channel = apps.get_model("hub", "Channel")
+    Message = apps.get_model("hub", "Message")
+
+    legacy_qs = Channel.objects.filter(kind="group").exclude(
+        name__startswith="#"
+    ).exclude(name__startswith="dm:")
+
+    merged = 0
+    deleted = 0
+    for legacy in legacy_qs.iterator():
+        name = legacy.name.strip()
+        if not name:
+            # Empty-name rows can't be merged into anything sensible;
+            # delete them outright (they were never reachable from the UI).
+            Message.objects.filter(channel=legacy).delete()
+            legacy.delete()
+            deleted += 1
+            continue
+        canonical_name = f"#{name}"
+        canonical, _ = Channel.objects.get_or_create(
+            workspace=legacy.workspace,
+            name=canonical_name,
+            defaults={
+                "description": legacy.description,
+                "kind": legacy.kind,
+            },
+        )
+        if canonical.pk == legacy.pk:
+            # get_or_create returned the same row — happens when name was
+            # already canonical and the .exclude() filter was bypassed by
+            # a race. Skip.
+            continue
+        Message.objects.filter(channel=legacy).update(channel=canonical)
+        legacy.delete()
+        merged += 1
+
+    if merged or deleted:
+        print(
+            f"  hub.0015: merged {merged} legacy channel(s) into "
+            f"# canonical, deleted {deleted} empty-name row(s)"
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("hub", "0014_pushsubscription"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            merge_unhashed_channels,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/hub/models.py
+++ b/hub/models.py
@@ -11,6 +11,34 @@ def _generate_workspace_token():
     return f"wks_{secrets.token_hex(16)}"
 
 
+def normalize_channel_name(name: str) -> str:
+    """Canonicalize a group-channel name to ``#<name>``.
+
+    Group channels live under the ``#`` namespace so the sidebar can
+    render them as Slack-style references. Direct-message channels use
+    the reserved ``dm:`` prefix and are passed through unchanged. Empty
+    or whitespace-only names raise ``ValueError`` so that callers fail
+    loudly at the boundary instead of silently creating ``#`` rows.
+
+    Why this exists: prior to todo#326 the hub had two separate Channel
+    rows for ``general`` and ``#general`` because clients posted with
+    inconsistent prefixes and ``Channel.objects.get_or_create`` is
+    name-sensitive. The read-side fix in 2f4e073 normalized the sidebar
+    response, but the database still accumulated bare-name rows on every
+    write. This helper closes the write path.
+    """
+    if name is None:
+        raise ValueError("channel name cannot be None")
+    cleaned = name.strip()
+    if not cleaned:
+        raise ValueError("channel name cannot be empty")
+    if cleaned.startswith("dm:"):
+        return cleaned
+    if cleaned.startswith("#"):
+        return cleaned
+    return f"#{cleaned}"
+
+
 class Workspace(models.Model):
     """A workspace groups channels, agents, and members — like a Slack workspace."""
 
@@ -149,6 +177,11 @@ class Channel(models.Model):
                     )
                 }
             )
+
+    def save(self, *args, **kwargs):
+        if self.kind == self.KIND_GROUP and self.name:
+            self.name = normalize_channel_name(self.name)
+        super().save(*args, **kwargs)
 
 
 class DMParticipant(models.Model):

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -14,6 +14,7 @@ from hub.models import (
     Workspace,
     WorkspaceMember,
     WorkspaceToken,
+    normalize_channel_name,
 )
 
 
@@ -43,6 +44,75 @@ class WorkspaceModelTest(TestCase):
         self.assertEqual(msg.sender, "agent-1")
         self.assertEqual(msg.content, "Hello")
         self.assertIsNotNone(msg.ts)
+
+
+class ChannelNameNormalizeTest(TestCase):
+    """Coverage for the todo#326 write-side normalization."""
+
+    def test_normalize_helper_adds_hash(self):
+        self.assertEqual(normalize_channel_name("general"), "#general")
+        self.assertEqual(normalize_channel_name("progress"), "#progress")
+
+    def test_normalize_helper_passthrough_canonical(self):
+        self.assertEqual(normalize_channel_name("#general"), "#general")
+        self.assertEqual(normalize_channel_name("#agent"), "#agent")
+
+    def test_normalize_helper_passthrough_dm(self):
+        self.assertEqual(
+            normalize_channel_name("dm:agent:head|human:ywatanabe"),
+            "dm:agent:head|human:ywatanabe",
+        )
+
+    def test_normalize_helper_strips_whitespace(self):
+        self.assertEqual(normalize_channel_name("  general  "), "#general")
+
+    def test_normalize_helper_rejects_empty(self):
+        with self.assertRaises(ValueError):
+            normalize_channel_name("")
+        with self.assertRaises(ValueError):
+            normalize_channel_name("   ")
+        with self.assertRaises(ValueError):
+            normalize_channel_name(None)
+
+    def test_channel_save_normalizes_bare_name(self):
+        ws = Workspace.objects.create(name="ws-norm")
+        ch = Channel.objects.create(workspace=ws, name="general")
+        ch.refresh_from_db()
+        self.assertEqual(ch.name, "#general")
+
+    def test_channel_save_passes_canonical_through(self):
+        ws = Workspace.objects.create(name="ws-norm-2")
+        ch = Channel.objects.create(workspace=ws, name="#agent")
+        ch.refresh_from_db()
+        self.assertEqual(ch.name, "#agent")
+
+    def test_channel_save_does_not_touch_dm_kind(self):
+        ws = Workspace.objects.create(name="ws-norm-3")
+        # DM channels keep their dm: prefix even on save.
+        ch = Channel.objects.create(
+            workspace=ws,
+            name="dm:agent:head|human:ywatanabe",
+            kind=Channel.KIND_DM,
+        )
+        ch.refresh_from_db()
+        self.assertEqual(ch.name, "dm:agent:head|human:ywatanabe")
+
+    def test_get_or_create_with_bare_then_canonical_collapses(self):
+        """The legacy duplication scenario: an agent posts to ``general``
+        then another posts to ``#general``. With the save() normalizer
+        and call-site normalize_channel_name(), both must converge on
+        the same row."""
+        ws = Workspace.objects.create(name="ws-collapse")
+        a, _ = Channel.objects.get_or_create(
+            workspace=ws, name=normalize_channel_name("general")
+        )
+        b, _ = Channel.objects.get_or_create(
+            workspace=ws, name=normalize_channel_name("#general")
+        )
+        self.assertEqual(a.pk, b.pk)
+        self.assertEqual(
+            Channel.objects.filter(workspace=ws).count(), 1
+        )
 
 
 class AuthTest(TestCase):

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -29,6 +29,7 @@ from hub.models import (
     Workspace,
     WorkspaceMember,
     WorkspaceToken,
+    normalize_channel_name,
 )
 from hub.views._helpers import get_workspace
 
@@ -110,10 +111,12 @@ def api_messages(request, slug=None):
     body = json.loads(request.body)
     # Support both flat format {text, channel} and nested {payload: {content, channel}}
     payload = body.get("payload", {})
-    ch_name = body.get("channel") or payload.get("channel") or "#general"
-    # Normalize group channel names: ensure # prefix to prevent duplicates (#326)
-    if not ch_name.startswith("dm:") and not ch_name.startswith("#"):
-        ch_name = "#" + ch_name
+    # Normalize via the canonical helper so write-path and read-path
+    # share the same logic. This subsumes the inline 2-line block that
+    # landed on develop in parallel.
+    ch_name = normalize_channel_name(
+        body.get("channel") or payload.get("channel") or "#general"
+    )
     text = body.get("text") or payload.get("content") or payload.get("text") or ""
     attachments = payload.get("attachments") or body.get("attachments") or []
     metadata = payload.get("metadata") or body.get("metadata") or {}
@@ -236,16 +239,17 @@ def api_stats(request, slug=None):
 
     agents_online = get_online_count(workspace_id=workspace.id)
 
-    # Normalize channel names: ensure # prefix, deduplicate, exclude DM channels
-    # Use kind field when available, fall back to name prefix for safety (#325, #326)
+    # Normalize channel names via the canonical helper, deduplicate,
+    # exclude DM channels (they have their own sidebar section).
+    # The write-side fix (Channel.save()) makes new rows always canonical;
+    # this loop handles legacy rows until migration 0015 backfills them.
+    # Use kind field when available, fall back to name prefix as defense.
     seen: set[str] = set()
     unique_channels: list[str] = []
     for ch in channels:
         if ch.kind == Channel.KIND_DM or ch.name.startswith("dm:"):
             continue
-        name = ch.name
-        if not name.startswith("#"):
-            name = "#" + name
+        name = normalize_channel_name(ch.name)
         if name not in seen:
             seen.add(name)
             unique_channels.append(name)


### PR DESCRIPTION
## Summary

Complement to 2f4e073 (which only normalized the api_stats sidebar response). This closes the write path so duplicate `Channel` rows can no longer accumulate, and ships a one-time data migration that merges existing legacy bare-name rows into their `#`-prefixed canonical row.

**Why**: the read-side patch hides the duplication in the sidebar, but the database keeps two rows with diverging message histories — clicking the canonical channel only shows one half. This PR closes the loop.

## What changed

- **`hub/models.py`**: new `normalize_channel_name()` helper. Group channels get a `#` prefix; `dm:` names pass through; empty names raise. Wired into `Channel.save()` so admin / shell / `get_or_create` create-paths all converge on canonical names.
- **`hub/consumers.py`**, **`hub/views/api.py`**: normalize at the four `Channel.objects.get_or_create(name=…)` call sites so the lookup phase already uses the canonical name (avoids a `name='general'` lookup missing the `name='#general'` row and creating a duplicate that would then trip the `unique_together` `IntegrityError`).
- **`hub/views/api.py`** (`api_stats`): replaces the inline `# prefix` block introduced in 2f4e073 with a `normalize_channel_name()` call so read-side and write-side share one canonical helper.
- **`hub/migrations/0015_dedupe_unhashed_channels.py`**: data migration walks all `kind="group"` channels whose name is neither `#`-prefixed nor `dm:`-prefixed, finds-or-creates the canonical `#name` row in the same workspace, reassigns every `Message` FK from the legacy row to the canonical row, then deletes the legacy row. Empty-name rows are deleted outright. Forward-only (`reverse_code=noop`).
- **`hub/tests.py`**: 9 new tests covering the helper (passthrough, prefix add, whitespace, empty rejection, `dm:`), `Channel.save()` (bare → canonical, canonical → canonical, dm-kind), and the full `get_or_create` collapse scenario that reproduces the original duplication bug.

## Coordination

- Does not touch `#325` (DM hide) — leaves head-ywata-note-win's fix in 2f4e073 intact.
- Does not touch `#332` (Alt+Enter), `#311`, `#320`, `#274 Part 2` — those land via head-mba / mamba-explorer-mba lanes.
- The `api_stats` defensive normalization loop is preserved (rewritten on top of the helper) so the sidebar stays clean even before migration 0015 runs.

## Test plan

- [x] `ast.parse` validation on all 5 modified files (Spartan HPC has no Django available locally)
- [ ] **Reviewer**: please run on a host with the dev env:
  - `python manage.py test hub.tests.ChannelNameNormalizeTest -v 2`
  - `python manage.py migrate --plan` to confirm 0015 sequences after 0014
  - `python manage.py migrate hub` on a staging DB containing both `general` and `#general` rows, then verify `Channel.objects.filter(workspace=ws).values('name').distinct()` returns only canonical names and that `Message.objects.filter(channel__name='#general').count()` equals the sum of the previous two rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)