### PR TITLE
feat(hub): setup-audit fields + OAuth rotation counter

### DIFF
--- a/hub/registry.py
+++ b/hub/registry.py
@@ -44,6 +44,29 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
     """
     with _lock:
         prev = _agents.get(name, {}) or {}
+        # Auth-rotation counting. When the OAuth token rotates (Claude
+        # Code refreshes it), its expiresAt jumps. Count a rotation if:
+        # - new heartbeat carries a non-null oauth_expires_at,
+        # - prev also had a non-null oauth_expires_at,
+        # - and they differ.
+        # This is the hub-side mirror of the client NDJSON log and
+        # gives the dashboard an instant "rotated N times" pill without
+        # reading the per-host file. Counter is preserved on reconnect
+        # so the value survives WS drops.
+        _new_exp = info.get("oauth_expires_at")
+        _prev_exp = prev.get("oauth_expires_at")
+        _rotation_count = prev.get("oauth_rotation_count") or 0
+        _last_rotation_at = prev.get("oauth_last_rotation_at") or ""
+        if (
+            isinstance(_new_exp, int)
+            and isinstance(_prev_exp, int)
+            and _new_exp != _prev_exp
+        ):
+            _rotation_count += 1
+            from datetime import datetime
+            from datetime import timezone as _tz
+
+            _last_rotation_at = datetime.now(tz=_tz.utc).isoformat()
         _agents[name] = {
             "name": name,
             "workspace_id": workspace_id,
@@ -272,6 +295,43 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             or "",
             "account_email": info.get("account_email")
             or prev.get("account_email")
+            or "",
+            # Setup-audit fields (sac PR#53). plan_label is the human
+            # plan name derived from rateLimitTier; dashboards prefer
+            # it over the older billing_type field (which is just
+            # payment method). oauth_expires_at is used for rotation
+            # tracking: count how many times the value changed across
+            # heartbeats per account_email.
+            "account_plan_label": info.get("account_plan_label")
+            or prev.get("account_plan_label")
+            or "",
+            "account_subscription_type": info.get("account_subscription_type")
+            or prev.get("account_subscription_type")
+            or "",
+            "account_rate_limit_tier": info.get("account_rate_limit_tier")
+            or prev.get("account_rate_limit_tier")
+            or "",
+            "account_organization_name": info.get("account_organization_name")
+            or prev.get("account_organization_name")
+            or "",
+            "account_uuid": info.get("account_uuid") or prev.get("account_uuid") or "",
+            "oauth_expires_at": (
+                info.get("oauth_expires_at")
+                if info.get("oauth_expires_at") is not None
+                else prev.get("oauth_expires_at")
+            ),
+            # Hub-side mirror of the client rotation log — see the
+            # computation at the top of register_agent for the diff
+            # rule. Preserved across reconnects.
+            "oauth_rotation_count": _rotation_count,
+            "oauth_last_rotation_at": _last_rotation_at,
+            "installed_plugins": (
+                list(info.get("installed_plugins") or [])
+                if info.get("installed_plugins") is not None
+                else list(prev.get("installed_plugins") or [])
+            ),
+            "status_line_command": info.get("status_line_command")
+            or prev.get("status_line_command")
             or "",
         }
 
@@ -697,6 +757,20 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "quota_weekly_remaining": a.get("quota_weekly_remaining", ""),
                 "statusline_model": a.get("statusline_model", ""),
                 "account_email": a.get("account_email", ""),
+                # Setup-audit fields (sac PR#53). Surfaced so the
+                # Agents-tab can render plan label, plugins, MCP setup,
+                # and auth-rotation timestamp without re-querying a
+                # per-host endpoint.
+                "account_plan_label": a.get("account_plan_label", ""),
+                "account_subscription_type": a.get("account_subscription_type", ""),
+                "account_rate_limit_tier": a.get("account_rate_limit_tier", ""),
+                "account_organization_name": a.get("account_organization_name", ""),
+                "account_uuid": a.get("account_uuid", ""),
+                "oauth_expires_at": a.get("oauth_expires_at"),
+                "oauth_rotation_count": a.get("oauth_rotation_count", 0),
+                "oauth_last_rotation_at": a.get("oauth_last_rotation_at", ""),
+                "installed_plugins": list(a.get("installed_plugins") or []),
+                "status_line_command": a.get("status_line_command", ""),
             }
         )
     return result

--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -140,10 +140,39 @@ function _renderAgentDetail(a) {
     if (reset) s += " (resets " + reset + ")";
     return s;
   }
+  /* Setup-audit data from sac PR#53. `Plan` uses the normalized
+   * human label ("Max 20x" etc.) derived from claudeAiOauth.rateLimitTier
+   * — the dashboard previously read billing_type, which only reports
+   * payment method ("stripe_subscription") and is not a plan. The raw
+   * tier is included in parens so unknown plans remain visible. */
+  var planLabel = d.account_plan_label || a.account_plan_label || "";
+  var rateLimitTier =
+    d.account_rate_limit_tier || a.account_rate_limit_tier || "";
+  var subscriptionType =
+    d.account_subscription_type || a.account_subscription_type || "";
+  var planDisplay = planLabel
+    ? planLabel +
+      (rateLimitTier && rateLimitTier !== planLabel
+        ? " (" + rateLimitTier + ")"
+        : "")
+    : rateLimitTier || subscriptionType || "-";
+  var acctEmail = d.account_email || a.account_email || "";
+  var rotCount =
+    d.oauth_rotation_count != null
+      ? d.oauth_rotation_count
+      : a.oauth_rotation_count != null
+        ? a.oauth_rotation_count
+        : 0;
+  var acctDisplay = acctEmail
+    ? acctEmail + (rotCount > 0 ? " (rotated " + rotCount + "×)" : "")
+    : "-";
+
   var metaFields = [
     ["Role", role],
     ["Machine", machine],
     ["Model", model],
+    ["Plan", planDisplay],
+    ["Account", acctDisplay],
     ["Multiplexer", multiplexer || "-"],
     ["PID", pid || "-"],
     ["Liveness", liveness],
@@ -315,11 +344,92 @@ function _renderAgentDetail(a) {
     "</div>" +
     "</div>";
 
+  /* Setup-audit section (sac PR#53). Compact table so the operator
+   * can tell at a glance: is claude-hud wired? which MCP servers is
+   * the agent actually talking to? which plugins have been installed?
+   * Missing items are greyed out rather than hidden so host-config
+   * drift is discoverable. Shown after the CLAUDE.md / pane split so
+   * the top of the card stays focused on live state. */
+  var installedPlugins = d.installed_plugins || a.installed_plugins || [];
+  var statusLineCommand = d.status_line_command || a.status_line_command || "";
+  var hasClaudeHud = installedPlugins.some(function (p) {
+    return (p.name || "").indexOf("claude-hud") >= 0;
+  });
+  var mcpServersStructured = d.mcp_servers || a.mcp_servers || [];
+  var lastRotationAt =
+    d.oauth_last_rotation_at || a.oauth_last_rotation_at || "";
+
+  function _muted(s) {
+    return '<span class="muted-cell">' + escapeHtml(s) + "</span>";
+  }
+
+  var pluginsCell = installedPlugins.length
+    ? installedPlugins
+        .map(function (p) {
+          var name = p.name || "?";
+          var ver = p.version ? " " + p.version : "";
+          var scope = p.scope ? " [" + p.scope + "]" : "";
+          return (
+            '<span class="ch-badge">' +
+            escapeHtml(name + ver + scope) +
+            "</span>"
+          );
+        })
+        .join(" ")
+    : _muted("none");
+
+  var mcpCell = mcpServersStructured.length
+    ? mcpServersStructured
+        .map(function (s) {
+          var t =
+            s.transport || (s.url_host ? "http" : s.command ? "stdio" : "?");
+          var via = s.url_host ? s.url_host : s.command || "?";
+          return (
+            '<span class="ch-badge">' +
+            escapeHtml((s.name || "?") + " · " + t + " · " + via) +
+            "</span>"
+          );
+        })
+        .join(" ")
+    : _muted("none");
+
+  var statuslineCell = statusLineCommand
+    ? (hasClaudeHud ? "✓ claude-hud · " : "custom · ") +
+      escapeHtml(statusLineCommand)
+    : _muted("unset (no claude-hud)");
+
+  var rotationCell =
+    rotCount > 0
+      ? rotCount + "× (last " + (lastRotationAt || "?") + ")"
+      : _muted("no rotation observed");
+
+  var setupRows = [
+    ["Plugins", pluginsCell],
+    ["MCP servers", mcpCell],
+    ["Statusline", statuslineCell],
+    ["Auth rotations", rotationCell],
+  ];
+  var setupTableHtml = setupRows
+    .map(function (r) {
+      return "<tr><th>" + escapeHtml(r[0]) + "</th><td>" + r[1] + "</td></tr>";
+    })
+    .join("");
+  var setupAuditHtml =
+    '<div class="agent-detail-section">' +
+    '<details class="agent-detail-setup-audit" open>' +
+    '<summary class="agent-detail-pane-label">Setup audit</summary>' +
+    '<table class="agent-detail-setup-table">' +
+    setupTableHtml +
+    "</table>" +
+    "</details>" +
+    "</div>";
+
   return (
     '<div class="agent-detail-view">' +
     headerHtml +
     channelsHtml +
     splitHtml +
+    setupAuditHtml +
     mcpHtml +
     mcpJsonHtml +
     "</div>"

--- a/hub/static/hub/components.css
+++ b/hub/static/hub/components.css
@@ -764,6 +764,26 @@
   margin-top: 4px;
   width: 100%;
 }
+.agent-detail-setup-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  margin-top: 4px;
+}
+.agent-detail-setup-table th {
+  text-align: left;
+  color: #9aa;
+  font-weight: 600;
+  padding: 4px 12px 4px 0;
+  white-space: nowrap;
+  vertical-align: top;
+  width: 110px;
+}
+.agent-detail-setup-table td {
+  padding: 4px 0;
+  vertical-align: top;
+  word-break: break-all;
+}
 .agent-detail-claude-md {
   background: #1a1a2e;
   color: #ccc;

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -1408,6 +1408,131 @@ class AgentMetaOAuthRegisterTest(TestCase):
             self.assertNotIn("secret", kl)
             self.assertFalse(kl.endswith("key"), f"key-like field: {k}")
 
+    def test_register_accepts_setup_audit_fields(self):
+        """Setup-audit fields from sac PR#53: plan_label, plugins, MCPs.
+
+        The hub should mirror every new field the client now pushes so
+        the dashboard can render a per-host setup-audit table without
+        re-querying a per-host endpoint.
+        """
+        from hub.registry import _agents as _reg_agents
+        from hub.registry import get_agents
+
+        _reg_agents.clear()
+        resp = self._post(
+            {
+                "token": self.token.token,
+                "name": "audit-agent-1",
+                "account_email": "audit@example.org",
+                "account_plan_label": "Max 20x",
+                "account_subscription_type": "max",
+                "account_rate_limit_tier": "default_claude_max_20x",
+                "account_organization_name": "Acme Research",
+                "account_uuid": "acct-uuid-1",
+                "oauth_expires_at": 1000000000000,
+                "installed_plugins": [
+                    {
+                        "name": "claude-hud@claude-hud",
+                        "version": "0.0.10",
+                        "scope": "user",
+                    }
+                ],
+                "status_line_command": "/usr/bin/node /path/to/claude-hud.js",
+                "mcp_servers": [
+                    {
+                        "name": "scitex-orochi",
+                        "transport": "stdio",
+                        "url_host": None,
+                        "command": "bun",
+                    }
+                ],
+            }
+        )
+        self.assertEqual(resp.status_code, 200)
+        a = [
+            x
+            for x in get_agents(workspace_id=self.ws.id)
+            if x["name"] == "audit-agent-1"
+        ][0]
+        self.assertEqual(a["account_plan_label"], "Max 20x")
+        self.assertEqual(a["account_subscription_type"], "max")
+        self.assertEqual(a["account_rate_limit_tier"], "default_claude_max_20x")
+        self.assertEqual(a["account_organization_name"], "Acme Research")
+        self.assertEqual(a["account_uuid"], "acct-uuid-1")
+        self.assertEqual(a["oauth_expires_at"], 1000000000000)
+        self.assertEqual(len(a["installed_plugins"]), 1)
+        self.assertEqual(a["installed_plugins"][0]["name"], "claude-hud@claude-hud")
+        self.assertEqual(
+            a["status_line_command"], "/usr/bin/node /path/to/claude-hud.js"
+        )
+        self.assertEqual(a["mcp_servers"][0]["name"], "scitex-orochi")
+        # First heartbeat: no previous expires_at -> rotation count stays 0.
+        self.assertEqual(a["oauth_rotation_count"], 0)
+        self.assertEqual(a["oauth_last_rotation_at"], "")
+
+    def test_register_increments_rotation_count_on_expires_change(self):
+        """Second heartbeat with a different oauth_expires_at should
+        bump oauth_rotation_count and stamp oauth_last_rotation_at.
+
+        Same expires_at twice in a row must NOT bump the counter
+        (idempotent).
+        """
+        from hub.registry import _agents as _reg_agents
+        from hub.registry import get_agents
+
+        _reg_agents.clear()
+
+        def _get():
+            return [
+                x
+                for x in get_agents(workspace_id=self.ws.id)
+                if x["name"] == "rot-agent"
+            ][0]
+
+        # First heartbeat primes the counter at 0.
+        resp = self._post(
+            {
+                "token": self.token.token,
+                "name": "rot-agent",
+                "account_email": "rotator@example.org",
+                "oauth_expires_at": 1000,
+            }
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(_get()["oauth_rotation_count"], 0)
+
+        # Second heartbeat with the same expires_at: still 0.
+        self._post(
+            {
+                "token": self.token.token,
+                "name": "rot-agent",
+                "oauth_expires_at": 1000,
+            }
+        )
+        self.assertEqual(_get()["oauth_rotation_count"], 0)
+
+        # Token rotates -> counter increments once.
+        self._post(
+            {
+                "token": self.token.token,
+                "name": "rot-agent",
+                "oauth_expires_at": 2000,
+            }
+        )
+        a = _get()
+        self.assertEqual(a["oauth_rotation_count"], 1)
+        self.assertTrue(a["oauth_last_rotation_at"])  # non-empty ISO timestamp
+
+        # One more rotation -> counter is now 2.
+        self._post(
+            {
+                "token": self.token.token,
+                "name": "rot-agent",
+                "oauth_expires_at": 3000,
+            }
+        )
+        self.assertEqual(_get()["oauth_rotation_count"], 2)
+
 
 class FunctionalHeartbeatAndHookEventsTest(TestCase):
     """Smoke tests for the functional-heartbeat shortcuts and

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -1822,6 +1822,20 @@ def api_agents_register(request):
             "quota_weekly_remaining": body.get("quota_weekly_remaining", ""),
             "statusline_model": body.get("statusline_model", ""),
             "account_email": body.get("account_email", ""),
