### PR TITLE
feat(mentions): group mentions frontend (todo#421 scope 2/3)

### DIFF
--- a/hub/static/hub/chat.js
+++ b/hub/static/hub/chat.js
@@ -397,10 +397,55 @@ function appendMessage(msg) {
     return s;
   }
 
+  /* Group mention tokens (@heads, @healers, @mambas, @all, @agents) get a
+   * distinct chip class with a tooltip describing who the group expands to.
+   * Kept in sync with hub/consumers.py GROUP_PATTERNS (todo#421). */
+  var MENTION_GROUP_TOKENS = {
+    heads: "all head-* agents",
+    healers: "all mamba-healer-* agents",
+    mambas: "all mamba-* agents",
+    all: "everyone in the workspace",
+    agents: "all agents in the workspace",
+  };
+
+  /* Return true if the character at index `idx` of `src` sits inside a
+   * single-line `...` inline-code span. Counts backticks from the start
+   * of the current line; odd count == inside. Used to suppress mention
+   * highlighting for @tokens that live inside backticks (todo#421). */
+  function _isInsideInlineCode(src, idx) {
+    var lineStart = src.lastIndexOf("\n", idx - 1) + 1;
+    var ticks = 0;
+    for (var i = lineStart; i < idx; i++) {
+      if (src.charCodeAt(i) === 96 /* ` */) ticks++;
+    }
+    return (ticks % 2) === 1;
+  }
+
   /* Match @ after any non-word char so CJK text like「こんにちは@mamba」highlights (#9958) */
   var highlightedContent = escaped.replace(
     /(^|[^\w])@([\w@.\-]+)/g,
-    function (_match, prefix, name) {
+    function (match, prefix, name, offset, full) {
+      /* Suppress chip/highlight if we are inside an inline `code` span.
+       * Fenced ```blocks``` are already replaced with NUL placeholders
+       * above, so this guard only needs to worry about backticks. */
+      if (_isInsideInlineCode(full, offset + prefix.length)) {
+        return match;
+      }
+      var desc = MENTION_GROUP_TOKENS[name];
+      if (desc) {
+        return (
+          prefix +
+          '<span class="mention-group-chip" data-mention-group="' +
+          name +
+          '" title="@' +
+          name +
+          " - " +
+          desc +
+          '">@' +
+          name +
+          "</span>"
+        );
+      }
       return prefix + '<span class="mention-highlight">@' + name + "</span>";
     },
   );

--- a/hub/static/hub/components.css
+++ b/hub/static/hub/components.css
@@ -327,6 +327,24 @@
   padding: 1px 3px;
 }
 
+/* Group mention chip (@heads, @healers, @mambas, @all, @agents) — todo#421.
+ * Visually distinct from individual @<agent> mentions so readers can see
+ * at a glance that a message fanned out to many agents. Hover reveals
+ * a tooltip with the group's expansion rule. */
+.mention-group-chip {
+  display: inline-block;
+  background: rgba(255, 217, 61, 0.18);
+  color: #ffd93d;
+  border: 1px solid rgba(255, 217, 61, 0.45);
+  border-radius: 10px;
+  padding: 0 6px;
+  font-weight: 600;
+  cursor: help;
+}
+.mention-group-chip:hover {
+  background: rgba(255, 217, 61, 0.28);
+}
+
 /* TODO list styles -- see todo-tab.css */
 
 /* Agents Registry Table */

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -9,7 +9,7 @@
     <link rel="manifest" href="{% static 'hub/manifest.json' %}">
     <link rel="apple-touch-icon" href="{% static 'hub/orochi-icon.png' %}">
     <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=123">
-    <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=101">
+    <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=102">
     <link rel="stylesheet" href="{% static 'hub/todo-tab.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/attachments.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/responsive.css' %}?v=99">
@@ -233,7 +233,7 @@
     <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>
     <script src="{% static 'hub/todo-tab.js' %}?v=100"></script>
     <script src="{% static 'hub/workspaces-tab.js' %}?v=99"></script>
-    <script src="{% static 'hub/chat.js' %}?v=120"></script>
+    <script src="{% static 'hub/chat.js' %}?v=121"></script>
     <script src="{% static 'hub/mention.js' %}?v=101"></script>
     <script src="{% static 'hub/settings-tab.js' %}?v=104"></script>
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -1573,3 +1573,118 @@ class ReadOauthMetadataHelperTest(TestCase):
                 )
         finally:
             path.unlink()
