### PR TITLE
fix(hub): upload_media dedup creates Message row via attach-by-hash (#97)

### DIFF
--- a/hub/views/upload.py
+++ b/hub/views/upload.py
@@ -319,12 +319,28 @@ def api_upload_base64(request):
 @csrf_exempt
 @_login_or_token_required
 def api_media_by_hash(request, content_hash: str):
-    """GET /api/media/by-hash/<sha256> — check if content already uploaded.
+    """``/api/media/by-hash/<sha256>`` — content-addressable media probe + attach.
 
-    Returns 200 + metadata if the hash is known, 404 otherwise.
-    HEAD requests can be used for existence checks without downloading metadata.
+    GET / HEAD
+        Existence check. Returns 200 + metadata if the hash is known, 404
+        otherwise. HEAD returns no body.
+
+    POST  (todo#97)
+        Attach an existing blob to a channel without re-uploading. Body::
+
+            { "channel": "#name", "sender": "agent-name" (optional) }
+
+        On success the server creates a ``Message`` row whose
+        ``metadata.attachments[0]`` references the existing blob, then
+        broadcasts the message to live dashboard listeners. This closes
+        the dedup-orphan bug where ``upload_media`` standalone returned
+        the existing URL but never produced a Message row, leaving the
+        file invisible in the Files tab.
+
+    All variants validate the hash format up front so injection probes
+    can't reach the filesystem layer.
     """
-    if request.method not in ("GET", "HEAD"):
+    if request.method not in ("GET", "HEAD", "POST"):
         return JsonResponse({"error": "Method not allowed"}, status=405)
 
     # Validate hash is plausible (64 hex chars for sha256)
@@ -341,4 +357,99 @@ def api_media_by_hash(request, content_hash: str):
         r["X-Content-Hash"] = content_hash
         return r
 
-    return JsonResponse({**existing, "content_hash": content_hash}, status=200)
+    if request.method == "GET":
+        return JsonResponse({**existing, "content_hash": content_hash}, status=200)
+
+    # ---- POST: attach existing blob to a channel as a Message row ----
+    try:
+        body = json.loads(request.body or b"{}")
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "Invalid JSON"}, status=400)
+
+    channel_name = (body.get("channel") or "").strip()
+    if not channel_name:
+        return JsonResponse(
+            {"error": "channel field required for POST attach"}, status=400
+        )
+    sender_name = (body.get("sender") or "").strip()
+
+    # Normalize channel names to match the #326 write-path convention so
+    # the attach-by-hash endpoint never creates a duplicate bare-name row.
+    if not channel_name.startswith("dm:") and not channel_name.startswith("#"):
+        channel_name = "#" + channel_name
+
+    try:
+        from hub.models import Channel, Message
+        from hub.views._helpers import get_workspace
+        from channels.layers import get_channel_layer
+        from asgiref.sync import async_to_sync
+
+        workspace = get_workspace(request)
+        ch, _ = Channel.objects.get_or_create(
+            workspace=workspace, name=channel_name
+        )
+
+        is_authed_user = (
+            getattr(request, "user", None) is not None
+            and request.user.is_authenticated
+        )
+        sender = sender_name or (
+            request.user.username if is_authed_user else "agent"
+        )
+        sender_type = "human" if is_authed_user else "agent"
+
+        attachment_meta = {
+            "url": existing.get("url"),
+            "filename": existing.get("filename"),
+            "mime_type": existing.get("mime_type"),
+            "size": existing.get("size"),
+            "file_id": existing.get("file_id"),
+            "content_hash": content_hash,
+        }
+        msg = Message.objects.create(
+            workspace=workspace,
+            channel=ch,
+            sender=sender,
+            sender_type=sender_type,
+            content="",
+            metadata={"attachments": [attachment_meta]},
+        )
+
+        # Broadcast to live dashboard listeners (best-effort).
+        try:
+            layer = get_channel_layer()
+            if layer is not None:
+                async_to_sync(layer.group_send)(
+                    f"workspace_{workspace.id}",
+                    {
+                        "type": "chat.message",
+                        "id": msg.id,
+                        "sender": sender,
+                        "sender_type": sender_type,
+                        "channel": channel_name,
+                        "text": "",
+                        "ts": msg.ts.isoformat(),
+                        "metadata": {"attachments": [attachment_meta]},
+                    },
+                )
+        except Exception:
+            log.warning(
+                "[attach-by-hash] live broadcast failed for %s",
+                content_hash[:12],
+            )
+
+        return JsonResponse(
+            {
+                **existing,
+                "content_hash": content_hash,
+                "deduplicated": True,
+                "message_id": msg.id,
+                "channel": channel_name,
+            },
+            status=201,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.exception("[attach-by-hash] failed for %s", content_hash[:12])
+        return JsonResponse(
+            {"error": f"attach failed: {exc}"}, status=500
+        )

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -460,32 +460,54 @@ export async function handleUploadMedia(args: {
     const filename = basename(args.file_path);
 
     // --- Content-addressable dedup: check hash before uploading ---
+    //
+    // todo#97: a HEAD/GET on /api/media/by-hash/ confirms the blob is
+    // already on the hub, but we MUST also create a Message row so the
+    // file shows up in the channel feed and Files tab. Prior versions
+    // returned the existing URL here without creating a Message, leaving
+    // dedup-hit uploads invisible (orphaned blobs). The fix is to POST
+    // back to the same endpoint with {channel, sender}; the server then
+    // creates the Message row referencing the existing blob without any
+    // bandwidth cost.
     const contentHash = createHash("sha256").update(fileData).digest("hex");
     const hashCheckUrl = `${httpBase}/api/media/by-hash/${contentHash}${tokenParam("?")}`;
+    const targetChannel = args.channel || "#general";
     try {
       const headResp = await fetch(hashCheckUrl, {
         method: "HEAD",
         headers: buildFetchHeaders(),
       });
       if (headResp.ok) {
-        // File already on hub — fetch metadata and return existing URL
-        const getResp = await fetch(hashCheckUrl, { headers: buildFetchHeaders() });
-        if (getResp.ok) {
-          const existing = (await getResp.json()) as { url?: string };
-          const mediaUrl = existing.url
-            ? existing.url.startsWith("http")
-              ? existing.url
-              : `${httpBase}${existing.url}`
+        // Dedup hit — POST to attach the existing blob to the target
+        // channel as a Message row (no upload required).
+        const attachResp = await fetch(hashCheckUrl, {
+          method: "POST",
+          headers: buildFetchHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({
+            channel: targetChannel,
+            sender: OROCHI_AGENT,
+          }),
+        });
+        if (attachResp.ok) {
+          const attached = (await attachResp.json()) as {
+            url?: string;
+            message_id?: number;
+          };
+          const mediaUrl = attached.url
+            ? attached.url.startsWith("http")
+              ? attached.url
+              : `${httpBase}${attached.url}`
             : "unknown";
           return {
             content: [
               {
                 type: "text",
-                text: `Uploaded ${filename} -> ${mediaUrl} (deduplicated, already on hub)`,
+                text: `Uploaded ${filename} -> ${mediaUrl} (deduplicated; attached as message ${attached.message_id ?? "?"})`,
               },
             ],
           };
         }
+        // attach failed — fall through to full upload
       }
     } catch {
       // Dedup check failed — fall through to normal upload


### PR DESCRIPTION
## Summary
Fixes #97 — `upload_media` standalone now creates a Message row even when the dedup probe hits an existing blob, so the file shows up in the channel feed and Files tab.

## Root cause
`handleUploadMedia` (ts) HEADed `/api/media/by-hash/<sha256>`. On hit it returned the existing URL early — no Message row was ever created. `api_media` only sees blobs referenced by `Message.metadata.attachments`, so dedup hits were invisible.

## Changes
- **`hub/views/upload.py`** — `api_media_by_hash` now accepts `POST {channel, sender}`. On POST it creates a `Message` row whose `metadata.attachments[0]` references the existing blob (file_id, url, mime, content_hash) and broadcasts it to live dashboard listeners. GET/HEAD unchanged. Channel name is normalized to the `#`-prefix convention to stay consistent with #326.
- **`ts/src/tools.ts`** (`handleUploadMedia`) — on dedup hit, POST the same URL with `{channel, sender}` to attach the existing blob. Falls through to full upload on attach failure.

## Net effect
Every `upload_media` call now produces exactly one Message row, regardless of whether the blob was new. Bandwidth saving from dedup is preserved (no body re-upload).

## Test plan
- [ ] Run on dev host: `python manage.py test hub.tests` (no new tests; relies on existing upload tests + manual)
- [ ] Manual: agent calls `upload_media(file_path=X, channel=#test)` twice in a row; both calls produce a Message row visible in the Files tab and the channel feed; only the first call writes bytes.
- [ ] Manual: `curl -X POST .../api/media/by-hash/<known-hash>?token=X -d '{"channel":"#test"}'` returns 201 with `message_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)