### PR TITLE
feat(hub/settings): add Change password link to User tab (todo#199)

### DIFF
--- a/hub/templates/account/password_change.html
+++ b/hub/templates/account/password_change.html
@@ -1,0 +1,41 @@
+{% extends "hub/base.html" %}
+{% load static %}
+{% block title %}Change Password - SciTeX Orochi{% endblock %}
+{% block extra_css %}
+    <link rel="stylesheet" href="{% static 'hub/auth.css' %}">
+{% endblock %}
+{% block body %}
+    <div class="auth-card">
+        <img src="{% static 'hub/orochi-icon.png' %}" alt="Orochi" class="logo">
+        <h1>Change Password</h1>
+        <p class="subtitle">Update your account password</p>
+        {% if messages %}
+            {% for message in messages %}<div class="{{ message.tags }}">{{ message }}</div>{% endfor %}
+        {% endif %}
+        {% if form.non_field_errors %}
+            <div class="error">{{ form.non_field_errors }}</div>
+        {% endif %}
+        <form method="post" action="{% url 'account_change_password' %}">
+            {% csrf_token %}
+            <div class="form-group">
+                <label for="id_oldpassword">Current password</label>
+                <input type="password" name="oldpassword" id="id_oldpassword" autocomplete="current-password" autofocus required>
+                {% if form.oldpassword.errors %}<div class="error">{{ form.oldpassword.errors }}</div>{% endif %}
+            </div>
+            <div class="form-group">
+                <label for="id_password1">New password</label>
+                <input type="password" name="password1" id="id_password1" autocomplete="new-password" required>
+                {% if form.password1.errors %}<div class="error">{{ form.password1.errors }}</div>{% endif %}
+            </div>
+            <div class="form-group">
+                <label for="id_password2">Confirm new password</label>
+                <input type="password" name="password2" id="id_password2" autocomplete="new-password" required>
+                {% if form.password2.errors %}<div class="error">{{ form.password2.errors }}</div>{% endif %}
+            </div>
+            <button type="submit" class="btn btn-primary">Change Password</button>
+        </form>
+        <div class="auth-footer">
+            <a href="/">Back to Dashboard</a>
+        </div>
+    </div>
+{% endblock %}

--- a/hub/templates/hub/workspace_settings.html
+++ b/hub/templates/hub/workspace_settings.html
@@ -72,27 +72,12 @@
                     </section>
                     <section class="settings-section">
                         <h4>Change Password</h4>
-                        <p class="settings-desc">Update your account password.</p>
-                        <form method="post" action="/accounts/password/change/" class="settings-form password-change-form">
-                            {% csrf_token %}
-                            <table class="settings-table">
-                                <tbody>
-                                    <tr>
-                                        <td class="info-label">Current password</td>
-                                        <td><input type="password" name="oldpassword" required autocomplete="current-password"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="info-label">New password</td>
-                                        <td><input type="password" name="password1" required autocomplete="new-password"></td>
-                                    </tr>
-                                    <tr>
-                                        <td class="info-label">Confirm new password</td>
-                                        <td><input type="password" name="password2" required autocomplete="new-password"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                            <button type="submit" class="btn-small btn-primary" style="margin-top:8px">Change Password</button>
-                        </form>
+                        <p class="settings-desc">Update your account password via the secure password change page.</p>
+                        <a href="/accounts/password/change/"
+                           class="btn-small btn-primary password-change-link"
+                           style="margin-top:4px;display:inline-block">
+                            &#128274; Change Password
+                        </a>
                     </section>
                 </div>
                 <div class="settings-mode-pane" data-mode="workspace" style="display:none">


### PR DESCRIPTION
## Summary

Replaces the inline AJAX password change form in the Settings -> User tab with a styled link to the existing Django allauth view at `/accounts/password/change/`. The previous inline form did not round-trip correctly through allauth, leaving users without an in-app way to change their password (workaround: `/accounts/password/reset/key/...`).

Also adds a dark-theme override of the allauth `password_change.html` template so the destination matches the rest of the hub UI (extends `hub/base.html`, uses `auth.css`).

Tracks: todo#199

## Test plan

- [ ] Open dashboard -> Settings -> User tab
- [ ] Click "Change Password" -> allauth form loads, styled to match hub
- [ ] Submit current + new password -> password updates, redirected back
- [ ] Sign out, sign in with new password