### PR TITLE
feat(hub): expose mcp_json in agent registry + api_agent_detail (todo#460 backend)

### DIFF
--- a/hub/registry.py
+++ b/hub/registry.py
@@ -97,6 +97,11 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             "pane_tail": info.get("pane_tail") or prev.get("pane_tail") or "",
             "pane_tail_block": info.get("pane_tail_block") or prev.get("pane_tail_block") or "",
             "claude_md_head": info.get("claude_md_head") or prev.get("claude_md_head") or "",
+            # todo#460: full .mcp.json content for the Agents tab file viewer.
+            # agent_meta.py --push (dotfiles PR #71) sends a size-capped,
+            # token-redacted copy of the workspace `.mcp.json`. Absent for
+            # legacy WS-only agents; falls through to the empty string.
+            "mcp_json": info.get("mcp_json") or prev.get("mcp_json") or "",
             "mcp_servers": (
                 list(info.get("mcp_servers"))
                 if isinstance(info.get("mcp_servers"), (list, tuple))
@@ -514,6 +519,7 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "pane_tail": a.get("pane_tail", ""),
                 "pane_tail_block": a.get("pane_tail_block", ""),
                 "claude_md_head": a.get("claude_md_head", ""),
+                "mcp_json": a.get("mcp_json", ""),
                 "mcp_servers": list(a.get("mcp_servers") or []),
                 # todo#265: OAuth account public metadata. Whitelist
                 # only — no tokens, credentials, or secrets are ever

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -150,6 +150,7 @@ def api_agent_detail(request, name: str):
           "last_heartbeat": iso8601 | None,
           "liveness": str,
           "claude_md": str,
+          "mcp_json": str,
           "pane_text": str,
           "pane_text_source": "cached" | "unavailable",
           "channel_subs": [str, ...],
@@ -199,6 +200,11 @@ def api_agent_detail(request, name: str):
         "last_heartbeat": agent.get("last_heartbeat"),
         "liveness": agent.get("liveness") or agent.get("status") or "unknown",
         "claude_md": redact_secrets(agent.get("claude_md") or ""),
+        # todo#460: serve the workspace .mcp.json for the Agents tab viewer.
+        # agent_meta.py --push (dotfiles PR #71) already redacts SCITEX_OROCHI_TOKEN
+        # and similar secrets before pushing, but we redact again defense-in-depth
+        # so any future push path that forgets still stays safe.
+        "mcp_json": redact_secrets(agent.get("mcp_json") or ""),
         "pane_text": pane_text,
         "pane_text_source": pane_text_source,
         "channel_subs": sorted({c for c in (agent.get("channels") or []) if c}),


### PR DESCRIPTION
## Summary

Hub-side complement to [dotfiles PR #71](https://github.com/ywatanabe1989/.dotfiles/pull/71) (head-mba), which extended `agent_meta.py --push` to send a size-capped, token-redacted copy of each agent's workspace `.mcp.json`. This PR wires that new field through the hub registry and out to the Agents-tab file viewer API.

## Changes

- `hub/registry.py` `register_agent()`: persist `mcp_json` with the same info/prev fallback chain used for `claude_md_head` and other agent_meta-pushed fields. Absent for legacy WS-only agents → empty string.
- `hub/registry.py` `get_agents()`: surface `mcp_json` in the dict returned to callers.
- `hub/views/agent_detail.py` `api_agent_detail()`: include `mcp_json` in the payload under `redact_secrets()` (defense-in-depth — `agent_meta.py` already redacts on the push side, but double-redact in case a future push path forgets).
- Docstring updated with the new key.

**+12 lines.** Additive only.

## Smoke test (post-merge on MBA)

```
curl -s -H "Authorization: Bearer $SCITEX_OROCHI_TOKEN" \
  https://scitex-orochi.com/api/agents/head-nas \
  | jq '{name, claude_md_len: (.claude_md | length), mcp_json_len: (.mcp_json | length)}'
```

Once agent_meta.py heartbeats on each host (30s tick), `mcp_json_len` populates to non-zero. Before the first post-PR#71 heartbeat, returns empty string (legacy-safe).

## Out of scope

- **Frontend Agents-tab card render** of the two file sections (CLAUDE.md markdown + `.mcp.json` JSON syntax highlight) → head-ywata-note-win lane post-WSL-recovery. Backend is callable via `GET /api/agents/<name>` today; the viewer UI layers on top.
- **Full terminal + state + metadata card** (parent [todo#420](https://github.com/ywatanabe1989/todo/issues/420)) → deferred.

## Refs

- [todo#460](https://github.com/ywatanabe1989/todo/issues/460) (MVD file viewer split from #420)
- [dotfiles PR #71](https://github.com/ywatanabe1989/.dotfiles/pull/71) (agent_meta push side, head-mba)
- scitex-orochi#155 + #265 (earlier agent_meta field additions this endpoint mirrors)
- Pulled autonomously per ywatanabe msg#13054 (full-throttle TODO consumption directive)