### PR TITLE
feat(ui): TODO stats tab — burn-down + label breakdown + starvation (#171)

### DIFF
--- a/hub/static/hub/todo-tab.css
+++ b/hub/static/hub/todo-tab.css
@@ -188,3 +188,194 @@
 .todo-state-closed {
   background: #8b949e;
 }
+
+/* ==================================================================== */
+/* TODO stats dashboard (#171) — cards / chart / label bars / tables    */
+/* ==================================================================== */
+.todo-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #1e1e1e;
+  margin-bottom: 12px;
+}
+.todo-stats-cards {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.todo-stats-card {
+  flex: 1 1 120px;
+  min-width: 120px;
+  background: #1a1a1a;
+  border: 1px solid #222;
+  border-radius: 4px;
+  padding: 10px 14px;
+  text-align: center;
+}
+.todo-stats-val {
+  font-size: 22px;
+  font-weight: 600;
+  color: #ddd;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.todo-stats-lbl {
+  font-size: 10px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 2px;
+}
+.todo-stats-section {
+  background: #131313;
+  border: 1px solid #1e1e1e;
+  border-radius: 4px;
+  padding: 10px 12px;
+}
+.todo-stats-h {
+  font-size: 11px;
+  font-weight: 600;
+  color: #aaa;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 8px;
+}
+/* Burn-down chart */
+.todo-chart {
+  width: 100%;
+  height: 180px;
+  display: block;
+}
+.todo-chart-axis {
+  font-size: 9px;
+  fill: #666;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.todo-chart-grid {
+  stroke: #1f1f1f;
+  stroke-width: 1;
+}
+.todo-chart-line {
+  fill: none;
+  stroke-width: 1.5;
+}
+.todo-chart-opened-line {
+  stroke: #ef4444;
+}
+.todo-chart-closed-line {
+  stroke: #3fb950;
+}
+.todo-chart-legend {
+  font-size: 10px;
+  color: #888;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 4px;
+}
+.todo-chart-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+.todo-chart-swatch.todo-chart-opened {
+  background: #ef4444;
+}
+.todo-chart-swatch.todo-chart-closed {
+  background: #3fb950;
+}
+/* Label breakdown bar list */
+.todo-label-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.todo-label-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 30%) 1fr 40px;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+}
+.todo-label-name {
+  color: #ccc;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.todo-label-bar {
+  position: relative;
+  background: #1a1a1a;
+  height: 10px;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.todo-label-fill {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, #4ecdc4, #3fa29b);
+}
+.todo-label-count {
+  font-size: 10px;
+  color: #888;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+/* By-repo + starvation tables */
+.todo-repo-table,
+.todo-starve-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+.todo-repo-table th,
+.todo-starve-table th {
+  text-align: left;
+  color: #888;
+  font-weight: 500;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 4px 6px;
+  border-bottom: 1px solid #222;
+}
+.todo-repo-table td,
+.todo-starve-table td {
+  padding: 4px 6px;
+  color: #ccc;
+  border-bottom: 1px solid #1a1a1a;
+  vertical-align: top;
+}
+.todo-repo-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: #aaa;
+  white-space: nowrap;
+}
+.todo-starve-table a {
+  color: #4ecdc4;
+  text-decoration: none;
+}
+.todo-starve-table a:hover {
+  text-decoration: underline;
+}
+.todo-starve-table .todo-labels {
+  flex-wrap: wrap;
+  gap: 2px;
+}
+.todo-starve-table .todo-label {
+  background: #222;
+  color: #aaa;
+}

--- a/hub/static/hub/todo-tab.js
+++ b/hub/static/hub/todo-tab.js
@@ -424,3 +424,253 @@ function isLightColor(hex) {
   var luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
   return luminance > 0.5;
 }
+
+/* ================================================================== */
+/* TODO stats dashboard (#171) — totals / burn-down / label breakdown  */
+/* / by-repo / starvation. Backend: GET /api/todo/stats/ cached 60s.   */
+/* ================================================================== */
+
+var _todoStatsRefreshTimer = null;
+var _TODO_STATS_REFRESH_MS = 60 * 1000; /* matches backend CACHE_TTL_S */
+
+function _shortRepo(repo) {
+  if (!repo) return "";
+  var slash = repo.lastIndexOf("/");
+  return slash >= 0 ? repo.substring(slash + 1) : repo;
+}
+
+function _renderTodoStatsTotals(totals) {
+  var openN = (totals && totals.open) || 0;
+  var closedN = (totals && totals.closed) || 0;
+  var total = openN + closedN;
+  return (
+    '<div class="todo-stats-cards">' +
+    '<div class="todo-stats-card"><div class="todo-stats-val">' + openN + '</div>' +
+    '<div class="todo-stats-lbl">Open</div></div>' +
+    '<div class="todo-stats-card"><div class="todo-stats-val">' + closedN + '</div>' +
+    '<div class="todo-stats-lbl">Closed</div></div>' +
+    '<div class="todo-stats-card"><div class="todo-stats-val">' + total + '</div>' +
+    '<div class="todo-stats-lbl">Total</div></div>' +
+    "</div>"
+  );
+}
+
+/* Inline SVG burn-down: two polylines (opened, closed) over the window. */
+function _renderTodoStatsBurndown(daily) {
+  if (!daily || daily.length === 0) {
+    return '<p class="empty-notice">No velocity data</p>';
+  }
+  var W = 720, H = 180;
+  var padL = 32, padR = 12, padT = 12, padB = 24;
+  var innerW = W - padL - padR;
+  var innerH = H - padT - padB;
+  var n = daily.length;
+  var maxY = 1;
+  for (var i = 0; i < n; i++) {
+    if (daily[i].opened > maxY) maxY = daily[i].opened;
+    if (daily[i].closed > maxY) maxY = daily[i].closed;
+  }
+  /* Round maxY up for nicer axis */
+  var step = n > 1 ? innerW / (n - 1) : innerW;
+  function pt(i, v) {
+    var x = padL + i * step;
+    var y = padT + innerH - (v / maxY) * innerH;
+    return x.toFixed(1) + "," + y.toFixed(1);
+  }
+  var openedPath = daily.map(function (d, i) { return pt(i, d.opened); }).join(" ");
+  var closedPath = daily.map(function (d, i) { return pt(i, d.closed); }).join(" ");
+
+  /* Y-axis ticks at 0, maxY/2, maxY */
+  function yLabel(v) {
+    var y = padT + innerH - (v / maxY) * innerH;
+    return '<text class="todo-chart-axis" x="' + (padL - 4) + '" y="' + (y + 3) +
+           '" text-anchor="end">' + v + '</text>' +
+           '<line class="todo-chart-grid" x1="' + padL + '" x2="' + (W - padR) +
+           '" y1="' + y + '" y2="' + y + '"/>';
+  }
+  var yLabels =
+    yLabel(0) +
+    yLabel(Math.round(maxY / 2)) +
+    yLabel(maxY);
+
+  /* X-axis: show first, middle, last date */
+  function xLabel(i) {
+    if (i < 0 || i >= n) return "";
+    var x = padL + i * step;
+    var label = (daily[i].date || "").substring(5); /* MM-DD */
+    return '<text class="todo-chart-axis" x="' + x + '" y="' + (H - 6) +
+           '" text-anchor="middle">' + label + '</text>';
+  }
+  var xLabels = xLabel(0) + xLabel(Math.floor(n / 2)) + xLabel(n - 1);
+
+  return (
+    '<div class="todo-stats-section">' +
+    '<div class="todo-stats-h">Daily velocity (14d)</div>' +
+    '<div class="todo-chart-legend">' +
+    '<span class="todo-chart-swatch todo-chart-opened"></span>Opened ' +
+    '<span class="todo-chart-swatch todo-chart-closed"></span>Closed' +
+    "</div>" +
+    '<svg class="todo-chart" viewBox="0 0 ' + W + ' ' + H +
+    '" preserveAspectRatio="none" role="img" aria-label="Daily open/close velocity">' +
+    yLabels +
+    xLabels +
+    '<polyline class="todo-chart-line todo-chart-opened-line" points="' + openedPath + '"/>' +
+    '<polyline class="todo-chart-line todo-chart-closed-line" points="' + closedPath + '"/>' +
+    "</svg>" +
+    "</div>"
+  );
+}
+
+function _renderTodoStatsLabels(labels) {
+  if (!labels || labels.length === 0) {
+    return '<div class="todo-stats-section"><div class="todo-stats-h">Labels</div>' +
+           '<p class="empty-notice">No labels</p></div>';
+  }
+  var maxCount = labels[0].open_count || 1;
+  var rows = labels.map(function (l) {
+    var pct = Math.max(2, Math.round((l.open_count / maxCount) * 100));
+    return (
+      '<li class="todo-label-row">' +
+      '<span class="todo-label-name">' + escapeHtml(l.label) + "</span>" +
+      '<span class="todo-label-bar"><span class="todo-label-fill" style="width:' + pct + '%"></span></span>' +
+      '<span class="todo-label-count">' + l.open_count + "</span>" +
+      "</li>"
+    );
+  }).join("");
+  return (
+    '<div class="todo-stats-section">' +
+    '<div class="todo-stats-h">Labels (open, top ' + labels.length + ")</div>" +
+    '<ul class="todo-label-list">' + rows + "</ul>" +
+    "</div>"
+  );
+}
+
+function _renderTodoStatsByRepo(rows) {
+  if (!rows || rows.length === 0) {
+    return "";
+  }
+  var body = rows.map(function (r) {
+    return (
+      "<tr>" +
+      "<td>" + escapeHtml(_shortRepo(r.repo)) + "</td>" +
+      '<td class="todo-repo-num">' + (r.open || 0) + "</td>" +
+      '<td class="todo-repo-num">' + (r.closed || 0) + "</td>" +
+      "</tr>"
+    );
+  }).join("");
+  return (
+    '<div class="todo-stats-section">' +
+    '<div class="todo-stats-h">By repo</div>' +
+    '<table class="todo-repo-table">' +
+    "<thead><tr><th>Repo</th><th>Open</th><th>Closed</th></tr></thead>" +
+    "<tbody>" + body + "</tbody>" +
+    "</table>" +
+    "</div>"
+  );
+}
+
+function _renderTodoStatsStarvation(rows, threshold) {
+  if (!rows || rows.length === 0) {
+    return '<div class="todo-stats-section"><div class="todo-stats-h">Starvation</div>' +
+           '<p class="empty-notice">Nothing stale — good job</p></div>';
+  }
+  var body = rows.map(function (r) {
+    var labels = (r.labels || []).map(function (n) {
+      return '<span class="todo-label">' + escapeHtml(n) + "</span>";
+    }).join("");
+    return (
+      "<tr>" +
+      "<td>" + escapeHtml(_shortRepo(r.repo)) + "</td>" +
+      '<td class="todo-repo-num">#' + escapeHtml(String(r.number)) + "</td>" +
+      '<td><a href="' + escapeHtml(r.url || "#") + '" target="_blank" rel="noopener">' +
+        escapeHtml(r.title || "") + "</a></td>" +
+      '<td class="todo-repo-num">' + (r.age_days || 0) + "d</td>" +
+      '<td><div class="todo-labels">' + labels + "</div></td>" +
+      "</tr>"
+    );
+  }).join("");
+  return (
+    '<div class="todo-stats-section">' +
+    '<div class="todo-stats-h">Starvation (open &gt; ' + (threshold || 7) +
+      "d, top " + rows.length + ")</div>" +
+    '<table class="todo-starve-table">' +
+    "<thead><tr><th>Repo</th><th>#</th><th>Title</th><th>Age</th><th>Labels</th></tr></thead>" +
+    "<tbody>" + body + "</tbody>" +
+    "</table>" +
+    "</div>"
+  );
+}
+
+function _renderTodoStats(data) {
+  var container = document.getElementById("todo-stats");
+  if (!container) return;
+  if (!data) {
+    container.innerHTML = '<p class="empty-notice">No TODO stats available</p>';
+    return;
+  }
+  var html =
+    _renderTodoStatsTotals(data.totals) +
+    _renderTodoStatsBurndown(data.daily_velocity) +
+    _renderTodoStatsLabels(data.label_breakdown) +
+    _renderTodoStatsByRepo(data.by_repo) +
+    _renderTodoStatsStarvation(data.starvation, data.starvation_threshold_days);
+  container.innerHTML = html;
+}
+
+async function fetchTodoStats(force) {
+  var container = document.getElementById("todo-stats");
+  if (!container) return;
+  if (!container.innerHTML) {
+    container.innerHTML = '<p class="empty-notice">Loading TODO stats...</p>';
+  }
+  try {
+    var url = "/api/todo/stats/" + (force ? "?refresh=1" : "");
+    var res = await fetch(url, { credentials: "same-origin" });
+    if (!res.ok) {
+      container.innerHTML =
+        '<p class="empty-notice">Failed to load TODO stats (HTTP ' + res.status + ")</p>";
+      return;
+    }
+    var data = await res.json();
+    _renderTodoStats(data);
+  } catch (e) {
+    console.error("TODO stats fetch error:", e);
+    container.innerHTML =
+      '<p class="empty-notice">Failed to load TODO stats</p>';
+  }
+}
+
+function startTodoStatsAutoRefresh() {
+  if (_todoStatsRefreshTimer) return;
+  _todoStatsRefreshTimer = setInterval(fetchTodoStats, _TODO_STATS_REFRESH_MS);
+}
+
+function stopTodoStatsAutoRefresh() {
+  if (_todoStatsRefreshTimer) {
+    clearInterval(_todoStatsRefreshTimer);
+    _todoStatsRefreshTimer = null;
+  }
+}
+
+/* Wire up: kick off stats fetch + auto-refresh when the TODO tab is clicked.
+ * Mirrors the activity-tab pattern (DOMContentLoaded → bind click on
+ * data-tab button → refresh + startAutoRefresh). The existing fetchTodoList
+ * flow for the issue list is untouched. */
+document.addEventListener("DOMContentLoaded", function () {
+  var btn = document.querySelector('[data-tab="todo"]');
+  if (btn) {
+    btn.addEventListener("click", function () {
+      fetchTodoStats();
+      startTodoStatsAutoRefresh();
+    });
+  }
+  /* If the TODO tab is the default-restored tab on reload, fetch stats once
+   * on first load too (tabs.js calls _activateTab before this handler binds). */
+  try {
+    var last = localStorage.getItem("orochi_active_tab");
+    if (last === "todo") {
+      fetchTodoStats();
+      startTodoStatsAutoRefresh();
+    }
+  } catch (_) {}
+});

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" href="{% static 'hub/orochi-icon.png' %}">
     <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=123">
     <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=102">
-    <link rel="stylesheet" href="{% static 'hub/todo-tab.css' %}?v=99">
+    <link rel="stylesheet" href="{% static 'hub/todo-tab.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/attachments.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/responsive.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/push.css' %}?v=99">
@@ -117,6 +117,7 @@
             </div>
             <div id="messages" class="messages"></div>
             <div id="todo-view" class="todo-view" style="display:none">
+                <div id="todo-stats" class="todo-stats"></div>
                 <div class="todo-state-filter">
                     <button type="button" class="todo-state-btn active" data-group="all">All</button>
                     <button type="button" class="todo-state-btn" data-group="high-priority">High</button>
@@ -234,7 +235,7 @@
     <script src="{% static 'hub/dms.js' %}?v=1"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
     <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>
-    <script src="{% static 'hub/todo-tab.js' %}?v=100"></script>
+    <script src="{% static 'hub/todo-tab.js' %}?v=101"></script>
     <script src="{% static 'hub/workspaces-tab.js' %}?v=99"></script>
     <script src="{% static 'hub/chat.js' %}?v=121"></script>
     <script src="{% static 'hub/mention.js' %}?v=101"></script>


### PR DESCRIPTION
## Summary

Renders an aggregated TODO stats dashboard at the top of the existing TODO tab, consuming the already-shipped backend endpoint `GET /api/todo/stats/` (shipped by PR #174 / head-mba — `login_required`, 60s cache). Closes frontend half of #171.

## Changes

- `hub/static/hub/todo-tab.js` (+250): `fetchTodoStats()` + render helpers (totals cards, inline SVG 14-day burn-down with Opened/Closed polylines, horizontal-bar label breakdown top-30, by-repo table, starvation table top-50 linked to GitHub). Auto-refreshes every 60s. Wired to the `[data-tab="todo"]` click and to the reload-restore path when TODO was the last active tab.
- `hub/static/hub/todo-tab.css` (+191): counter cards / chart grid + legend / label bars / tables. Matches existing dark theme.
- `hub/templates/hub/dashboard.html`: adds `#todo-stats` container above the existing filter pills + issue list; bumps cache-busters on `todo-tab.{js,css}`.

The existing per-issue grouped list below remains untouched.

## Test plan

- [x] `node --check hub/static/hub/todo-tab.js` — passes
- [x] Backend field alignment verified against `hub/views/todo_stats.py` docstring (`totals.{open,closed}`, `by_repo[]={repo,open,closed}`, `daily_velocity[]={date,opened,closed}`, `label_breakdown[]={label,open_count}`, `starvation[]={repo,number,title,age_days,url,labels[]}`, `starvation_threshold_days`)
- [x] URL `/api/todo/stats/` live (HEAD returns 405 method-not-allowed → route exists, `@require_GET` enforced)
- [ ] Browser smoke on deployed hub — click TODO tab, verify no JS console errors, cards + chart + tables render, data auto-refreshes after 60s
- [ ] Visual check on mobile viewport

## Refs

- Closes #171 (frontend half)
- Builds on #174 (backend endpoint, merged)
- Builds on #177 (URL routing — trailing slash fix across all 3 url confs)
- Spec: ywatanabe msg#13109 (visual TODO consumption dashboard, Option A = new TODO tab)

## Notes

- No new deps. Inline SVG line chart (~100 lines, vanilla).
- No server-side changes.
- No real-time WebSocket push — polling 60s matches backend cache TTL.
- No drill-down yet (clicking a repo row doesn't filter).

Do NOT self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)