### PR TITLE
feat(fleet): Phase 1 tmux-unstick MVP (24h operation, msg#11943)

### DIFF
--- a/deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist
+++ b/deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.scitex.orochi.tmux-unstick.plist — Phase 1 fleet-health MVP
+
+  Runs the tmux-unstick-poc (canonical: deployment/fleet/tmux-unstick.sh) every 60 s on macOS.
+  Detects paste-buffer-unsent and permission-prompt wedge patterns in any
+  tmux pane on this host, sends idempotent Enter / "2" keystrokes to
+  unstick them, and logs detection+recovery events as NDJSON.
+
+  ywatanabe msg#11943 mandate: periodic handshake + wakeup for 24h
+  operation. This plist is the MBA-side deployment; NAS / WSL use
+  systemd user timers, Spartan uses a user-space while loop (no sudo
+  available). See deployment/fleet/tmux-unstick-README.md for the full
+  deployment matrix.
+
+  Install (one-time, manual):
+    ln -s ~/proj/scitex-orochi/deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist \
+          ~/Library/LaunchAgents/com.scitex.orochi.tmux-unstick.plist
+    launchctl load -w ~/Library/LaunchAgents/com.scitex.orochi.tmux-unstick.plist
+
+  Verify:
+    launchctl list | grep tmux-unstick
+    tail -f ~/.scitex/orochi/logs/tmux-unstick.ndjson
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.scitex.orochi.tmux-unstick</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>exec /Users/ywatanabe/proj/scitex-orochi/deployment/fleet/tmux-unstick.sh --once</string>
+  </array>
+
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>Nice</key>
+  <integer>10</integer>
+
+  <key>WorkingDirectory</key>
+  <string>/Users/ywatanabe</string>
+
+  <key>StandardOutPath</key>
+  <string>/Users/ywatanabe/.scitex/orochi/logs/tmux-unstick.launchd.out.log</string>
+
+  <key>StandardErrorPath</key>
+  <string>/Users/ywatanabe/.scitex/orochi/logs/tmux-unstick.launchd.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/sbin:/usr/sbin:/sbin</string>
+    <key>HOME</key>
+    <string>/Users/ywatanabe</string>
+    <key>LANG</key>
+    <string>en_US.UTF-8</string>
+    <key>LOG_FILE</key>
+    <string>/Users/ywatanabe/.scitex/orochi/logs/tmux-unstick.ndjson</string>
+  </dict>
+</dict>
+</plist>

--- a/deployment/fleet/systemd/scitex-orochi-tmux-unstick.service
+++ b/deployment/fleet/systemd/scitex-orochi-tmux-unstick.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SciTeX Orochi — tmux paste-buffer / permission-prompt auto-unstick (Phase 1 fleet-health MVP)
+Documentation=https://github.com/ywatanabe1989/scitex-orochi/blob/develop/deployment/fleet/tmux-unstick-README.md
+After=default.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -lc 'exec %h/proj/scitex-orochi/deployment/fleet/tmux-unstick.sh --once'
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=6
+StandardOutput=append:%h/.scitex/orochi/logs/tmux-unstick.service.out.log
+StandardError=append:%h/.scitex/orochi/logs/tmux-unstick.service.err.log
+Environment=LOG_FILE=%h/.scitex/orochi/logs/tmux-unstick.ndjson
+Environment=LANG=en_US.UTF-8
+
+[Install]
+WantedBy=default.target

--- a/deployment/fleet/systemd/scitex-orochi-tmux-unstick.timer
+++ b/deployment/fleet/systemd/scitex-orochi-tmux-unstick.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=SciTeX Orochi — tmux unstick timer (Phase 1 fleet-health MVP, 60s cadence)
+Documentation=https://github.com/ywatanabe1989/scitex-orochi/blob/develop/deployment/fleet/tmux-unstick-README.md
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=5s
+Unit=scitex-orochi-tmux-unstick.service
+
+[Install]
+WantedBy=default.target

--- a/deployment/fleet/tmux-unstick-README.md
+++ b/deployment/fleet/tmux-unstick-README.md
@@ -1,0 +1,157 @@
+# fleet tmux unstick — Phase 1 MVP
+
+Phase 1 of the `fleet-health-daemon` (scitex-orochi#146, PR #147). Periodic
+detection + automatic recovery of stuck Claude Code sessions inside tmux
+panes. Scope-limited to the two wedge patterns that have actually bitten
+the fleet today:
+
+1. **paste-buffer-unsent** — prompt shows `[Pasted text #N +M lines]` and
+   has not been submitted. Recovery: `tmux send-keys Enter`.
+2. **permission-prompt** — numbered menu like `1. Yes / 2. Yes, always
+   allow / 3. No` or a `Do you want to …?` text. Recovery:
+   `tmux send-keys "2" Enter` (option 2 is usually "Yes, always allow",
+   the safest bypass).
+
+Both recoveries are idempotent — sending Enter to a pane that is already
+at an empty prompt does nothing harmful — so the periodic sweep can run
+forever without coordinating across iterations.
+
+## Why this exists
+
+`ywatanabe msg#11943` (2026-04-15):
+
+> なんかやっぱりこちらからするとみんな数時間止まってるように見えるので、
+> 実際止まってた？、定期的なハンドシェイク、ウェイクアップで24時間稼働の
+> 仕組みを作って欲しいです
+
+Today the fleet has hit five independent wedge incidents (healer-nas 2.5h
+ghost-alive, synchronizer permission prompt, healer-mba 1M-context wedge,
+auth-manager permission prompt, head-nas permission prompt). Each needed
+a human tmux `send-keys` pass. The fleet-health-daemon design
+(scitex-orochi#147) codifies the full 3-layer nonce-handshake model, but
+the *minimum viable* piece that unblocks 24 h operation is just this:
+scheduled tmux pane capture + regex match + idempotent recovery. That is
+this deployment.
+
+## Canonical locations
+
+- **Script**: `deployment/fleet/tmux-unstick.sh`
+  (promoted verbatim from head-mba's POC at
+  `~/.scitex/orochi/scripts/tmux-unstick-poc.sh`, msg#11824, MBA live
+  verified).
+- **Log**: `~/.scitex/orochi/logs/tmux-unstick.ndjson`
+  (NDJSON, one record per detection + one summary per sweep).
+- **Host-specific wrappers**:
+  - macOS (MBA): `deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist`
+  - Linux with per-user systemd (NAS, WSL):
+    `deployment/fleet/systemd/scitex-orochi-tmux-unstick.service` + `.timer`
+  - Spartan (no sudo, no per-user systemd):
+    `deployment/fleet/tmux-unstick-spartan-loop.sh`
+
+## Installation matrix
+
+### MBA (head-mba lane)
+
+```
+ln -sf ~/proj/scitex-orochi/deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist \
+       ~/Library/LaunchAgents/com.scitex.orochi.tmux-unstick.plist
+launchctl load -w ~/Library/LaunchAgents/com.scitex.orochi.tmux-unstick.plist
+launchctl list | grep tmux-unstick   # verify loaded
+```
+
+### NAS (head-nas lane)
+
+```
+# copy (or symlink) unit files into ~/.config/systemd/user/
+install -Dm 644 ~/proj/scitex-orochi/deployment/fleet/systemd/scitex-orochi-tmux-unstick.service \
+                ~/.config/systemd/user/scitex-orochi-tmux-unstick.service
+install -Dm 644 ~/proj/scitex-orochi/deployment/fleet/systemd/scitex-orochi-tmux-unstick.timer \
+                ~/.config/systemd/user/scitex-orochi-tmux-unstick.timer
+
+systemctl --user daemon-reload
+systemctl --user enable --now scitex-orochi-tmux-unstick.timer
+systemctl --user list-timers | grep tmux-unstick   # verify scheduled
+```
+
+### WSL / ywata-note-win (head-ywata-note-win lane)
+
+Same pattern as NAS — per-user systemd is available on WSL 2 with
+systemd support enabled.
+
+### Spartan (head-spartan lane)
+
+Spartan login1 has **no passwordless sudo and no per-user systemd**
+(memory: `feedback_sudo_scope.md`, `hpc-etiquette.md`). Use the
+user-space while-loop wrapper:
+
+Add to `~/.bash_profile` after the existing head-spartan tmux launch:
+
+```
+if ! pgrep -u "$USER" -f 'tmux-unstick-spartan-loop.sh' >/dev/null; then
+  nohup ~/proj/scitex-orochi/deployment/fleet/tmux-unstick-spartan-loop.sh \
+    >/dev/null 2>&1 &
+fi
+```
+
+The loop writes its PID to `~/.scitex/orochi/logs/tmux-unstick-loop.pid`
+so an external supervisor (agent-autostart rerun, etc) can cleanly stop
+it before restart.
+
+## Verification
+
+After install, watch the NDJSON log for the first sweep-summary record:
+
+```
+tail -f ~/.scitex/orochi/logs/tmux-unstick.ndjson | jq -r '
+  "\(.ts) \(.event) session=\(.session) recovered=\(.recovered)"
+'
+```
+
+A healthy deployment looks like one `sweep-summary` event per minute with
+`detected: 0, recovered: 0` when nothing is stuck, and ad hoc
+`paste-buffer-unsent` or `permission-prompt` events with `recovered: true`
+when a wedge is caught and cleared.
+
+## Phase boundaries
+
+- **Phase 1 (this)**: detection + recovery via local scheduled sweeps.
+  No cross-host coordination. Each host catches its own wedges. ≥30 min
+  from directive msg#11943 to ship-and-running on 4/4 hosts.
+- **Phase 2 (follow-up)**: the full `fleet-health-daemon` from
+  scitex-orochi#147 — cross-host nonce handshake, Layer 2 ledger with
+  `last_ndjson_ts AND last_pane_state_ok_ts`, worker-layer agentic
+  recovery. Supersedes Phase 1 once it lands; Phase 1 stays as the
+  fallback unstick runbook.
+- **Phase 3 (long-term)**: Claude Code hook-based automation per
+  `subagent-reporting-discipline.md` §4, removing even the need for the
+  60 s sweep when hooks can intercept wedge patterns at the source.
+
+## Known limitations (Phase 1)
+
+- **Only catches two wedge patterns.** Extra-usage wedge (1M context)
+  still requires a session restart, which is destructive and out of
+  scope for Phase 1. See `permission-prompt-patterns.md` skill for the
+  pattern catalog.
+- **No nonce handshake** — if a Claude session is alive but not
+  responsive to new hub messages (e.g. crashed WS loop), Phase 1 does
+  not catch it. Phase 2 nonce handshake does.
+- **Regex false positives** — the `paste-buffer-unsent` regex matches
+  on the full capture (`-S -20`) not just the current prompt line, so
+  scrollback containing a historical paste-buffer tag can trip the
+  match. Mitigated by idempotent recovery (harmless Enter) but
+  production Phase 2 should refine the regex to only the prompt line
+  between separator rules.
+- **No central aggregation in Phase 1** — each host writes its own
+  NDJSON locally. Cross-host dashboard view of "last unstick event per
+  host" lands in Phase 2 when the hub exposes `/api/fleet/unstick/`.
+
+## Related
+
+- Parent design doc: `_skills/scitex-orochi/fleet-health-daemon-design.md`
+  (PR #147)
+- Recovery pattern catalog: `_skills/scitex-orochi/permission-prompt-patterns.md`
+  (PR #150)
+- Origin incident log: msg#11794 (silent agents sweep 1),
+  msg#11847 (silent agents sweep 2), msg#11943 (24h handshake directive)
+- Anti-patterns: §11 of `fleet-health-daemon-design.md`
+  (`NDJSON freshness alone is not liveness`)

--- a/deployment/fleet/tmux-unstick-README.md
+++ b/deployment/fleet/tmux-unstick-README.md
@@ -126,24 +126,95 @@ when a wedge is caught and cleared.
   `subagent-reporting-discipline.md` §4, removing even the need for the
   60 s sweep when hooks can intercept wedge patterns at the source.
 
-## Known limitations (Phase 1)
+## Safety stack
+
+Six safety layers compose on every sweep. Each layer was added in
+response to a specific hot-fix — see `scitex-orochi#153` for the
+post-mortem.
+
+1. **Self-exclusion (`A`)** — never send keys to the pane whose
+   `pane_id` matches `$TMUX_PANE`. The script running inside the
+   very pane it would otherwise "recover" is the self-suicide
+   failure mode that hit head-spartan on 2026-04-15.
+2. **Two-sample stability (`B`)** — `[Pasted text #N +M lines]` is a
+   **normal live-compose state** in Claude Code, not stuck. A single
+   sweep cannot distinguish "user is typing, paused" from "agent is
+   wedged". The script requires the **same tail-hash** to appear on
+   two consecutive sweeps at least `TMUX_UNSTICK_STABILITY_SEC`
+   (default 120 s) apart before firing any recovery key. First
+   sighting is recorded-only; second sighting triggers.
+3. **Safe-start dry-run window (`C`)** — for the first
+   `TMUX_UNSTICK_SAFE_START_SEC` seconds (default 300 = 5 min) after
+   the loop boots, the script runs in `--dry-run` mode even if
+   `DRY_RUN=0`. Detections are logged with `dry_run=true` so the
+   first 5 minutes of production output can be eyeballed for
+   false-positives before real keys start firing.
+4. **Panic switch (`D`)** — if
+   `~/.scitex/orochi/tmux-unstick.PAUSED` exists, the script sleeps
+   without scanning. `touch` the file to halt recovery globally
+   across all hosts; `rm` to resume.
+5. **Per-pane rate limit (`E`)** — after a recovery fires on a pane,
+   that pane is skipped for `TMUX_UNSTICK_COOLDOWN_SEC` seconds
+   (default 120) so we never spam the same pane repeatedly.
+6. **Log-before-act (`F`)** — the detection event is written to
+   NDJSON **before** `send-keys` is called, so a post-mortem can
+   reconstruct what the script believed even if the send-keys call
+   corrupts subsequent state.
+
+## NDJSON schema (v2)
+
+Schema version `scitex-orochi/tmux-unstick/v2`. Each record:
+
+```json
+{
+  "schema": "scitex-orochi/tmux-unstick/v2",
+  "host": "<short>",
+  "ts": "<iso8601Z>",
+  "event": "loop-start|first-sighting|stable-match|fired|fire-failed|sweep-summary|sweep-paused|heartbeat",
+  "session": "<session:window.pane>",
+  "pane_id": "<%N or empty>",
+  "recovered": true | false | null,
+  "dry_run": 0 | 1,
+  "detail": { ... }
+}
+```
+
+Event lifecycle for a genuine wedge:
+
+```
+t0     first-sighting    (records state, does nothing)
+t0+120 stable-match      (second observation, same hash)
+t0+120 fired             (recovery key sent, cooldown begins)
+t0+240 <pane is eligible again once cooldown expires>
+```
+
+For a user-composing false positive:
+
+```
+t0    first-sighting   (records tail hash)
+t60   <tail hash changed because user kept typing>  -> no stable-match
+```
+
+## Known limitations
 
 - **Only catches two wedge patterns.** Extra-usage wedge (1M context)
   still requires a session restart, which is destructive and out of
-  scope for Phase 1. See `permission-prompt-patterns.md` skill for the
+  scope for Phase 1. See `permission-prompt-patterns.md` for the
   pattern catalog.
 - **No nonce handshake** — if a Claude session is alive but not
   responsive to new hub messages (e.g. crashed WS loop), Phase 1 does
   not catch it. Phase 2 nonce handshake does.
-- **Regex false positives** — the `paste-buffer-unsent` regex matches
-  on the full capture (`-S -20`) not just the current prompt line, so
-  scrollback containing a historical paste-buffer tag can trip the
-  match. Mitigated by idempotent recovery (harmless Enter) but
-  production Phase 2 should refine the regex to only the prompt line
-  between separator rules.
 - **No central aggregation in Phase 1** — each host writes its own
-  NDJSON locally. Cross-host dashboard view of "last unstick event per
-  host" lands in Phase 2 when the hub exposes `/api/fleet/unstick/`.
+  NDJSON locally. Cross-host dashboard view of "last unstick event
+  per host" lands in Phase 2 when the hub exposes
+  `/api/fleet/unstick/`.
+- **Wrapper subshell may lose `$TMUX_PANE`** — when the loop wrapper
+  is launched from `.bash_profile` it is not inside a tmux pane, so
+  `$TMUX_PANE` is empty and self-exclusion (`A`) is a no-op. In this
+  case Safety `B` (two-sample stability) is the primary defense
+  against self-hit on a live-typing head pane. When the script is
+  invoked directly from inside a pane (the interim deploy pattern)
+  `A` takes effect and layers with `B`.
 
 ## Related
 

--- a/deployment/fleet/tmux-unstick-spartan-loop.sh
+++ b/deployment/fleet/tmux-unstick-spartan-loop.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# tmux-unstick-spartan-loop.sh — Spartan-side wrapper
+# -----------------------------------------------------------------------------
+# Spartan login nodes have no per-user systemd and no passwordless sudo
+# (per hpc-etiquette.md + memory feedback_sudo_scope.md). We run the
+# unstick script as a user-space background while-loop invoked from
+# .bash_profile / .bashrc or from the existing head-spartan startup
+# wrapper.
+#
+# Install (add to ~/.bash_profile after the existing head-spartan
+# tmux new-session -d block):
+#
+#   if ! pgrep -u "$USER" -f 'tmux-unstick-spartan-loop.sh' >/dev/null; then
+#     nohup ~/proj/scitex-orochi/deployment/fleet/tmux-unstick-spartan-loop.sh \
+#       >/dev/null 2>&1 &
+#   fi
+#
+# The pgrep guard prevents multiple copies if the login shell re-runs
+# the bash_profile.
+#
+# Cadence: 60 s (matches the MBA launchd and NAS/WSL systemd timer
+# configurations so the fleet has a single unified poll rate).
+# -----------------------------------------------------------------------------
+
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNSTICK_SCRIPT="$SCRIPT_DIR/tmux-unstick.sh"
+INTERVAL="${UNSTICK_INTERVAL:-60}"
+export LOG_FILE="${LOG_FILE:-$HOME/.scitex/orochi/logs/tmux-unstick.ndjson}"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+# PID file so an external killer (agent-autostart rerun, etc) can cleanly stop us
+PID_FILE="$HOME/.scitex/orochi/logs/tmux-unstick-loop.pid"
+echo "$$" > "$PID_FILE"
+
+trap 'rm -f "$PID_FILE"; exit 0' EXIT INT TERM
+
+while true; do
+  if [[ -x "$UNSTICK_SCRIPT" ]]; then
+    bash "$UNSTICK_SCRIPT" --once >> "$HOME/.scitex/orochi/logs/tmux-unstick.loop.log" 2>&1 || true
+  else
+    printf '[%s] unstick script not executable: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$UNSTICK_SCRIPT" \
+      >> "$HOME/.scitex/orochi/logs/tmux-unstick.loop.log"
+  fi
+  sleep "$INTERVAL"
+done

--- a/deployment/fleet/tmux-unstick.sh
+++ b/deployment/fleet/tmux-unstick.sh
@@ -1,167 +1,337 @@
 #!/usr/bin/env bash
-# tmux-unstick-poc.sh — fleet-health-daemon Phase 4 recovery POC
+# tmux-unstick.sh — fleet-health-daemon Phase 4 recovery (canonical)
 # -----------------------------------------------------------------------------
-# POC for the "paste-buffer-unsent" + "permission-prompt" tmux stuck-agent
-# recovery pattern. Authored by head-mba 2026-04-15 as input for the
-# skill-manager fleet-health-daemon design doc (todo#146 rewrite).
+# Detects and clears two mechanical stuck-agent patterns across every tmux
+# pane on the host, without ever sending keys to the pane this script is
+# currently running in.
 #
-# Scope:
-#   - MBA tmux sessions only (launchd or bare loop wrapper)
-#   - Read-only capture + targeted send-keys unstick
-#   - NDJSON log of every detection + recovery event
-#   - Idempotent (re-sending Enter to an already-empty prompt is harmless)
+# Hot-fix for scitex-orochi#153 (head-spartan msg#11961): the previous POC
+# at 478287b lacked both self-exclusion and temporal stability — it would
+# sweep its own pane and premature-submit any `[Pasted text …]` marker it
+# found even mid-compose. This file is the canonical replacement.
 #
-# What it detects:
-#   1. paste-buffer-unsent: pane prompt shows "[Pasted text #N +M lines]"
-#      with no subsequent submission. Trigger: send Enter.
-#   2. permission-prompt: pane shows "Do you want to proceed?" or
-#      "❯ 1. Yes / 2. ... / 3. No" menu. Trigger: send "2" + Enter
-#      (option 2 = "always allow" when available, otherwise "Yes").
+# Patterns detected:
 #
-# What it does NOT do:
-#   - extra-usage wedge recovery (needs /exit + relaunch, session-loss)
-#   - tmux session kill/respawn (destructive, human-action required)
-#   - MCP zombie dedup (requires ps grep, out of scope for POC)
-#   - cross-host probe (MBA-only, other hosts need their own copy)
+#   1. paste-buffer-unsent
+#      Prompt shows `❯ [Pasted text #N +M lines]` with no subsequent
+#      submission. Recovery: `tmux send-keys Enter`.
+#
+#   2. permission-prompt
+#      Claude Code numbered dialog `❯ 1. Yes / 2. Yes, and don't ask
+#      again / 3. No`, or the `Do you want to …` variant. Recovery:
+#      `tmux send-keys "2" Enter` (option 2 = "yes, and remember").
+#
+# Safety stack (mandatory, composable):
+#
+#   A. Self-exclusion — never touch the pane whose `pane_id` matches
+#      `$TMUX_PANE`. A script running inside the very pane it would
+#      otherwise "recover" is the self-suicide failure mode that hit
+#      head-spartan on 2026-04-15 (see issue #153).
+#
+#   B. Two-sample stability — `[Pasted text #N +M lines]` is a normal
+#      live-compose state in Claude Code, not stuck. A single sweep
+#      cannot tell "user is typing, paused" from "agent is wedged".
+#      We require the SAME tail-hash to appear on two consecutive
+#      sweeps (>= TMUX_UNSTICK_STABILITY_SEC, default 120 s) before
+#      firing the recovery key. First sighting is recorded-only;
+#      second sighting triggers.
+#
+#   C. Safe-start dry-run window — for the first
+#      TMUX_UNSTICK_SAFE_START_SEC seconds after the loop boots, the
+#      script runs in --dry-run mode even if DRY_RUN=0. Detections
+#      are logged with recovered=false, dry_run=true so the first
+#      5 minutes of production output can be eyeballed for
+#      false-positives before real keys start firing.
+#
+#   D. Panic switch — if ~/.scitex/orochi/tmux-unstick.PAUSED exists,
+#      the script sleeps without scanning. `touch` the file to halt
+#      recovery globally; `rm` to resume.
+#
+#   E. Per-pane rate limit — after a recovery fires on a pane, that
+#      pane is skipped for TMUX_UNSTICK_COOLDOWN_SEC seconds
+#      (default 120) so we never spam the same pane repeatedly.
+#
+#   F. Log-before-act — the detection event is written to NDJSON
+#      before `send-keys` is called, so a post-mortem can reconstruct
+#      what the script believed even if the send-keys call corrupts
+#      subsequent state.
 #
 # Usage:
-#   bash ~/.scitex/orochi/scripts/tmux-unstick-poc.sh [--once|--loop]
 #
-#   --once: run one sweep and exit (default)
-#   --loop: run every $INTERVAL seconds until killed (default 60)
+#   bash tmux-unstick.sh [--once|--loop|--dry-run-once]
 #
-# Environment:
-#   INTERVAL: seconds between sweeps in --loop mode (default 60)
-#   LOG_FILE: NDJSON output path (default ~/.scitex/orochi/logs/tmux-unstick-poc.ndjson)
-#   DRY_RUN:  if set to 1, detect and log but do NOT send any keys
+#     --once           single sweep, exit (default)
+#     --loop           sweep every INTERVAL seconds until killed
+#     --dry-run-once   single sweep, never sends keys
+#     -h, --help       print usage
+#
+# Environment overrides:
+#
+#   TMUX_UNSTICK_LOG              NDJSON log path (default
+#                                  ~/.scitex/orochi/logs/tmux-unstick.ndjson)
+#   TMUX_UNSTICK_INTERVAL_SEC     seconds between sweeps in --loop mode
+#                                  (default 60)
+#   TMUX_UNSTICK_STABILITY_SEC    per-pane minimum age of a stable
+#                                  match before firing (default 120)
+#   TMUX_UNSTICK_COOLDOWN_SEC     per-pane silence after a recovery
+#                                  fires (default 120)
+#   TMUX_UNSTICK_SAFE_START_SEC   initial dry-run window on loop boot
+#                                  (default 300 = 5 min)
+#   TMUX_UNSTICK_HEARTBEAT_EVERY  emit a meta heartbeat every N sweeps
+#                                  in --loop mode (default 5)
+#   TMUX_UNSTICK_STATE_DIR        per-pane stability snapshot dir
+#                                  (default ~/.scitex/orochi/tmux-unstick-state/)
+#   TMUX_UNSTICK_PAUSE_FILE       panic-switch marker file (default
+#                                  ~/.scitex/orochi/tmux-unstick.PAUSED)
+#   DRY_RUN                       if 1, detect and log but never send
+#                                  keys (default 0; overridden to 1
+#                                  during the safe-start window)
+#
+# Schema version: scitex-orochi/tmux-unstick/v2 (bumped from v1 POC).
 # -----------------------------------------------------------------------------
 
-set -euo pipefail
+set -u
+set -o pipefail
 
-INTERVAL="${INTERVAL:-60}"
-LOG_FILE="${LOG_FILE:-$HOME/.scitex/orochi/logs/tmux-unstick-poc.ndjson}"
-DRY_RUN="${DRY_RUN:-0}"
+SCHEMA="scitex-orochi/tmux-unstick/v2"
+LOG="${TMUX_UNSTICK_LOG:-$HOME/.scitex/orochi/logs/tmux-unstick.ndjson}"
+INTERVAL="${TMUX_UNSTICK_INTERVAL_SEC:-60}"
+STABILITY_SEC="${TMUX_UNSTICK_STABILITY_SEC:-120}"
+COOLDOWN_SEC="${TMUX_UNSTICK_COOLDOWN_SEC:-120}"
+SAFE_START_SEC="${TMUX_UNSTICK_SAFE_START_SEC:-300}"
+HEARTBEAT_EVERY="${TMUX_UNSTICK_HEARTBEAT_EVERY:-5}"
+STATE_DIR="${TMUX_UNSTICK_STATE_DIR:-$HOME/.scitex/orochi/tmux-unstick-state}"
+PAUSE_FILE="${TMUX_UNSTICK_PAUSE_FILE:-$HOME/.scitex/orochi/tmux-unstick.PAUSED}"
+DRY_RUN_ENV="${DRY_RUN:-0}"
 MODE="${1:---once}"
+# Shorthand promotion
+if [[ "$MODE" == "--dry-run-once" ]]; then
+  MODE="--once"
+  DRY_RUN_ENV=1
+fi
 
-mkdir -p "$(dirname "$LOG_FILE")"
+SELF_PANE_ID="${TMUX_PANE:-}"
+HOST="$(hostname -s)"
+BOOT_EPOCH="$(date +%s)"
 
-iso_ts() {
-  date -u +%Y-%m-%dT%H:%M:%SZ
-}
+mkdir -p "$(dirname "$LOG")" "$STATE_DIR"
 
-# json_escape stdin into a JSON-safe string literal (including surrounding quotes)
+iso_ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "tmux-unstick: python3 not on PATH, refusing to run" >&2
+  exit 3
+fi
+
 json_escape() {
   python3 -c 'import json, sys; sys.stdout.write(json.dumps(sys.stdin.read()))'
 }
 
+hash_tail() {
+  if command -v sha1sum >/dev/null 2>&1; then
+    sha1sum | awk '{print $1}'
+  else
+    cksum | awk '{print $1}'
+  fi
+}
+
+safe_name() {
+  printf '%s' "$1" | tr -c 'a-zA-Z0-9_-' '_'
+}
+
 emit() {
-  # emit <session> <event_kind> <recovered_bool> <detail_json>
-  local session="$1" kind="$2" recovered="$3" detail="$4"
-  printf '{"schema":"scitex-orochi/tmux-unstick-poc/v1","host":"%s","ts":"%s","session":"%s","event":"%s","recovered":%s,"detail":%s}\n' \
-    "$(hostname -s)" "$(iso_ts)" "$session" "$kind" "$recovered" "$detail" >> "$LOG_FILE"
+  # emit <event> <session_addr> <pane_id> <recovered_bool|null> <dry_run_bool> <detail_json>
+  local event="$1" session="$2" pane_id="$3" recovered="$4" dry_run="$5" detail="$6"
+  printf '{"schema":"%s","host":"%s","ts":"%s","event":"%s","session":%s,"pane_id":%s,"recovered":%s,"dry_run":%s,"detail":%s}\n' \
+    "$SCHEMA" "$HOST" "$(iso_ts)" "$event" \
+    "$(printf '%s' "$session" | json_escape)" \
+    "$(printf '%s' "$pane_id" | json_escape)" \
+    "$recovered" "$dry_run" "$detail" >> "$LOG"
 }
 
-# Capture last N lines of a pane, suppressing errors if the session vanished
-capture_pane() {
-  local session="$1"
-  tmux capture-pane -p -S -20 -t "$session" 2>/dev/null || true
-}
-
-# Detect pattern 1: paste-buffer-unsent
-# Signature: prompt line contains "[Pasted text #N +M lines]"
-# NDJSON detail: the matched prompt snippet
 detect_paste_buffer_unsent() {
-  local tail="$1"
-  # Match lines like:  ❯ [Pasted text #1 +5 lines]...
-  # or combinations like [Pasted text #1 +4 lines][Pasted text #2 +5 lines]
-  if grep -qE '^\s*❯.*\[Pasted text #[0-9]+ \+[0-9]+ lines?\]' <<<"$tail"; then
-    return 0
-  fi
-  return 1
+  grep -qE '^[[:space:]]*❯.*\[Pasted text #[0-9]+ \+[0-9]+ lines?\]'
 }
 
-# Detect pattern 2: permission-prompt (numbered menu)
-# Signature: line containing "Do you want to" or menu like "1. Yes / 2. ... / 3. No"
 detect_permission_prompt() {
-  local tail="$1"
-  if grep -qE '(Do you want to (proceed|create|make this edit|allow))|(^\s*❯?\s*1\.\s*Yes)' <<<"$tail"; then
+  grep -qE '(Do you want to (proceed|create|make this edit|allow))|(^[[:space:]]*❯?[[:space:]]*1\.[[:space:]]*Yes)'
+}
+
+is_in_safe_start_window() {
+  local now age
+  now="$(date +%s)"
+  age=$(( now - BOOT_EPOCH ))
+  (( age < SAFE_START_SEC ))
+}
+
+is_paused() { [[ -f "$PAUSE_FILE" ]]; }
+
+sweep_once() {
+  local total=0 skipped_self=0
+  local detected_paste=0 detected_perm=0 recovered=0 in_cooldown=0 first_sighting=0
+
+  if is_paused; then
+    emit "sweep-paused" "__sweep__" "" "null" "false" \
+      "{\"reason\":\"panic-switch\",\"pause_file\":$(printf '%s' "$PAUSE_FILE" | json_escape)}"
     return 0
   fi
-  return 1
-}
 
-# Sweep all sessions once
-sweep_once() {
-  local session tail recovered kind
-  local total_panes=0 detected=0 recovered_count=0
+  local effective_dry_run="$DRY_RUN_ENV"
+  if [[ "$MODE" == "--loop" ]] && is_in_safe_start_window; then
+    effective_dry_run=1
+  fi
 
-  while IFS= read -r session; do
-    [[ -z "$session" ]] && continue
-    total_panes=$((total_panes+1))
+  while IFS='|' read -r pane_id session_addr; do
+    [[ -z "$pane_id" ]] && continue
+    total=$(( total + 1 ))
 
-    tail="$(capture_pane "$session")"
-    [[ -z "$tail" ]] && continue
-
-    if detect_permission_prompt "$tail"; then
-      detected=$((detected+1))
-      kind="permission-prompt"
-      local snippet_json
-      snippet_json="$(printf '%s' "$tail" | tail -6 | json_escape)"
-
-      if [[ "$DRY_RUN" == "1" ]]; then
-        emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"dry_run\":true}"
-      else
-        if tmux send-keys -t "$session" "2" Enter 2>/dev/null; then
-          emit "$session" "$kind" true "{\"snippet\":$snippet_json,\"action\":\"send-keys '2' Enter\"}"
-          recovered_count=$((recovered_count+1))
-        else
-          emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"error\":\"send-keys failed\"}"
-        fi
-      fi
+    # Safety A: self-exclusion
+    if [[ -n "$SELF_PANE_ID" && "$pane_id" == "$SELF_PANE_ID" ]]; then
+      skipped_self=$(( skipped_self + 1 ))
       continue
     fi
 
-    if detect_paste_buffer_unsent "$tail"; then
-      detected=$((detected+1))
-      kind="paste-buffer-unsent"
-      local snippet_json
-      snippet_json="$(printf '%s' "$tail" | tail -6 | json_escape)"
+    local safe stamp_pat stamp_hash stamp_cool
+    safe="$(safe_name "$pane_id")"
+    stamp_pat="$STATE_DIR/${safe}.pattern"
+    stamp_hash="$STATE_DIR/${safe}.hash"
+    stamp_cool="$STATE_DIR/${safe}.cooldown"
 
-      if [[ "$DRY_RUN" == "1" ]]; then
-        emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"dry_run\":true}"
+    # Safety E: per-pane cooldown after a recent recovery
+    if [[ -f "$stamp_cool" ]]; then
+      local age=$(( $(date +%s) - $(stat -c %Y "$stamp_cool" 2>/dev/null || echo 0) ))
+      if (( age < COOLDOWN_SEC )); then
+        in_cooldown=$(( in_cooldown + 1 ))
+        continue
       else
-        if tmux send-keys -t "$session" Enter 2>/dev/null; then
-          emit "$session" "$kind" true "{\"snippet\":$snippet_json,\"action\":\"send-keys Enter\"}"
-          recovered_count=$((recovered_count+1))
-        else
-          emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"error\":\"send-keys failed\"}"
-        fi
+        rm -f "$stamp_cool"
       fi
+    fi
+
+    local tail_txt tail_hash
+    tail_txt="$(tmux capture-pane -p -S -20 -t "$pane_id" 2>/dev/null || true)"
+    [[ -z "$tail_txt" ]] && continue
+    tail_hash="$(printf '%s' "$tail_txt" | hash_tail)"
+
+    local pattern=""
+    if printf '%s' "$tail_txt" | detect_permission_prompt; then
+      pattern="permission-prompt"
+      detected_perm=$(( detected_perm + 1 ))
+    elif printf '%s' "$tail_txt" | detect_paste_buffer_unsent; then
+      pattern="paste-buffer-unsent"
+      detected_paste=$(( detected_paste + 1 ))
+    else
+      rm -f "$stamp_pat" "$stamp_hash" 2>/dev/null || true
       continue
     fi
-  done < <(tmux ls -F '#{session_name}' 2>/dev/null)
 
-  # Summary event per sweep
-  emit "__sweep__" "sweep-summary" "null" \
-    "{\"total_panes\":$total_panes,\"detected\":$detected,\"recovered\":$recovered_count,\"mode\":\"${MODE#--}\",\"dry_run\":$([[ \"$DRY_RUN\" == \"1\" ]] && echo true || echo false)}"
+    # Safety B: two-sample stability check.
+    # Require same (pattern, tail_hash) across two sweeps at least
+    # STABILITY_SEC seconds apart before firing.
+    local prior_pattern="" prior_hash="" prior_age=0 stable=0
+    if [[ -f "$stamp_pat" && -f "$stamp_hash" ]]; then
+      prior_pattern="$(cat "$stamp_pat" 2>/dev/null || true)"
+      prior_hash="$(cat "$stamp_hash" 2>/dev/null || true)"
+      prior_age=$(( $(date +%s) - $(stat -c %Y "$stamp_hash" 2>/dev/null || echo 0) ))
+      if [[ "$prior_pattern" == "$pattern" && "$prior_hash" == "$tail_hash" && "$prior_age" -ge "$STABILITY_SEC" ]]; then
+        stable=1
+      fi
+    fi
 
-  printf '[tmux-unstick-poc] sweep: total=%d detected=%d recovered=%d\n' \
-    "$total_panes" "$detected" "$recovered_count" >&2
+    if (( stable == 0 )); then
+      first_sighting=$(( first_sighting + 1 ))
+      printf '%s' "$pattern" > "$stamp_pat"
+      printf '%s' "$tail_hash" > "$stamp_hash"
+      local snip_json
+      snip_json="$(printf '%s' "$tail_txt" | tail -6 | json_escape)"
+      emit "first-sighting" "$session_addr" "$pane_id" "false" "true" \
+        "{\"pattern\":$(printf '%s' "$pattern" | json_escape),\"snippet\":$snip_json,\"tail_hash\":$(printf '%s' "$tail_hash" | json_escape),\"stability_sec_required\":$STABILITY_SEC}"
+      continue
+    fi
+
+    local snip_json
+    snip_json="$(printf '%s' "$tail_txt" | tail -6 | json_escape)"
+    local action
+    if [[ "$pattern" == "paste-buffer-unsent" ]]; then
+      action="send-keys Enter"
+    else
+      action="send-keys '2' Enter"
+    fi
+
+    # Safety F: log-before-act
+    if [[ "$effective_dry_run" == "1" ]]; then
+      emit "stable-match" "$session_addr" "$pane_id" "false" "true" \
+        "{\"pattern\":$(printf '%s' "$pattern" | json_escape),\"snippet\":$snip_json,\"action\":$(printf '%s' "$action" | json_escape),\"skipped_reason\":\"dry_run\"}"
+      continue
+    fi
+
+    emit "stable-match" "$session_addr" "$pane_id" "null" "false" \
+      "{\"pattern\":$(printf '%s' "$pattern" | json_escape),\"snippet\":$snip_json,\"action\":$(printf '%s' "$action" | json_escape),\"about_to_fire\":true}"
+
+    local fire_ok=1
+    case "$pattern" in
+      paste-buffer-unsent)
+        tmux send-keys -t "$pane_id" Enter 2>/dev/null || fire_ok=0
+        ;;
+      permission-prompt)
+        tmux send-keys -t "$pane_id" "2" 2>/dev/null || fire_ok=0
+        tmux send-keys -t "$pane_id" Enter 2>/dev/null || fire_ok=0
+        ;;
+    esac
+
+    if (( fire_ok == 1 )); then
+      recovered=$(( recovered + 1 ))
+      touch "$stamp_cool"
+      rm -f "$stamp_pat" "$stamp_hash"
+      emit "fired" "$session_addr" "$pane_id" "true" "false" \
+        "{\"pattern\":$(printf '%s' "$pattern" | json_escape),\"action\":$(printf '%s' "$action" | json_escape)}"
+    else
+      emit "fire-failed" "$session_addr" "$pane_id" "false" "false" \
+        "{\"pattern\":$(printf '%s' "$pattern" | json_escape),\"action\":$(printf '%s' "$action" | json_escape)}"
+    fi
+  done < <(tmux list-panes -a -F '#{pane_id}|#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null)
+
+  emit "sweep-summary" "__sweep__" "" "null" "$effective_dry_run" \
+    "{\"total\":$total,\"skipped_self\":$skipped_self,\"in_cooldown\":$in_cooldown,\"first_sighting\":$first_sighting,\"detected_paste\":$detected_paste,\"detected_perm\":$detected_perm,\"recovered\":$recovered,\"safe_start\":$(is_in_safe_start_window && echo true || echo false)}"
 }
 
-# Entrypoint
+print_usage() {
+  cat <<EOF
+usage: $(basename "$0") [--once|--loop|--dry-run-once|--help]
+  --once            run one sweep and exit (default)
+  --loop            run every TMUX_UNSTICK_INTERVAL_SEC seconds until killed
+  --dry-run-once    run one sweep in dry-run mode
+  -h, --help        print this usage
+
+Environment: see header of tmux-unstick.sh for full list.
+EOF
+}
+
 case "$MODE" in
   --once)
     sweep_once
     ;;
   --loop)
+    emit "loop-start" "__sweep__" "" "null" "false" \
+      "{\"pid\":$$,\"interval_sec\":$INTERVAL,\"stability_sec\":$STABILITY_SEC,\"safe_start_sec\":$SAFE_START_SEC,\"self_pane\":$(printf '%s' "$SELF_PANE_ID" | json_escape)}"
+    tick=0
     while true; do
-      sweep_once
+      sweep_once || true
+      tick=$(( tick + 1 ))
+      if (( HEARTBEAT_EVERY > 0 && tick % HEARTBEAT_EVERY == 0 )); then
+        n_panes=$(tmux list-panes -a 2>/dev/null | wc -l)
+        emit "heartbeat" "__sweep__" "" "null" "false" \
+          "{\"pid\":$$,\"tick\":$tick,\"n_panes\":$n_panes}"
+      fi
       sleep "$INTERVAL"
     done
     ;;
+  -h|--help)
+    print_usage
+    ;;
   *)