+            # Setup-audit fields from scitex-agent-container PR#53.
+            # plan_label is the authoritative plan name ("Max 20x" etc.)
+            # derived from rateLimitTier; billing_type only reports payment
+            # method. oauth_expires_at is the unix-ms token expiry — the
+            # hub can diff across heartbeats to count rotations per email.
+            # installed_plugins + mcp_servers power the setup-audit grid.
+            "account_plan_label": body.get("account_plan_label", ""),
+            "account_subscription_type": body.get("account_subscription_type", ""),
+            "account_rate_limit_tier": body.get("account_rate_limit_tier", ""),
+            "account_organization_name": body.get("account_organization_name", ""),
+            "account_uuid": body.get("account_uuid", ""),
+            "oauth_expires_at": body.get("oauth_expires_at"),
+            "installed_plugins": body.get("installed_plugins") or [],
+            "status_line_command": body.get("status_line_command", ""),
             # scitex-agent-container heartbeat-push payload. Long names are
             # preferred by the dashboard; accept the short-name aliases too
             # for backward compat with older pushers.


### PR DESCRIPTION
## Summary

Hub side of sac PR#53. The heartbeat payload now carries plan label, installed plugins, structured MCP servers, and OAuth token expiry; this PR wires those through \`register_agent\` and renders a setup-audit section on the agent detail card.

- **Plan row** on the meta grid uses \`account_plan_label\` ('Max 20x' etc.) derived from \`rateLimitTier\` — replaces the previous display that showed \`billing_type=stripe_subscription\` as the plan.
- **Account row** shows the email plus rotation count ('rotator@example.org (rotated 3×)').
- **Setup audit section** shows Plugins / MCP servers / Statusline / Auth rotations in a compact table. Missing items greyed out so host-config drift (mba/spartan/nas have no \`claude-hud\`) is discoverable.
- **Hub-side rotation counter**: \`register_agent\` diffs \`oauth_expires_at\` across heartbeats and increments \`oauth_rotation_count\` when the value changes. Mirrors the per-email NDJSON log the client writes.

Depends on:
- sac#53 — client payload

## Test plan

- [x] 6 \`AgentMetaOAuthRegisterTest\` tests pass (2 new: setup_audit round-trip, rotation counter idempotency + increment)
- [ ] Visually verify on localhost with a real agent heartbeat (staging instance)
- [ ] Smoke on scitex-orochi.com after deploy

## Security

- New fields are all non-secret metadata (plan label, plugin name/version, MCP host+command, unix-ms expiry).
- Existing leak-regression test \`test_register_does_not_echo_tokens\` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)