### PR TITLE
feat(agents-tab): show credential account badge per agent (#354)

### DIFF
--- a/src/scitex_orochi/_client.py
+++ b/src/scitex_orochi/_client.py
@@ -16,6 +16,29 @@ from scitex_orochi._models import Message
 log = logging.getLogger("orochi.client")
 
 
+def _read_claude_email() -> str:
+    """Safely read the email address from ~/.claude.json -> oauthAccount.emailAddress.
+
+    Returns empty string on any error (missing file, bad JSON, no field).
+    Never raises.
+    """
+    try:
+        import json as _json
+        from pathlib import Path as _Path
+
+        claude_json_path = _Path.home() / ".claude.json"
+        with claude_json_path.open("r", encoding="utf-8") as fh:
+            data = _json.load(fh)
+        oauth = data.get("oauthAccount")
+        if isinstance(oauth, dict):
+            email = oauth.get("emailAddress", "")
+            if isinstance(email, str):
+                return email
+    except Exception:
+        pass
+    return ""
+
+
 class OrochiClient:
     """Async WebSocket client for agent communication.
 
@@ -45,6 +68,7 @@ class OrochiClient:
         agent_id: str = "",
         project: str = "",
         ws_path: str = "",
+        credential_email: str = "",
     ) -> None:
         import platform as _platform
 
@@ -60,6 +84,8 @@ class OrochiClient:
         self._token = token or OROCHI_TOKEN
         self._ws_path = ws_path
         self._django_mode = bool(ws_path)
+        # Resolve credential email: explicit arg > auto-detected from ~/.claude.json
+        self.credential_email = credential_email or _read_claude_email()
 
         # Build URI
         path = ws_path.rstrip("/") + "/" if ws_path else ""
@@ -93,6 +119,7 @@ class OrochiClient:
                             "agent_id": self.agent_id,
                             "project": self.project,
                             "workdir": self.project,
+                            "credential_email": self.credential_email,
                         },
                     }
                 )
@@ -112,6 +139,7 @@ class OrochiClient:
                     "role": self.role,
                     "agent_id": self.agent_id,
                     "project": self.project,
+                    "credential_email": self.credential_email,
                 },
             )
             await self._ws.send(reg.to_json())

--- a/src/scitex_orochi/_dashboard/static/agents-tab.js
+++ b/src/scitex_orochi/_dashboard/static/agents-tab.js
@@ -59,6 +59,7 @@ async function renderAgentsTab() {
       "<thead><tr>" +
       "<th>Status</th>" +
       "<th>Agent ID</th>" +
+      "<th>Account</th>" +
       "<th>Role</th>" +
       "<th>Host / Machine</th>" +
       "<th>Model</th>" +
@@ -134,6 +135,19 @@ function buildAgentRow(a) {
       );
     })
     .join("");
+  /* Credential account badge: show username part of email (before @) */
+  var credBadgeHtml = "";
+  if (a.credential_email) {
+    var credLabel = a.credential_email.split("@")[0] || a.credential_email;
+    credBadgeHtml =
+      '<span style="display:inline-block;background:#2a3a5a;color:#7ab8f5;' +
+      "border:1px solid #3a5a8a;border-radius:3px;font-size:10px;" +
+      'padding:1px 5px;font-family:monospace">' +
+      escapeHtml(credLabel) +
+      "</span>";
+  } else {
+    credBadgeHtml = '<span style="color:#555;font-size:11px">-</span>';
+  }
   return (
     "<tr" +
     (inactive ? ' style="opacity:0.5"' : "") +
@@ -147,6 +161,9 @@ function buildAgentRow(a) {
     color +
     ';font-weight:600">' +
     escapeHtml(a.agent_id || a.name) +
+    "</td>" +
+    "<td>" +
+    credBadgeHtml +
     "</td>" +
     "<td>" +
     escapeHtml(a.role || "agent") +

--- a/src/scitex_orochi/_server.py
+++ b/src/scitex_orochi/_server.py
@@ -57,6 +57,7 @@ class Agent:
     current_task: str = ""
     subagent_count: int = 0
     resources: dict[str, Any] = field(default_factory=dict)
+    credential_email: str = ""
     last_heartbeat: str = field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat()
     )
@@ -225,6 +226,7 @@ class OrochiServer:
         project = msg.payload.get("project", "")
         multiplexer = msg.payload.get("multiplexer", "")
         current_task = msg.payload.get("current_task", "") or ""
+        credential_email = msg.payload.get("credential_email", "") or ""
         try:
             subagent_count = int(msg.payload.get("subagent_count", 0) or 0)
         except (TypeError, ValueError):
@@ -283,6 +285,7 @@ class OrochiServer:
             status="online",
             current_task=current_task,
             subagent_count=subagent_count,
+            credential_email=credential_email,
             last_heartbeat=now,
             registered_at=now,
         )
@@ -571,6 +574,7 @@ class OrochiServer:
                 "current_task": a.current_task,
                 "subagent_count": a.subagent_count,
                 "resources": a.resources,
+                "credential_email": a.credential_email,
                 "last_heartbeat": a.last_heartbeat,
                 "workspace_id": a.workspace_id,
                 "registered_at": a.registered_at,


### PR DESCRIPTION
## Summary
- Each agent card in the Agents tab now shows which Claude credential (account) it is using as a small username badge in a new Account column
- OrochiClient auto-detects the email from ~/.claude.json oauthAccount.emailAddress at init and includes it in the register payload; no token material is ever read
- Hub Agent dataclass, register handler, and get_agents_info() all carry the new credential_email field end-to-end

## Test plan
- pytest tests/ (30 tests green, excluding unrelated deepeval test)
- _read_claude_email() confirmed returning ywata1989@gmail.com on MBA
- After deploy + daphne restart, agents registered from MBA will show [ywata1989] badge in Account column

## Related
Closes ywatanabe1989/todo#354

Generated with Claude Code