### PR TITLE
fix(ui): #msg-webcam button color parity with sibling composer buttons

### DIFF
--- a/hub/static/hub/attachments.css
+++ b/hub/static/hub/attachments.css
@@ -118,6 +118,19 @@
   border-color: #4ecdc4;
   color: #4ecdc4;
 }
+#msg-webcam {
+  background: transparent;
+  border: 1px solid #333;
+  color: #999;
+  border-radius: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 16px;
+}
+#msg-webcam:hover {
+  border-color: #4ecdc4;
+  color: #4ecdc4;
+}
 
 /* Sketch Canvas */
 .sketch-overlay {


### PR DESCRIPTION
## Summary

Quick CSS fix: the webcam composer button introduced in PR #176 (scitex-orochi#166) had no explicit stylesheet rule, so it fell back to native browser button styling. Visually inconsistent with neighbouring \`#msg-attach\` / \`#msg-sketch\`.

## Root cause

\`hub/static/hub/attachments.css\` defines \`#msg-attach\` and \`#msg-sketch\` with an explicit dark-theme rule (transparent bg, \`#333\` border, \`#999\` text, teal \`#4ecdc4\` hover). PR #176 added the composer button element but not a matching CSS rule — it inherited native button styling instead.

## Changes

- \`hub/static/hub/attachments.css\`: add \`#msg-webcam\` + \`#msg-webcam:hover\` declarations that mirror \`#msg-sketch\` one-for-one.

## Test plan

- Diff review: the new rules are copy-identical to the neighbouring \`#msg-sketch\` block apart from the selector. No cascade conflict possible.
- Visual verification pending post-merge deploy — the three composer buttons (attach / sketch / webcam) should render indistinguishably when not hovered and all teal on hover.

## Out of scope

Refactoring \`#msg-attach\` / \`#msg-sketch\` / \`#msg-webcam\` into a shared \`.composer-btn\` class. That's correct DRY but a separate cleanup PR.

## Refs

- Reported: ywatanabe msg#13181 + fleet-lead msg#13182
- Introduced the gap: PR #176 (scitex-orochi#166 webcam composer button)