### PR TITLE
chore(ruff): clean 17 lint errors blocking advisory lint job (todo#422)

### DIFF
--- a/src/scitex_orochi/_cli/_helpers.py
+++ b/src/scitex_orochi/_cli/_helpers.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import os
 import platform
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scitex_orochi._client import OrochiClient
 
 EXAMPLES_HEADER = "\nExamples:\n"
 

--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -1,4 +1,11 @@
-"""Orochi CLI -- thin orchestrator that registers all subcommands."""
+"""Orochi CLI -- thin orchestrator that registers all subcommands.
+
+Subcommand imports must be deferred until after the ``orochi`` click group is
+defined below (each command attaches itself to this group via
+``orochi.add_command``). Ruff's E402 check is suppressed at file level for
+that reason.
+"""
+# ruff: noqa: E402
 
 from __future__ import annotations
 

--- a/src/scitex_orochi/_main.py
+++ b/src/scitex_orochi/_main.py
@@ -70,7 +70,7 @@ def main() -> None:
         await server.workspaces.init_schema()
         ws_token = await server.workspaces.ensure_default_token()
         log.info("Default workspace token: %s", ws_token)
-        ws_server = await websockets.serve(
+        await websockets.serve(
             server._handle_connection,
             server.host,
             server.port,

--- a/src/scitex_orochi/_web.py
+++ b/src/scitex_orochi/_web.py
@@ -18,7 +18,6 @@ from scitex_orochi._config import (
     MEDIA_MAX_SIZE,
     MEDIA_ROOT,
 )
-
 from scitex_orochi._media import MediaStore
 from scitex_orochi._models import Message
 from scitex_orochi._push import PushStore

--- a/src/scitex_orochi/mcp_server.py
+++ b/src/scitex_orochi/mcp_server.py
@@ -6,6 +6,10 @@ import json
 import os
 import platform
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scitex_orochi._client import OrochiClient
 
 # ---------------------------------------------------------------------------
 # Safety guards -- must run before any MCP setup


### PR DESCRIPTION
## Summary
- mcp_server.py: add TYPE_CHECKING-guarded OrochiClient import (F821)
- _cli/_helpers.py: same TYPE_CHECKING pattern for OrochiClient forward ref
- _cli/_main.py: file-level ruff noqa E402 — subcommand imports must be deferred until after the click group is defined (intentional pattern)
- _main.py: drop unused ws_server assignment (F841)
- _web.py: remove extra blank line between import groups (I001 auto-fix)

## Test plan
- [x] ruff check src/ tests/ passes (0 errors)
- [x] pytest tests/ -m "not llm_eval" : 30 passed
- [x] No behavioral change — all fixes are type-hint / unused-var / import-order only

Closes todo#422. Unblocks the advisory lint red indicator on open PRs #118, #117, #101, #100, #84.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>