### PR TITLE
feat(ui): .mcp.json viewer in Agents tab per-agent page (todo#460 frontend)

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -87,6 +87,11 @@ function _renderAgentDetail(a) {
   var currentTask = d.current_task || a.current_task || "";
   var channels = d.channel_subs || a.channels || [];
   var claudeMd = d.claude_md || a.claude_md || "";
+  /* todo#460: .mcp.json is served by the detail endpoint only (not in the
+   * registry summary row). Empty string = agent has not yet heartbeated
+   * with dotfiles PR#71 agent_meta.py --push; we render an explicit
+   * empty-state so the absence is discoverable rather than invisible. */
+  var mcpJson = d.mcp_json || "";
   var mcpServers = d.mcp_servers || a.mcp_servers || [];
   /* pane_text from the detail endpoint is already redacted; the
    * registry fallback (pane_tail_block / pane_tail) is NOT, so prefer
@@ -139,6 +144,37 @@ function _renderAgentDetail(a) {
       "</div>"
     : "";
 
+  /* todo#460: .mcp.json viewer. Collapsed by default so the per-agent
+   * card stays scannable — users opt in when they actually need to
+   * inspect the agent's MCP wiring. Content is already redacted
+   * server-side (redact_secrets); we pretty-print best-effort but fall
+   * back to the raw string on JSON.parse failure so a future schema
+   * change never blanks the viewer. */
+  var mcpJsonPretty = mcpJson;
+  if (mcpJson) {
+    try {
+      mcpJsonPretty = JSON.stringify(JSON.parse(mcpJson), null, 2);
+    } catch (_e) {
+      mcpJsonPretty = mcpJson;
+    }
+  }
+  var mcpJsonBodyHtml = mcpJson
+    ? '<pre class="agent-detail-mcp-json">' + escapeHtml(mcpJsonPretty) + "</pre>"
+    : '<div class="agent-detail-mcp-json-empty muted-cell">' +
+      "No .mcp.json (agent has not heartbeated with agent_meta.py yet)" +
+      "</div>";
+  var mcpJsonHtml =
+    '<div class="agent-detail-section">' +
+    '<details class="agent-detail-mcp-json-wrap"' +
+    (mcpJson ? "" : " open") +
+    ">" +
+    '<summary class="agent-detail-pane-label agent-detail-mcp-json-summary">' +
+    ".mcp.json" +
+    "</summary>" +
+    mcpJsonBodyHtml +
+    "</details>" +
+    "</div>";
+
   var channelsHtml = "";
   if (channels && channels.length) {
     var unique = [...new Set(channels)];
@@ -168,6 +204,7 @@ function _renderAgentDetail(a) {
     channelsHtml +
     mcpHtml +
     claudeMdHtml +
+    mcpJsonHtml +
     "</div>"
   );
 }

--- a/hub/static/hub/components.css
+++ b/hub/static/hub/components.css
@@ -657,6 +657,40 @@
   overflow-y: auto;
   border: 1px solid #333;
 }
+/* todo#460: .mcp.json viewer — sits next to CLAUDE.md in the per-agent
+ * detail view. Collapsible via native <details>/<summary> so it defaults
+ * to hidden when populated (JSON can be long); the summary is styled to
+ * match .agent-detail-pane-label with an added caret affordance. */
+.agent-detail-mcp-json-wrap {
+  margin-top: 4px;
+}
+.agent-detail-mcp-json-summary {
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.agent-detail-mcp-json-summary:hover {
+  color: #9ecbff;
+}
+.agent-detail-mcp-json {
+  background: #0d1117;
+  color: #c9d1d9;
+  padding: 12px;
+  border-radius: 6px;
+  white-space: pre;
+  font-family: monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  max-height: 300px;
+  overflow: auto;
+  border: 1px solid #333;
+  margin-top: 4px;
+}
+.agent-detail-mcp-json-empty {
+  font-size: 12px;
+  padding: 8px 12px;
+  margin-top: 4px;
+}
 /* todo#420: per-agent detail header actions (DM quick-action) + pane source badge */
 .agent-detail-actions {
   float: right;


### PR DESCRIPTION
## Summary

Frontend half of todo#460. Mirrors the existing CLAUDE.md viewer pattern in the Agents tab per-agent detail view to render the newly-exposed \`mcp_json\` field from \`/api/agents/<name>/detail\` (backend shipped in PR #169, commit ce9c07f). The viewer sits next to the CLAUDE.md block, is collapsible via native \`<details>\`/\`<summary>\` (defaulted to closed when populated — JSON payloads would otherwise dominate the card), pretty-prints the JSON with a safe raw-string fallback on parse failure, and renders an explicit empty-state for legacy agents that have not yet heartbeated via dotfiles PR#71 \`agent_meta.py --push\`.

## Changes

- \`hub/static/hub/agents-tab.js\` (+37 lines) — read \`d.mcp_json\` from the detail response in \`_renderAgentDetail\`, pretty-print with try/catch fallback, emit a \`<details>\`-wrapped \`<pre>\` block appended after \`claudeMdHtml\`.
- \`hub/static/hub/components.css\` (+34 lines) — \`.agent-detail-mcp-json\` / \`.agent-detail-mcp-json-wrap\` / \`.agent-detail-mcp-json-summary\` / \`.agent-detail-mcp-json-empty\`, styled to match the existing pane/claude-md blocks (monospace, dark background, 300px max-height, hover affordance on the summary).

No backend changes. No new dependencies. No refactor of the existing CLAUDE.md viewer.

## Test plan

- [x] \`node --check hub/static/hub/agents-tab.js\` passes
- [x] Diff reviewed — data path matches backend contract (\`mcp_json: str\` per PR #169 \`api_agent_detail\` response shape)
- [x] Empty-state message rendered when \`mcp_json\` is empty or missing (legacy / pre-heartbeat agents)
- [x] JSON pretty-printer has raw-string fallback so malformed payloads still render
- [x] Content trusted to be redacted server-side (\`redact_secrets()\`); no client-side scrubbing layered on top
- [ ] Live smoke test on production hub after merge — navigate to Agents tab → click into an agent that has heartbeated post-PR#71 (e.g. \`head-nas\`), verify the \`.mcp.json\` summary expands to show pretty-printed JSON
- [ ] Live smoke test on a legacy / pre-heartbeat agent — verify the empty-state muted message renders instead of an empty box

## Refs

- todo#460 (the feature request)
- PR #169 / commit ce9c07f — backend half (exposed \`mcp_json\` in \`api_agent_detail\`)
- dotfiles PR#71 — \`agent_meta.py --push\` reads and redacts the workspace \`.mcp.json\` before pushing to the hub

## Not in scope

- No \"show secrets\" toggle (backend already redacts defense-in-depth per \`agent_detail.py\` L203-207).
- No full per-agent page redesign (todo#420 track).
- No refactor of the existing CLAUDE.md viewer beyond placing \`.mcp.json\` next to it.