### PR TITLE
feat(hub): per-agent detail page MVP (todo#420)

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -4,6 +4,38 @@
 var _agentsTabInterval = null;
 var _selectedAgentTab = "overview"; /* "overview" or agent name */
 var _lastAgentsData = [];           /* cached for sub-tab renders */
+var _agentDetailCache = {};         /* name -> last /detail response */
+var _agentDetailInflight = {};      /* name -> bool (in-flight guard) */
+
+/* Fetch the full per-agent detail payload (todo#420).
+ *
+ * Responses are cached into _agentDetailCache and rendered via
+ * _renderAgentContent. The registry-based fallback in
+ * _renderAgentDetail still runs on first paint so the user never
+ * sees a blank screen while the detail call is in flight. */
+async function _fetchAgentDetail(name) {
+  if (!name || name === "overview") return;
+  if (_agentDetailInflight[name]) return;
+  _agentDetailInflight[name] = true;
+  try {
+    var res = await fetch(apiUrl("/api/agents/" + encodeURIComponent(name) + "/detail/"));
+    if (!res.ok) {
+      console.warn("agent detail fetch failed:", name, res.status);
+      return;
+    }
+    var data = await res.json();
+    _agentDetailCache[name] = data;
+    /* Only re-render if still viewing this agent */
+    if (_selectedAgentTab === name) {
+      var grid = document.getElementById("agents-grid");
+      if (grid) _renderAgentContent(grid);
+    }
+  } catch (e) {
+    console.warn("agent detail fetch error:", name, e);
+  } finally {
+    _agentDetailInflight[name] = false;
+  }
+}
 
 /* ── Sub-tab bar ────────────────────────────────────────────────────── */
 function _renderSubTabBar(agents) {
@@ -40,46 +72,92 @@ function _bindSubTabBar(grid) {
 }
 
 /* ── Per-agent detail view ──────────────────────────────────────────── */
+/* Merges registry row (`a`) with cached /api/agents/<name>/detail/
+ * payload (`d`). The merge is forgiving: either source can be missing
+ * a field, and the view always renders something so the user is never
+ * staring at an empty panel while the detail call is in flight. */
 function _renderAgentDetail(a) {
-  var liveness = a.liveness || (isAgentInactive(a) ? "offline" : "online");
+  var d = _agentDetailCache[a.name] || {};
+  var liveness = d.liveness || a.liveness || (isAgentInactive(a) ? "offline" : "online");
   var statusColor = livenessColor(liveness);
-  var pane = a.pane_tail_block || a.pane_tail || "";
+  var role = d.role || a.role || "agent";
+  var machine = d.machine || a.machine || "?";
+  var model = d.model || a.model || "-";
+  var ctxPct = d.context_pct != null ? d.context_pct : a.context_pct;
+  var currentTask = d.current_task || a.current_task || "";
+  var channels = d.channel_subs || a.channels || [];
+  var claudeMd = d.claude_md || a.claude_md || "";
+  var mcpServers = d.mcp_servers || a.mcp_servers || [];
+  /* pane_text from the detail endpoint is already redacted; the
+   * registry fallback (pane_tail_block / pane_tail) is NOT, so prefer
+   * detail whenever we have it. */
+  var pane = "";
+  var paneSource = "unavailable";
+  if (d.pane_text != null) {
+    pane = d.pane_text;
+    paneSource = d.pane_text_source || (pane ? "cached" : "unavailable");
+  } else {
+    pane = a.pane_tail_block || a.pane_tail || "";
+    paneSource = pane ? "cached" : "unavailable";
+  }
 
   var headerHtml =
     '<div class="agent-detail-header">' +
     '<span class="status-dot-inline" style="background:' + statusColor + '"></span>' +
     '<strong>' + escapeHtml(a.name) + '</strong>' +
     ' <span class="agent-detail-meta">' +
-    escapeHtml(a.role || "agent") + " · " +
-    escapeHtml(a.machine || "?") + " · " +
-    escapeHtml(a.model || "-") +
-    (a.context_pct != null ? " · ctx " + Number(a.context_pct).toFixed(1) + "%" : "") +
-    (a.current_task ? ' · <em>' + escapeHtml(a.current_task) + '</em>' : '') +
+    escapeHtml(role) + " · " +
+    escapeHtml(machine) + " · " +
+    escapeHtml(model) +
+    (ctxPct != null ? " · ctx " + Number(ctxPct).toFixed(1) + "%" : "") +
+    (d.uptime_seconds != null ? " · up " + _fmtDuration(d.uptime_seconds) : "") +
+    (currentTask ? ' · <em>' + escapeHtml(currentTask) + '</em>' : '') +
+    "</span>" +
+    '<span class="agent-detail-actions">' +
+    '<button class="agent-detail-dm-btn" data-dm-name="' + escapeHtml(a.name) + '" ' +
+    'title="Open DM with ' + escapeHtml(a.name) + '">DM</button>' +
     "</span>" +
     "</div>";
 
+  var paneLabel =
+    'Terminal output <span class="agent-detail-pane-source">(' + escapeHtml(paneSource) + ')</span>';
   var paneHtml =
     '<div class="agent-detail-pane-wrap">' +
-    '<div class="agent-detail-pane-label">Terminal output</div>' +
+    '<div class="agent-detail-pane-label">' + paneLabel + "</div>" +
     '<pre class="agent-detail-pane">' +
-    (pane ? escapeHtml(pane) : '<span class="muted-cell">No terminal output available</span>') +
+    (pane
+      ? escapeHtml(pane)
+      : '<span class="muted-cell">No terminal output available (pane_text_source=' +
+        escapeHtml(paneSource) + ")</span>") +
     "</pre>" +
     "</div>";
 
-  var claudeMdHtml = a.claude_md
+  var claudeMdHtml = claudeMd
     ? '<div class="agent-detail-section">' +
       '<div class="agent-detail-pane-label">CLAUDE.md</div>' +
-      '<pre class="agent-detail-claude-md">' + escapeHtml(a.claude_md) + "</pre>" +
+      '<pre class="agent-detail-claude-md">' + escapeHtml(claudeMd) + "</pre>" +
       "</div>"
     : "";
 
   var channelsHtml = "";
-  if (a.channels && a.channels.length) {
-    var unique = [...new Set(a.channels)];
+  if (channels && channels.length) {
+    var unique = [...new Set(channels)];
     channelsHtml =
       '<div class="agent-detail-section">' +
       '<span class="agent-detail-pane-label">Channels: </span>' +
       unique.map(function(c){ return '<span class="ch-badge">' + escapeHtml(c) + "</span>"; }).join("") +
+      "</div>";
+  }
+
+  var mcpHtml = "";
+  if (mcpServers && mcpServers.length) {
+    mcpHtml =
+      '<div class="agent-detail-section">' +
+      '<span class="agent-detail-pane-label">MCP servers: </span>' +
+      mcpServers.map(function(m) {
+        var label = typeof m === "string" ? m : (m.name || JSON.stringify(m));
+        return '<span class="ch-badge">' + escapeHtml(label) + "</span>";
+      }).join("") +
       "</div>";
   }
 
@@ -88,9 +166,22 @@ function _renderAgentDetail(a) {
     headerHtml +
     paneHtml +
     channelsHtml +
+    mcpHtml +
     claudeMdHtml +
     "</div>"
   );
+}
+
+/* Compact human-friendly seconds formatter used in the detail header. */
+function _fmtDuration(sec) {
+  sec = Number(sec) || 0;
+  if (sec < 60) return sec + "s";
+  var m = Math.floor(sec / 60);
+  if (m < 60) return m + "m";
+  var h = Math.floor(m / 60);
+  if (h < 24) return h + "h " + (m % 60) + "m";
+  var d = Math.floor(h / 24);
+  return d + "d " + (h % 24) + "h";
 }
 
 /* Render only the content area (below tab bar) */
@@ -126,6 +217,31 @@ function _renderAgentContent(grid) {
   /* Scroll pane to bottom so latest output is visible */
   var pre = content.querySelector(".agent-detail-pane");
   if (pre) pre.scrollTop = pre.scrollHeight;
+  /* Kick off an async detail fetch so the next re-render has the
+   * redacted pane_text, MCP servers, uptime, etc. The cache shields
+   * subsequent renders from flicker. */
+  _fetchAgentDetail(agent.name);
+  /* Wire the DM quick-action: reuse the existing DM pipeline by
+   * dispatching a lightweight custom event the dashboard listens for.
+   * Falls back to addTag so even without a global DM opener the user
+   * at least gets the agent pre-filtered into the feed. */
+  var dmBtn = content.querySelector(".agent-detail-dm-btn");
+  if (dmBtn) {
+    dmBtn.addEventListener("click", function(ev) {
+      ev.stopPropagation();
+      var name = dmBtn.getAttribute("data-dm-name");
+      try {
+        if (typeof window.openDmWithAgent === "function") {
+          window.openDmWithAgent(name);
+          return;
+        }
+        document.dispatchEvent(new CustomEvent("orochi:open-dm", {
+          detail: { agent: name },
+        }));
+      } catch (_) {}
+      if (typeof addTag === "function") addTag("agent", name);
+    });
+  }
 }
 
 /* ── Overview HTML builder (extracted from renderAgentsTab) ─────────── */

--- a/hub/static/hub/components.css
+++ b/hub/static/hub/components.css
@@ -657,3 +657,28 @@
   overflow-y: auto;
   border: 1px solid #333;
 }
+/* todo#420: per-agent detail header actions (DM quick-action) + pane source badge */
+.agent-detail-actions {
+  float: right;
+}
+.agent-detail-dm-btn {
+  background: #1f2937;
+  color: #9ecbff;
+  border: 1px solid #334155;
+  border-radius: 4px;
+  padding: 2px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.agent-detail-dm-btn:hover {
+  color: #4ecdc4;
+  border-color: #4ecdc4;
+}
+.agent-detail-pane-source {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  color: #555;
+  font-size: 10px;
+  margin-left: 4px;
+}

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -1688,3 +1688,144 @@ class GroupMentionExpansionTest(TestCase):
             expand(["not-a-group", "heads"]),
             ["not-a-group", "head-mba", "head-spartan"],
         )
+
+
+class AgentDetailApiTest(TestCase):
+    """todo#420: /api/agents/<name>/detail/ — per-agent single-screen view.
+
+    Pins the response shape the Agents tab sub-tab depends on (see
+    ``hub/static/hub/agents-tab.js::_renderAgentDetail``) and verifies
+    server-side secret redaction of ``pane_text`` before it leaves the
+    hub. The endpoint is authenticated via workspace token so it can
+    be polled both from the dashboard and from ``agent_meta.py`` without
+    a browser session.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="detail-ws")
+        self.token = WorkspaceToken.objects.create(
+            workspace=self.ws, label="detail-test"
+        )
+        # Wipe the in-memory registry so state does not bleed across
+        # tests — the registry is a module-level dict.
+        from hub.registry import _agents as _reg_agents
+        _reg_agents.clear()
+
+    def _register(self, **overrides):
+        from hub.registry import register_agent, set_current_task
+        current_task = overrides.pop("current_task", "todo#420")
+        info = {
+            "agent_id": "alpha",
+            "machine": "MBA",
+            "role": "head",
+            "model": "claude-opus-4-6",
+            "channels": ["#general", "#agent"],
+            "pane_tail_block": "line1\nline2\n",
+            "claude_md": "# CLAUDE.md\n",
+            "mcp_servers": ["scitex-orochi"],
+        }
+        info.update(overrides)
+        register_agent(name="alpha", workspace_id=self.ws.id, info=info)
+        if current_task:
+            set_current_task("alpha", current_task)
+
+    def _get(self, name="alpha"):
+        return self.client.get(
+            f"/api/agents/{name}/detail/",
+            data={"token": self.token.token},
+        )
+
+    def test_returns_expected_shape(self):
+        self._register()
+        resp = self._get()
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        # Canonical fields the frontend pins.
+        for key in (
+            "name", "role", "machine", "model",
+            "uptime_seconds", "registered_at", "last_action_ts",
+            "last_heartbeat", "liveness", "claude_md",
+            "pane_text", "pane_text_source",
+            "channel_subs", "mcp_servers", "current_task",
+            "context_pct", "pid", "subagents", "health",
+        ):
+            self.assertIn(key, data, f"missing key: {key}")
+        self.assertEqual(data["name"], "alpha")
+        self.assertEqual(data["role"], "head")
+        self.assertEqual(data["machine"], "MBA")
+        self.assertEqual(data["current_task"], "todo#420")
+        self.assertEqual(data["pane_text_source"], "cached")
+        self.assertIn("line1", data["pane_text"])
+        self.assertEqual(
+            sorted(data["channel_subs"]), ["#agent", "#general"]
+        )
+        self.assertIn("scitex-orochi", data["mcp_servers"])
+
+    def test_unavailable_pane_source_when_no_capture(self):
+        self._register(pane_tail_block="", pane_tail="")
+        resp = self._get()
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["pane_text_source"], "unavailable")
+        self.assertEqual(data["pane_text"], "")
+
+    def test_missing_agent_returns_404(self):
+        self._register()
+        resp = self._get(name="bravo")
+        self.assertEqual(resp.status_code, 404)
+
+    def test_auth_required(self):
+        self._register()
+        resp = self.client.get("/api/agents/alpha/detail/")
+        self.assertEqual(resp.status_code, 401)
+
+    def test_invalid_token_rejected(self):
+        self._register()
+        resp = self.client.get(
+            "/api/agents/alpha/detail/",
+            data={"token": "wks_invalid"},
+        )
+        self.assertEqual(resp.status_code, 401)
+
+    def test_pane_text_redacts_secrets(self):
+        """sk-ant / ghp / JWT / bearer / credentials-file patterns
+        must never leak through ``pane_text``."""
+        leak = "\n".join([
+            "normal line 1",
+            "ANTHROPIC_API_KEY=sk-ant-oat01-ABCDEFGHIJKLMNOPQRST",
+            "gh token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            "id_token: eyJabcdefghij.eyJklmnopqrst.signatureXYZ123",
+            "Authorization: Bearer sk-oat-ABCDEFGHIJKLMNOPQR",
+            "cat ~/.credentials.json",
+            "normal line 2",
+        ])
+        self._register(pane_tail_block=leak)
+        resp = self._get()
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        pane = data["pane_text"]
+        for forbidden in (
+            "sk-ant-oat01-ABCDEFGHIJKLMNOPQRST",
+            "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            "eyJabcdefghij.eyJklmnopqrst.signatureXYZ123",
+            ".credentials.json",
+        ):
+            self.assertNotIn(
+                forbidden, pane,
+                f"unredacted secret {forbidden!r} leaked into pane_text",
+            )
+        # The non-secret content survives so the UI is still useful.
+        self.assertIn("normal line 1", pane)
+        self.assertIn("normal line 2", pane)
+        self.assertIn("[REDACTED]", pane)
+
+    def test_redact_secrets_helper_direct(self):
+        """Unit-level pin on :func:`redact_secrets` itself, independent
+        of the HTTP layer — cheap regression guard."""
+        from hub.views.agent_detail import redact_secrets
+        src = "prefix sk-ant-api03-ABCDEFGHIJKLMNOPQRST suffix"
+        out = redact_secrets(src)
+        self.assertNotIn("sk-ant-api03-ABCDEFGHIJKLMNOPQRST", out)
+        self.assertIn("[REDACTED]", out)
+        self.assertEqual(redact_secrets(""), "")

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -80,6 +80,12 @@ urlpatterns = [
     path("api/agents/pinned/", views.api_agents_pinned, name="api-agents-pinned"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
+    # Per-agent single-screen detail payload (todo#420 MVP).
+    path(
+        "api/agents/<str:name>/detail/",
+        views.api_agent_detail,
+        name="api-agent-detail",
+    ),
     # Central container-agent registry (replaces ~/.scitex/agent-container/registry/)
     path(
         "api/registry/agents/",

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -67,6 +67,12 @@ urlpatterns = [
     ),
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/health/", views.api_agent_health, name="api-agent-health"),
+    # Per-agent single-screen detail payload (todo#420 MVP).
+    path(
+        "api/agents/<str:name>/detail/",
+        views.api_agent_detail,
+        name="api-agent-detail",
+    ),
     # Bun MCP sidecars POST registry heartbeats here. Must exist on the
     # bare domain because SCITEX_OROCHI_URL defaults to wss://scitex-orochi.com
     # (no subdomain). Without this entry the heartbeat 404s and the

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -68,6 +68,12 @@ urlpatterns = [
     path("api/agents/kill/", views.api_agents_kill, name="api-agents-kill"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
+    # Per-agent single-screen detail payload (todo#420 MVP).
+    path(
+        "api/agents/<str:name>/detail/",
+        views.api_agent_detail,
+        name="api-agent-detail",
+    ),
     path(
         "api/subagents/update/", views.api_subagents_update, name="api-subagents-update"
     ),

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -48,6 +48,7 @@ from hub.views.auth import (  # noqa: F401
     signout_view,
     signup_view,
 )
+from hub.views.agent_detail import api_agent_detail  # noqa: F401
 from hub.views.avatar import api_agents_avatar  # noqa: F401
 from hub.views.registry import (  # noqa: F401
     api_registry_agent_detail,

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -1,0 +1,213 @@
+"""Per-agent detail endpoint (todo#420 MVP).
+
+Returns a single-screen payload for the Agents tab's per-agent page:
+metadata, CLAUDE.md, cached terminal pane text, channel subscriptions,
+MCP servers, and the current task. This is the read-only backing for
+the per-agent sub-tab in ``hub/static/hub/agents-tab.js``.
+
+Scope explicitly excludes:
+
+- Pane-state classification (todo#419) — UI infers from ``liveness``.
+- Cross-host SSH capture of the live tmux pane — kept best-effort
+  against the already-cached ``pane_tail_block`` field pushed by
+  ``agent_meta.py --push``; the response advertises the source via
+  ``pane_text_source`` so the frontend can show "cached" vs
+  "unavailable" without inventing a new transport.
+- Destructive quick-actions (Unblock / Restart / Kill). Only the
+  read-only data surface ships here; the frontend adds a non-destructive
+  DM quick-action that reuses the existing DM pipeline.
+
+Privacy: ``pane_text`` is run through :func:`redact_secrets` before
+serving so any token pasted into the pane by mistake does not escape
+the hub. See :data:`_SECRET_PATTERNS` for the canonical list.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from collections.abc import Iterable
+from datetime import datetime, timezone
+
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+
+from hub.registry import get_agents
+
+# Canonical list of credential-ish strings to redact from terminal
+# captures before serving them to the dashboard. These are matched as
+# standalone tokens so ordinary prose is not mangled.
+_SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    # Anthropic API keys and OAuth access tokens.
+    ("sk-ant", re.compile(r"sk-ant-[A-Za-z0-9_\-]{10,}")),
+    # GitHub personal access tokens / fine-grained tokens / app tokens.
+    ("ghp", re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}")),
+    # JWTs (three base64url segments separated by dots). Used by OAuth
+    # id_tokens, Django session JWTs, etc.
+    ("jwt", re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}")),
+    # OpenAI-style keys.
+    ("sk-", re.compile(r"\bsk-[A-Za-z0-9]{20,}")),
+    # AWS access-key-id prefixes.
+    ("aws", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    # Generic "Bearer <token>" authorization headers in curl/log output.
+    ("bearer", re.compile(r"(?i)bearer\s+[A-Za-z0-9._\-]{20,}")),
+    # Anything that looks like a password-store grep result.
+    ("password", re.compile(r"(?i)password[:=]\s*\S{4,}")),
+)
+
+# Matches a full line that contains credential-file paths. The whole line
+# is dropped rather than masked so we don't leak an environment variable
+# name followed by a masked value (the name itself is often sensitive).
+_CREDENTIAL_LINE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\.credentials\.json"),
+    re.compile(r"(?i)\bpassword-store\b"),
+    re.compile(r"(?i)\.env\.(local|secrets?)"),
+)
+
+
+def redact_secrets(text: str) -> str:
+    """Replace credential-like substrings in ``text`` with ``[REDACTED]``.
+
+    Best-effort: the goal is to stop copy-pasted tokens from reaching
+    the dashboard, not to prove the absence of secrets. Tests pin the
+    canonical patterns listed in :data:`_SECRET_PATTERNS`.
+    """
+    if not text:
+        return ""
+    cleaned: list[str] = []
+    for line in text.splitlines():
+        if any(p.search(line) for p in _CREDENTIAL_LINE_PATTERNS):
+            cleaned.append("[REDACTED credential-referencing line]")
+            continue
+        for _label, pat in _SECRET_PATTERNS:
+            line = pat.sub("[REDACTED]", line)
+        cleaned.append(line)
+    # Preserve a trailing newline when the source had one so the
+    # frontend's scroll-to-bottom heuristic still works.
+    suffix = "\n" if text.endswith("\n") else ""
+    return "\n".join(cleaned) + suffix
+
+
+def _iso(ts: float | int | None) -> str | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _find_agent(name: str, candidates: Iterable[dict]) -> dict | None:
+    for a in candidates:
+        if a.get("name") == name:
+            return a
+    return None
+
+
+def _resolve_workspace(request):
+    """Return the authenticated workspace or a JsonResponse error.
+
+    Accepts either an authenticated Django session (middleware already
+    resolved ``request.workspace`` from the subdomain) or a workspace
+    token passed via ``?token=wks_...``. This mirrors the auth shape
+    of :func:`hub.views.api.api_agents` so agent_meta.py and the
+    dashboard can both poll the endpoint.
+    """
+    workspace = getattr(request, "workspace", None)
+    if workspace is not None and (request.user and request.user.is_authenticated):
+        return workspace, None
+
+    token = request.GET.get("token")
+    if token:
+        from hub.models import WorkspaceToken
+
+        try:
+            wt = WorkspaceToken.objects.select_related("workspace").get(token=token)
+        except WorkspaceToken.DoesNotExist:
+            return None, JsonResponse({"error": "invalid token"}, status=401)
+        return wt.workspace, None
+
+    if workspace is not None:
+        # Session-less subdomain hit — refuse rather than leak.
+        return None, JsonResponse({"error": "authentication required"}, status=401)
+    return None, JsonResponse({"error": "authentication required"}, status=401)
+
+
+@require_GET
+def api_agent_detail(request, name: str):
+    """GET /api/agents/<name>/detail — full single-screen payload.
+
+    Response shape (stable; frontend pins these keys)::
+
+        {
+          "name": str,
+          "role": str,
+          "machine": str,
+          "model": str,
+          "uptime_seconds": int | None,
+          "registered_at": iso8601 | None,
+          "last_action_ts": iso8601 | None,
+          "last_heartbeat": iso8601 | None,
+          "liveness": str,
+          "claude_md": str,
+          "pane_text": str,
+          "pane_text_source": "cached" | "unavailable",
+          "channel_subs": [str, ...],
+          "mcp_servers": [str | dict, ...],
+          "current_task": str,
+          "context_pct": float | None,
+          "pid": int,
+          "subagents": [ ... ],
+          "health": { ... }
+        }
+    """
+    workspace, err = _resolve_workspace(request)
+    if err is not None:
+        return err
+
+    agents = get_agents(workspace_id=workspace.id)
+    agent = _find_agent(name, agents)
+    if agent is None:
+        return JsonResponse({"error": "agent not found", "name": name}, status=404)
+
+    # Prefer the richer pane_tail_block pushed by agent_meta.py --push;
+    # fall back to pane_tail, then advertise unavailable. We deliberately
+    # do NOT reach out to a cross-host tmux capture-pane over SSH here —
+    # that expansion is tracked in todo#420 follow-up.
+    raw_pane = agent.get("pane_tail_block") or agent.get("pane_tail") or ""
+    pane_text = redact_secrets(raw_pane) if raw_pane else ""
+    pane_text_source = "cached" if raw_pane else "unavailable"
+
+    # Compute uptime from registered_at ISO string when available.
+    uptime_seconds: int | None = None
+    reg_iso = agent.get("registered_at")
+    if reg_iso:
+        try:
+            reg_dt = datetime.fromisoformat(reg_iso.replace("Z", "+00:00"))
+            uptime_seconds = int(time.time() - reg_dt.timestamp())
+        except (TypeError, ValueError):
+            uptime_seconds = None
+
+    payload = {
+        "name": agent.get("name", name),
+        "role": agent.get("role", ""),
+        "machine": agent.get("machine", ""),
+        "model": agent.get("model", ""),
+        "uptime_seconds": uptime_seconds,
+        "registered_at": agent.get("registered_at"),
+        "last_action_ts": agent.get("last_action"),
+        "last_heartbeat": agent.get("last_heartbeat"),
+        "liveness": agent.get("liveness") or agent.get("status") or "unknown",
+        "claude_md": redact_secrets(agent.get("claude_md") or ""),
+        "pane_text": pane_text,
+        "pane_text_source": pane_text_source,
+        "channel_subs": sorted({c for c in (agent.get("channels") or []) if c}),
+        "mcp_servers": list(agent.get("mcp_servers") or []),
+        "current_task": agent.get("current_task", ""),
+        "context_pct": agent.get("context_pct"),
+        "pid": int(agent.get("pid") or 0),
+        "subagents": list(agent.get("subagents") or []),
+        "subagent_count": int(agent.get("subagent_count") or 0),
+        "health": agent.get("health") or {},
+    }
+    return JsonResponse(payload)


### PR DESCRIPTION
## Summary

- Ship a minimum-viable per-agent sub-tab in the Agents tab so ywatanabe can read an agent's metadata, CLAUDE.md, cached terminal pane, channel subs, MCP servers and current task in one scroll (todo#420, msg#10679 / #10682 rant about agent visibility).
- Add `GET /api/agents/<name>/detail/` returning a stable payload pinned by a new `AgentDetailApiTest` class. Auth: Django session or `?token=wks_...`.
- Add server-side secret redaction (`sk-ant-*`, `ghp_*`, JWTs, AWS keys, `Bearer` headers, credential-file lines) so pane captures can never leak tokens through the dashboard.
- Frontend (`hub/static/hub/agents-tab.js`) overlays the detail payload onto the existing sub-tab renderer, adds a DM quick-action, pane source badge, MCP server chips, and uptime.

## What's in the response

```
{
  "name", "role", "machine", "model",
  "uptime_seconds", "registered_at", "last_action_ts", "last_heartbeat",
  "liveness",
  "claude_md",            // redacted
  "pane_text",            // redacted
  "pane_text_source",     // "cached" | "unavailable"
  "channel_subs",
  "mcp_servers",
  "current_task",
  "context_pct", "pid", "subagents", "subagent_count", "health"
}
```

`pane_text` is best-effort — sourced from the `pane_tail_block` already pushed by `agent_meta.py --push` on each heartbeat. No new cross-host SSH relay was invented in this PR (too risky for a P0 ship); the frontend advertises `pane_text_source` as `unavailable` when we have nothing, so the follow-up can fill it in without an API break.

## Deferred to follow-ups (explicitly NOT in this PR)

- **todo#419 pane-state classifier + raw/clean toggle** — the UI still uses the existing `liveness` badge; a `:stuck-prompt` classifier + `[raw] [clean]` switch ships separately.
- **Destructive quick-actions (Unblock / Restart / Kill)** — only the non-destructive DM button is wired. The existing `/api/agents/restart/` and `/api/agents/kill/` endpoints are untouched.
- **Cross-host SSH `tmux capture-pane` relay** — currently we reuse the `pane_tail_block` field already present in the registry. A per-host `/agents/<name>/pane` SSH endpoint is a separate PR so this one can ship tonight.
- **New DB migrations** — intentionally reuses the in-memory registry + existing persisted fields.
- **`hub/consumers.py` mention-reply code** — untouched. PR #126 from head-mba owns that lane.

## Test plan

- [x] New `hub.tests.AgentDetailApiTest` — 7 cases covering shape, missing-agent 404, auth required (401), invalid token (401), `pane_text_source="unavailable"`, server-side redaction of 4 token-class secrets, and the `redact_secrets` helper unit test.
- [x] `python manage.py test hub` — 94/94 tests, same 9 pre-existing AuthTest errors as baseline (staticfiles manifest + `workspace_dashboard(slug=)` signature), no new failures introduced.
- [x] `ruff check hub/views/agent_detail.py` — clean.
- [x] `node -c hub/static/hub/agents-tab.js` — syntax OK.
- [ ] Manual deploy verification: daphne `docker restart` after `collectstatic`, playwright screenshot of the per-agent sub-tab showing pane text + DM button + channel chips on `https://scitex-orochi.com/workspace/orochi/#agents`. (Deferred to whoever deploys; per deploy-workflow.md "collectstatic ≠ deployed" discipline.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)