### PR TITLE
docs(skills): pane-state — session-existence preflight (tmux vs screen)

### DIFF
--- a/src/scitex_orochi/_skills/scitex-orochi/pane-state-patterns.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/pane-state-patterns.md
@@ -134,6 +134,48 @@ Do not auto-retry — capture pane, post to `#escalation`, let a human route.
 ```
 Or `tmux capture-pane` returns empty. Claude exited, shell prompt or blank. Action: autostart unit should respawn; if autostart fails, escalate.
 
+## Session-existence preflight — `tmux ls`, not `screen -ls`
+
+Added 2026-04-15 after `mamba-healer-mba` msg #12799 false-alarmed
+"MBA fleet down — all 12 agents + screen sessions gone" while all 12
+tmux sessions were in fact alive.
+
+Before any pane-state classification, a healer must first confirm
+the session exists. The session-existence check must use the same
+multiplexer the agents are actually running in:
+
+- scitex-agent-container defaults to `multiplexer: tmux` since v0.7.
+  Session-existence check: **`tmux ls`**.
+- `screen -ls` is only valid on hosts where an agent's YAML explicitly
+  sets `multiplexer: screen`. On all other hosts (MBA included) the
+  screen socket is empty and `screen -ls` reports "No Sockets found",
+  which is **not** evidence that the agents are dead.
+
+Contract for any liveness probe:
+
+1. **Primary signal**: `tmux ls` (or `screen -ls` iff the agent's
+   configured multiplexer is screen). If the expected session name is
+   present, the session exists. Classify pane state from here.
+2. **Secondary signal only**: `scitex-agent-container list` output.
+   Treat an empty list as a **hypothesis** to cross-check with the
+   primary signal, never as ground truth. A stale / crashed
+   scitex-agent-container list command can return an empty list while
+   the underlying sessions are fine.
+3. **Never escalate** a "fleet down" classification on the secondary
+   signal alone. If `tmux ls` shows the session, the session is alive;
+   post-fix the probe code instead of the fleet.
+4. If the probe cannot reach the multiplexer at all (e.g. SSH is
+   down), classify the **host** as unreachable — not the individual
+   sessions as dead. The agents inside an unreachable host cannot be
+   probed, and "can't probe" is distinct from "confirmed dead"
+   (rule #11 absence-of-response still applies for DM-based probes,
+   but the host layer is a separate question).
+
+A healer that short-circuits this preflight will false-alarm ywatanabe
+and the heads, waste fleet attention on a non-incident, and risk
+triggering a destructive "restart everything" response. Always two
+signals, primary-before-secondary, before classifying a host as down.
+
 ## Scrollback false-positive guard — strict last-N-lines window
 
 Added 2026-04-14 after `mamba-healer-mba` msg #10865. Regexes must match against the **last 5 lines** of `tmux capture-pane -p -S -5`, not the full scrollback buffer.


### PR DESCRIPTION
## Summary

Captures a canonical rule in `pane-state-patterns.md` that any liveness probe must confirm session existence via the same multiplexer the agent is actually running in. Lesson from `mamba-healer-mba` msg#12799 / #12812 on 2026-04-15.

## Why

healer false-alarmed "MBA fleet down — all 12 agents + screen sessions gone" in #general while all 12 tmux sessions were actually alive. Root cause: healer ran `screen -ls` on MBA, but scitex-agent-container defaults to `multiplexer: tmux` since v0.7, so the screen socket was empty and the probe treated that as "fleet dead". The false alarm pulled head-mba, head-ywata-note-win, mamba-verifier-mba, and ywatanabe into a non-incident.

healer has already patched its own probe code (msg#12812, "tmux ls as primary, scitex-agent-container list as secondary, never escalate on list=[] without tmux cross-check"). This PR captures the **rule** in the canonical skill so any future healer / liveness checker inherits the same discipline rather than relearning it from a false alarm.

## Rule added

Section "Session-existence preflight — `tmux ls`, not `screen -ls`" in `pane-state-patterns.md`:

1. **Primary signal**: `tmux ls` (or `screen -ls` iff the agent's YAML explicitly sets `multiplexer: screen`). If the session exists, classify pane state from there.
2. **Secondary signal only**: `scitex-agent-container list` — as a hypothesis to cross-check with the primary signal, never as ground truth.
3. **Never escalate** "fleet down" on the secondary signal alone. `tmux ls` wins.
4. **Unreachable host ≠ confirmed dead sessions**. If the probe can't reach the multiplexer at all (e.g. SSH down), classify the host as unreachable, not the sessions as dead.

No code change — rule is documented so implementations consuming `pane-state-patterns.md` pick it up.

## Test plan

- [x] No code to test; markdown-only skill update.
- [ ] `mamba-healer-mba`'s patched probe (msg#12812) is consistent with this rule — healer author confirms on merge.
- [ ] Any future liveness-checker author (healer, watchdog, fleet-health-daemon) reads this section before shipping.

## Related

- Orochi msg#12799 (false alarm), #12811 (head-ywata-note-win correction), #12812 (healer own-fix), #12813 (head-ywata-note-win ack).
- Companion to scitex-agent-container#39 (the actual restart race fix that triggered healer's suspicion in the first place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
