### PR TITLE
feat(ui): UTC-at-rest, browser-locale-at-display for timestamps (#155)

### DIFF
--- a/hub/static/hub/init.js
+++ b/hub/static/hub/init.js
@@ -25,12 +25,16 @@
   }
 })();
 
-/* Wall clock for screenshot timestamps (#342) */
+/* Wall clock for screenshot timestamps (#342).
+ * Render in the user's browser locale (no hard-coded TZ) per #155:
+ * timestamps are UTC at rest on the hub, displayed in local TZ at the UI.
+ * Pass `undefined` for locale so Intl uses the browser default; omit
+ * timeZone so it falls back to the user's system TZ. */
 (function () {
   var el = document.getElementById("wall-clock");
   if (!el) return;
   function tick() {
-    el.textContent = new Date().toLocaleString("ja-JP", {
+    el.textContent = new Date().toLocaleString(undefined, {
       year: "numeric", month: "2-digit", day: "2-digit",
       hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false
     });


### PR DESCRIPTION
## Summary

Normalize the dashboard wall-clock to render in the user's browser
locale + TZ instead of hard-coded `ja-JP`, completing the
"UTC-at-rest, locale-at-display" contract called out in #155. After
auditing every timestamp path in this repo, this is the only display
site that was pinning a specific locale / TZ; all other paths already
store UTC and render with the browser default.

## Root cause

`hub/static/hub/init.js:33` passed `"ja-JP"` as the first argument to
`Date.prototype.toLocaleString`. That forces every visitor's wall-clock
to JST regardless of where they're viewing from (AEST on MBA/Spartan,
UTC on CI, anywhere else on end-users). The hub itself is already
correct — `orochi/settings.py:187-189` sets `TIME_ZONE="UTC"` +
`USE_TZ=True`, every `msg.ts.isoformat()` in `hub/views/api.py`,
`hub/consumers.py`, `hub/registry.py`, etc. emits a UTC-offset ISO-8601
string, and every other JS render site (`chat.js:379`, `app.js:746`
`timeAgo`, `agents-tab.js:397`, `resources-tab.js:260`,
`search-palette.js:188`, `todo-tab.js:32`) uses `new Date(iso)` plus
`toLocale*()` with no explicit locale, which Intl interprets as the
browser default. Agent-side emission (`src/scitex_orochi/_models.py:19`,
`_server.py:61,64`, `_workspaces.py`) uses
`datetime.now(timezone.utc).isoformat()`, also correct.

## Changes

- `hub/static/hub/init.js` — replace `toLocaleString("ja-JP", ...)`
  with `toLocaleString(undefined, ...)` in the wall-clock tick (+4
  lines of rationale comment). 1 file, 6 insertions, 2 deletions.

## Test plan

- [ ] Load dashboard from a JST-system browser → wall-clock shows
      `2026/04/16 13:45:22` (Japanese 2-digit format) as before.
- [ ] Load dashboard from an AEST-system browser → wall-clock shows
      `16/04/2026, 14:45:22` (or whatever the AU locale default is),
      ticking in Melbourne time rather than a 2h-offset JST clock.
- [ ] Load dashboard from a UTC-system browser → wall-clock ticks in
      UTC.
- [ ] Verify chat messages (`#general`, `#progress`) continue to show
      `fullTs` (title-tooltip on hover) in the viewer's local TZ —
      unchanged behavior, sanity check only.
- [ ] Verify `/api/messages/?channel=...` still returns ISO-8601 with
      `+00:00` offset (UTC) — unchanged server behavior.

## Refs

- scitex-orochi#155
- No new deps; no schema changes; diff is 4 net lines + comment.