### PR TITLE
fix(hub/sidebar): preserve agent multi-select across re-renders (todo#274 Part 2)

### DIFF
--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -548,6 +548,16 @@ async function fetchAgents() {
     var newAgentsJson = JSON.stringify(agents);
     if (container._lastAgentsJson === newAgentsJson) return;
     container._lastAgentsJson = newAgentsJson;
+    /* Preserve Ctrl+Click multi-select state across re-renders (#274 Part 2).
+     * Without this, every fetchAgents() poll/WS presence event clobbers
+     * .selected on agent-cards, defeating multi-select. */
+    var prevSelectedAgents = {};
+    container
+      .querySelectorAll(".agent-card.selected[data-agent-name]")
+      .forEach(function (el) {
+        var n = el.getAttribute("data-agent-name");
+        if (n) prevSelectedAgents[n] = true;
+      });
     /* todo#320: sidebar agent cards are now compact — name + status
      * dot only. Full detail (badges, kill/pin/restart, task rows,
      * detail popup, health pill, tooltip) lives in the Agents tab. */
@@ -578,6 +588,9 @@ async function fetchAgents() {
     container
       .querySelectorAll(".agent-card[data-agent-name]")
       .forEach(function (el) {
+        /* Restore .selected from before re-render (#274 Part 2) */
+        var elName = el.getAttribute("data-agent-name");
+        if (elName && prevSelectedAgents[elName]) el.classList.add("selected");
         el.addEventListener("click", function (ev) {
           if (ev.target.closest(".pin-btn")) return; /* handled separately */
           if (ev.target.closest(".kill-btn")) return; /* handled separately */

--- a/hub/static/hub/chat.js
+++ b/hub/static/hub/chat.js
@@ -616,6 +616,11 @@ function appendMessage(msg) {
   var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
   var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
   container.appendChild(el);
+  /* todo#274 Part 2: re-apply multi-select feed filter so newly-arrived
+   * messages get hidden if they don't match the current selection. */
+  if (typeof applyFeedFilter === "function") {
+    try { applyFeedFilter(); } catch (_) {}
+  }
   /* ALWAYS auto-scroll when near the bottom — including when the user is
    * actively typing. Skipping the scroll while focused was too aggressive
    * and broke the "I just sent a message" case (todo#227): the user's own


### PR DESCRIPTION
## Summary

Follow-up to #108 / commit c415f22. Ctrl/Cmd+Click multi-select on `.agent-card` was visually working on the click event but Playwright kept seeing only 1 selected agent. Root cause: every `fetchAgents()` REST poll / WS presence event rebuilt `#agents` `innerHTML` and silently clobbered `.selected` before the user (or test) could observe more than one. `fetchStats()` already had a `prevSelected` save/restore for `.channel-item`; this PR mirrors the same idiom for `.agent-card`.

Also fixes a related leak: `appendMessage()` did not re-run the multi-select feed filter, so newly arrived WS messages bypassed the active AND-product filter and the UI looked broken.

## Changes

- `hub/static/hub/app.js` — snapshot `data-agent-name` of every selected card before `innerHTML` rebuild in `fetchAgents()`, restore `.selected` in the post-rebuild click-binding loop.
- `hub/static/hub/chat.js` — call `applyFeedFilter()` at the end of `appendMessage()` so newly-arrived messages respect the current selection.

Total: 18 lines added across 2 files. Pure JS, no new deps, no backend changes, no files outside `hub/static/hub/`.

## Implementation notes

- `applyFeedFilter()` (already in `chat.js`) reads `.channel-item.selected[data-channel]` and `.agent-card.selected[data-agent-name]`, then applies `(channel ∈ X OR X empty) AND (sender ∈ Y OR Y empty)` to every `.msg`. No structural change needed there.
- `.machine-item` exists only as a CSS rule (`style.css:311`) with no DOM instances; nothing to wire up.
- Channel-side handler (`fetchStats`) was already correct from c415f22 — agent-side was the missing half.

## Manual test plan

- [ ] Open dashboard, plain-click `#general` — only `#general` highlighted, others dimmed.
- [ ] Ctrl+Click `#agent` — both `#general` and `#agent` highlighted, feed shows messages from both.
- [ ] Cmd+Click `#general` again — only `#agent` selected.
- [ ] Plain-click `#ywatanabe` — only `#ywatanabe` selected, multi-select cleared.
- [ ] Ctrl+Click two agent cards in the sidebar — both stay highlighted across multiple WS presence ticks (the regression this PR fixes).
- [ ] Wait for new messages to arrive while multi-select is active — they should be hidden if they don't match the AND product.
- [ ] Cross-category: select `#general` AND `head-mba` — feed shows `head-mba`'s messages in `#general` only.
- [ ] Screenshot of 2+ highlighted agent cards after ~10s of WS activity (proves persistence).

Refs: todo#274 Part 2.