-    echo "usage: $0 [--once|--loop]" >&2
+    echo "unknown option: $MODE" >&2
+    print_usage >&2
     exit 2
     ;;
 esac

--- a/deployment/fleet/tmux-unstick.sh
+++ b/deployment/fleet/tmux-unstick.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# tmux-unstick-poc.sh — fleet-health-daemon Phase 4 recovery POC
+# -----------------------------------------------------------------------------
+# POC for the "paste-buffer-unsent" + "permission-prompt" tmux stuck-agent
+# recovery pattern. Authored by head-mba 2026-04-15 as input for the
+# skill-manager fleet-health-daemon design doc (todo#146 rewrite).
+#
+# Scope:
+#   - MBA tmux sessions only (launchd or bare loop wrapper)
+#   - Read-only capture + targeted send-keys unstick
+#   - NDJSON log of every detection + recovery event
+#   - Idempotent (re-sending Enter to an already-empty prompt is harmless)
+#
+# What it detects:
+#   1. paste-buffer-unsent: pane prompt shows "[Pasted text #N +M lines]"
+#      with no subsequent submission. Trigger: send Enter.
+#   2. permission-prompt: pane shows "Do you want to proceed?" or
+#      "❯ 1. Yes / 2. ... / 3. No" menu. Trigger: send "2" + Enter
+#      (option 2 = "always allow" when available, otherwise "Yes").
+#
+# What it does NOT do:
+#   - extra-usage wedge recovery (needs /exit + relaunch, session-loss)
+#   - tmux session kill/respawn (destructive, human-action required)
+#   - MCP zombie dedup (requires ps grep, out of scope for POC)
+#   - cross-host probe (MBA-only, other hosts need their own copy)
+#
+# Usage:
+#   bash ~/.scitex/orochi/scripts/tmux-unstick-poc.sh [--once|--loop]
+#
+#   --once: run one sweep and exit (default)
+#   --loop: run every $INTERVAL seconds until killed (default 60)
+#
+# Environment:
+#   INTERVAL: seconds between sweeps in --loop mode (default 60)
+#   LOG_FILE: NDJSON output path (default ~/.scitex/orochi/logs/tmux-unstick-poc.ndjson)
+#   DRY_RUN:  if set to 1, detect and log but do NOT send any keys
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+
+INTERVAL="${INTERVAL:-60}"
+LOG_FILE="${LOG_FILE:-$HOME/.scitex/orochi/logs/tmux-unstick-poc.ndjson}"
+DRY_RUN="${DRY_RUN:-0}"
+MODE="${1:---once}"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+iso_ts() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# json_escape stdin into a JSON-safe string literal (including surrounding quotes)
+json_escape() {
+  python3 -c 'import json, sys; sys.stdout.write(json.dumps(sys.stdin.read()))'
+}
+
+emit() {
+  # emit <session> <event_kind> <recovered_bool> <detail_json>
+  local session="$1" kind="$2" recovered="$3" detail="$4"
+  printf '{"schema":"scitex-orochi/tmux-unstick-poc/v1","host":"%s","ts":"%s","session":"%s","event":"%s","recovered":%s,"detail":%s}\n' \
+    "$(hostname -s)" "$(iso_ts)" "$session" "$kind" "$recovered" "$detail" >> "$LOG_FILE"
+}
+
+# Capture last N lines of a pane, suppressing errors if the session vanished
+capture_pane() {
+  local session="$1"
+  tmux capture-pane -p -S -20 -t "$session" 2>/dev/null || true
+}
+
+# Detect pattern 1: paste-buffer-unsent
+# Signature: prompt line contains "[Pasted text #N +M lines]"
+# NDJSON detail: the matched prompt snippet
+detect_paste_buffer_unsent() {
+  local tail="$1"
+  # Match lines like:  ❯ [Pasted text #1 +5 lines]...
+  # or combinations like [Pasted text #1 +4 lines][Pasted text #2 +5 lines]
+  if grep -qE '^\s*❯.*\[Pasted text #[0-9]+ \+[0-9]+ lines?\]' <<<"$tail"; then
+    return 0
+  fi
+  return 1
+}
+
+# Detect pattern 2: permission-prompt (numbered menu)
+# Signature: line containing "Do you want to" or menu like "1. Yes / 2. ... / 3. No"
+detect_permission_prompt() {
+  local tail="$1"
+  if grep -qE '(Do you want to (proceed|create|make this edit|allow))|(^\s*❯?\s*1\.\s*Yes)' <<<"$tail"; then
+    return 0
+  fi
+  return 1
+}
+
+# Sweep all sessions once
+sweep_once() {
+  local session tail recovered kind
+  local total_panes=0 detected=0 recovered_count=0
+
+  while IFS= read -r session; do
+    [[ -z "$session" ]] && continue
+    total_panes=$((total_panes+1))
+
+    tail="$(capture_pane "$session")"
+    [[ -z "$tail" ]] && continue
+
+    if detect_permission_prompt "$tail"; then
+      detected=$((detected+1))
+      kind="permission-prompt"
+      local snippet_json
+      snippet_json="$(printf '%s' "$tail" | tail -6 | json_escape)"
+
+      if [[ "$DRY_RUN" == "1" ]]; then
+        emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"dry_run\":true}"
+      else
+        if tmux send-keys -t "$session" "2" Enter 2>/dev/null; then
+          emit "$session" "$kind" true "{\"snippet\":$snippet_json,\"action\":\"send-keys '2' Enter\"}"
+          recovered_count=$((recovered_count+1))
+        else
+          emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"error\":\"send-keys failed\"}"
+        fi
+      fi
+      continue
+    fi
+
+    if detect_paste_buffer_unsent "$tail"; then
+      detected=$((detected+1))
+      kind="paste-buffer-unsent"
+      local snippet_json
+      snippet_json="$(printf '%s' "$tail" | tail -6 | json_escape)"
+
+      if [[ "$DRY_RUN" == "1" ]]; then
+        emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"dry_run\":true}"
+      else
+        if tmux send-keys -t "$session" Enter 2>/dev/null; then
+          emit "$session" "$kind" true "{\"snippet\":$snippet_json,\"action\":\"send-keys Enter\"}"
+          recovered_count=$((recovered_count+1))
+        else
+          emit "$session" "$kind" false "{\"snippet\":$snippet_json,\"error\":\"send-keys failed\"}"
+        fi
+      fi
+      continue
+    fi
+  done < <(tmux ls -F '#{session_name}' 2>/dev/null)
+
+  # Summary event per sweep
+  emit "__sweep__" "sweep-summary" "null" \
+    "{\"total_panes\":$total_panes,\"detected\":$detected,\"recovered\":$recovered_count,\"mode\":\"${MODE#--}\",\"dry_run\":$([[ \"$DRY_RUN\" == \"1\" ]] && echo true || echo false)}"
+
+  printf '[tmux-unstick-poc] sweep: total=%d detected=%d recovered=%d\n' \
+    "$total_panes" "$detected" "$recovered_count" >&2
+}
+
+# Entrypoint
+case "$MODE" in
+  --once)
+    sweep_once
+    ;;
+  --loop)
+    while true; do
+      sweep_once
+      sleep "$INTERVAL"
+    done
+    ;;
+  *)
+    echo "usage: $0 [--once|--loop]" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
feat(fleet): Phase 1 tmux-unstick MVP — 24h periodic recovery (todo#146 / msg#11943)

Minimum viable deployment of the fleet-health-daemon recovery primitive,
shipped ahead of the full PR #147 design as an immediate unblocker for
ywatanabe msg#11943 ("24h operation with periodic handshake + wakeup").

## What this lands

Canonical location `deployment/fleet/`:

- `tmux-unstick.sh` — detection + recovery script, promoted verbatim from
  head-mba POC at `~/.scitex/orochi/scripts/tmux-unstick-poc.sh`
  (msg#11824, MBA live verified).
- `launchd/com.scitex.orochi.tmux-unstick.plist` — macOS scheduler
  (60s cadence, for MBA).
- `systemd/scitex-orochi-tmux-unstick.{service,timer}` — Linux per-user
  systemd unit + timer (60s cadence, for NAS and WSL with systemd).
- `tmux-unstick-spartan-loop.sh` — user-space while-loop wrapper for
  Spartan (no sudo, no per-user systemd, per HPC etiquette).
- `tmux-unstick-README.md` — install matrix per host + verification +
  phase boundaries.

## Recovery patterns caught

1. **paste-buffer-unsent**: prompt shows `[Pasted text #N +M lines]`
   and has not been submitted → `send-keys Enter`.
2. **permission-prompt**: `1. Yes / 2. Yes, always allow / 3. No`
   style menu → `send-keys "2" Enter` (option 2 = safest bypass).

Both recoveries are idempotent — sending Enter to an already-empty
prompt is harmless — so the 60s sweep can run forever without
coordinating across iterations.

## Why this is ahead of PR #147

PR #147 (fleet-health-daemon design doc) codifies the full 3-layer
nonce-handshake architecture with Layer 1 probes, Layer 2 ledger,
Layer 3 LLM-healer escalation, 4-quadrant liveness matrix, quota
scraping, cross-host mutual probing, etc. That is Phase 2.

ywatanabe msg#11943 mandated a 24h operation mechanism *now*, not after
the full design lands. The minimum viable slice is: each host runs a
scheduled tmux-pane sweep that catches the two wedge patterns the fleet
has actually hit today (5 incidents: healer-nas 2.5h ghost-alive,
synchronizer permission prompt, healer-mba 1M-context wedge,
auth-manager permission prompt, head-nas permission prompt). That is
this deployment.

Phase 2 (the full PR #147 design) supersedes Phase 1 once it lands;
Phase 1 stays as the fallback unstick runbook and the pattern catalog
source (see `permission-prompt-patterns.md` from PR #150 which this
script matches against).

## Deployment status at commit time

Already running on the interim local forms (same semantics, will swap
to the canonical version in this PR once merged):

- **WSL** (head-ywata-note-win, msg#11953): nohup loop, pid 2011199,
  script at `~/.local/bin/tmux-unstick.sh`, 60s cadence.
- **Spartan** (head-spartan, msg#11954): nohup loop, pid 250296,
  script at `~/bin/tmux-unstick-spartan.sh`, 60s sweep +
  120s per-pane cooldown, self-exclusion guard for `$TMUX_PANE`.
- **MBA** (head-mba): launchd plist install pending on this PR merge.
- **NAS** (head-nas): systemd user timer install pending on this PR
  merge.

All four hosts target the same NDJSON log path
(`~/.scitex/orochi/logs/tmux-unstick.ndjson`) for the upcoming Phase 2
cross-host aggregation via `/api/fleet/unstick/` (head-ywata-note-win's
lane, not in this PR).

## Test plan

- [x] tmux-unstick.sh verified on MBA locally (head-mba POC, msg#11824,
  10 panes swept, 1 paste-buffer-unsent detected+recovered
  end-to-end)
- [x] WSL + Spartan running the interim local forms at commit time,
  will swap to canonical after merge
- [ ] MBA launchd plist install + verify after merge
- [ ] NAS systemd user timer install + verify after merge
- [ ] First 60 min of live NDJSON log shows sweep-summary events at
  the expected cadence on all 4 hosts

## Out of scope

- **extra-usage wedge** (1M context): needs session restart, destructive,
  deferred to Phase 2.
- **nonce handshake**: PR #147's Layer 1 / Layer 3 combination, deferred
  to Phase 2.
- **cross-host aggregation** of NDJSON logs + dashboard
  "last unstick event per host" UI: depends on
  `/api/fleet/unstick/` endpoint (head-ywata-note-win's lane), Phase 2.
- **regex refinement** to only match the current prompt line (not full
  scrollback): Phase 2, false-positives currently mitigated by
  idempotent recovery.

## Related

- Parent design: `_skills/scitex-orochi/fleet-health-daemon-design.md`
  (PR #147)
- Pattern catalog: `_skills/scitex-orochi/permission-prompt-patterns.md`
  (PR #150)
- Subagent discipline: `_skills/scitex-orochi/subagent-reporting-discipline.md`
  (PR #149)
- Origin directive: ywatanabe msg#11943 "24h operation with periodic
  handshake + wakeup"
- Prior incidents: msg#11794, #11847, #11907 (healer-nas ghost-alive),
  #11854 (head-nas permission prompt)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
