### PR TITLE
feat(cli): add --help-recursive and top-level --json to scitex-orochi root (#438)

### DIFF
--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -23,7 +23,39 @@ def _get_version() -> str:
         return "dev"
 
 
-@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+class _HelpRecursiveGroup(click.Group):
+    """Click group that supports ``--help-recursive`` to dump every subcommand."""
+
+    def get_help_recursive(self, ctx: click.Context) -> str:
+        lines = [
+            "=" * 60,
+            "scitex-orochi -- Complete Command Reference",
+            "=" * 60,
+            "",
+            self.get_help(ctx),
+            "",
+        ]
+        for name in sorted(self.list_commands(ctx)):
+            cmd = self.get_command(ctx, name)
+            if cmd is None:
+                continue
+            lines.append("-" * 60)
+            lines.append(f"Command: {name}")
+            lines.append("-" * 60)
+            sub_ctx = click.Context(cmd, info_name=name, parent=ctx)
+            try:
+                lines.append(cmd.get_help(sub_ctx))
+            except Exception as exc:  # pragma: no cover - defensive
+                lines.append(f"<help unavailable: {exc}>")
+            lines.append("")
+        return "\n".join(lines)
+
+
+@click.group(
+    cls=_HelpRecursiveGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    invoke_without_command=True,
+)
 @click.version_option(version=_get_version(), prog_name="scitex-orochi")
 @click.option(
     "--host",
@@ -38,17 +70,45 @@ def _get_version() -> str:
     envvar="SCITEX_OROCHI_PORT",
     help="Server port [$SCITEX_OROCHI_PORT].",
 )
+@click.option(
+    "--help-recursive",
+    "help_recursive",
+    is_flag=True,
+    default=False,
+    help="Show help for all commands recursively, then exit.",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit structured JSON output (propagates to subcommands that honour it).",
+)
 @click.pass_context
-def orochi(ctx: click.Context, host: str | None, port: int | None) -> None:
+def orochi(
+    ctx: click.Context,
+    host: str | None,
+    port: int | None,
+    help_recursive: bool,
+    as_json: bool,
+) -> None:
     """scitex-orochi -- Agent Communication Hub CLI."""
     from scitex_orochi._config import HOST, PORT
 
     ctx.ensure_object(dict)
     ctx.obj["host"] = host or HOST
     ctx.obj["port"] = port or PORT
+    ctx.obj["json"] = as_json
     from scitex_orochi._config import DASHBOARD_PORT
 
     ctx.obj["dashboard_port"] = DASHBOARD_PORT
+
+    if help_recursive:
+        click.echo(ctx.command.get_help_recursive(ctx))  # type: ignore[attr-defined]
+        ctx.exit(0)
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(0)
 
 
 # ── Register subcommands ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add `--help-recursive` and top-level `--json` options to the `scitex-orochi` root click group, closing part of the CLI convention gap surfaced by the fleet quality audit ([ywatanabe1989/todo#438](https://github.com/ywatanabe1989/todo/issues/438)).

Before this PR:

```
$ scitex-orochi --json
Error: No such option: --json Did you mean --version?
$ scitex-orochi --help-recursive
Error: No such option: --help-recursive
```

After:

```
$ scitex-orochi --version
scitex-orochi, version 0.11.52
$ scitex-orochi --help-recursive | wc -l
506
$ scitex-orochi --json list-channels   # accepted, hits hub normally
$ scitex-orochi                         # prints help, rc=0
```

## Changes

All in `src/scitex_orochi/_cli/_main.py`:

1. **New `_HelpRecursiveGroup(click.Group)`** — mirrors `scitex-agent-container/src/scitex_agent_container/cli_pkg/_helpers.py::HelpRecursiveGroup`. Walks every registered subcommand and prints a consolidated reference. Defensive `try/except` around each `cmd.get_help(sub_ctx)` so a single misbehaving subcommand cannot crash the whole dump.

2. **`--help-recursive`** — new flag at the root group. When passed, echoes the full recursive help and exits 0 without requiring a subcommand.

3. **`--json`** — new flag at the root group, with dest `as_json`. Sets `ctx.obj["json"] = True` so subcommands can honour a global default in a follow-up PR without breaking backward-compat today. Every subcommand (see `query_cmd.py`, `agent_cmd.py`, `launch_cmd.py`, `workspace_cmd.py`, …) already has its own local `--json`, so nothing regresses; this just adds the canonical top-level entry point that the fleet convention expects.

4. **`invoke_without_command=True`** — bare `scitex-orochi` (and `scitex-orochi --help-recursive`) now emit help and exit 0 cleanly instead of erroring out on missing subcommand.

No subcommand was modified. Wiring each subcommand's local `--json` to ALSO consult `ctx.obj["json"]` is an orthogonal follow-up that can land incrementally in separate small PRs.

## Why

`scitex-orochi` is the fleet's agent communication hub. Fleet probes that machine-parse CLI output (`scitex-smoke-test.py`, any future dashboards, CI gates) need `--json` to be a stable first-class flag on the root group, not an error. Likewise, `--help-recursive` is the one-shot command-reference dump the rest of the fleet CLIs already expose (scitex-agent-container, and will soon be scitex-slurm/resource/dev per #438).

This is the smallest possible change that restores convention compliance for two of the four flags flagged in the [#438 scorecard](https://github.com/ywatanabe1989/todo/issues/438). Separate scoped PRs will handle scitex-slurm, scitex-resource (`--version` semantic mismatch), and scitex-dev.

## Verification

Local install + smoke test on MBA (`~/.venv`, scitex-orochi editable, tracked in commit 352fbf9):

```
$ scitex-orochi --version
scitex-orochi, version 0.11.52

$ scitex-orochi --help-recursive | head -10
============================================================
scitex-orochi -- Complete Command Reference
============================================================

Usage: scitex-orochi [OPTIONS] COMMAND [ARGS]...

  scitex-orochi -- Agent Communication Hub CLI.
...

$ scitex-orochi --help-recursive | wc -l
506

$ scitex-orochi                 # no args, invoke_without_command path
Usage: scitex-orochi [OPTIONS] COMMAND [ARGS]...
  scitex-orochi -- Agent Communication Hub CLI.
$ echo $?
0

$ scitex-orochi --json list-channels
Error: Connection refused at 127.0.0.1:9559   # hub not running — flag WAS accepted
```

No existing subcommand behavior changed; only the root group gained flags.

## Related

- [ywatanabe1989/todo#438](https://github.com/ywatanabe1989/todo/issues/438) — CLI convention scorecard (4 scitex-* packages miss `--version`/`--json`/`--help-recursive`)
- [ywatanabe1989/todo#279](https://github.com/ywatanabe1989/todo/issues/279) — adjacent structural issue (`scitex --json` bs4 leak; different package)
- [ywatanabe1989/todo#439](https://github.com/ywatanabe1989/todo/issues/439) — `scitex-smoke-test.py` feature gap (needs `--version`/`--json`/`--help-recursive` testing to catch this class of drift automatically)

## Follow-ups (out of scope for this PR)

- Wire each subcommand's local `--json` to also consult `ctx.obj["json"]` (one small PR per cmd file, low-risk).
- Extend `scitex-smoke-test.py` to auto-probe `--help-recursive` + `--json` across every installed `scitex-*` CLI (tracked in #439).
- Corresponding PRs for scitex-slurm, scitex-resource, scitex-dev.

🤖 Generated by mamba-quality-checker-mba (Orochi fleet quality auditor).
