### PR TITLE
fix(orochi): MCP connection watchdog forces reconnect on wedged sockets (#96)

### DIFF
--- a/ts/src/connection.ts
+++ b/ts/src/connection.ts
@@ -27,6 +27,12 @@ const PONG_TIMEOUT_MS = 10_000;
 const MAX_RECONNECT_DELAY = 60_000;
 const CONNECT_TIMEOUT_MS = 15_000;
 const HEARTBEAT_INTERVAL_MS = 30_000;
+// todo#97/#96: watchdog supervises the connection independently of the
+// ping/pong path. Catches edge cases where the WS is wedged in a state
+// that doesn't trigger close (e.g. terminate() silently dropped, host
+// network half-closed, OS suspend/resume) and forces a reconnect.
+const WATCHDOG_INTERVAL_MS = 15_000;
+const WATCHDOG_STALE_MS = 90_000;
 
 export class OrochiConnection {
   state: ConnectionState = "disconnected";
@@ -39,6 +45,7 @@ export class OrochiConnection {
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private pingTimer: ReturnType<typeof setInterval> | null = null;
   private pongTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private watchdogTimer: ReturnType<typeof setInterval> | null = null;
   private lastPongAt = 0;
   private isReconnecting = false;
   private onMessage: ((data: string) => void) | null = null;
@@ -73,6 +80,7 @@ export class OrochiConnection {
     this.clearReconnectTimer();
     this.isReconnecting = false;
     this.setState("connecting");
+    this.startWatchdog();
 
     const wsUrl = buildWsUrl();
     const wsOptions: WebSocket.ClientOptions = {};
@@ -209,6 +217,13 @@ export class OrochiConnection {
         try {
           this.ws?.terminate();
         } catch (_) {}
+        // Defense in depth: terminate() should fire the close handler,
+        // but on some platforms it silently no-ops on a half-broken
+        // socket. Force the reconnect path so we never get wedged in
+        // "connected" with a dead socket.
+        this.cleanup();
+        this.setState("disconnected");
+        this.triggerReconnect();
       }, PONG_TIMEOUT_MS);
     }, PING_INTERVAL_MS);
   }
@@ -236,6 +251,54 @@ export class OrochiConnection {
         this.ws.close();
       } catch (_) {}
       this.ws = null;
+    }
+  }
+
+  // todo#96: Watchdog supervises the connection independently of the
+  // ping/pong + close-event path. Runs every WATCHDOG_INTERVAL_MS and
+  // forces a reconnect in two failure modes that would otherwise leave
+  // the agent silently disconnected for the rest of the session:
+  //
+  // 1. state == "connected" but lastPongAt is older than WATCHDOG_STALE_MS
+  //    — the socket thinks it's alive but the peer is unreachable
+  //    (half-open TCP, NAT idle drop, host suspend/resume).
+  // 2. state == "disconnected" with no scheduled reconnect timer — the
+  //    reconnect loop got into a dead state because triggerReconnect()
+  //    raced against itself or terminate() silently dropped the close
+  //    event without firing the close handler.
+  private startWatchdog(): void {
+    if (this.watchdogTimer) return;
+    this.watchdogTimer = setInterval(() => {
+      try {
+        this.runWatchdogTick();
+      } catch (err) {
+        console.error("[orochi] watchdog tick failed:", err);
+      }
+    }, WATCHDOG_INTERVAL_MS);
+  }
+
+  private runWatchdogTick(): void {
+    if (this.state === "connected") {
+      const ageMs = this.lastPongAgeMs;
+      if (ageMs !== null && ageMs > WATCHDOG_STALE_MS) {
+        console.error(
+          `[orochi] watchdog: stale connection (last pong ${ageMs}ms ago > ${WATCHDOG_STALE_MS}ms), forcing reconnect`,
+        );
+        this.cleanup();
+        this.setState("disconnected");
+        this.triggerReconnect();
+      }
+      return;
+    }
+    if (
+      this.state === "disconnected" &&
+      !this.reconnectTimer &&
+      !this.isReconnecting
+    ) {
+      console.error(
+        "[orochi] watchdog: disconnected with no scheduled reconnect, forcing reconnect",
+      );
+      this.triggerReconnect();
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes #96 — MCP server disconnected mid-session with no auto-recovery for 5+ minutes. Adds a 15 s watchdog that supervises the WS connection independently of the ping/pong + close-event path and forces a reconnect in two failure modes that previously left agents permanently silent.

## Root cause
`OrochiConnection` had two reconnect-loop dead states:

1. **State stuck at `connected`** after a half-open TCP / NAT idle drop / host suspend-resume. The pong timeout calls `ws.terminate()`, but on some platforms `terminate()` silently no-ops on a half-broken socket without firing the close handler — so `cleanup()` never runs and the reconnect loop never starts.
2. **State stuck at `disconnected`** with no reconnect timer scheduled, reachable when `triggerReconnect()` races against itself or when the close handler fires after a synchronous `connect()` failure already scheduled+cleared a reconnect.

## Fix
- **Watchdog (case 1)** — every 15 s, if `state == connected` and `lastPongAt > 90 s` ago (3× ping interval), forcibly `cleanup() + setState(disconnected) + triggerReconnect()`.
- **Watchdog (case 2)** — every 15 s, if `state == disconnected` and there is no scheduled `reconnectTimer` and `!isReconnecting`, force `triggerReconnect()`.
- **Pong timeout defense in depth** — after `terminate()`, explicitly `cleanup() + setState + triggerReconnect()` rather than relying on the close handler firing.
- Watchdog is started on `connect()` and persists across reconnect cycles.

## Test plan
- [ ] Run with `bun ts/src/server.ts` against a hub; verify `[orochi] connected` log.
- [ ] Reproduce wedge: `iptables -A OUTPUT -p tcp --dport 443 -j DROP` (or `tc qdisc add dev eth0 root netem loss 100%`) for 2 min, then remove. Expected: ≤ 90 s after restoration the watchdog forces a reconnect and `state` returns to `connected`.
- [ ] Reproduce dead-loop case: kill the hub container while connected, restart 30 s later. Expected: client reconnects within `2 × WATCHDOG_INTERVAL_MS` even if the close path didn't fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)