### PR TITLE
fix(hub): suppress @mention auto-status-reply in user channels (todo#405)

### DIFF
--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -130,6 +130,35 @@ def _sanitize_group(name: str) -> str:
     return sanitized[:99]
 
 
+# todo#405: auto-status-reply (`[agent] status: online`) belongs in fleet
+# channels only. User-facing channels are the ywatanabe ↔ fleet interface
+# (fleet-communication-discipline.md rule #8). Any channel not in this
+# allowlist — including #general, #ywatanabe, project channels like
+# #neurovista / #paper-*, and DMs — must stay free of fleet heartbeat noise.
+_FLEET_CHANNELS = frozenset({
+    "#agent",
+    "#progress",
+    "#audit",
+    "#escalation",
+    "#fleet",
+    "#system",
+})
+
+
+def _is_fleet_channel(ch_name: str) -> bool:
+    """True if ch_name is a fleet-only coordination channel.
+
+    Fleet channels may receive mention-reply status posts; user channels
+    must not. Unknown channels default to user-facing (fail-closed) to
+    preserve the user experience if someone adds a new channel without
+    updating this allowlist.
+    """
+    if not ch_name:
+        return False
+    name = ch_name if ch_name.startswith("#") else f"#{ch_name}"
+    return name in _FLEET_CHANNELS
+
+
 class AgentConsumer(AsyncJsonWebsocketConsumer):
     """WebSocket consumer for AI agents — authenticates with workspace token."""
 
@@ -772,7 +801,17 @@ class DashboardConsumer(AsyncJsonWebsocketConsumer):
             # @mention auto-reply (issue #98): when a message contains @agentname,
             # hub immediately posts a brief system status for the mentioned agent
             # so the sender knows whether it's alive and what it's doing.
-            if "@" in text and not is_dm:
+            #
+            # todo#405: never auto-post `[agent] status: online / (no recent activity)`
+            # into user-facing channels. User channels are the ywatanabe ↔ fleet
+            # interface (per `fleet-communication-discipline.md` rule #8); status
+            # replies belong in fleet channels only. `@all` from ywatanabe used to
+            # explode into 12+ status replies flooding the feed.
+            if (
+                "@" in text
+                and not is_dm
+                and _is_fleet_channel(ch_name)
+            ):
                 await self._maybe_mention_reply(text, ch_name)
 
     async def _maybe_mention_reply(self, text: str, ch_name: str) -> None:


### PR DESCRIPTION
## Summary

Fixes todo#405 — hub was auto-posting `[agent] status: online / Recent activity: ...` into user-facing channels (#ywatanabe, #general, #neurovista, #paper-*) every time a message contained an @mention. `@all` from ywatanabe exploded into 12+ status-reply messages per ping, drowning the feed (observed live in #ywatanabe around msg#11120–#11147).

- Gate `_maybe_mention_reply` behind a fleet-channel allowlist (#agent, #progress, #audit, #escalation, #fleet, #system)
- New `_is_fleet_channel()` helper with fail-closed semantics: unknown channels default to user-facing, so adding a new channel never accidentally re-introduces heartbeat noise
- Aligns with `fleet-communication-discipline.md` rule #8 (project-channel allowlist)

## Test plan

- [x] `_is_fleet_channel` 13 inline unit cases pass (#agent/#progress/#audit/#escalation/#fleet/#system → True; #general/#ywatanabe/#neurovista/#paper-neurovista/dm:alice|bob/"" → False; bare `agent` → True for hash-less input)
- [x] `python manage.py test hub` — 87 tests, identical 9 pre-existing failures to develop baseline (staticfiles manifest + workspace_dashboard slug arg, unrelated to mentions)
- [ ] Post-deploy verification: `daphne docker restart` → `@all` in #general produces zero `[agent] status: online` posts in user channels; `@head-mba` in #agent still produces the status reply
- [ ] Monitor #ywatanabe for 10 min post-deploy; confirm no heartbeat noise

## Rollout

1. Merge this PR to `develop`
2. Deploy to scitex-orochi.com hub via `docker restart orochi-server-stable` (per `deploy-workflow.md`)
3. Verify with a `@all` probe in #general — should NOT trigger the mention-reply cascade into user channels
4. Close todo#405 via `gh-issue-close-safe` with commit SHA + screenshot of clean #ywatanabe feed after the probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)
