### PR TITLE
fix(ui): render own posts during voice dictation (#172)

### DIFF
--- a/hub/static/hub/chat.js
+++ b/hub/static/hub/chat.js
@@ -344,8 +344,22 @@ function appendMessage(msg) {
   /* Voice-recording guard: defer the DOM update to avoid interrupting the
    * Web Speech API SpeechRecognition session. Scroll and layout changes
    * during active recording can cause the browser to abort recognition.
-   * The queue is flushed by _flushVoiceQueue() when recording stops. */
-  if (window.isVoiceRecording) {
+   * The queue is flushed by _flushVoiceQueue() when recording stops.
+   *
+   * Exception (scitex-orochi#172): render the user's OWN echoed post
+   * immediately even during continuous dictation. Deferring own-posts made
+   * the feed look frozen after Ctrl+Enter-send-while-dictating — ywatanabe's
+   * primary voice workflow (msg#6500/#6504 + msg#13124). Auto-scroll is
+   * already suppressed during recording (see the `!window.isVoiceRecording`
+   * guard in the appendChild block below) and focus is restored after the
+   * DOM write, so the layout shift from rendering one own-post is tolerable
+   * for recognition. Other agents' / other users' messages continue to be
+   * deferred to keep the feed quiet during dictation. */
+  var _ownPostDuringVoice =
+    window.isVoiceRecording &&
+    typeof userName !== "undefined" &&
+    msg.sender === userName;
+  if (window.isVoiceRecording && !_ownPostDuringVoice) {
     _voiceDeferQueue.push(msg);
     return;
   }


### PR DESCRIPTION
## Summary

Hypothesis 1 + 3 combined was the root cause. During continuous voice
dictation, the user's own echoed post was being pushed onto
`_voiceDeferQueue` and never rendered until they manually stopped the
mic — so the feed looked frozen. Fix: bypass the defer queue for
messages where `msg.sender === userName`, so own-posts render
immediately while foreign messages continue to defer for
recognition-safety.

## Root cause

`hub/static/hub/chat.js:348` — `appendMessage()` unconditionally
queues every message when `window.isVoiceRecording` is true.
`hub/static/hub/voice-input.js:259-271` — `voiceInputResetAfterSend()`
(called by `sendMessage()` at `chat.js:1150`) calls `recognition.stop()`
with `_restartAfterStop=true`, which takes the restart branch at
`voice-input.js:114-119` and creates a fresh recognition instance
**without** going through `_setStoppedUI()`. Since `_setStoppedUI()`
is the only caller of `_flushVoiceQueue()` (voice-input.js:70-72),
the flag stays `true` across the entire continuous-dictation session
and own-posts never appear in the feed.

## Changes

- `hub/static/hub/chat.js` — 16 lines (mostly comment): new
  `_ownPostDuringVoice` check that lets `msg.sender === userName`
  bypass the defer queue. Foreign-sender messages still defer. Focus
  restore (chat.js:822-831) and auto-scroll suppression (chat.js:819)
  are already in place, so the single own-post `appendChild` is
  recognition-safe.

## Test plan

1. Open Orochi UI in Chrome/Edge devtools (Network → WS → Messages).
2. Click the mic button, start dictating — textarea fills with
   transcription.
3. Press Ctrl+Enter (or Alt+Enter) to send while still dictating.
4. **Expected:** within ~1 s the sent message appears in the feed
   under your own sender name. The mic stays red (continuous
   dictation continues), the textarea is cleared, and you can keep
   dictating the next message.
5. **Regression check:** during dictation, a message from another
   agent should NOT render until you stop the mic (foreign senders
   still defer — this preserves the original recognition-stability
   guard).
6. **Non-voice regression:** send a text message with the mic off —
   should render immediately as before.

## Refs

- Fixes scitex-orochi#172
- Related class: todo#451 (WS reconnect subscription orphan — same
  "event handler stops firing" family, but independent root cause)
- Context: msg#6500 / msg#6504 (continuous-dictation workflow
  established), msg#13124 (bug report)