### PR TITLE
fix(ui): throttle fetchResources on WS heartbeats — fixes Machines tab flicker (#337)

### DIFF
--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -302,6 +302,26 @@ function fetchAgentsThrottled() {
 var _fetchStatsTimer = null;
 var _fetchStatsPending = false;
 
+/* fetchResources throttle — prevents Machines tab flicker from burst heartbeats (#337) */
+var _fetchResourcesTimer = null;
+var _fetchResourcesPending = false;
+var FETCH_RESOURCES_THROTTLE_MS = 3000;
+
+function fetchResourcesThrottled() {
+  if (_fetchResourcesTimer) {
+    _fetchResourcesPending = true;
+    return;
+  }
+  if (typeof fetchResources === "function") fetchResources();
+  _fetchResourcesTimer = setTimeout(function () {
+    _fetchResourcesTimer = null;
+    if (_fetchResourcesPending) {
+      _fetchResourcesPending = false;
+      fetchResourcesThrottled();
+    }
+  }, FETCH_RESOURCES_THROTTLE_MS);
+}
+
 function fetchStatsThrottled() {
   if (_fetchStatsTimer) {
     _fetchStatsPending = true;
@@ -413,7 +433,7 @@ function handleMessage(msg) {
   ) {
     fetchAgentsThrottled();
     fetchStatsThrottled();
-    fetchResources();
+    fetchResourcesThrottled();
   } else if (msg.type === "reaction_update") {
     if (typeof handleReactionUpdate === "function") handleReactionUpdate(msg);
   } else if (msg.type === "thread_reply") {


### PR DESCRIPTION
## Summary
- Burst agent heartbeats triggered 9+ concurrent fetchResources() calls completing in <500ms
- Each completion re-rendered the entire Machines grid → visible DOM thrash / flicker
- Fix: fetchResourcesThrottled() with 3s window, same pattern as existing fetchAgentsThrottled()

## Root cause (Playwright MutationObserver)
9 re-renders in 500ms at 11:38:28-29Z, all with data present — not empty flicker but visual DOM thrash

## Test plan
- [ ] Machines tab stays stable during normal fleet heartbeat traffic
- [ ] Data still updates within 3s window

🤖 Generated with [Claude Code](https://claude.com/claude-code)