+
+
+class GroupMentionExpansionTest(TestCase):
+    """Regression guard for @heads/@healers/@mambas/@all/@agents expansion.
+
+    The frontend chip renderer in hub/static/hub/chat.js hard-codes the
+    same five group tokens as the hub-side GROUP_PATTERNS dict in
+    hub/consumers.py (introduced in 526c490). If either side drifts the
+    user will see a chip that the backend refuses to expand (or vice
+    versa). This test asserts both sides still agree — todo#421.
+    """
+
+    #: Must match MENTION_GROUP_TOKENS in hub/static/hub/chat.js and the
+    #: GROUP_PATTERNS dict in hub/consumers.py._maybe_mention_reply.
+    EXPECTED_TOKENS = {"heads", "healers", "mambas", "all", "agents"}
+
+    def test_consumers_group_patterns_has_expected_tokens(self):
+        """consumers.py still declares all five group tokens."""
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parent / "consumers.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "GROUP_PATTERNS = {",
+            src,
+            "consumers.py lost the GROUP_PATTERNS dict (526c490 regression)",
+        )
+        for token in self.EXPECTED_TOKENS:
+            self.assertIn(
+                f'"{token}"',
+                src,
+                f"GROUP_PATTERNS missing @{token} token",
+            )
+
+    def test_frontend_chat_js_has_matching_group_tokens(self):
+        """chat.js MENTION_GROUP_TOKENS agrees with backend GROUP_PATTERNS."""
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parent
+            / "static"
+            / "hub"
+            / "chat.js"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            "MENTION_GROUP_TOKENS",
+            src,
+            "chat.js missing MENTION_GROUP_TOKENS (todo#421)",
+        )
+        for token in self.EXPECTED_TOKENS:
+            self.assertIn(
+                f"{token}:",
+                src,
+                f"chat.js MENTION_GROUP_TOKENS missing @{token}",
+            )
+
+    def test_group_expansion_algorithm(self):
+        """Pure-Python replication of the consumer's expansion step.
+
+        Guards the algorithm shape (startswith rules + dedupe-preserving
+        order) without requiring an async consumer harness.
+        """
+        GROUP_PATTERNS = {
+            "heads": lambda n: n.startswith("head-"),
+            "healers": lambda n: n.startswith("mamba-healer"),
+            "mambas": lambda n: n.startswith("mamba-"),
+            "all": lambda n: True,
+            "agents": lambda n: True,
+        }
+        all_names = [
+            "head-mba",
+            "head-spartan",
+            "mamba-healer-mba",
+            "mamba-todo-manager",
+            "ywata-note-win",
+        ]
+
+        def expand(mentioned):
+            out: list[str] = []
+            for tok in mentioned:
+                if tok in GROUP_PATTERNS:
+                    out.extend(
+                        n for n in all_names if GROUP_PATTERNS[tok](n)
+                    )
+                else:
+                    out.append(tok)
+            return list(dict.fromkeys(out))
+
+        self.assertEqual(
+            expand(["heads"]),
+            ["head-mba", "head-spartan"],
+        )
+        self.assertEqual(
+            expand(["healers"]),
+            ["mamba-healer-mba"],
+        )
+        self.assertEqual(
+            expand(["mambas"]),
+            ["mamba-healer-mba", "mamba-todo-manager"],
+        )
+        self.assertEqual(
+            expand(["all"]),
+            all_names,
+        )
+        # Dedupe: @heads + head-mba should not double-fire head-mba.
+        self.assertEqual(
+            expand(["heads", "head-mba"]),
+            ["head-mba", "head-spartan"],
+        )
+        # Unknown tokens pass through unchanged.
+        self.assertEqual(
+            expand(["not-a-group", "heads"]),
+            ["not-a-group", "head-mba", "head-spartan"],
+        )


