### PR TITLE
fix(urls): /api/todo/stats/ trailing slash + route mirror (#171)

### DIFF
--- a/hub/urls.py
+++ b/hub/urls.py
@@ -128,8 +128,8 @@ urlpatterns = [
     ),
     path("api/threads/", views.api_threads, name="api-threads"),
     path("api/resources/", views.api_resources, name="api-resources"),
-    # TODO stats (scitex-orochi#171)
-    path("api/todo/stats", _todo_stats_view.api_todo_stats, name="api-todo-stats"),
+    # TODO stats (scitex-orochi#171) — trailing slash to match fleet convention
+    path("api/todo/stats/", _todo_stats_view.api_todo_stats, name="api-todo-stats"),
     # Discovery
     path("api/discover/", views.api_discover, name="api-discover"),
     # File upload

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -6,6 +6,7 @@ from django.urls import include, path, re_path
 from django.views.static import serve as static_serve
 
 from hub import views
+from hub.views import todo_stats as _todo_stats_view
 
 _media_url = settings.MEDIA_URL.strip("/")
 
@@ -113,4 +114,7 @@ urlpatterns = [
     # Public status page (issue #75)
     path("status/", views.status_page, name="status"),
     path("api/status/", views.api_status, name="api-status"),
+    # TODO stats (scitex-orochi#171) — bare domain mirror so MCP sidecars +
+    # localhost clients can reach the endpoint without subdomain routing.
+    path("api/todo/stats/", _todo_stats_view.api_todo_stats, name="api-todo-stats"),
 ]

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -9,6 +9,7 @@ from django.urls import include, path, re_path
 from django.views.static import serve as _serve_media
 
 from hub import views
+from hub.views import todo_stats as _todo_stats_view
 
 _sw_js_path = os.path.join(os.path.dirname(__file__), "static", "hub", "sw.js")
 
@@ -95,6 +96,7 @@ urlpatterns = [
     ),
     path("api/threads/", views.api_threads, name="api-threads"),
     path("api/resources/", views.api_resources, name="api-resources"),
+    path("api/todo/stats/", _todo_stats_view.api_todo_stats, name="api-todo-stats"),
     path("api/config/", views.api_config, name="api-config"),
     # Discovery
     path("api/discover/", views.api_discover, name="api-discover"),


### PR DESCRIPTION
Fix 404 on /api/todo/stats (mamba-verifier-mba msg#13150 catch). Trailing slash + mirror to urls_workspace + urls_bare.