### PR TITLE
feat(hub): expose pane_state + stuck_prompt_text (todo#418 backend)

### DIFF
--- a/hub/registry.py
+++ b/hub/registry.py
@@ -102,6 +102,17 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             # token-redacted copy of the workspace `.mcp.json`. Absent for
             # legacy WS-only agents; falls through to the empty string.
             "mcp_json": info.get("mcp_json") or prev.get("mcp_json") or "",
+            # todo#418: agent decision-transparency fields for the Agents tab.
+            # `pane_state` is the classifier label (`running` / `waiting` /
+            # `y_n_prompt` / `compose_pending_unsent` / `auth_error` / etc.)
+            # computed by agent_meta.py --push using the same classifiers
+            # fleet-prompt-actuator uses (scitex_agent_container.runtimes.
+            # prompts + detect_compose_pending). `stuck_prompt_text` carries
+            # the verbatim prompt so ywatanabe / dashboard viewers can see
+            # what the agent is blocked on. Both empty when agent_meta can't
+            # classify or the agent is a legacy WS-only pusher.
+            "pane_state": info.get("pane_state") or prev.get("pane_state") or "",
+            "stuck_prompt_text": info.get("stuck_prompt_text") or prev.get("stuck_prompt_text") or "",
             "mcp_servers": (
                 list(info.get("mcp_servers"))
                 if isinstance(info.get("mcp_servers"), (list, tuple))
@@ -520,6 +531,8 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "pane_tail_block": a.get("pane_tail_block", ""),
                 "claude_md_head": a.get("claude_md_head", ""),
                 "mcp_json": a.get("mcp_json", ""),
+                "pane_state": a.get("pane_state", ""),
+                "stuck_prompt_text": a.get("stuck_prompt_text", ""),
                 "mcp_servers": list(a.get("mcp_servers") or []),
                 # todo#265: OAuth account public metadata. Whitelist
                 # only — no tokens, credentials, or secrets are ever

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -151,6 +151,8 @@ def api_agent_detail(request, name: str):
           "liveness": str,
           "claude_md": str,
           "mcp_json": str,
+          "pane_state": str,
+          "stuck_prompt_text": str,
           "pane_text": str,
           "pane_text_source": "cached" | "unavailable",
           "channel_subs": [str, ...],
@@ -205,6 +207,15 @@ def api_agent_detail(request, name: str):
         # and similar secrets before pushing, but we redact again defense-in-depth
         # so any future push path that forgets still stays safe.
         "mcp_json": redact_secrets(agent.get("mcp_json") or ""),
+        # todo#418: agent decision-transparency for the Agents tab.
+        # `pane_state` is the classifier label agent_meta.py --push
+        # computes (`running` / `compose_pending_unsent` /
+        # `y_n_prompt` / `auth_error` / etc.); `stuck_prompt_text`
+        # is the verbatim prompt the agent is blocked on (empty
+        # when `pane_state == running`). Both are redacted defense-
+        # in-depth.
+        "pane_state": agent.get("pane_state") or "",
+        "stuck_prompt_text": redact_secrets(agent.get("stuck_prompt_text") or ""),
         "pane_text": pane_text,
         "pane_text_source": pane_text_source,
         "channel_subs": sorted({c for c in (agent.get("channels") or []) if c}),


### PR DESCRIPTION
Hub-side backend for todo#418 Agents tab decision-transparency. Adds `pane_state` + `stuck_prompt_text` fields to registry + api_agent_detail. Populator (agent_meta.py --push extension) is a separate PR; frontend render is head-ywata-note-win lane. +19/-0.