### PR DESCRIPTION
## Summary

- Render `@heads` / `@healers` / `@mambas` / `@all` / `@agents` as a distinct yellow pill (`.mention-group-chip`) with a tooltip describing the group's expansion rule, so readers can see at a glance that a message fanned out to many agents.
- Suppress chip/highlight rendering for `@tokens` that sit inside single-line `` ` ``...`` ` `` backticks (fenced ```` ``` ```` blocks were already handled upstream).
- Add a regression test (`GroupMentionExpansionTest`) that guards both sides of the contract: the backend `GROUP_PATTERNS` dict in `hub/consumers.py` and the frontend `MENTION_GROUP_TOKENS` dict in `hub/static/hub/chat.js`.

## Changes

- `hub/static/hub/chat.js`
  - New `MENTION_GROUP_TOKENS` constant mirroring the backend `GROUP_PATTERNS` from 526c490.
  - New `_isInsideInlineCode()` helper — counts backticks on the current line to detect whether a match is inside an inline-code span, and skips chip/highlight rendering when it is (todo#421 edge-case requirement).
  - Existing `mention-highlight` path is unchanged for non-group `@<agent>` mentions; only group tokens produce the new chip.
- `hub/static/hub/components.css`
  - `.mention-group-chip` pill style (yellow, rounded, hover brighten, `cursor: help` for the tooltip).
- `hub/templates/hub/dashboard.html`
  - `chat.js` `v=120` -> `v=121`, `components.css` `v=101` -> `v=102` so browsers pick up the new rendering after the next daphne restart (per `deploy-workflow.md`).
- `hub/tests.py`
  - `GroupMentionExpansionTest` with three tests — see Test plan below.

## Autocomplete

Already complete in `hub/static/hub/mention.js` since commit 526c490 (lines 10-17, `SPECIAL_MENTIONS`). No changes needed; the autocomplete already surfaces `heads` / `healers` / `mambas` / `all` / `agents` above individual agent names with the `.mention-special` styling.

## Explicitly deferred (NOT in this PR)

- **Custom user-defined `AgentGroup` DB model** — no new migrations.
- **Admin UI** for managing custom groups.
- **REST API** (`/api/agent-groups/`) for CRUD on custom groups.
- Backend `consumers.py` is intentionally untouched (parallel PR#126 from head-mba already landed fix/405 on that file; we stay out of its lane).

## Test plan

- [x] `python manage.py test hub` — 90 tests total, 9 pre-existing errors (all in `AuthTest`, caused by `workspace_dashboard() got an unexpected keyword argument 'slug'` and a manifest-missing `hub/orochi-icon.png`, both unrelated to this PR), **0 new failures**.
- [x] `python manage.py test hub.tests.GroupMentionExpansionTest` — 3/3 pass:
  - `test_consumers_group_patterns_has_expected_tokens` — guards 526c490 from being reverted.
  - `test_frontend_chat_js_has_matching_group_tokens` — guards drift between backend and frontend token sets.
  - `test_group_expansion_algorithm` — pure-Python replication of the consumer's expansion step (startswith rules, dedupe-preserving order, unknown-token passthrough).
- [x] `node --check hub/static/hub/chat.js` / `mention.js` — both parse cleanly.
- [ ] Post-deploy visual verification on scitex-orochi.com after `docker restart orochi-server-stable` (collectstatic + restart): type `@heads` in the composer, send, confirm the rendered chip is the yellow pill with hover tooltip, and confirm `` `@heads` `` (inside backticks) renders as plain code with no chip.
- [ ] Screenshot the flow on the running server and attach to this PR before merge (per `feedback_ui_fix_needs_screenshot_proof.md`).

## Related

- Builds on 526c490 (feat(mentions): group mention expansion (@heads, @healers, @mambas)).
- Coexists with PR#126 (fix/405-suppress-status-reply-user-channels), which also landed on `hub/consumers.py`; zero overlap.
- todo#421 scope 2 of 3 (autocomplete = scope 1, done in 526c490; this PR = scope 2 chip rendering; scope 3 = custom `AgentGroup` model + admin UI, deferred).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>