### PR TITLE
feat(hub): active session counter for concurrent-instance visibility (#144 path 4)

### DIFF
--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -202,19 +202,40 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             await self.channel_layer.group_add(group, self.channel_name)
 
         await self.accept()
+
+        # scitex-orochi#144 fix path 4: track this WebSocket as one of N
+        # active connections under self.agent_name, so the registry can
+        # surface concurrent-instance situations without altering identity.
+        from hub.registry import register_connection
+
+        active_sessions = register_connection(self.agent_name, self.channel_name)
+
         log.info(
-            "Agent %s connected to workspace %s",
+            "Agent %s connected to workspace %s (active_sessions=%d)",
             self.agent_name,
             self.workspace_name,
+            active_sessions,
         )
+        if active_sessions > 1:
+            log.warning(
+                "Concurrent-instance hazard: %s now has %d active sessions "
+                "(scitex-orochi#144). Dispatch to @%s may race; coordinators "
+                "should prefer DM-routing.",
+                self.agent_name,
+                active_sessions,
+                self.agent_name,
+            )
 
-        # Broadcast presence to dashboard observers
+        # Broadcast presence to dashboard observers, including the new
+        # active_sessions field so the Agents tab can surface a warning
+        # icon when sessions > 1.
         await self.channel_layer.group_send(
             self.workspace_group,
             {
                 "type": "agent.presence",
                 "agent": self.agent_name,
                 "status": "connected",
+                "active_sessions": active_sessions,
             },
         )
 
@@ -223,19 +244,30 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
 
     async def disconnect(self, code):
         if hasattr(self, "workspace_group"):
-            # Mark agent offline in registry
-            from hub.registry import unregister_agent
+            # scitex-orochi#144 fix path 4: drop only THIS connection from
+            # the per-agent set, not the whole agent record. The agent only
+            # transitions to offline when its last sibling connection drops.
+            from hub.registry import unregister_connection
 
             agent_name = getattr(self, "agent_name", "?")
-            unregister_agent(agent_name)
+            remaining = unregister_connection(agent_name, self.channel_name)
+            if remaining > 0:
+                log.info(
+                    "Agent %s disconnected one session; %d sibling "
+                    "session(s) still active (scitex-orochi#144).",
+                    agent_name,
+                    remaining,
+                )
 
-            # Broadcast departure before leaving group
+            # Broadcast departure before leaving group, including remaining
+            # session count so the dashboard can update the warning state.
             await self.channel_layer.group_send(
                 self.workspace_group,
                 {
                     "type": "agent.presence",
                     "agent": agent_name,
-                    "status": "disconnected",
+                    "status": "disconnected" if remaining == 0 else "connected",
+                    "active_sessions": remaining,
                 },
             )
 

--- a/hub/registry.py
+++ b/hub/registry.py
@@ -2,6 +2,20 @@
 
 AgentConsumer writes to this registry on register/heartbeat/disconnect.
 The REST API reads from it for /api/agents and /api/stats.
+
+Active-session tracking (scitex-orochi#144 fix path 4):
+A single ``SCITEX_OROCHI_AGENT=<name>`` identity may have multiple
+WebSocket connections at once (a known race hazard — two Claude Code
+processes booting from the same yaml). The registry tracks the set of
+live connection IDs per agent in ``_connections[name]`` so:
+
+  - the dashboard can render a warning when ``active_sessions > 1``;
+  - ``unregister_agent()`` only marks offline when the LAST connection
+    drops, not when the first of N sibling sessions disconnects.
+
+The connection IDs are opaque strings (Django Channels' ``channel_name``
+attribute, unique per WebSocket); the registry treats them as
+identifiers, not as data.
 """
 
 import logging
@@ -12,6 +26,7 @@ log = logging.getLogger("orochi.registry")
 
 _lock = threading.Lock()
 _agents: dict[str, dict] = {}
+_connections: dict[str, set[str]] = {}
 
 # Agents with no heartbeat for this many seconds are auto-marked offline
 HEARTBEAT_TIMEOUT_S = 60
@@ -109,6 +124,12 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
                 else prev.get("has_extra_usage_enabled")
             ),
             "subscription_created_at": info.get("subscription_created_at") or prev.get("subscription_created_at") or "",
+            # scitex-orochi#144 fix path 4: how many WebSocket sessions are
+            # currently authenticated under this agent name. > 1 indicates
+            # a concurrent-instance race situation worth surfacing in the
+            # dashboard. The set of connection IDs is held separately in
+            # ``_connections`` and counted on read.
+            "active_sessions": _active_session_count(name),
             # Quota telemetry from statusline parsing
             "quota_5h_pct": (
                 info.get("quota_5h_pct")
@@ -251,12 +272,85 @@ def update_heartbeat(name: str, metrics: dict | None = None) -> None:
                 _agents[name]["metrics"] = metrics
 
 
+def register_connection(name: str, conn_id: str) -> int:
+    """Track a new WebSocket connection for ``name``.
+
+    Returns the resulting active-session count (i.e. how many connections
+    this agent now has, including the one just registered). The caller
+    can use this to detect concurrent-instance race situations
+    (scitex-orochi#144 fix path 4) and emit visibility warnings when
+    the count is > 1.
+
+    Connections are stored as opaque IDs in a per-agent set; passing the
+    same ``conn_id`` twice is a no-op (idempotent).
+    """
+    if not name or not conn_id:
+        return 0
+    with _lock:
+        conns = _connections.setdefault(name, set())
+        conns.add(conn_id)
+        return len(conns)
+
+
+def unregister_connection(name: str, conn_id: str) -> int:
+    """Remove a WebSocket connection for ``name``.
+
+    Returns the resulting active-session count after removal. When the
+    count reaches zero, the agent is marked offline (caller need not
+    invoke ``unregister_agent`` separately). When the count is still
+    >0 (a sibling session is still alive), the agent remains online.
+
+    This is the fix for the symmetric half of scitex-orochi#144: before
+    this change, the first-to-disconnect of N sibling sessions would
+    mark the agent offline even though other sessions were still alive.
+    """
+    if not name or not conn_id:
+        return _active_session_count(name)
+    with _lock:
+        conns = _connections.get(name)
+        if conns:
+            conns.discard(conn_id)
+            if not conns:
+                _connections.pop(name, None)
+        remaining = len(_connections.get(name, ()))
+        if remaining == 0 and name in _agents:
+            _agents[name]["status"] = "offline"
+            _agents[name]["offline_since"] = time.time()
+        return remaining
+
+
+def _active_session_count(name: str) -> int:
+    """Return the active-session count for ``name`` without acquiring the lock.
+
+    Caller must hold ``_lock`` if reading inside another locked region;
+    used internally + by ``get_agents()``.
+    """
+    return len(_connections.get(name, ()))
+
+
+def active_session_count(name: str) -> int:
+    """Public read of the active-session count for ``name`` (lock-acquiring)."""
+    with _lock:
+        return _active_session_count(name)
+
+
 def unregister_agent(name: str) -> None:
-    """Mark agent as offline and record the time it went offline."""
+    """Mark agent as offline and record the time it went offline.
+
+    Compatibility shim: pre-#144, ``AgentConsumer.disconnect()`` called
+    this directly. New flow uses ``unregister_connection(name, conn_id)``
+    which handles the offline transition only when the LAST connection
+    drops. This function preserves the old contract for callers that
+    don't have a connection_id (registry pruning, manual marking, etc.).
+    """
     with _lock:
         if name in _agents:
             _agents[name]["status"] = "offline"
             _agents[name]["offline_since"] = time.time()
+        # Also clear any tracked connections; this is the "force offline"
+        # semantic. If the caller meant a single-session disconnect, they
+        # should use unregister_connection instead.
+        _connections.pop(name, None)
 
 
 def _cleanup_locked() -> None:
@@ -295,6 +389,11 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
     """
     with _lock:
         _cleanup_locked()
+        # Refresh active_sessions on read so the count reflects the latest
+        # connect/disconnect events, not just the last register call.
+        # scitex-orochi#144 fix path 4.
+        for n, a in _agents.items():
+            a["active_sessions"] = _active_session_count(n)
         agents = list(_agents.values())
     if workspace_id is not None:
         agents = [a for a in agents if a.get("workspace_id") == workspace_id]
@@ -390,6 +489,10 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                     else None
                 ),
                 "metrics": a.get("metrics", {}),
+                # scitex-orochi#144 fix path 4: number of WebSocket
+                # sessions currently authenticated under this name.
+                # >1 indicates a concurrent-instance race situation.
+                "active_sessions": int(a.get("active_sessions", 0) or 0),
                 "current_task": a.get("current_task", ""),
                 "last_message_preview": a.get("last_message_preview", ""),
                 "subagents": list(a.get("subagents", [])),

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -1829,3 +1829,134 @@ class AgentDetailApiTest(TestCase):
         self.assertNotIn("sk-ant-api03-ABCDEFGHIJKLMNOPQRST", out)
         self.assertIn("[REDACTED]", out)
         self.assertEqual(redact_secrets(""), "")
+
+
+# scitex-orochi#144 fix path 4 — active session counter regression tests
+class ActiveSessionCounterTests(TestCase):
+    """Tests for per-agent active WebSocket session tracking.
+
+    Background: a single SCITEX_OROCHI_AGENT identity may have multiple
+    WebSocket connections at once (today's incident: head-spartan twice).
+    Before #144, the first-to-disconnect of N siblings marked the agent
+    offline, even though other sessions were still alive. After #144,
+    the agent transitions to offline only when the LAST connection drops.
+    """
+
+    def setUp(self):
+        # Reset registry state per test
+        from hub.registry import _agents, _connections
+        _agents.clear()
+        _connections.clear()
+
+    def test_register_connection_increments_count(self):
+        from hub.registry import register_agent, register_connection, active_session_count
+
+        register_agent("head-spartan", 1, {})
+        self.assertEqual(active_session_count("head-spartan"), 0)
+
+        n = register_connection("head-spartan", "conn-A")
+        self.assertEqual(n, 1)
+        self.assertEqual(active_session_count("head-spartan"), 1)
+
+        n = register_connection("head-spartan", "conn-B")
+        self.assertEqual(n, 2)
+        self.assertEqual(active_session_count("head-spartan"), 2)
+
+    def test_register_connection_idempotent(self):
+        from hub.registry import register_connection, active_session_count
+
+        register_connection("agent-X", "conn-A")
+        register_connection("agent-X", "conn-A")
+        register_connection("agent-X", "conn-A")
+        self.assertEqual(active_session_count("agent-X"), 1)
+
+    def test_disconnect_one_of_many_keeps_agent_online(self):
+        from hub.registry import (
+            _agents,
+            register_agent,
+            register_connection,
+            unregister_connection,
+        )
+
+        register_agent("head-spartan", 1, {})
+        register_connection("head-spartan", "conn-A")
+        register_connection("head-spartan", "conn-B")
+        self.assertEqual(_agents["head-spartan"]["status"], "online")
+
+        # Disconnect ONE sibling
+        remaining = unregister_connection("head-spartan", "conn-A")
+        self.assertEqual(remaining, 1)
+
+        # Agent must still be online — symmetric pre-#144 bug regression
+        self.assertEqual(_agents["head-spartan"]["status"], "online")
+
+    def test_disconnect_last_marks_offline(self):
+        from hub.registry import (
+            _agents,
+            register_agent,
+            register_connection,
+            unregister_connection,
+        )
+
+        register_agent("head-spartan", 1, {})
+        register_connection("head-spartan", "conn-A")
+
+        remaining = unregister_connection("head-spartan", "conn-A")
+        self.assertEqual(remaining, 0)
+        self.assertEqual(_agents["head-spartan"]["status"], "offline")
+        self.assertIn("offline_since", _agents["head-spartan"])
+
+    def test_get_agents_exposes_active_sessions(self):
+        from hub.registry import (
+            register_agent,
+            register_connection,
+            get_agents,
+        )
+
+        register_agent("head-spartan", 1, {})
+        register_connection("head-spartan", "conn-A")
+        register_connection("head-spartan", "conn-B")
+
+        agents = get_agents(workspace_id=1)
+        # find our agent
+        found = next((a for a in agents if a["name"] == "head-spartan"), None)
+        self.assertIsNotNone(found)
+        self.assertEqual(found["active_sessions"], 2)
+
+    def test_get_agents_active_sessions_zero_when_no_connections(self):
+        from hub.registry import register_agent, get_agents
+
+        register_agent("solo-agent", 1, {})
+        agents = get_agents(workspace_id=1)
+        found = next((a for a in agents if a["name"] == "solo-agent"), None)
+        self.assertIsNotNone(found)
+        self.assertEqual(found["active_sessions"], 0)
+
+    def test_unregister_agent_force_offline_clears_connections(self):
+        """unregister_agent (the legacy/force-offline path) clears connections too."""
+        from hub.registry import (
+            register_agent,
+            register_connection,
+            unregister_agent,
+            active_session_count,
+            _agents,
+        )
+
+        register_agent("head-spartan", 1, {})
+        register_connection("head-spartan", "conn-A")
+        register_connection("head-spartan", "conn-B")
+        self.assertEqual(active_session_count("head-spartan"), 2)
+
+        unregister_agent("head-spartan")
+        self.assertEqual(active_session_count("head-spartan"), 0)
+        self.assertEqual(_agents["head-spartan"]["status"], "offline")
+
+    def test_empty_or_invalid_args_safe(self):
+        from hub.registry import register_connection, unregister_connection
+
+        # Empty/None args do not raise + do not mutate state
+        self.assertEqual(register_connection("", "conn"), 0)
+        self.assertEqual(register_connection("agent", ""), 0)
+        self.assertEqual(register_connection(None, None), 0)  # type: ignore[arg-type]
+        self.assertEqual(unregister_connection("", "conn"), 0)
+        self.assertEqual(unregister_connection("agent", ""), 0)

--- a/src/scitex_orochi/_skills/scitex-orochi/pane-state-patterns.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/pane-state-patterns.md
@@ -134,6 +134,48 @@ Do not auto-retry — capture pane, post to `#escalation`, let a human route.
 ```
 Or `tmux capture-pane` returns empty. Claude exited, shell prompt or blank. Action: autostart unit should respawn; if autostart fails, escalate.
 
+## Session-existence preflight — `tmux ls`, not `screen -ls`
+
+Added 2026-04-15 after `mamba-healer-mba` msg #12799 false-alarmed
+"MBA fleet down — all 12 agents + screen sessions gone" while all 12
+tmux sessions were in fact alive.
+
+Before any pane-state classification, a healer must first confirm
+the session exists. The session-existence check must use the same
+multiplexer the agents are actually running in:
+
+- scitex-agent-container defaults to `multiplexer: tmux` since v0.7.
+  Session-existence check: **`tmux ls`**.
+- `screen -ls` is only valid on hosts where an agent's YAML explicitly
+  sets `multiplexer: screen`. On all other hosts (MBA included) the
+  screen socket is empty and `screen -ls` reports "No Sockets found",
+  which is **not** evidence that the agents are dead.
+
+Contract for any liveness probe:
+
+1. **Primary signal**: `tmux ls` (or `screen -ls` iff the agent's
+   configured multiplexer is screen). If the expected session name is
+   present, the session exists. Classify pane state from here.
+2. **Secondary signal only**: `scitex-agent-container list` output.
+   Treat an empty list as a **hypothesis** to cross-check with the
+   primary signal, never as ground truth. A stale / crashed
+   scitex-agent-container list command can return an empty list while
+   the underlying sessions are fine.
+3. **Never escalate** a "fleet down" classification on the secondary
+   signal alone. If `tmux ls` shows the session, the session is alive;
+   post-fix the probe code instead of the fleet.
+4. If the probe cannot reach the multiplexer at all (e.g. SSH is
+   down), classify the **host** as unreachable — not the individual
+   sessions as dead. The agents inside an unreachable host cannot be
+   probed, and "can't probe" is distinct from "confirmed dead"
+   (rule #11 absence-of-response still applies for DM-based probes,
+   but the host layer is a separate question).
+
+A healer that short-circuits this preflight will false-alarm ywatanabe
+and the heads, waste fleet attention on a non-incident, and risk
+triggering a destructive "restart everything" response. Always two
+signals, primary-before-secondary, before classifying a host as down.
+
 ## Scrollback false-positive guard — strict last-N-lines window
 
 Added 2026-04-14 after `mamba-healer-mba` msg #10865. Regexes must match against the **last 5 lines** of `tmux capture-pane -p -S -5`, not the full scrollback buffer.


### PR DESCRIPTION
Implements scitex-orochi#144 fix path 4. Per-agent WebSocket session tracking exposes active_sessions field via get_agents(); >1 indicates concurrent-instance race. 8 regression tests pass. Pre-existing 9 AuthTest URL-routing errors are unrelated.