### PR TITLE
Phase A.3: migrate scitex-orochi to ~/.scitex/orochi/ runtime/ + shared/ layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,21 +277,31 @@ You should see `Listening for channel messages from: server:scitex-orochi` in th
 
 ## Agent Definitions
 
-Agent configuration lives in `~/.scitex/orochi/agents/<agent-name>/`, **not** in this repository. This directory is the single source of truth for all agent configuration, shared across machines via dotfiles.
+Agent configuration lives under `~/.scitex/orochi/` in the canonical
+two-tier layout (dotfiles commit `68bd1592`), **not** in this
+repository. `~/.scitex/orochi/` is the single source of truth for all
+agent configuration, shared across machines via dotfiles.
 
 ```
-~/.scitex/orochi/agents/<agent-name>/
-├── <agent-name>.yaml  — Agent definition (apiVersion, kind, metadata, spec)
-├── CLAUDE.md           — Agent instructions (role, behavior, tools)
-└── .mcp.json           — MCP server configuration (orochi hub connection)
+~/.scitex/orochi/
+├── shared/agents/<agent-name>/      # Shared template (hostname-substituted)
+│   ├── <agent-name>.yaml            —  apiVersion, kind, metadata, spec
+│   ├── src_CLAUDE.md                —  copied to {workdir}/CLAUDE.md at launch
+│   └── src_mcp.json                 —  copied to {workdir}/.mcp.json at launch
+└── <host>/agents/<agent-name>/      # Host-specific concrete agents
+    └── ...
 ```
+
+The legacy flat layout `~/.scitex/orochi/agents/<agent-name>/` is still
+accepted as a fallback during the dotfiles 68bd1592 rollout
+(DEPRECATED — will be removed once every host is re-bootstrapped).
 
 The `scitex-orochi` CLI is the **dispatcher** that reads these definitions and launches agents:
 
 1. `scitex-orochi launch <agent-name>` reads the agent definition directory
-2. Creates a workspace at `~/.scitex/orochi/workspaces/<agent-name>/`
-3. Copies `.mcp.json` and `CLAUDE.md` into the workspace
-4. Starts Claude Code in a GNU screen session from the workspace directory
+2. Creates a workspace at `~/.scitex/orochi/runtime/workspaces/<agent-name>/`
+3. Copies `src_mcp.json` and `src_CLAUDE.md` into the workspace
+4. Starts Claude Code in a GNU screen/tmux session from the workspace directory
 
 ### Current Fleet
 

--- a/README.md
+++ b/README.md
@@ -292,10 +292,6 @@ agent configuration, shared across machines via dotfiles.
     └── ...
 ```
 
-The legacy flat layout `~/.scitex/orochi/agents/<agent-name>/` is still
-accepted as a fallback during the dotfiles 68bd1592 rollout
-(DEPRECATED — will be removed once every host is re-bootstrapped).
-
 The `scitex-orochi` CLI is the **dispatcher** that reads these definitions and launches agents:
 
 1. `scitex-orochi launch <agent-name>` reads the agent definition directory

--- a/deployment/fleet/agent-respawn.sh
+++ b/deployment/fleet/agent-respawn.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 # Canonical post-68bd1592 agent-definition roots, searched in order:
 #   1. <host>/agents/        (host-specific)
 #   2. shared/agents/        (shared template)
-#   3. agents/               (legacy flat; DEPRECATED)
 # The :- default is what `hostname -s` would give; users who want a short
 # logical name set SCITEX_OROCHI_HOSTNAME in their shell rc.
 HOST_NAME_FOR_AGENTS="${SCITEX_OROCHI_HOSTNAME:-$(hostname -s 2>/dev/null || hostname)}"
@@ -23,11 +22,7 @@ OROCHI_ROOT="${HOME}/.scitex/orochi"
 AGENT_DIRS=(
   "${OROCHI_ROOT}/${HOST_NAME_FOR_AGENTS}/agents"
   "${OROCHI_ROOT}/shared/agents"
-  "${OROCHI_ROOT}/agents"
 )
-# Back-compat alias for external callers that source this script and expect
-# AGENT_DIR to be set.
-AGENT_DIR="${OROCHI_ROOT}/agents"
 LOG="/tmp/agent-respawn.log"
 DELAY_BETWEEN=10  # seconds between agent starts to avoid reconnect storm
 
@@ -42,7 +37,7 @@ case "$HOSTNAME" in
   *)               HOST="ywata-note-win" ;;
 esac
 
-# Resolve an agent name's yaml across the canonical roots (host/shared/legacy).
+# Resolve an agent name's yaml across the canonical roots (host, then shared).
 # Echoes the path on stdout, or nothing if not found.
 _resolve_agent_yaml() {
   local name="$1"

--- a/deployment/fleet/agent-respawn.sh
+++ b/deployment/fleet/agent-respawn.sh
@@ -12,7 +12,22 @@
 
 set -euo pipefail
 
-AGENT_DIR="${HOME}/.scitex/orochi/agents"
+# Canonical post-68bd1592 agent-definition roots, searched in order:
+#   1. <host>/agents/        (host-specific)
+#   2. shared/agents/        (shared template)
+#   3. agents/               (legacy flat; DEPRECATED)
+# The :- default is what `hostname -s` would give; users who want a short
+# logical name set SCITEX_OROCHI_HOSTNAME in their shell rc.
+HOST_NAME_FOR_AGENTS="${SCITEX_OROCHI_HOSTNAME:-$(hostname -s 2>/dev/null || hostname)}"
+OROCHI_ROOT="${HOME}/.scitex/orochi"
+AGENT_DIRS=(
+  "${OROCHI_ROOT}/${HOST_NAME_FOR_AGENTS}/agents"
+  "${OROCHI_ROOT}/shared/agents"
+  "${OROCHI_ROOT}/agents"
+)
+# Back-compat alias for external callers that source this script and expect
+# AGENT_DIR to be set.
+AGENT_DIR="${OROCHI_ROOT}/agents"
 LOG="/tmp/agent-respawn.log"
 DELAY_BETWEEN=10  # seconds between agent starts to avoid reconnect storm
 
@@ -27,6 +42,21 @@ case "$HOSTNAME" in
   *)               HOST="ywata-note-win" ;;
 esac
 
+# Resolve an agent name's yaml across the canonical roots (host/shared/legacy).
+# Echoes the path on stdout, or nothing if not found.
+_resolve_agent_yaml() {
+  local name="$1"
+  local root yaml
+  for root in "${AGENT_DIRS[@]}"; do
+    yaml="${root}/${name}/${name}.yaml"
+    if [[ -f "$yaml" ]]; then
+      printf '%s\n' "$yaml"
+      return 0
+    fi
+  done
+  return 1
+}
+
 is_running() {
   local name="$1"
   tmux has-session -t "$name" 2>/dev/null
@@ -34,15 +64,16 @@ is_running() {
 
 start_agent() {
   local name="$1"
-  local yaml="${AGENT_DIR}/${name}/${name}.yaml"
-  if [[ ! -f "$yaml" ]]; then
+  local yaml
+  yaml="$(_resolve_agent_yaml "$name" || true)"
+  if [[ -z "$yaml" || ! -f "$yaml" ]]; then
     echo "$(ts) SKIP: no yaml for $name" >> "$LOG"
     return 1
   fi
   if is_running "$name"; then
     return 0  # already running, silent
   fi
-  echo "$(ts) STARTING: $name" >> "$LOG"
+  echo "$(ts) STARTING: $name (yaml=$yaml)" >> "$LOG"
   scitex-agent-container start "$yaml" 2>>"$LOG" || {
     echo "$(ts) FAILED: $name" >> "$LOG"
     return 1
@@ -51,16 +82,36 @@ start_agent() {
   return 0
 }
 
+# List unique agent names across the canonical roots.
+_all_agent_names() {
+  local root sub name
+  declare -A seen=()
+  for root in "${AGENT_DIRS[@]}"; do
+    [[ -d "$root" ]] || continue
+    for sub in "$root"/*/; do
+      [[ -d "$sub" ]] || continue
+      name="$(basename "$sub")"
+      case "$name" in
+        legacy|legacy-agents|_*) continue ;;
+      esac
+      if [[ -z "${seen[$name]+x}" ]]; then
+        seen[$name]=1
+        printf '%s\n' "$name"
+      fi
+    done
+  done
+}
+
 # If --check, just report status
 if [[ "${1:-}" == "--check" ]]; then
-  for dir in "${AGENT_DIR}"/*/; do
-    name=$(basename "$dir")
+  while IFS= read -r name; do
+    [[ -n "$name" ]] || continue
     if is_running "$name"; then
       echo "  RUNNING: $name"
     else
       echo "  STOPPED: $name"
     fi
-  done
+  done < <(_all_agent_names)
   exit 0
 fi
 
@@ -72,10 +123,10 @@ fi
 
 # Otherwise, start all agents for this host with throttling
 started=0
-for dir in "${AGENT_DIR}"/*/; do
-  name=$(basename "$dir")
-  yaml="${dir}/${name}.yaml"
-  [[ -f "$yaml" ]] || continue
+while IFS= read -r name; do
+  [[ -n "$name" ]] || continue
+  yaml="$(_resolve_agent_yaml "$name" || true)"
+  [[ -n "$yaml" && -f "$yaml" ]] || continue
 
   # Check if this agent belongs to this host
   agent_host=$(grep -oP 'machine:\s*\K\S+' "$yaml" 2>/dev/null || echo "")
@@ -91,7 +142,7 @@ for dir in "${AGENT_DIR}"/*/; do
       sleep "$DELAY_BETWEEN"
     fi
   fi
-done
+done < <(_all_agent_names)
 
 if (( started > 0 )); then
   echo "$(ts) Started $started agents on $HOST" >> "$LOG"

--- a/deployment/fleet/cloudflared-watchdog.sh
+++ b/deployment/fleet/cloudflared-watchdog.sh
@@ -12,8 +12,19 @@
 set -euo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-LOG="${HOME}/.scitex/orochi/logs/cloudflared-watchdog.log"
-STATE="${HOME}/.scitex/orochi/logs/watchdog-state"
+# Canonical runtime/ layout (dotfiles commit 68bd1592). Fall back to the
+# legacy flat logs/ dir if the runtime/ skeleton hasn't been bootstrapped
+# here yet so existing operators' `tail -f` keeps following the same file.
+# DEPRECATED: drop the legacy branch after rollout completes.
+if [[ -d "${HOME}/.scitex/orochi/runtime" ]]; then
+  _OROCHI_LOG_DIR="${HOME}/.scitex/orochi/runtime/logs"
+elif [[ -d "${HOME}/.scitex/orochi/logs" ]]; then
+  _OROCHI_LOG_DIR="${HOME}/.scitex/orochi/logs"
+else
+  _OROCHI_LOG_DIR="${HOME}/.scitex/orochi/runtime/logs"
+fi
+LOG="${_OROCHI_LOG_DIR}/cloudflared-watchdog.log"
+STATE="${_OROCHI_LOG_DIR}/watchdog-state"
 mkdir -p "$(dirname "$LOG")"
 ts() { date -u '+%Y-%m-%dT%H:%M:%SZ'; }
 

--- a/deployment/fleet/cloudflared-watchdog.sh
+++ b/deployment/fleet/cloudflared-watchdog.sh
@@ -12,17 +12,8 @@
 set -euo pipefail
 export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-# Canonical runtime/ layout (dotfiles commit 68bd1592). Fall back to the
-# legacy flat logs/ dir if the runtime/ skeleton hasn't been bootstrapped
-# here yet so existing operators' `tail -f` keeps following the same file.
-# DEPRECATED: drop the legacy branch after rollout completes.
-if [[ -d "${HOME}/.scitex/orochi/runtime" ]]; then
-  _OROCHI_LOG_DIR="${HOME}/.scitex/orochi/runtime/logs"
-elif [[ -d "${HOME}/.scitex/orochi/logs" ]]; then
-  _OROCHI_LOG_DIR="${HOME}/.scitex/orochi/logs"
-else
-  _OROCHI_LOG_DIR="${HOME}/.scitex/orochi/runtime/logs"
-fi
+# Canonical runtime/ layout (dotfiles commit 68bd1592).
+_OROCHI_LOG_DIR="${HOME}/.scitex/orochi/runtime/logs"
 LOG="${_OROCHI_LOG_DIR}/cloudflared-watchdog.log"
 STATE="${_OROCHI_LOG_DIR}/watchdog-state"
 mkdir -p "$(dirname "$LOG")"

--- a/deployment/fleet/launchd/com.scitex.orochi.AGENT_NAME.plist.template
+++ b/deployment/fleet/launchd/com.scitex.orochi.AGENT_NAME.plist.template
@@ -11,7 +11,7 @@
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>source ~/.venv/bin/activate 2>/dev/null; exec scitex-agent-container start ~/.dotfiles/src/.scitex/orochi/agents/AGENT_NAME/AGENT_NAME.yaml</string>
+    <string>source ~/.venv/bin/activate 2>/dev/null; exec scitex-agent-container start ~/.dotfiles/src/.scitex/orochi/shared/agents/AGENT_NAME/AGENT_NAME.yaml</string>
   </array>
   <key>RunAtLoad</key>
   <true/>

--- a/deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist
+++ b/deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist
@@ -21,7 +21,7 @@
 
   Verify:
     launchctl list | grep tmux-unstick
-    tail -f ~/.scitex/orochi/logs/tmux-unstick.ndjson
+    tail -f ~/.scitex/orochi/runtime/logs/tmux-unstick.ndjson
 -->
 <plist version="1.0">
 <dict>
@@ -48,10 +48,10 @@
   <string>/Users/ywatanabe</string>
 
   <key>StandardOutPath</key>
-  <string>/Users/ywatanabe/.scitex/orochi/logs/tmux-unstick.launchd.out.log</string>
+  <string>/Users/ywatanabe/.scitex/orochi/runtime/logs/tmux-unstick.launchd.out.log</string>
 
   <key>StandardErrorPath</key>
-  <string>/Users/ywatanabe/.scitex/orochi/logs/tmux-unstick.launchd.err.log</string>
+  <string>/Users/ywatanabe/.scitex/orochi/runtime/logs/tmux-unstick.launchd.err.log</string>
 
   <key>EnvironmentVariables</key>
   <dict>
@@ -62,7 +62,7 @@
     <key>LANG</key>
     <string>en_US.UTF-8</string>
     <key>LOG_FILE</key>
-    <string>/Users/ywatanabe/.scitex/orochi/logs/tmux-unstick.ndjson</string>
+    <string>/Users/ywatanabe/.scitex/orochi/runtime/logs/tmux-unstick.ndjson</string>
   </dict>
 </dict>
 </plist>

--- a/deployment/fleet/launchd/install-launchd.sh
+++ b/deployment/fleet/launchd/install-launchd.sh
@@ -12,7 +12,10 @@ set -euo pipefail
 TEMPLATE_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATE="${TEMPLATE_DIR}/com.scitex.orochi.AGENT_NAME.plist.template"
 INSTALL_DIR="${HOME}/Library/LaunchAgents"
-AGENT_DIR="${HOME}/.dotfiles/src/.scitex/orochi/agents"
+# Canonical post-68bd1592 layout: shared templates live under shared/agents/.
+# ``AGENT_DIR`` is informational only — the template bakes the full path in
+# the plist, so this path is not dereferenced here.
+AGENT_DIR="${HOME}/.dotfiles/src/.scitex/orochi/shared/agents"
 
 # MBA agents only
 MBA_AGENTS=(

--- a/deployment/fleet/systemd/scitex-orochi-tmux-unstick.service
+++ b/deployment/fleet/systemd/scitex-orochi-tmux-unstick.service
@@ -9,9 +9,9 @@ ExecStart=/bin/bash -lc 'exec %h/proj/scitex-orochi/deployment/fleet/tmux-unstic
 Nice=10
 IOSchedulingClass=best-effort
 IOSchedulingPriority=6
-StandardOutput=append:%h/.scitex/orochi/logs/tmux-unstick.service.out.log
-StandardError=append:%h/.scitex/orochi/logs/tmux-unstick.service.err.log
-Environment=LOG_FILE=%h/.scitex/orochi/logs/tmux-unstick.ndjson
+StandardOutput=append:%h/.scitex/orochi/runtime/logs/tmux-unstick.service.out.log
+StandardError=append:%h/.scitex/orochi/runtime/logs/tmux-unstick.service.err.log
+Environment=LOG_FILE=%h/.scitex/orochi/runtime/logs/tmux-unstick.ndjson
 Environment=LANG=en_US.UTF-8
 
 [Install]

--- a/deployment/fleet/tmux-unstick-README.md
+++ b/deployment/fleet/tmux-unstick-README.md
@@ -37,10 +37,13 @@ this deployment.
 
 - **Script**: `deployment/fleet/tmux-unstick.sh`
   (promoted verbatim from head-mba's POC at
-  `~/.scitex/orochi/scripts/tmux-unstick-poc.sh`, msg#11824, MBA live
-  verified).
-- **Log**: `~/.scitex/orochi/logs/tmux-unstick.ndjson`
-  (NDJSON, one record per detection + one summary per sweep).
+  `~/.scitex/orochi/shared/scripts/tmux-unstick-poc.sh` — post-68bd1592
+  canonical path; legacy `~/.scitex/orochi/scripts/` still accepted during
+  rollout — msg#11824, MBA live verified).
+- **Log**: `~/.scitex/orochi/runtime/logs/tmux-unstick.ndjson`
+  (NDJSON, one record per detection + one summary per sweep). If the
+  runtime/ layout is not yet bootstrapped on this host, the script falls
+  back to the legacy `~/.scitex/orochi/logs/` path automatically.
 - **Host-specific wrappers**:
   - macOS (MBA): `deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist`
   - Linux with per-user systemd (NAS, WSL):
@@ -93,7 +96,7 @@ if ! pgrep -u "$USER" -f 'tmux-unstick-spartan-loop.sh' >/dev/null; then
 fi
 ```
 
-The loop writes its PID to `~/.scitex/orochi/logs/tmux-unstick-loop.pid`
+The loop writes its PID to `~/.scitex/orochi/runtime/logs/tmux-unstick-loop.pid`
 so an external supervisor (agent-autostart rerun, etc) can cleanly stop
 it before restart.
 
@@ -102,7 +105,7 @@ it before restart.
 After install, watch the NDJSON log for the first sweep-summary record:
 
 ```
-tail -f ~/.scitex/orochi/logs/tmux-unstick.ndjson | jq -r '
+tail -f ~/.scitex/orochi/runtime/logs/tmux-unstick.ndjson | jq -r '
   "\(.ts) \(.event) session=\(.session) recovered=\(.recovered)"
 '
 ```
@@ -150,7 +153,7 @@ post-mortem.
    first 5 minutes of production output can be eyeballed for
    false-positives before real keys start firing.
 4. **Panic switch (`D`)** — if
-   `~/.scitex/orochi/tmux-unstick.PAUSED` exists, the script sleeps
+   `~/.scitex/orochi/runtime/tmux-unstick.PAUSED` exists, the script sleeps
    without scanning. `touch` the file to halt recovery globally
    across all hosts; `rm` to resume.
 5. **Per-pane rate limit (`E`)** — after a recovery fires on a pane,

--- a/deployment/fleet/tmux-unstick-README.md
+++ b/deployment/fleet/tmux-unstick-README.md
@@ -38,12 +38,9 @@ this deployment.
 - **Script**: `deployment/fleet/tmux-unstick.sh`
   (promoted verbatim from head-mba's POC at
   `~/.scitex/orochi/shared/scripts/tmux-unstick-poc.sh` — post-68bd1592
-  canonical path; legacy `~/.scitex/orochi/scripts/` still accepted during
-  rollout — msg#11824, MBA live verified).
+  canonical path — msg#11824, MBA live verified).
 - **Log**: `~/.scitex/orochi/runtime/logs/tmux-unstick.ndjson`
-  (NDJSON, one record per detection + one summary per sweep). If the
-  runtime/ layout is not yet bootstrapped on this host, the script falls
-  back to the legacy `~/.scitex/orochi/logs/` path automatically.
+  (NDJSON, one record per detection + one summary per sweep).
 - **Host-specific wrappers**:
   - macOS (MBA): `deployment/fleet/launchd/com.scitex.orochi.tmux-unstick.plist`
   - Linux with per-user systemd (NAS, WSL):

--- a/deployment/fleet/tmux-unstick-spartan-loop.sh
+++ b/deployment/fleet/tmux-unstick-spartan-loop.sh
@@ -29,20 +29,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UNSTICK_SCRIPT="$SCRIPT_DIR/tmux-unstick.sh"
 INTERVAL="${UNSTICK_INTERVAL:-60}"
 
-# Canonical runtime/ layout from dotfiles commit 68bd1592 — but keep honoring
-# the legacy flat ~/.scitex/orochi/logs/ path while hosts finish migrating so
-# the operator's `tail -f` keeps following the same file.
-# DEPRECATED: drop legacy branch after rollout.
-_orochi_logs_dir() {
-  if [ -d "$HOME/.scitex/orochi/runtime" ]; then
-    printf '%s' "$HOME/.scitex/orochi/runtime/logs"
-  elif [ -d "$HOME/.scitex/orochi/logs" ]; then
-    printf '%s' "$HOME/.scitex/orochi/logs"
-  else
-    printf '%s' "$HOME/.scitex/orochi/runtime/logs"
-  fi
-}
-_LOGS_DIR="$(_orochi_logs_dir)"
+# Canonical runtime/ layout from dotfiles commit 68bd1592.
+_LOGS_DIR="$HOME/.scitex/orochi/runtime/logs"
 export LOG_FILE="${LOG_FILE:-$_LOGS_DIR/tmux-unstick.ndjson}"
 
 mkdir -p "$(dirname "$LOG_FILE")"

--- a/deployment/fleet/tmux-unstick-spartan-loop.sh
+++ b/deployment/fleet/tmux-unstick-spartan-loop.sh
@@ -28,22 +28,37 @@ set -o pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UNSTICK_SCRIPT="$SCRIPT_DIR/tmux-unstick.sh"
 INTERVAL="${UNSTICK_INTERVAL:-60}"
-export LOG_FILE="${LOG_FILE:-$HOME/.scitex/orochi/logs/tmux-unstick.ndjson}"
+
+# Canonical runtime/ layout from dotfiles commit 68bd1592 — but keep honoring
+# the legacy flat ~/.scitex/orochi/logs/ path while hosts finish migrating so
+# the operator's `tail -f` keeps following the same file.
+# DEPRECATED: drop legacy branch after rollout.
+_orochi_logs_dir() {
+  if [ -d "$HOME/.scitex/orochi/runtime" ]; then
+    printf '%s' "$HOME/.scitex/orochi/runtime/logs"
+  elif [ -d "$HOME/.scitex/orochi/logs" ]; then
+    printf '%s' "$HOME/.scitex/orochi/logs"
+  else
+    printf '%s' "$HOME/.scitex/orochi/runtime/logs"
+  fi
+}
+_LOGS_DIR="$(_orochi_logs_dir)"
+export LOG_FILE="${LOG_FILE:-$_LOGS_DIR/tmux-unstick.ndjson}"
 
 mkdir -p "$(dirname "$LOG_FILE")"
 
 # PID file so an external killer (agent-autostart rerun, etc) can cleanly stop us
-PID_FILE="$HOME/.scitex/orochi/logs/tmux-unstick-loop.pid"
+PID_FILE="$_LOGS_DIR/tmux-unstick-loop.pid"
 echo "$$" > "$PID_FILE"
 
 trap 'rm -f "$PID_FILE"; exit 0' EXIT INT TERM
 
 while true; do
   if [[ -x "$UNSTICK_SCRIPT" ]]; then
-    bash "$UNSTICK_SCRIPT" --once >> "$HOME/.scitex/orochi/logs/tmux-unstick.loop.log" 2>&1 || true
+    bash "$UNSTICK_SCRIPT" --once >> "$_LOGS_DIR/tmux-unstick.loop.log" 2>&1 || true
   else
     printf '[%s] unstick script not executable: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$UNSTICK_SCRIPT" \
-      >> "$HOME/.scitex/orochi/logs/tmux-unstick.loop.log"
+      >> "$_LOGS_DIR/tmux-unstick.loop.log"
   fi
   sleep "$INTERVAL"
 done

--- a/deployment/fleet/tmux-unstick.sh
+++ b/deployment/fleet/tmux-unstick.sh
@@ -43,9 +43,7 @@
 #      5 minutes of production output can be eyeballed for
 #      false-positives before real keys start firing.
 #
-#   D. Panic switch — if ~/.scitex/orochi/runtime/tmux-unstick.PAUSED exists
-#      (or the legacy ~/.scitex/orochi/tmux-unstick.PAUSED during 68bd1592
-#      rollout),
+#   D. Panic switch — if ~/.scitex/orochi/runtime/tmux-unstick.PAUSED exists,
 #      the script sleeps without scanning. `touch` the file to halt
 #      recovery globally; `rm` to resume.
 #
@@ -70,10 +68,7 @@
 # Environment overrides:
 #
 #   TMUX_UNSTICK_LOG              NDJSON log path (default
-#                                  ~/.scitex/orochi/runtime/logs/tmux-unstick.ndjson;
-#                                  falls back to legacy ~/.scitex/orochi/logs/
-#                                  during 68bd1592 rollout if runtime/ is
-#                                  missing)
+#                                  ~/.scitex/orochi/runtime/logs/tmux-unstick.ndjson)
 #   TMUX_UNSTICK_INTERVAL_SEC     seconds between sweeps in --loop mode
 #                                  (default 60)
 #   TMUX_UNSTICK_STABILITY_SEC    per-pane minimum age of a stable
@@ -85,13 +80,9 @@
 #   TMUX_UNSTICK_HEARTBEAT_EVERY  emit a meta heartbeat every N sweeps
 #                                  in --loop mode (default 5)
 #   TMUX_UNSTICK_STATE_DIR        per-pane stability snapshot dir (default
-#                                  ~/.scitex/orochi/runtime/tmux-unstick-state/;
-#                                  legacy ~/.scitex/orochi/tmux-unstick-state/
-#                                  still honored during 68bd1592 rollout)
+#                                  ~/.scitex/orochi/runtime/tmux-unstick-state/)
 #   TMUX_UNSTICK_PAUSE_FILE       panic-switch marker file (default
-#                                  ~/.scitex/orochi/runtime/tmux-unstick.PAUSED;
-#                                  legacy ~/.scitex/orochi/tmux-unstick.PAUSED
-#                                  still honored during 68bd1592 rollout)
+#                                  ~/.scitex/orochi/runtime/tmux-unstick.PAUSED)
 #   DRY_RUN                       if 1, detect and log but never send
 #                                  keys (default 0; overridden to 1
 #                                  during the safe-start window)
@@ -103,30 +94,15 @@ set -u
 set -o pipefail
 
 SCHEMA="scitex-orochi/tmux-unstick/v2"
-# Canonical paths live under runtime/ (dotfiles commit 68bd1592). When the
-# legacy flat path is present on a not-yet-migrated host, honour it instead
-# so the daemon keeps writing to the same file the operator is tailing.
-# DEPRECATED: remove the legacy fallbacks after every host is re-bootstrapped.
-_pick_path() {
-  # _pick_path <canonical> <legacy>
-  # Returns $canonical unless only $legacy's parent dir already exists.
-  local canonical="$1" legacy="$2"
-  if [ -e "$canonical" ]; then
-    printf '%s' "$canonical"
-  elif [ -e "$legacy" ] || [ -d "$(dirname "$legacy")" ] && ! [ -d "$(dirname "$canonical")" ]; then
-    printf '%s' "$legacy"
-  else
-    printf '%s' "$canonical"
-  fi
-}
-LOG="${TMUX_UNSTICK_LOG:-$(_pick_path "$HOME/.scitex/orochi/runtime/logs/tmux-unstick.ndjson" "$HOME/.scitex/orochi/logs/tmux-unstick.ndjson")}"
+# Canonical paths live under runtime/ (dotfiles commit 68bd1592).
+LOG="${TMUX_UNSTICK_LOG:-$HOME/.scitex/orochi/runtime/logs/tmux-unstick.ndjson}"
 INTERVAL="${TMUX_UNSTICK_INTERVAL_SEC:-60}"
 STABILITY_SEC="${TMUX_UNSTICK_STABILITY_SEC:-120}"
 COOLDOWN_SEC="${TMUX_UNSTICK_COOLDOWN_SEC:-120}"
 SAFE_START_SEC="${TMUX_UNSTICK_SAFE_START_SEC:-300}"
 HEARTBEAT_EVERY="${TMUX_UNSTICK_HEARTBEAT_EVERY:-5}"
-STATE_DIR="${TMUX_UNSTICK_STATE_DIR:-$(_pick_path "$HOME/.scitex/orochi/runtime/tmux-unstick-state" "$HOME/.scitex/orochi/tmux-unstick-state")}"
-PAUSE_FILE="${TMUX_UNSTICK_PAUSE_FILE:-$(_pick_path "$HOME/.scitex/orochi/runtime/tmux-unstick.PAUSED" "$HOME/.scitex/orochi/tmux-unstick.PAUSED")}"
+STATE_DIR="${TMUX_UNSTICK_STATE_DIR:-$HOME/.scitex/orochi/runtime/tmux-unstick-state}"
+PAUSE_FILE="${TMUX_UNSTICK_PAUSE_FILE:-$HOME/.scitex/orochi/runtime/tmux-unstick.PAUSED}"
 DRY_RUN_ENV="${DRY_RUN:-0}"
 MODE="${1:---once}"
 # Shorthand promotion

--- a/deployment/fleet/tmux-unstick.sh
+++ b/deployment/fleet/tmux-unstick.sh
@@ -43,7 +43,9 @@
 #      5 minutes of production output can be eyeballed for
 #      false-positives before real keys start firing.
 #
-#   D. Panic switch — if ~/.scitex/orochi/tmux-unstick.PAUSED exists,
+#   D. Panic switch — if ~/.scitex/orochi/runtime/tmux-unstick.PAUSED exists
+#      (or the legacy ~/.scitex/orochi/tmux-unstick.PAUSED during 68bd1592
+#      rollout),
 #      the script sleeps without scanning. `touch` the file to halt
 #      recovery globally; `rm` to resume.
 #
@@ -68,7 +70,10 @@
 # Environment overrides:
 #
 #   TMUX_UNSTICK_LOG              NDJSON log path (default
-#                                  ~/.scitex/orochi/logs/tmux-unstick.ndjson)
+#                                  ~/.scitex/orochi/runtime/logs/tmux-unstick.ndjson;
+#                                  falls back to legacy ~/.scitex/orochi/logs/
+#                                  during 68bd1592 rollout if runtime/ is
+#                                  missing)
 #   TMUX_UNSTICK_INTERVAL_SEC     seconds between sweeps in --loop mode
 #                                  (default 60)
 #   TMUX_UNSTICK_STABILITY_SEC    per-pane minimum age of a stable
@@ -79,10 +84,14 @@
 #                                  (default 300 = 5 min)
 #   TMUX_UNSTICK_HEARTBEAT_EVERY  emit a meta heartbeat every N sweeps
 #                                  in --loop mode (default 5)
-#   TMUX_UNSTICK_STATE_DIR        per-pane stability snapshot dir
-#                                  (default ~/.scitex/orochi/tmux-unstick-state/)
+#   TMUX_UNSTICK_STATE_DIR        per-pane stability snapshot dir (default
+#                                  ~/.scitex/orochi/runtime/tmux-unstick-state/;
+#                                  legacy ~/.scitex/orochi/tmux-unstick-state/
+#                                  still honored during 68bd1592 rollout)
 #   TMUX_UNSTICK_PAUSE_FILE       panic-switch marker file (default
-#                                  ~/.scitex/orochi/tmux-unstick.PAUSED)
+#                                  ~/.scitex/orochi/runtime/tmux-unstick.PAUSED;
+#                                  legacy ~/.scitex/orochi/tmux-unstick.PAUSED
+#                                  still honored during 68bd1592 rollout)
 #   DRY_RUN                       if 1, detect and log but never send
 #                                  keys (default 0; overridden to 1
 #                                  during the safe-start window)
@@ -94,14 +103,30 @@ set -u
 set -o pipefail
 
 SCHEMA="scitex-orochi/tmux-unstick/v2"
-LOG="${TMUX_UNSTICK_LOG:-$HOME/.scitex/orochi/logs/tmux-unstick.ndjson}"
+# Canonical paths live under runtime/ (dotfiles commit 68bd1592). When the
+# legacy flat path is present on a not-yet-migrated host, honour it instead
+# so the daemon keeps writing to the same file the operator is tailing.
+# DEPRECATED: remove the legacy fallbacks after every host is re-bootstrapped.
+_pick_path() {
+  # _pick_path <canonical> <legacy>
+  # Returns $canonical unless only $legacy's parent dir already exists.
+  local canonical="$1" legacy="$2"
+  if [ -e "$canonical" ]; then
+    printf '%s' "$canonical"
+  elif [ -e "$legacy" ] || [ -d "$(dirname "$legacy")" ] && ! [ -d "$(dirname "$canonical")" ]; then
+    printf '%s' "$legacy"
+  else
+    printf '%s' "$canonical"
+  fi
+}
+LOG="${TMUX_UNSTICK_LOG:-$(_pick_path "$HOME/.scitex/orochi/runtime/logs/tmux-unstick.ndjson" "$HOME/.scitex/orochi/logs/tmux-unstick.ndjson")}"
 INTERVAL="${TMUX_UNSTICK_INTERVAL_SEC:-60}"
 STABILITY_SEC="${TMUX_UNSTICK_STABILITY_SEC:-120}"
 COOLDOWN_SEC="${TMUX_UNSTICK_COOLDOWN_SEC:-120}"
 SAFE_START_SEC="${TMUX_UNSTICK_SAFE_START_SEC:-300}"
 HEARTBEAT_EVERY="${TMUX_UNSTICK_HEARTBEAT_EVERY:-5}"
-STATE_DIR="${TMUX_UNSTICK_STATE_DIR:-$HOME/.scitex/orochi/tmux-unstick-state}"
-PAUSE_FILE="${TMUX_UNSTICK_PAUSE_FILE:-$HOME/.scitex/orochi/tmux-unstick.PAUSED}"
+STATE_DIR="${TMUX_UNSTICK_STATE_DIR:-$(_pick_path "$HOME/.scitex/orochi/runtime/tmux-unstick-state" "$HOME/.scitex/orochi/tmux-unstick-state")}"
+PAUSE_FILE="${TMUX_UNSTICK_PAUSE_FILE:-$(_pick_path "$HOME/.scitex/orochi/runtime/tmux-unstick.PAUSED" "$HOME/.scitex/orochi/tmux-unstick.PAUSED")}"
 DRY_RUN_ENV="${DRY_RUN:-0}"
 MODE="${1:---once}"
 # Shorthand promotion

--- a/deployment/host-setup/logrotate/scitex-orochi.conf
+++ b/deployment/host-setup/logrotate/scitex-orochi.conf
@@ -4,6 +4,20 @@
 # Closes:  scitex-orochi#138
 
 # fleet-watch log: ~260 KB/day, no SIGHUP support → copytruncate
+# Canonical location post-dotfiles-68bd1592:
+/home/ywatanabe/.scitex/orochi/runtime/fleet-watch/*.log {
+    weekly
+    rotate 4
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}
+
+# Legacy flat path — kept for the rollout window so logrotate keeps
+# working on hosts that haven't been re-bootstrapped yet.
+# DEPRECATED: remove once every host uses the runtime/ layout.
 /home/ywatanabe/.scitex/orochi/fleet-watch/*.log {
     weekly
     rotate 4
@@ -16,7 +30,7 @@
 
 # fleet-health-daemon / caduceus probe NDJSON logs (future)
 # Add paths here when daemon-layer probers are deployed (todo#146)
-# /home/ywatanabe/.scitex/orochi/probes/caduceus/*.ndjson {
+# /home/ywatanabe/.scitex/orochi/runtime/probes/caduceus/*.ndjson {
 #     weekly
 #     rotate 4
 #     compress

--- a/deployment/host-setup/logrotate/scitex-orochi.conf
+++ b/deployment/host-setup/logrotate/scitex-orochi.conf
@@ -15,19 +15,6 @@
     copytruncate
 }
 
-# Legacy flat path — kept for the rollout window so logrotate keeps
-# working on hosts that haven't been re-bootstrapped yet.
-# DEPRECATED: remove once every host uses the runtime/ layout.
-/home/ywatanabe/.scitex/orochi/fleet-watch/*.log {
-    weekly
-    rotate 4
-    compress
-    delaycompress
-    missingok
-    notifempty
-    copytruncate
-}
-
 # fleet-health-daemon / caduceus probe NDJSON logs (future)
 # Add paths here when daemon-layer probers are deployed (todo#146)
 # /home/ywatanabe/.scitex/orochi/runtime/probes/caduceus/*.ndjson {

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -11,10 +11,6 @@ directly by `scitex-orochi launch` -- operational configs live under
 └── <host>/agents/<name>/<name>.yaml     # host-specific concrete yaml
 ```
 
-The legacy flat `~/.scitex/orochi/agents/` layout is still accepted as a
-fallback while hosts finish bootstrapping against the new layout
-(DEPRECATED — will be removed once rollout is complete).
-
 ## Usage
 
 Copy an example into the appropriate canonical location and customize:

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -1,21 +1,41 @@
 # Example Agent Definitions
 
 Reference YAML templates for Orochi fleet agents. These are **not** used
-directly by `scitex-orochi launch` -- operational configs live in:
+directly by `scitex-orochi launch` -- operational configs live under
+`~/.scitex/orochi/` in the canonical layout (see
+`~/.scitex/orochi/README.md`, dotfiles commit `68bd1592`):
 
 ```
-~/.scitex/orochi/agents/
+~/.scitex/orochi/
+├── shared/agents/<name>/<name>.yaml     # shared template (hostname-substituted)
+└── <host>/agents/<name>/<name>.yaml     # host-specific concrete yaml
 ```
+
+The legacy flat `~/.scitex/orochi/agents/` layout is still accepted as a
+fallback while hosts finish bootstrapping against the new layout
+(DEPRECATED — will be removed once rollout is complete).
 
 ## Usage
 
-Copy an example to your user config directory and customize:
+Copy an example into the appropriate canonical location and customize:
 
 ```bash
-mkdir -p ~/.scitex/orochi/agents
-cp examples/agents/head-general.yaml ~/.scitex/orochi/agents/head-myhost.yaml
+# Shared template — behaves identically on every host, only ${HOSTNAME}
+# substitutions differ.
+mkdir -p ~/.scitex/orochi/shared/agents/head-myrole
+cp examples/agents/head-general.yaml \
+   ~/.scitex/orochi/shared/agents/head-myrole/head-myrole.yaml
 # Edit host, model, channels, etc.
-scitex-orochi launch head myhost
+scitex-orochi launch head myrole
+```
+
+For a host-specific agent (hardcoded paths, local-only tools):
+
+```bash
+HOST=$(hostname -s)
+mkdir -p ~/.scitex/orochi/$HOST/agents/head-myrole
+cp examples/agents/head-general.yaml \
+   ~/.scitex/orochi/$HOST/agents/head-myrole/head-myrole.yaml
 ```
 
 ## Files
@@ -34,8 +54,13 @@ scitex-orochi launch head myhost
 For production, use the dir-per-agent layout with a `CLAUDE.md` alongside:
 
 ```
-~/.scitex/orochi/agents/
-  head-myhost/
-    head-myhost.yaml
-    CLAUDE.md
+~/.scitex/orochi/shared/agents/
+  head-myrole/
+    head-myrole.yaml
+    src_CLAUDE.md          # copied to {workdir}/CLAUDE.md at launch
+    src_mcp.json           # copied to {workdir}/.mcp.json at launch
 ```
+
+At launch time, sac creates the per-agent workdir at
+`~/.scitex/orochi/runtime/workspaces/<effective-agent-id>/` (gitignored,
+regenerated per host).

--- a/examples/agents/head-deploy.yaml
+++ b/examples/agents/head-deploy.yaml
@@ -1,4 +1,8 @@
-# Template: copy to ~/.scitex/orochi/agents/ and customize
+# Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
+#           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
+#           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
+#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
+#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (Deploy/CI) -- agent-container definition
 # Launched via: scitex-orochi launch head deploy
 # Or explicitly: scitex-orochi launch head deploy --agent-config agents/head-deploy.yaml

--- a/examples/agents/head-deploy.yaml
+++ b/examples/agents/head-deploy.yaml
@@ -1,8 +1,6 @@
 # Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
 #           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
 #           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
-#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
-#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (Deploy/CI) -- agent-container definition
 # Launched via: scitex-orochi launch head deploy
 # Or explicitly: scitex-orochi launch head deploy --agent-config agents/head-deploy.yaml

--- a/examples/agents/head-general.yaml
+++ b/examples/agents/head-general.yaml
@@ -1,8 +1,6 @@
 # Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
 #           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
 #           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
-#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
-#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (General) -- agent-container definition
 # Launched via: scitex-orochi launch head general
 # Auto-discovered from agents/head-general.yaml (no --agent-config needed)

--- a/examples/agents/head-general.yaml
+++ b/examples/agents/head-general.yaml
@@ -1,4 +1,8 @@
-# Template: copy to ~/.scitex/orochi/agents/ and customize
+# Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
+#           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
+#           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
+#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
+#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (General) -- agent-container definition
 # Launched via: scitex-orochi launch head general
 # Auto-discovered from agents/head-general.yaml (no --agent-config needed)

--- a/examples/agents/head-mba.yaml
+++ b/examples/agents/head-mba.yaml
@@ -1,8 +1,6 @@
 # Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
 #           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
 #           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
-#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
-#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (MBA) -- agent-container definition
 # Runs on MacBook Air for iOS/mobile development tasks
 # Launched via: scitex-orochi launch head mba

--- a/examples/agents/head-mba.yaml
+++ b/examples/agents/head-mba.yaml
@@ -1,4 +1,8 @@
-# Template: copy to ~/.scitex/orochi/agents/ and customize
+# Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
+#           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
+#           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
+#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
+#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (MBA) -- agent-container definition
 # Runs on MacBook Air for iOS/mobile development tasks
 # Launched via: scitex-orochi launch head mba

--- a/examples/agents/head-research.yaml
+++ b/examples/agents/head-research.yaml
@@ -1,8 +1,6 @@
 # Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
 #           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
 #           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
-#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
-#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (Research) -- agent-container definition
 # Launched via: scitex-orochi launch head research
 # Or explicitly: scitex-orochi launch head research --agent-config agents/head-research.yaml

--- a/examples/agents/head-research.yaml
+++ b/examples/agents/head-research.yaml
@@ -1,4 +1,8 @@
-# Template: copy to ~/.scitex/orochi/agents/ and customize
+# Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
+#           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
+#           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
+#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
+#           as a fallback but is DEPRECATED.
 # Orochi Head Agent (Research) -- agent-container definition
 # Launched via: scitex-orochi launch head research
 # Or explicitly: scitex-orochi launch head research --agent-config agents/head-research.yaml

--- a/examples/agents/master.yaml
+++ b/examples/agents/master.yaml
@@ -1,4 +1,8 @@
-# Template: copy to ~/.scitex/orochi/agents/ and customize
+# Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
+#           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
+#           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
+#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
+#           as a fallback but is DEPRECATED.
 # Orochi Master Agent -- agent-container definition
 # Launched via: scitex-orochi launch master
 # Auto-discovered from agents/master.yaml (no --agent-config needed)

--- a/examples/agents/master.yaml
+++ b/examples/agents/master.yaml
@@ -1,8 +1,6 @@
 # Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
 #           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
 #           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
-#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
-#           as a fallback but is DEPRECATED.
 # Orochi Master Agent -- agent-container definition
 # Launched via: scitex-orochi launch master
 # Auto-discovered from agents/master.yaml (no --agent-config needed)

--- a/examples/agents/telegrammer.yaml
+++ b/examples/agents/telegrammer.yaml
@@ -1,8 +1,6 @@
 # Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
 #           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
 #           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
-#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
-#           as a fallback but is DEPRECATED.
 # Orochi Telegrammer Agent -- agent-container definition
 #
 # IMPORTANT: This agent runs SEPARATELY from the Orochi launch system.

--- a/examples/agents/telegrammer.yaml
+++ b/examples/agents/telegrammer.yaml
@@ -1,4 +1,8 @@
-# Template: copy to ~/.scitex/orochi/agents/ and customize
+# Template: copy to ~/.scitex/orochi/shared/agents/<name>/<name>.yaml
+#           or ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml
+#           (see ~/.scitex/orochi/README.md; dotfiles 68bd1592).
+#           The legacy flat ~/.scitex/orochi/agents/ path is still accepted
+#           as a fallback but is DEPRECATED.
 # Orochi Telegrammer Agent -- agent-container definition
 #
 # IMPORTANT: This agent runs SEPARATELY from the Orochi launch system.

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -1,6 +1,7 @@
 """Tests for the Orochi hub Django app."""
 
 import json
+import os
 
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -1708,25 +1709,49 @@ class PaneActionSummaryRegistryTest(TestCase):
 class ReadOauthMetadataHelperTest(TestCase):
     """todo#265: unit tests for the read_oauth_metadata() helper.
 
-    The helper lives in the canonical agent_meta.py shipped from
-    ``.dotfiles/src/.scitex/orochi/scripts/agent_meta.py`` (see PR
-    body for dotfiles sync notes). This test imports it directly
-    from that path so the scitex-orochi hub test suite guards the
-    token-leak regression even though the helper lives upstream.
+    The helper lives in the canonical agent_meta.py shipped from the
+    dotfiles Orochi tree. Post-68bd1592 it is at
+    ``.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py``; the
+    legacy flat ``.dotfiles/src/.scitex/orochi/scripts/agent_meta.py``
+    path is still probed for hosts that haven't been re-bootstrapped.
+    This test imports it directly from whichever path exists so the
+    scitex-orochi hub test suite guards the token-leak regression even
+    though the helper lives upstream.
     """
 
-    DOTFILES_AGENT_META = (
-        "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py"
-    )
+    # Ordered candidate paths — first existing wins. Covers both
+    # macOS and Linux HOMEs since the scitex-orochi hub runs in Docker
+    # on mba in production but can be tested on any host.
+    _CANDIDATE_AGENT_META_PATHS = [
+        os.path.expanduser("~/.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py"),
+        os.path.expanduser("~/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py"),
+        "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py",
+        "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py",
+        "/home/ywatanabe/.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py",
+        "/home/ywatanabe/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py",
+    ]
+
+    @classmethod
+    def _resolve_agent_meta_path(cls) -> str | None:
+        import os as _os
+
+        for candidate in cls._CANDIDATE_AGENT_META_PATHS:
+            if _os.path.isfile(candidate):
+                return candidate
+        return None
+
+    # Kept for backward-compat with any external subclasses; prefer
+    # ``_resolve_agent_meta_path`` in new tests.
+    DOTFILES_AGENT_META = _CANDIDATE_AGENT_META_PATHS[0]
 
     def _import_helper(self):
         import importlib.util
-        import os
 
-        if not os.path.isfile(self.DOTFILES_AGENT_META):
+        resolved = self._resolve_agent_meta_path()
+        if resolved is None:
             self.skipTest("dotfiles agent_meta.py not present on this host")
         spec = importlib.util.spec_from_file_location(
-            "agent_meta_under_test", self.DOTFILES_AGENT_META
+            "agent_meta_under_test", resolved
         )
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)  # type: ignore[union-attr]

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -1710,13 +1710,11 @@ class ReadOauthMetadataHelperTest(TestCase):
     """todo#265: unit tests for the read_oauth_metadata() helper.
 
     The helper lives in the canonical agent_meta.py shipped from the
-    dotfiles Orochi tree. Post-68bd1592 it is at
-    ``.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py``; the
-    legacy flat ``.dotfiles/src/.scitex/orochi/scripts/agent_meta.py``
-    path is still probed for hosts that haven't been re-bootstrapped.
-    This test imports it directly from whichever path exists so the
-    scitex-orochi hub test suite guards the token-leak regression even
-    though the helper lives upstream.
+    dotfiles Orochi tree (post-68bd1592):
+    ``.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py``.
+    This test imports it directly so the scitex-orochi hub test suite
+    guards the token-leak regression even though the helper lives
+    upstream.
     """
 
     # Ordered candidate paths — first existing wins. Covers both
@@ -1724,11 +1722,8 @@ class ReadOauthMetadataHelperTest(TestCase):
     # on mba in production but can be tested on any host.
     _CANDIDATE_AGENT_META_PATHS = [
         os.path.expanduser("~/.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py"),
-        os.path.expanduser("~/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py"),
         "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py",
-        "/Users/ywatanabe/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py",
         "/home/ywatanabe/.dotfiles/src/.scitex/orochi/shared/scripts/agent_meta.py",
-        "/home/ywatanabe/.dotfiles/src/.scitex/orochi/scripts/agent_meta.py",
     ]
 
     @classmethod
@@ -1740,8 +1735,6 @@ class ReadOauthMetadataHelperTest(TestCase):
                 return candidate
         return None
 
-    # Kept for backward-compat with any external subclasses; prefer
-    # ``_resolve_agent_meta_path`` in new tests.
     DOTFILES_AGENT_META = _CANDIDATE_AGENT_META_PATHS[0]
 
     def _import_helper(self):

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -2065,10 +2065,8 @@ def api_agents_restart(request):
     host = _derive_host(name)
     is_local = host in ("localhost", "127.0.0.1", "::1", "")
     screen_name = name
-    # Canonical workspace path under the new runtime/ layout (dotfiles
-    # commit 68bd1592). Old flat path ~/.scitex/orochi/workspaces/<n>/
-    # is deprecated and will be removed once every host has been
-    # bootstrapped against the new layout.
+    # Canonical workspace path under the runtime/ layout (dotfiles
+    # commit 68bd1592).
     workspace = f"~/.scitex/orochi/runtime/workspaces/{name}"
 
     ssh_prefix = None

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -2065,7 +2065,11 @@ def api_agents_restart(request):
     host = _derive_host(name)
     is_local = host in ("localhost", "127.0.0.1", "::1", "")
     screen_name = name
-    workspace = f"~/.scitex/orochi/workspaces/{name}"
+    # Canonical workspace path under the new runtime/ layout (dotfiles
+    # commit 68bd1592). Old flat path ~/.scitex/orochi/workspaces/<n>/
+    # is deprecated and will be removed once every host has been
+    # bootstrapped against the new layout.
+    workspace = f"~/.scitex/orochi/runtime/workspaces/{name}"
 
     ssh_prefix = None
     if not is_local:

--- a/orochi-config.yaml
+++ b/orochi-config.yaml
@@ -58,10 +58,15 @@ orochi:
       workdir: ~/proj
 
   # Agent Container Integration (recommended)
-  # Agent YAML definitions live in ~/.scitex/orochi/agents/ (per-user).
+  # Agent YAML definitions live under ~/.scitex/orochi/ (per-user):
+  #   ~/.scitex/orochi/shared/agents/<name>/<name>.yaml   (template)
+  #   ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml   (host-specific)
+  # See ~/.scitex/orochi/README.md for the full layout.
+  # The legacy flat ~/.scitex/orochi/agents/ path is accepted as a
+  # fallback during the dotfiles 68bd1592 rollout (DEPRECATED).
   # The repo ships example definitions under examples/agents/ as reference.
   # No --agent-config flag needed -- just run:
-  #   scitex-orochi launch master        # discovers ~/.scitex/orochi/agents/master*.yaml
+  #   scitex-orochi launch master        # discovers ~/.scitex/orochi/.../agents/master*.yaml
   #   scitex-orochi launch head general  # discovers head-general*.yaml
   #   scitex-orochi launch all           # discovers all YAMLs
   #
@@ -70,7 +75,11 @@ orochi:
   # Falls back to the master/heads sections above if agent-container is
   # not installed or no YAML files are found.
   agents:
-    directory: ~/.scitex/orochi/agents   # Per-user agent definitions
+    # Per-user agent definition root. The CLI also searches
+    # ~/.scitex/orochi/shared/agents/ and ~/.scitex/orochi/<host>/agents/
+    # automatically; this ``directory`` key only controls the legacy
+    # flat-layout fallback (kept for backward compat).
+    directory: ~/.scitex/orochi/agents
     examples: ./examples/agents          # Example definitions shipped with repo
     master: master.yaml
     heads:

--- a/orochi-config.yaml
+++ b/orochi-config.yaml
@@ -62,8 +62,6 @@ orochi:
   #   ~/.scitex/orochi/shared/agents/<name>/<name>.yaml   (template)
   #   ~/.scitex/orochi/<host>/agents/<name>/<name>.yaml   (host-specific)
   # See ~/.scitex/orochi/README.md for the full layout.
-  # The legacy flat ~/.scitex/orochi/agents/ path is accepted as a
-  # fallback during the dotfiles 68bd1592 rollout (DEPRECATED).
   # The repo ships example definitions under examples/agents/ as reference.
   # No --agent-config flag needed -- just run:
   #   scitex-orochi launch master        # discovers ~/.scitex/orochi/.../agents/master*.yaml
@@ -75,11 +73,8 @@ orochi:
   # Falls back to the master/heads sections above if agent-container is
   # not installed or no YAML files are found.
   agents:
-    # Per-user agent definition root. The CLI also searches
-    # ~/.scitex/orochi/shared/agents/ and ~/.scitex/orochi/<host>/agents/
-    # automatically; this ``directory`` key only controls the legacy
-    # flat-layout fallback (kept for backward compat).
-    directory: ~/.scitex/orochi/agents
+    # The CLI searches ~/.scitex/orochi/<host>/agents/ (host-specific)
+    # then ~/.scitex/orochi/shared/agents/ (shared template).
     examples: ./examples/agents          # Example definitions shipped with repo
     master: master.yaml
     heads:

--- a/orochi-machines.yaml
+++ b/orochi-machines.yaml
@@ -136,7 +136,7 @@ machines:
     notes:
       - "Two cloudflared tunnels run side-by-side: scitex.ai (docker stack) and bastion-nas (systemd user)."
       - "fleet_watch.sh is the canonical NAS producer; scripts live at ~/proj/scitex-orochi/scripts/fleet-watch/."
-      - "ngate hosts ~/.scitex/orochi/scripts/agent_meta.py (per-session context_pct extractor)."
+      - "ngate hosts ~/.scitex/orochi/shared/scripts/agent_meta.py (per-session context_pct extractor; post-68bd1592 canonical path)."
 
   # ---------------------------------------------------------------------------
   - canonical_name: spartan

--- a/scripts/fleet-watch/compact_actuator.sh
+++ b/scripts/fleet-watch/compact_actuator.sh
@@ -16,18 +16,8 @@ HOST=""
 AGENT=""
 STRATEGY=""
 SESSION=""
-# Canonical post-68bd1592 path: runtime/fleet-watch/. Honour the legacy flat
-# path if that's where the existing log lives so operators don't lose tail.
-# DEPRECATED: drop legacy fallback after rollout.
-_default_compact_log() {
-  if [ -f "$HOME/.scitex/orochi/fleet-watch/compact_actuator.log" ] \
-     && [ ! -f "$HOME/.scitex/orochi/runtime/fleet-watch/compact_actuator.log" ]; then
-    printf '%s' "$HOME/.scitex/orochi/fleet-watch/compact_actuator.log"
-  else
-    printf '%s' "$HOME/.scitex/orochi/runtime/fleet-watch/compact_actuator.log"
-  fi
-}
-LOG_FILE="${COMPACT_ACTUATOR_LOG:-$(_default_compact_log)}"
+# Canonical post-68bd1592 path: runtime/fleet-watch/.
+LOG_FILE="${COMPACT_ACTUATOR_LOG:-$HOME/.scitex/orochi/runtime/fleet-watch/compact_actuator.log}"
 SELF_AGENT="head-nas"
 
 usage() {

--- a/scripts/fleet-watch/compact_actuator.sh
+++ b/scripts/fleet-watch/compact_actuator.sh
@@ -16,7 +16,18 @@ HOST=""
 AGENT=""
 STRATEGY=""
 SESSION=""
-LOG_FILE="${COMPACT_ACTUATOR_LOG:-$HOME/.scitex/orochi/fleet-watch/compact_actuator.log}"
+# Canonical post-68bd1592 path: runtime/fleet-watch/. Honour the legacy flat
+# path if that's where the existing log lives so operators don't lose tail.
+# DEPRECATED: drop legacy fallback after rollout.
+_default_compact_log() {
+  if [ -f "$HOME/.scitex/orochi/fleet-watch/compact_actuator.log" ] \
+     && [ ! -f "$HOME/.scitex/orochi/runtime/fleet-watch/compact_actuator.log" ]; then
+    printf '%s' "$HOME/.scitex/orochi/fleet-watch/compact_actuator.log"
+  else
+    printf '%s' "$HOME/.scitex/orochi/runtime/fleet-watch/compact_actuator.log"
+  fi
+}
+LOG_FILE="${COMPACT_ACTUATOR_LOG:-$(_default_compact_log)}"
 SELF_AGENT="head-nas"
 
 usage() {

--- a/scripts/fleet-watch/drift_check.py
+++ b/scripts/fleet-watch/drift_check.py
@@ -3,9 +3,7 @@
 
 For one host alias, compares the declared `expected_tmux_sessions` in
 ``orochi-machines.yaml`` against the runtime ``tmux_names`` field from
-the most recent snapshot in ``~/.scitex/orochi/runtime/fleet-watch/<host>.json``
-(or the legacy ``~/.scitex/orochi/fleet-watch/<host>.json`` path; see
-backward-compat note in :func:`_runtime_sessions`).
+the most recent snapshot in ``~/.scitex/orochi/runtime/fleet-watch/<host>.json``.
 
 Prints exactly one line per (host, drift_kind) finding to stdout in a
 fleet_watch-friendly shape so the bash wrapper can pipe it straight to
@@ -32,17 +30,12 @@ SCITEX_OROCHI_DIR = Path(os.environ.get(
     os.path.expanduser("~/proj/scitex-orochi"),
 ))
 MACHINES_YAML = SCITEX_OROCHI_DIR / "orochi-machines.yaml"
-# Canonical fleet-watch snapshot dir moved under runtime/ in dotfiles
-# commit 68bd1592 (Orochi fleet restructure Phase A). The legacy flat
-# path is accepted as a fallback so mixed-host fleets (some bootstrapped
-# against the new layout, some not) keep working during rollout.
-# DEPRECATED: remove the legacy fallback once every host has been
-# re-bootstrapped — estimate Q3 2026.
+# Canonical fleet-watch snapshot dir under runtime/ (dotfiles commit
+# 68bd1592, Orochi fleet restructure Phase A).
 WATCH_DIR = Path(os.environ.get(
     "FLEET_WATCH_OUT",
     os.path.expanduser("~/.scitex/orochi/runtime/fleet-watch"),
 ))
-_LEGACY_WATCH_DIR = Path(os.path.expanduser("~/.scitex/orochi/fleet-watch"))
 
 
 def _load_machines_yaml() -> list[dict]:
@@ -72,16 +65,9 @@ def _expected_sessions(host: str) -> set[str]:
 
 
 def _runtime_sessions(host: str) -> set[str] | None:
-    # Prefer the canonical runtime/ path; fall back to the legacy flat
-    # path if the runtime/ snapshot isn't there yet (backward compat
-    # during dotfiles 68bd1592 rollout).
     snap_path = WATCH_DIR / f"{host}.json"
     if not snap_path.exists():
-        legacy = _LEGACY_WATCH_DIR / f"{host}.json"
-        if legacy.exists():
-            snap_path = legacy
-        else:
-            return None
+        return None
     try:
         with open(snap_path) as f:
             snap = json.load(f)

--- a/scripts/fleet-watch/drift_check.py
+++ b/scripts/fleet-watch/drift_check.py
@@ -3,7 +3,9 @@
 
 For one host alias, compares the declared `expected_tmux_sessions` in
 ``orochi-machines.yaml`` against the runtime ``tmux_names`` field from
-the most recent snapshot in ``~/.scitex/orochi/fleet-watch/<host>.json``.
+the most recent snapshot in ``~/.scitex/orochi/runtime/fleet-watch/<host>.json``
+(or the legacy ``~/.scitex/orochi/fleet-watch/<host>.json`` path; see
+backward-compat note in :func:`_runtime_sessions`).
 
 Prints exactly one line per (host, drift_kind) finding to stdout in a
 fleet_watch-friendly shape so the bash wrapper can pipe it straight to
@@ -30,10 +32,17 @@ SCITEX_OROCHI_DIR = Path(os.environ.get(
     os.path.expanduser("~/proj/scitex-orochi"),
 ))
 MACHINES_YAML = SCITEX_OROCHI_DIR / "orochi-machines.yaml"
+# Canonical fleet-watch snapshot dir moved under runtime/ in dotfiles
+# commit 68bd1592 (Orochi fleet restructure Phase A). The legacy flat
+# path is accepted as a fallback so mixed-host fleets (some bootstrapped
+# against the new layout, some not) keep working during rollout.
+# DEPRECATED: remove the legacy fallback once every host has been
+# re-bootstrapped — estimate Q3 2026.
 WATCH_DIR = Path(os.environ.get(
     "FLEET_WATCH_OUT",
-    os.path.expanduser("~/.scitex/orochi/fleet-watch"),
+    os.path.expanduser("~/.scitex/orochi/runtime/fleet-watch"),
 ))
+_LEGACY_WATCH_DIR = Path(os.path.expanduser("~/.scitex/orochi/fleet-watch"))
 
 
 def _load_machines_yaml() -> list[dict]:
@@ -63,9 +72,16 @@ def _expected_sessions(host: str) -> set[str]:
 
 
 def _runtime_sessions(host: str) -> set[str] | None:
+    # Prefer the canonical runtime/ path; fall back to the legacy flat
+    # path if the runtime/ snapshot isn't there yet (backward compat
+    # during dotfiles 68bd1592 rollout).
     snap_path = WATCH_DIR / f"{host}.json"
     if not snap_path.exists():
-        return None
+        legacy = _LEGACY_WATCH_DIR / f"{host}.json"
+        if legacy.exists():
+            snap_path = legacy
+        else:
+            return None
     try:
         with open(snap_path) as f:
             snap = json.load(f)

--- a/scripts/fleet-watch/fleet_watch.sh
+++ b/scripts/fleet-watch/fleet_watch.sh
@@ -8,7 +8,19 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROBE_SCRIPT="$SCRIPT_DIR/probe_remote.sh"
 DRIFT_SCRIPT="$SCRIPT_DIR/drift_check.py"
-OUT_DIR="${FLEET_WATCH_OUT:-$HOME/.scitex/orochi/fleet-watch}"
+# Canonical out-dir post-68bd1592: runtime/fleet-watch/. Honour the legacy
+# flat path if runtime/ isn't bootstrapped here yet so operators don't lose
+# their `tail -f` target. DEPRECATED: drop legacy fallback after rollout.
+_default_fleet_watch_out() {
+  if [ -d "$HOME/.scitex/orochi/runtime" ]; then
+    printf '%s' "$HOME/.scitex/orochi/runtime/fleet-watch"
+  elif [ -d "$HOME/.scitex/orochi/fleet-watch" ]; then
+    printf '%s' "$HOME/.scitex/orochi/fleet-watch"
+  else
+    printf '%s' "$HOME/.scitex/orochi/runtime/fleet-watch"
+  fi
+}
+OUT_DIR="${FLEET_WATCH_OUT:-$(_default_fleet_watch_out)}"
 LOG_FILE="$OUT_DIR/fleet_watch.log"
 HOSTS=( mba spartan ywata-note-win )
 SSH_TIMEOUT=8

--- a/scripts/fleet-watch/fleet_watch.sh
+++ b/scripts/fleet-watch/fleet_watch.sh
@@ -8,19 +8,8 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROBE_SCRIPT="$SCRIPT_DIR/probe_remote.sh"
 DRIFT_SCRIPT="$SCRIPT_DIR/drift_check.py"
-# Canonical out-dir post-68bd1592: runtime/fleet-watch/. Honour the legacy
-# flat path if runtime/ isn't bootstrapped here yet so operators don't lose
-# their `tail -f` target. DEPRECATED: drop legacy fallback after rollout.
-_default_fleet_watch_out() {
-  if [ -d "$HOME/.scitex/orochi/runtime" ]; then
-    printf '%s' "$HOME/.scitex/orochi/runtime/fleet-watch"
-  elif [ -d "$HOME/.scitex/orochi/fleet-watch" ]; then
-    printf '%s' "$HOME/.scitex/orochi/fleet-watch"
-  else
-    printf '%s' "$HOME/.scitex/orochi/runtime/fleet-watch"
-  fi
-}
-OUT_DIR="${FLEET_WATCH_OUT:-$(_default_fleet_watch_out)}"
+# Canonical out-dir post-68bd1592: runtime/fleet-watch/.
+OUT_DIR="${FLEET_WATCH_OUT:-$HOME/.scitex/orochi/runtime/fleet-watch}"
 LOG_FILE="$OUT_DIR/fleet_watch.log"
 HOSTS=( mba spartan ywata-note-win )
 SSH_TIMEOUT=8

--- a/scripts/fleet-watch/host-telemetry-probe.sh
+++ b/scripts/fleet-watch/host-telemetry-probe.sh
@@ -12,7 +12,9 @@
 # Side effects: none. Read-only queries only. No sudo. No Claude quota.
 #
 # Output: one NDJSON line per probe per invocation, appended to
-#   ${OUT_DIR:-$HOME/.scitex/orochi/host-telemetry}/host-telemetry-$(hostname -s).ndjson
+#   ${OUT_DIR:-$HOME/.scitex/orochi/runtime/host-telemetry}/host-telemetry-$(hostname -s).ndjson
+# (or the legacy ~/.scitex/orochi/host-telemetry/ during dotfiles 68bd1592
+#  rollout, if the runtime/ skeleton isn't bootstrapped on this host yet)
 # -----------------------------------------------------------------------------
 
 set -u
@@ -20,7 +22,18 @@ set -o pipefail
 
 HOST="$(hostname -s 2>/dev/null || hostname)"
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-OUT_DIR="${HOST_TELEMETRY_OUT_DIR:-$HOME/.scitex/orochi/host-telemetry}"
+# Canonical post-68bd1592: runtime/host-telemetry/. Legacy flat path is
+# honoured while runtime/ is being rolled out. DEPRECATED.
+_default_host_telemetry_dir() {
+  if [ -d "$HOME/.scitex/orochi/runtime" ]; then
+    printf '%s' "$HOME/.scitex/orochi/runtime/host-telemetry"
+  elif [ -d "$HOME/.scitex/orochi/host-telemetry" ]; then
+    printf '%s' "$HOME/.scitex/orochi/host-telemetry"
+  else
+    printf '%s' "$HOME/.scitex/orochi/runtime/host-telemetry"
+  fi
+}
+OUT_DIR="${HOST_TELEMETRY_OUT_DIR:-$(_default_host_telemetry_dir)}"
 OUT_FILE="$OUT_DIR/host-telemetry-${HOST}.ndjson"
 mkdir -p "$OUT_DIR"
 

--- a/scripts/fleet-watch/host-telemetry-probe.sh
+++ b/scripts/fleet-watch/host-telemetry-probe.sh
@@ -13,8 +13,6 @@
 #
 # Output: one NDJSON line per probe per invocation, appended to
 #   ${OUT_DIR:-$HOME/.scitex/orochi/runtime/host-telemetry}/host-telemetry-$(hostname -s).ndjson
-# (or the legacy ~/.scitex/orochi/host-telemetry/ during dotfiles 68bd1592
-#  rollout, if the runtime/ skeleton isn't bootstrapped on this host yet)
 # -----------------------------------------------------------------------------
 
 set -u
@@ -22,18 +20,8 @@ set -o pipefail
 
 HOST="$(hostname -s 2>/dev/null || hostname)"
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-# Canonical post-68bd1592: runtime/host-telemetry/. Legacy flat path is
-# honoured while runtime/ is being rolled out. DEPRECATED.
-_default_host_telemetry_dir() {
-  if [ -d "$HOME/.scitex/orochi/runtime" ]; then
-    printf '%s' "$HOME/.scitex/orochi/runtime/host-telemetry"
-  elif [ -d "$HOME/.scitex/orochi/host-telemetry" ]; then
-    printf '%s' "$HOME/.scitex/orochi/host-telemetry"
-  else
-    printf '%s' "$HOME/.scitex/orochi/runtime/host-telemetry"
-  fi
-}
-OUT_DIR="${HOST_TELEMETRY_OUT_DIR:-$(_default_host_telemetry_dir)}"
+# Canonical post-68bd1592: runtime/host-telemetry/.
+OUT_DIR="${HOST_TELEMETRY_OUT_DIR:-$HOME/.scitex/orochi/runtime/host-telemetry}"
 OUT_FILE="$OUT_DIR/host-telemetry-${HOST}.ndjson"
 mkdir -p "$OUT_DIR"
 

--- a/scripts/fleet-watch/probe_remote.sh
+++ b/scripts/fleet-watch/probe_remote.sh
@@ -102,13 +102,8 @@ fi
 # agent_meta.py reads the live Claude Code session jsonl and emits
 # {agent, alive, context_pct, current_tool, last_activity, model, subagents}.
 # We call it for each tmux session name and aggregate into agents_meta JSON.
-# Canonical post-68bd1592 path: shared/scripts/agent_meta.py. Fall back to
-# the legacy flat scripts/ path until every host is re-bootstrapped.
-# DEPRECATED: drop legacy branch after rollout.
+# Canonical post-68bd1592 path: shared/scripts/agent_meta.py.
 agent_meta_script="$HOME/.scitex/orochi/shared/scripts/agent_meta.py"
-if [ ! -x "$agent_meta_script" ]; then
-    agent_meta_script="$HOME/.scitex/orochi/scripts/agent_meta.py"
-fi
 agents_meta="{}"
 if [ -x "$agent_meta_script" ] && [ -n "$tmux_names" ]; then
     parts=""

--- a/scripts/fleet-watch/probe_remote.sh
+++ b/scripts/fleet-watch/probe_remote.sh
@@ -102,7 +102,13 @@ fi
 # agent_meta.py reads the live Claude Code session jsonl and emits
 # {agent, alive, context_pct, current_tool, last_activity, model, subagents}.
 # We call it for each tmux session name and aggregate into agents_meta JSON.
-agent_meta_script="$HOME/.scitex/orochi/scripts/agent_meta.py"
+# Canonical post-68bd1592 path: shared/scripts/agent_meta.py. Fall back to
+# the legacy flat scripts/ path until every host is re-bootstrapped.
+# DEPRECATED: drop legacy branch after rollout.
+agent_meta_script="$HOME/.scitex/orochi/shared/scripts/agent_meta.py"
+if [ ! -x "$agent_meta_script" ]; then
+    agent_meta_script="$HOME/.scitex/orochi/scripts/agent_meta.py"
+fi
 agents_meta="{}"
 if [ -x "$agent_meta_script" ] && [ -n "$tmux_names" ]; then
     parts=""

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -10,8 +10,62 @@
 
 set -euo pipefail
 
-AGENTS_DIR="${SCITEX_OROCHI_AGENTS_DIR:-$HOME/.scitex/orochi/agents}"
-WORKSPACES_DIR="${SCITEX_OROCHI_WORKSPACES_DIR:-$HOME/.scitex/orochi/workspaces}"
+# Canonical post-68bd1592 layout:
+#   agent defs  → shared/agents/<name>/ or <host>/agents/<name>/
+#   workspaces  → runtime/workspaces/<name>/
+# Legacy flat ~/.scitex/orochi/{agents,workspaces}/ are honoured as a
+# fallback when the runtime/ skeleton hasn't been bootstrapped yet.
+# DEPRECATED: drop the legacy fallbacks after rollout.
+_OROCHI_ROOT="$HOME/.scitex/orochi"
+# Ordered list of agent-definition roots. Host override wins, shared next,
+# legacy last. Callers that override via SCITEX_OROCHI_AGENTS_DIR bypass
+# the entire search.
+_HOST_FOR_AGENTS="${SCITEX_OROCHI_HOSTNAME:-$(hostname -s 2>/dev/null || hostname)}"
+_DEFAULT_AGENT_DIRS=(
+    "$_OROCHI_ROOT/$_HOST_FOR_AGENTS/agents"
+    "$_OROCHI_ROOT/shared/agents"
+    "$_OROCHI_ROOT/agents"
+)
+# Back-compat: AGENTS_DIR is still a single path (first usable root). Most
+# consumers just want "one place to start looking".
+_first_existing_agents_dir() {
+    local d
+    for d in "${_DEFAULT_AGENT_DIRS[@]}"; do
+        if [[ -d "$d" ]]; then
+            printf '%s' "$d"
+            return
+        fi
+    done
+    # Fall back to the canonical shared/agents/ path so error messages
+    # point users to the correct, expected location.
+    printf '%s' "$_OROCHI_ROOT/shared/agents"
+}
+AGENTS_DIR="${SCITEX_OROCHI_AGENTS_DIR:-$(_first_existing_agents_dir)}"
+_default_workspaces_dir() {
+    if [[ -d "$_OROCHI_ROOT/runtime" ]]; then
+        printf '%s' "$_OROCHI_ROOT/runtime/workspaces"
+    elif [[ -d "$_OROCHI_ROOT/workspaces" ]]; then
+        printf '%s' "$_OROCHI_ROOT/workspaces"
+    else
+        printf '%s' "$_OROCHI_ROOT/runtime/workspaces"
+    fi
+}
+WORKSPACES_DIR="${SCITEX_OROCHI_WORKSPACES_DIR:-$(_default_workspaces_dir)}"
+
+# Resolve an agent dir by name across all canonical roots. Echoes the
+# first match on stdout. Falls back to the default AGENTS_DIR/<name> so
+# callers get a consistent "not found" error path.
+_resolve_agent_dir() {
+    local name="$1" d candidate
+    for d in "${_DEFAULT_AGENT_DIRS[@]}"; do
+        candidate="$d/$name"
+        if [[ -d "$candidate" ]]; then
+            printf '%s' "$candidate"
+            return
+        fi
+    done
+    printf '%s' "$AGENTS_DIR/$name"
+}
 
 # ──────────────────────────────────────────
 # Helpers
@@ -47,7 +101,8 @@ expand_env_vars() {
 
 setup_agent() {
     local agent_name="$1"
-    local agent_dir="$AGENTS_DIR/$agent_name"
+    local agent_dir
+    agent_dir="$(_resolve_agent_dir "$agent_name")"
     local workspace_dir="$WORKSPACES_DIR/$agent_name"
     local example="$agent_dir/.mcp.json.example"
 
@@ -89,13 +144,25 @@ fi
 
 if [[ "$1" == "--all" ]]; then
     count=0
-    for agent_dir in "$AGENTS_DIR"/*/; do
-        agent_name="$(basename "$agent_dir")"
-        [[ "$agent_name" == "legacy" ]] && continue
-        if [[ -f "$agent_dir/.mcp.json.example" ]]; then
-            setup_agent "$agent_name"
-            count=$((count + 1))
-        fi
+    declare -A _seen_all=()
+    for root in "${_DEFAULT_AGENT_DIRS[@]}"; do
+        [[ -d "$root" ]] || continue
+        for agent_dir in "$root"/*/; do
+            [[ -d "$agent_dir" ]] || continue
+            agent_name="$(basename "$agent_dir")"
+            case "$agent_name" in
+                legacy|legacy-agents|_*) continue ;;
+            esac
+            # Skip duplicates across roots (host override wins).
+            if [[ -n "${_seen_all[$agent_name]:-}" ]]; then
+                continue
+            fi
+            _seen_all[$agent_name]=1
+            if [[ -f "$agent_dir/.mcp.json.example" ]]; then
+                setup_agent "$agent_name"
+                count=$((count + 1))
+            fi
+        done
     done
     printf "done: %d agent(s) processed\n" "$count"
 else

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -13,21 +13,16 @@ set -euo pipefail
 # Canonical post-68bd1592 layout:
 #   agent defs  → shared/agents/<name>/ or <host>/agents/<name>/
 #   workspaces  → runtime/workspaces/<name>/
-# Legacy flat ~/.scitex/orochi/{agents,workspaces}/ are honoured as a
-# fallback when the runtime/ skeleton hasn't been bootstrapped yet.
-# DEPRECATED: drop the legacy fallbacks after rollout.
 _OROCHI_ROOT="$HOME/.scitex/orochi"
-# Ordered list of agent-definition roots. Host override wins, shared next,
-# legacy last. Callers that override via SCITEX_OROCHI_AGENTS_DIR bypass
-# the entire search.
+# Ordered list of agent-definition roots. Host override wins, shared next.
+# Callers that override via SCITEX_OROCHI_AGENTS_DIR bypass the entire search.
 _HOST_FOR_AGENTS="${SCITEX_OROCHI_HOSTNAME:-$(hostname -s 2>/dev/null || hostname)}"
 _DEFAULT_AGENT_DIRS=(
     "$_OROCHI_ROOT/$_HOST_FOR_AGENTS/agents"
     "$_OROCHI_ROOT/shared/agents"
-    "$_OROCHI_ROOT/agents"
 )
-# Back-compat: AGENTS_DIR is still a single path (first usable root). Most
-# consumers just want "one place to start looking".
+# AGENTS_DIR is a single path (first usable root). Most consumers just
+# want "one place to start looking".
 _first_existing_agents_dir() {
     local d
     for d in "${_DEFAULT_AGENT_DIRS[@]}"; do
@@ -41,16 +36,7 @@ _first_existing_agents_dir() {
     printf '%s' "$_OROCHI_ROOT/shared/agents"
 }
 AGENTS_DIR="${SCITEX_OROCHI_AGENTS_DIR:-$(_first_existing_agents_dir)}"
-_default_workspaces_dir() {
-    if [[ -d "$_OROCHI_ROOT/runtime" ]]; then
-        printf '%s' "$_OROCHI_ROOT/runtime/workspaces"
-    elif [[ -d "$_OROCHI_ROOT/workspaces" ]]; then
-        printf '%s' "$_OROCHI_ROOT/workspaces"
-    else
-        printf '%s' "$_OROCHI_ROOT/runtime/workspaces"
-    fi
-}
-WORKSPACES_DIR="${SCITEX_OROCHI_WORKSPACES_DIR:-$(_default_workspaces_dir)}"
+WORKSPACES_DIR="${SCITEX_OROCHI_WORKSPACES_DIR:-$_OROCHI_ROOT/runtime/workspaces}"
 
 # Resolve an agent dir by name across all canonical roots. Echoes the
 # first match on stdout. Falls back to the default AGENTS_DIR/<name> so

--- a/src/scitex_orochi/_cli/commands/_launch_helpers.py
+++ b/src/scitex_orochi/_cli/commands/_launch_helpers.py
@@ -27,10 +27,52 @@ except ImportError:
     HAS_AGENT_CONTAINER = False
 
 # Default agents directory (relative to project root / cwd)
-# The repo ships example definitions under examples/agents/; real configs
-# live in ~/.scitex/orochi/agents/ (USER_AGENTS_DIR) and are checked first.
+# The repo ships example definitions under examples/agents/; real agent
+# definitions live under ~/.scitex/orochi/ in one of two canonical places
+# (dotfiles 68bd1592, Phase A restructure):
+#   - shared/agents/<name>/<name>.yaml   (template, hostname-substituted)
+#   - <host>/agents/<name>/<name>.yaml   (host-specific concrete yaml)
+# The legacy flat ~/.scitex/orochi/agents/ is accepted as a fallback until
+# every host has been re-bootstrapped. DEPRECATED: remove the legacy fallback
+# after rollout completes.
 DEFAULT_AGENTS_DIR = Path("examples/agents")
-USER_AGENTS_DIR = Path.home() / ".scitex" / "orochi" / "agents"
+_OROCHI_ROOT = Path.home() / ".scitex" / "orochi"
+SHARED_AGENTS_DIR = _OROCHI_ROOT / "shared" / "agents"
+LEGACY_AGENTS_DIR = _OROCHI_ROOT / "agents"
+# Back-compat alias: external callers used USER_AGENTS_DIR.
+USER_AGENTS_DIR = LEGACY_AGENTS_DIR
+
+
+def _host_agents_dir() -> Path:
+    """Resolve the per-host agents dir: ``<host>/agents/``.
+
+    Mirrors the canonical hostname resolution documented in
+    ``~/.scitex/orochi/README.md``:
+    ``${SCITEX_OROCHI_HOSTNAME:-$(hostname -s)}``.
+    """
+    import os
+    import socket
+
+    host = os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
+    if not host:
+        try:
+            host = socket.gethostname().split(".")[0]
+        except Exception:
+            host = ""
+    if not host:
+        # No usable hostname — return a non-existent path so callers simply
+        # skip this search layer.
+        return _OROCHI_ROOT / "_no_host_"
+    return _OROCHI_ROOT / host / "agents"
+
+
+def _candidate_agents_dirs() -> list[Path]:
+    """Ordered list of user-level agent definition roots.
+
+    Host-specific overrides win, then shared templates, then the legacy
+    flat layout (backward compat during dotfiles 68bd1592 rollout).
+    """
+    return [_host_agents_dir(), SHARED_AGENTS_DIR, LEGACY_AGENTS_DIR]
 
 
 def find_agent_yaml(name: str, agents_dir: Path | None = None) -> Path | None:
@@ -39,30 +81,37 @@ def find_agent_yaml(name: str, agents_dir: Path | None = None) -> Path | None:
     Given a short role name like "master", "head", "mamba", or a more
     specific "head-mba", find the agent yaml file to launch.
 
-    Search order (first hit wins):
-      1. ``~/.scitex/orochi/agents/<name>.yaml`` (flat file)
-      2. ``~/.scitex/orochi/agents/<name>/<name>.yaml`` (dir-per-agent)
-      3. ``~/.scitex/orochi/agents/head-<name>/head-<name>.yaml``
-         (dir-per-agent with "head-" prefix, e.g. ``head-mba``)
-      4. ``~/.scitex/orochi/agents/<name>-*/` — machine-suffix convention,
+    Search order (first hit wins), for each of:
+      - ``<host>/agents/``   (host-specific override)
+      - ``shared/agents/``   (shared template)
+      - ``agents/``          (legacy flat layout, DEPRECATED)
+
+    Within each root:
+      1. ``<root>/<name>.yaml`` (flat file — only meaningful for the
+         legacy layout; the new layout is always dir-per-agent)
+      2. ``<root>/<name>/<name>.yaml`` (dir-per-agent)
+      3. ``<root>/head-<name>/head-<name>.yaml`` (with "head-" prefix,
+         e.g. ``head-mba``)
+      4. ``<root>/<name>-*/`` — machine-suffix convention,
          e.g. ``master`` resolves to ``master-ywata-note-win`` if that is
-         the only matching directory. If multiple matches exist, returns
-         None (ambiguous — caller should use --agent-config explicitly).
+         the only matching directory. If multiple matches exist, the
+         search continues to the next root instead of returning None.
       5. Repo fallback: ``examples/agents/{name,head-<name>}.{yaml,yml}``
 
     Returns the resolved Path or None if not found.
     """
-    # Check user config dir first (flat files + subdirectory convention)
-    if USER_AGENTS_DIR.is_dir():
+    for root in _candidate_agents_dirs():
+        if not root.is_dir():
+            continue
         for ext in (".yaml", ".yml"):
             for prefix in ("", "head-"):
                 prefixed = f"{prefix}{name}"
                 for candidate in (
-                    USER_AGENTS_DIR / f"{prefixed}{ext}",
-                    USER_AGENTS_DIR / name / f"{prefixed}{ext}",
+                    root / f"{prefixed}{ext}",
+                    root / name / f"{prefixed}{ext}",
                     # dir-per-agent with prefix applied to both dir and
                     # file, e.g. head-nas/head-nas.yaml
-                    USER_AGENTS_DIR / prefixed / f"{prefixed}{ext}",
+                    root / prefixed / f"{prefixed}{ext}",
                 ):
                     if candidate.exists():
                         return candidate
@@ -70,12 +119,13 @@ def find_agent_yaml(name: str, agents_dir: Path | None = None) -> Path | None:
         # Machine-suffix convention: resolve ``master`` to the
         # unambiguous ``master-*/master-*.yaml``, ``mamba`` to
         # ``mamba-*/mamba-*.yaml``, etc. Only match at the start of the
-        # directory name, and only if exactly one directory matches.
+        # directory name, and only if exactly one directory matches in
+        # this root.
         matches: list[Path] = []
-        for sub in sorted(USER_AGENTS_DIR.iterdir()):
+        for sub in sorted(root.iterdir()):
             if not sub.is_dir():
                 continue
-            if sub.name == "legacy" or sub.name.startswith("_"):
+            if sub.name in ("legacy", "legacy-agents") or sub.name.startswith("_"):
                 continue
             if not (sub.name == name or sub.name.startswith(f"{name}-")):
                 continue
@@ -105,46 +155,57 @@ def find_agent_yaml(name: str, agents_dir: Path | None = None) -> Path | None:
 
 
 def find_all_agent_yamls(agents_dir: Path | None = None) -> list[Path]:
-    """Find all agent YAML files in the agents directory.
+    """Find all agent YAML files across the canonical agent roots.
 
-    Prefers the user config dir (~/.scitex/orochi/agents/) when it exists,
-    otherwise falls back to the repo ``examples/agents/`` directory.
+    Merges results from (in order): ``<host>/agents/``, ``shared/agents/``,
+    and the legacy ``agents/`` dir (backward compat during dotfiles
+    68bd1592 rollout). Duplicates by resolved path are de-duped so the
+    same agent isn't returned twice.
 
     Walks one level deep to support the dir-per-agent layout
     (e.g. ``mamba/mamba.yaml``). Excludes:
       - files whose names start with ``_`` (disabled/template convention)
-      - anything under a ``legacy/`` directory
+      - anything under a ``legacy/`` or ``legacy-agents/`` directory
       - for dir-per-agent entries, only the YAML matching the dir name
         (e.g. ``mamba/mamba.yaml``) is collected, to avoid duplicates when
         an agent dir holds multiple yamls.
     """
     if agents_dir is not None:
-        d = agents_dir.resolve()
-    elif USER_AGENTS_DIR.is_dir():
-        d = USER_AGENTS_DIR.resolve()
+        roots = [agents_dir.resolve()]
     else:
-        d = DEFAULT_AGENTS_DIR.resolve()
-
-    if not d.is_dir():
-        return []
+        roots = [r for r in _candidate_agents_dirs() if r.is_dir()]
+        if not roots:
+            roots = [DEFAULT_AGENTS_DIR.resolve()]
 
     found: list[Path] = []
-
-    # Top-level flat yamls: agents/<name>.yaml
-    for p in sorted(d.glob("*.yaml")) + sorted(d.glob("*.yml")):
-        if p.name.startswith("_"):
+    seen: set[Path] = set()
+    for d in roots:
+        if not d.is_dir():
             continue
-        found.append(p)
 
-    # Dir-per-agent: agents/<name>/<name>.yaml
-    for sub in sorted(p for p in d.iterdir() if p.is_dir()):
-        if sub.name == "legacy" or sub.name.startswith("_"):
-            continue
-        for ext in (".yaml", ".yml"):
-            candidate = sub / f"{sub.name}{ext}"
-            if candidate.exists():
-                found.append(candidate)
-                break
+        # Top-level flat yamls: agents/<name>.yaml
+        for p in sorted(d.glob("*.yaml")) + sorted(d.glob("*.yml")):
+            if p.name.startswith("_"):
+                continue
+            resolved = p.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
+            found.append(p)
+
+        # Dir-per-agent: agents/<name>/<name>.yaml
+        for sub in sorted(p for p in d.iterdir() if p.is_dir()):
+            if sub.name in ("legacy", "legacy-agents") or sub.name.startswith("_"):
+                continue
+            for ext in (".yaml", ".yml"):
+                candidate = sub / f"{sub.name}{ext}"
+                if candidate.exists():
+                    resolved = candidate.resolve()
+                    if resolved in seen:
+                        break
+                    seen.add(resolved)
+                    found.append(candidate)
+                    break
 
     return found
 

--- a/src/scitex_orochi/_cli/commands/_launch_helpers.py
+++ b/src/scitex_orochi/_cli/commands/_launch_helpers.py
@@ -1,4 +1,4 @@
-"""Helper functions for launch commands: resolution, legacy fallback."""
+"""Helper functions for launch commands: yaml resolution, container dispatch."""
 
 from __future__ import annotations
 
@@ -32,15 +32,9 @@ except ImportError:
 # (dotfiles 68bd1592, Phase A restructure):
 #   - shared/agents/<name>/<name>.yaml   (template, hostname-substituted)
 #   - <host>/agents/<name>/<name>.yaml   (host-specific concrete yaml)
-# The legacy flat ~/.scitex/orochi/agents/ is accepted as a fallback until
-# every host has been re-bootstrapped. DEPRECATED: remove the legacy fallback
-# after rollout completes.
 DEFAULT_AGENTS_DIR = Path("examples/agents")
 _OROCHI_ROOT = Path.home() / ".scitex" / "orochi"
 SHARED_AGENTS_DIR = _OROCHI_ROOT / "shared" / "agents"
-LEGACY_AGENTS_DIR = _OROCHI_ROOT / "agents"
-# Back-compat alias: external callers used USER_AGENTS_DIR.
-USER_AGENTS_DIR = LEGACY_AGENTS_DIR
 
 
 def _host_agents_dir() -> Path:
@@ -69,10 +63,9 @@ def _host_agents_dir() -> Path:
 def _candidate_agents_dirs() -> list[Path]:
     """Ordered list of user-level agent definition roots.
 
-    Host-specific overrides win, then shared templates, then the legacy
-    flat layout (backward compat during dotfiles 68bd1592 rollout).
+    Host-specific overrides win, then shared templates.
     """
-    return [_host_agents_dir(), SHARED_AGENTS_DIR, LEGACY_AGENTS_DIR]
+    return [_host_agents_dir(), SHARED_AGENTS_DIR]
 
 
 def find_agent_yaml(name: str, agents_dir: Path | None = None) -> Path | None:
@@ -84,11 +77,9 @@ def find_agent_yaml(name: str, agents_dir: Path | None = None) -> Path | None:
     Search order (first hit wins), for each of:
       - ``<host>/agents/``   (host-specific override)
       - ``shared/agents/``   (shared template)
-      - ``agents/``          (legacy flat layout, DEPRECATED)
 
     Within each root:
-      1. ``<root>/<name>.yaml`` (flat file — only meaningful for the
-         legacy layout; the new layout is always dir-per-agent)
+      1. ``<root>/<name>.yaml`` (flat file)
       2. ``<root>/<name>/<name>.yaml`` (dir-per-agent)
       3. ``<root>/head-<name>/head-<name>.yaml`` (with "head-" prefix,
          e.g. ``head-mba``)
@@ -157,9 +148,8 @@ def find_agent_yaml(name: str, agents_dir: Path | None = None) -> Path | None:
 def find_all_agent_yamls(agents_dir: Path | None = None) -> list[Path]:
     """Find all agent YAML files across the canonical agent roots.
 
-    Merges results from (in order): ``<host>/agents/``, ``shared/agents/``,
-    and the legacy ``agents/`` dir (backward compat during dotfiles
-    68bd1592 rollout). Duplicates by resolved path are de-duped so the
+    Merges results from (in order): ``<host>/agents/`` and
+    ``shared/agents/``. Duplicates by resolved path are de-duped so the
     same agent isn't returned twice.
 
     Walks one level deep to support the dir-per-agent layout

--- a/src/scitex_orochi/_cli/commands/agent_cmd.py
+++ b/src/scitex_orochi/_cli/commands/agent_cmd.py
@@ -1,7 +1,12 @@
 """CLI commands: scitex-orochi {launch,restart,stop,status} for agent lifecycle.
 
 Direct agent lifecycle management using agent definitions from
-~/.scitex/orochi/agents/<name>/.  Each agent directory may contain:
+``~/.scitex/orochi/shared/agents/<name>/`` or
+``~/.scitex/orochi/<host>/agents/<name>/`` (see
+``~/.scitex/orochi/README.md``; dotfiles commit 68bd1592).
+The legacy flat ``~/.scitex/orochi/agents/<name>/`` layout is accepted
+as a fallback until every host is re-bootstrapped. DEPRECATED.
+Each agent directory may contain:
   - config.yaml  (host, role, channels, etc.)
   - .mcp.json.example  (MCP config template with $HOME etc.)
   - CLAUDE.md  (agent-specific instructions)
@@ -30,29 +35,79 @@ import yaml
 from scitex_orochi._cli._helpers import EXAMPLES_HEADER
 
 # ── Constants ──────────────────────────────────────────────────────
-AGENTS_DIR = Path.home() / ".scitex" / "orochi" / "agents"
-WORKSPACES_DIR = Path.home() / ".scitex" / "orochi" / "workspaces"
+# Agent definition lookup roots, in order of precedence (dotfiles 68bd1592):
+#   1. ~/.scitex/orochi/<host>/agents/     (host-specific override)
+#   2. ~/.scitex/orochi/shared/agents/     (shared template)
+#   3. ~/.scitex/orochi/agents/            (legacy flat layout; DEPRECATED)
+_OROCHI_ROOT = Path.home() / ".scitex" / "orochi"
+SHARED_AGENTS_DIR = _OROCHI_ROOT / "shared" / "agents"
+LEGACY_AGENTS_DIR = _OROCHI_ROOT / "agents"
+# Kept as an alias for backward compatibility with external callers /
+# scripts that import AGENTS_DIR expecting a single path. Prefer
+# :func:`_candidate_agents_dirs` for new code.
+AGENTS_DIR = LEGACY_AGENTS_DIR
+# Deployed per-agent workdir (runtime, gitignored).
+WORKSPACES_DIR = _OROCHI_ROOT / "runtime" / "workspaces"
 SETUP_SCRIPT = Path.home() / "proj" / "scitex-orochi" / "scripts" / "setup-workspace.sh"
 DEV_CHANNEL_CONFIRM_DELAY = 8  # seconds before pressing Enter
+
+
+def _host_agents_dir() -> Path:
+    """Resolve ``<host>/agents/`` using the canonical hostname rule."""
+    import os
+    import socket
+
+    host = os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
+    if not host:
+        try:
+            host = socket.gethostname().split(".")[0]
+        except Exception:
+            host = ""
+    if not host:
+        return _OROCHI_ROOT / "_no_host_"
+    return _OROCHI_ROOT / host / "agents"
+
+
+def _candidate_agents_dirs() -> list[Path]:
+    """Ordered candidate roots for agent-definition lookup."""
+    return [_host_agents_dir(), SHARED_AGENTS_DIR, LEGACY_AGENTS_DIR]
+
+
+def _resolve_agent_dir(name: str) -> Path:
+    """Return the first existing agent definition dir for ``name``.
+
+    Falls back to the legacy layout path so callers that then try to
+    open subfiles get a consistent "not found" error referring to the
+    canonical location.
+    """
+    for root in _candidate_agents_dirs():
+        candidate = root / name
+        if candidate.is_dir():
+            return candidate
+    return LEGACY_AGENTS_DIR / name
 
 
 # ── Helpers ────────────────────────────────────────────────────────
 
 
 def _list_agent_names() -> list[str]:
-    """Return sorted list of agent names from AGENTS_DIR."""
-    if not AGENTS_DIR.is_dir():
-        return []
-    return sorted(
-        d.name
-        for d in AGENTS_DIR.iterdir()
-        if d.is_dir() and d.name != "legacy" and not d.name.startswith("_")
-    )
+    """Return sorted list of agent names across canonical roots."""
+    names: set[str] = set()
+    for root in _candidate_agents_dirs():
+        if not root.is_dir():
+            continue
+        for d in root.iterdir():
+            if not d.is_dir():
+                continue
+            if d.name in ("legacy", "legacy-agents") or d.name.startswith("_"):
+                continue
+            names.add(d.name)
+    return sorted(names)
 
 
 def _load_agent_config(name: str) -> dict:
     """Load config.yaml for an agent, falling back to derived defaults."""
-    agent_dir = AGENTS_DIR / name
+    agent_dir = _resolve_agent_dir(name)
     config_file = agent_dir / "config.yaml"
 
     if config_file.exists():
@@ -97,7 +152,10 @@ def _extract_config_from_ac_yaml(yaml_path: Path) -> dict:
         "role": labels.get("role", "head"),
         "screen_name": screen_cfg.get("name", meta.get("name", yaml_path.stem)),
         "model": spec.get("model", "opus[1m]"),
-        "workdir": spec.get("workdir", f"~/.scitex/orochi/workspaces/{yaml_path.stem}"),
+        "workdir": spec.get(
+            "workdir",
+            f"~/.scitex/orochi/runtime/workspaces/{yaml_path.stem}",
+        ),
     }
 
 
@@ -141,7 +199,7 @@ def _derive_config(name: str) -> dict:
         "role": role,
         "screen_name": name,
         "model": "opus[1m]",
-        "workdir": f"~/.scitex/orochi/workspaces/{name}",
+        "workdir": f"~/.scitex/orochi/runtime/workspaces/{name}",
     }
 
 
@@ -282,7 +340,7 @@ def _launch_agent(name: str, dry_run: bool = False, force: bool = False) -> bool
         return False
 
     # Build the launch command
-    workspace = f"~/.scitex/orochi/workspaces/{name}"
+    workspace = f"~/.scitex/orochi/runtime/workspaces/{name}"
     claude_cmd = (
         f"cd {workspace} && "
         f"exec claude "
@@ -453,8 +511,11 @@ def agent_launch(
 ) -> None:
     """Launch an agent by name, or all agents with --all.
 
-    Reads agent definition from ~/.scitex/orochi/agents/<name>/,
-    sets up the workspace, and starts a screen session with claude.
+    Reads agent definition from ~/.scitex/orochi/<host>/agents/<name>/ or
+    ~/.scitex/orochi/shared/agents/<name>/ (legacy ~/.scitex/orochi/agents/
+    accepted as fallback). Creates/uses
+    ~/.scitex/orochi/runtime/workspaces/<name>/ as the workdir and starts a
+    screen session with claude.
     """
     if not launch_all and not name:
         click.echo("Error: provide an agent NAME or use --all.", err=True)
@@ -463,7 +524,11 @@ def agent_launch(
     if launch_all:
         agents = _list_agent_names()
         if not agents:
-            click.echo("No agents found in ~/.scitex/orochi/agents/", err=True)
+            click.echo(
+                "No agents found in ~/.scitex/orochi/{shared,<host>}/agents/"
+                " (or legacy ~/.scitex/orochi/agents/).",
+                err=True,
+            )
             sys.exit(1)
 
         click.echo(f"Launching {len(agents)} agent(s)...\n")
@@ -585,7 +650,10 @@ def agent_status(as_json: bool) -> None:
         if as_json:
             click.echo(json.dumps([], indent=2))
         else:
-            click.echo("No agents found in ~/.scitex/orochi/agents/")
+            click.echo(
+                "No agents found in ~/.scitex/orochi/{shared,<host>}/agents/"
+                " (or legacy ~/.scitex/orochi/agents/)."
+            )
         return
 
     rows = []

--- a/src/scitex_orochi/_cli/commands/agent_cmd.py
+++ b/src/scitex_orochi/_cli/commands/agent_cmd.py
@@ -4,8 +4,6 @@ Direct agent lifecycle management using agent definitions from
 ``~/.scitex/orochi/shared/agents/<name>/`` or
 ``~/.scitex/orochi/<host>/agents/<name>/`` (see
 ``~/.scitex/orochi/README.md``; dotfiles commit 68bd1592).
-The legacy flat ``~/.scitex/orochi/agents/<name>/`` layout is accepted
-as a fallback until every host is re-bootstrapped. DEPRECATED.
 Each agent directory may contain:
   - config.yaml  (host, role, channels, etc.)
   - .mcp.json.example  (MCP config template with $HOME etc.)
@@ -38,14 +36,8 @@ from scitex_orochi._cli._helpers import EXAMPLES_HEADER
 # Agent definition lookup roots, in order of precedence (dotfiles 68bd1592):
 #   1. ~/.scitex/orochi/<host>/agents/     (host-specific override)
 #   2. ~/.scitex/orochi/shared/agents/     (shared template)
-#   3. ~/.scitex/orochi/agents/            (legacy flat layout; DEPRECATED)
 _OROCHI_ROOT = Path.home() / ".scitex" / "orochi"
 SHARED_AGENTS_DIR = _OROCHI_ROOT / "shared" / "agents"
-LEGACY_AGENTS_DIR = _OROCHI_ROOT / "agents"
-# Kept as an alias for backward compatibility with external callers /
-# scripts that import AGENTS_DIR expecting a single path. Prefer
-# :func:`_candidate_agents_dirs` for new code.
-AGENTS_DIR = LEGACY_AGENTS_DIR
 # Deployed per-agent workdir (runtime, gitignored).
 WORKSPACES_DIR = _OROCHI_ROOT / "runtime" / "workspaces"
 SETUP_SCRIPT = Path.home() / "proj" / "scitex-orochi" / "scripts" / "setup-workspace.sh"
@@ -70,21 +62,21 @@ def _host_agents_dir() -> Path:
 
 def _candidate_agents_dirs() -> list[Path]:
     """Ordered candidate roots for agent-definition lookup."""
-    return [_host_agents_dir(), SHARED_AGENTS_DIR, LEGACY_AGENTS_DIR]
+    return [_host_agents_dir(), SHARED_AGENTS_DIR]
 
 
 def _resolve_agent_dir(name: str) -> Path:
     """Return the first existing agent definition dir for ``name``.
 
-    Falls back to the legacy layout path so callers that then try to
-    open subfiles get a consistent "not found" error referring to the
-    canonical location.
+    Falls back to the canonical shared-layout path so callers that then
+    try to open subfiles get a consistent "not found" error pointing to
+    the expected location.
     """
     for root in _candidate_agents_dirs():
         candidate = root / name
         if candidate.is_dir():
             return candidate
-    return LEGACY_AGENTS_DIR / name
+    return SHARED_AGENTS_DIR / name
 
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -305,7 +297,7 @@ def _setup_workspace(name: str, ssh: str | None = None) -> bool:
 
 def _launch_agent(name: str, dry_run: bool = False, force: bool = False) -> bool:
     """Launch a single agent. Returns True on success."""
-    agent_dir = AGENTS_DIR / name
+    agent_dir = _resolve_agent_dir(name)
     if not agent_dir.is_dir():
         click.echo(f"Error: agent directory not found: {agent_dir}", err=True)
         return False
@@ -512,8 +504,7 @@ def agent_launch(
     """Launch an agent by name, or all agents with --all.
 
     Reads agent definition from ~/.scitex/orochi/<host>/agents/<name>/ or
-    ~/.scitex/orochi/shared/agents/<name>/ (legacy ~/.scitex/orochi/agents/
-    accepted as fallback). Creates/uses
+    ~/.scitex/orochi/shared/agents/<name>/. Creates/uses
     ~/.scitex/orochi/runtime/workspaces/<name>/ as the workdir and starts a
     screen session with claude.
     """
@@ -525,8 +516,7 @@ def agent_launch(
         agents = _list_agent_names()
         if not agents:
             click.echo(
-                "No agents found in ~/.scitex/orochi/{shared,<host>}/agents/"
-                " (or legacy ~/.scitex/orochi/agents/).",
+                "No agents found in ~/.scitex/orochi/{shared,<host>}/agents/.",
                 err=True,
             )
             sys.exit(1)
@@ -561,7 +551,7 @@ def agent_launch(
 @click.option("--dry-run", is_flag=True, help="Print commands without executing.")
 def agent_restart(name: str, dry_run: bool) -> None:
     """Restart an agent: quit existing screen, then relaunch."""
-    agent_dir = AGENTS_DIR / name
+    agent_dir = _resolve_agent_dir(name)
     if not agent_dir.is_dir():
         click.echo(f"Error: agent directory not found: {agent_dir}", err=True)
         sys.exit(1)
@@ -626,7 +616,7 @@ def agent_stop(name: str | None, stop_all: bool, force: bool) -> None:
         return
 
     assert name is not None
-    agent_dir = AGENTS_DIR / name
+    agent_dir = _resolve_agent_dir(name)
     if not agent_dir.is_dir():
         click.echo(f"Error: agent directory not found: {agent_dir}", err=True)
         sys.exit(1)
@@ -651,8 +641,7 @@ def agent_status(as_json: bool) -> None:
             click.echo(json.dumps([], indent=2))
         else:
             click.echo(
-                "No agents found in ~/.scitex/orochi/{shared,<host>}/agents/"
-                " (or legacy ~/.scitex/orochi/agents/)."
+                "No agents found in ~/.scitex/orochi/{shared,<host>}/agents/."
             )
         return
 

--- a/src/scitex_orochi/_cli/commands/launch_cmd.py
+++ b/src/scitex_orochi/_cli/commands/launch_cmd.py
@@ -30,9 +30,10 @@ def launch() -> None:
     """Launch orochi agents (master, head, or all).
 
     By default, agents are launched via scitex-agent-container using YAML
-    definitions from ~/.scitex/orochi/agents/ (or examples/agents/ as
-    fallback). If no YAML is found and agent-container is not installed,
-    falls back to legacy orochi-config.yaml.
+    definitions from ~/.scitex/orochi/{shared,<host>}/agents/ (or legacy
+    ~/.scitex/orochi/agents/, or examples/agents/ as fallback). If no YAML
+    is found and agent-container is not installed, falls back to legacy
+    orochi-config.yaml.
     """
 
 
@@ -83,7 +84,8 @@ def launch_master(
 
     Resolution order:
       1. --agent-config (explicit YAML path)
-      2. ~/.scitex/orochi/agents/ or examples/agents/ (auto-discovery)
+      2. ~/.scitex/orochi/{<host>,shared}/agents/ (or legacy
+         ~/.scitex/orochi/agents/), or examples/agents/ (auto-discovery)
       3. orochi-config.yaml (legacy fallback)
     """
     if agent_config_path:
@@ -159,7 +161,8 @@ def launch_head(
 
     Resolution order:
       1. --agent-config (explicit YAML path)
-      2. ~/.scitex/orochi/agents/ or examples/agents/ (auto-discovery)
+      2. ~/.scitex/orochi/{<host>,shared}/agents/ (or legacy
+         ~/.scitex/orochi/agents/), or examples/agents/ (auto-discovery)
       3. orochi-config.yaml (legacy fallback)
     """
     if agent_config_path:
@@ -235,7 +238,9 @@ def launch_all(
 
     Resolution order:
       1. --agent-config-dir (explicit directory, all YAMLs launched)
-      2. ~/.scitex/orochi/agents/ or examples/agents/ (if agent-container installed)
+      2. ~/.scitex/orochi/{<host>,shared}/agents/ (or legacy
+         ~/.scitex/orochi/agents/), or examples/agents/ (if
+         agent-container installed)
       3. orochi-config.yaml (legacy fallback)
     """
     if agent_config_dir:

--- a/src/scitex_orochi/_cli/commands/launch_cmd.py
+++ b/src/scitex_orochi/_cli/commands/launch_cmd.py
@@ -30,10 +30,9 @@ def launch() -> None:
     """Launch orochi agents (master, head, or all).
 
     By default, agents are launched via scitex-agent-container using YAML
-    definitions from ~/.scitex/orochi/{shared,<host>}/agents/ (or legacy
-    ~/.scitex/orochi/agents/, or examples/agents/ as fallback). If no YAML
-    is found and agent-container is not installed, falls back to legacy
-    orochi-config.yaml.
+    definitions from ~/.scitex/orochi/{shared,<host>}/agents/ (or
+    examples/agents/ as fallback). If no YAML is found and agent-container
+    is not installed, falls back to legacy orochi-config.yaml.
     """
 
 
@@ -84,8 +83,8 @@ def launch_master(
 
     Resolution order:
       1. --agent-config (explicit YAML path)
-      2. ~/.scitex/orochi/{<host>,shared}/agents/ (or legacy
-         ~/.scitex/orochi/agents/), or examples/agents/ (auto-discovery)
+      2. ~/.scitex/orochi/{<host>,shared}/agents/, or examples/agents/
+         (auto-discovery)
       3. orochi-config.yaml (legacy fallback)
     """
     if agent_config_path:
@@ -161,8 +160,8 @@ def launch_head(
 
     Resolution order:
       1. --agent-config (explicit YAML path)
-      2. ~/.scitex/orochi/{<host>,shared}/agents/ (or legacy
-         ~/.scitex/orochi/agents/), or examples/agents/ (auto-discovery)
+      2. ~/.scitex/orochi/{<host>,shared}/agents/, or examples/agents/
+         (auto-discovery)
       3. orochi-config.yaml (legacy fallback)
     """
     if agent_config_path:
@@ -238,9 +237,8 @@ def launch_all(
 
     Resolution order:
       1. --agent-config-dir (explicit directory, all YAMLs launched)
-      2. ~/.scitex/orochi/{<host>,shared}/agents/ (or legacy
-         ~/.scitex/orochi/agents/), or examples/agents/ (if
-         agent-container installed)
+      2. ~/.scitex/orochi/{<host>,shared}/agents/, or examples/agents/
+         (if agent-container installed)
       3. orochi-config.yaml (legacy fallback)
     """
     if agent_config_dir:

--- a/src/scitex_orochi/_cli/commands/stop_cmd.py
+++ b/src/scitex_orochi/_cli/commands/stop_cmd.py
@@ -10,9 +10,8 @@ Design notes:
   agents because scitex-agent-container's SSHRemote runtime handles
   the dispatch.
 - ``stop --all`` walks every yaml discovered under
-  ``~/.scitex/orochi/{<host>,shared}/agents/`` (or the legacy
-  ``~/.scitex/orochi/agents/`` during dotfiles 68bd1592 rollout) and
-  stops each. Telegrammer agents are skipped (same exclusion logic as
+  ``~/.scitex/orochi/{<host>,shared}/agents/`` and stops each.
+  Telegrammer agents are skipped (same exclusion logic as
   ``launch all``) — they run independently.
 - ``--force`` is passed through to the underlying ``agent_stop`` so
   stale registry entries, ghost screens, and hook failures don't
@@ -96,8 +95,7 @@ def _call_agent_stop(yaml_path: Path, force: bool) -> tuple[bool, str]:
     default=False,
     help=(
         "Stop every fleet agent discovered in "
-        "~/.scitex/orochi/{<host>,shared}/agents/ (or legacy "
-        "~/.scitex/orochi/agents/)."
+        "~/.scitex/orochi/{<host>,shared}/agents/."
     ),
 )
 @click.option(
@@ -112,8 +110,7 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
 
     Resolution for a single NAME follows the same rules as
     ``launch head <name>``: searches
-    ``~/.scitex/orochi/{<host>,shared}/agents/<name>{,.yaml}``
-    (then the legacy ``~/.scitex/orochi/agents/...``) with
+    ``~/.scitex/orochi/{<host>,shared}/agents/<name>{,.yaml}`` with
     ``head-<name>`` fallbacks.
     """
     if not stop_all and not name:
@@ -167,7 +164,7 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
     if yaml_path is None:
         click.echo(
             f"Error: no yaml found for '{name}'.\n"
-            f"  Searched: ~/.scitex/orochi/{{<host>,shared,}}/agents/"
+            f"  Searched: ~/.scitex/orochi/{{<host>,shared}}/agents/"
             f"{{{name},{name}/{name},head-{name}}}.yaml",
             err=True,
         )

--- a/src/scitex_orochi/_cli/commands/stop_cmd.py
+++ b/src/scitex_orochi/_cli/commands/stop_cmd.py
@@ -9,7 +9,9 @@ Design notes:
   scitex-agent-container. That works for both local and remote
   agents because scitex-agent-container's SSHRemote runtime handles
   the dispatch.
-- ``stop --all`` walks every yaml in ``~/.scitex/orochi/agents/`` and
+- ``stop --all`` walks every yaml discovered under
+  ``~/.scitex/orochi/{<host>,shared}/agents/`` (or the legacy
+  ``~/.scitex/orochi/agents/`` during dotfiles 68bd1592 rollout) and
   stops each. Telegrammer agents are skipped (same exclusion logic as
   ``launch all``) — they run independently.
 - ``--force`` is passed through to the underlying ``agent_stop`` so
@@ -92,7 +94,11 @@ def _call_agent_stop(yaml_path: Path, force: bool) -> tuple[bool, str]:
     "stop_all",
     is_flag=True,
     default=False,
-    help="Stop every fleet agent discovered in ~/.scitex/orochi/agents/.",
+    help=(
+        "Stop every fleet agent discovered in "
+        "~/.scitex/orochi/{<host>,shared}/agents/ (or legacy "
+        "~/.scitex/orochi/agents/)."
+    ),
 )
 @click.option(
     "--force",
@@ -105,8 +111,10 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
     """Stop an Orochi fleet agent (one or all).
 
     Resolution for a single NAME follows the same rules as
-    ``launch head <name>``: ``~/.scitex/orochi/agents/<name>{,.yaml}``
-    and ``head-<name>`` fallbacks.
+    ``launch head <name>``: searches
+    ``~/.scitex/orochi/{<host>,shared}/agents/<name>{,.yaml}``
+    (then the legacy ``~/.scitex/orochi/agents/...``) with
+    ``head-<name>`` fallbacks.
     """
     if not stop_all and not name:
         click.echo(
@@ -159,7 +167,8 @@ def stop(name: str | None, stop_all: bool, force: bool) -> None:
     if yaml_path is None:
         click.echo(
             f"Error: no yaml found for '{name}'.\n"
-            f"  Searched: ~/.scitex/orochi/agents/{{{name},{name}/{name},head-{name}}}.yaml",
+            f"  Searched: ~/.scitex/orochi/{{<host>,shared,}}/agents/"
+            f"{{{name},{name}/{name},head-{name}}}.yaml",
             err=True,
         )
         sys.exit(1)

--- a/src/scitex_orochi/_skills/scitex-orochi/agent-deployment.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-deployment.md
@@ -175,20 +175,28 @@ After deploying a new dashboard version:
 
 ### Agent Directory Structure (YAML-first)
 
-Agents are defined as YAML + CLAUDE.md in `~/.scitex/orochi/agents/`. Two layouts supported:
+Agents are defined under `~/.scitex/orochi/` in the canonical two-tier
+layout (dotfiles commit `68bd1592`, see `~/.scitex/orochi/README.md`):
 
 ```
-~/.scitex/orochi/agents/
-  master.yaml                    # Flat layout (simple agents)
-  head-general.yaml
-  mamba/                         # Subdirectory layout (agent + CLAUDE.md together)
-    mamba.yaml
-    CLAUDE.md                    # Source of truth
+~/.scitex/orochi/
+├── shared/agents/<name>/        # Shared template (hostname-substituted)
+│   ├── <name>.yaml
+│   ├── src_CLAUDE.md            # copied to {workdir}/CLAUDE.md at launch
+│   └── src_mcp.json
+└── <host>/agents/<name>/        # Host-specific (concrete yaml, no templating)
+    └── ...
 ```
 
-For subdirectory agents, symlink CLAUDE.md into the workdir:
+The legacy flat `~/.scitex/orochi/agents/` layout is accepted as a
+fallback while hosts finish re-bootstrapping (DEPRECATED).
+
+For an agent that also needs its `CLAUDE.md` visible inside a working
+project directory, symlink the `src_CLAUDE.md` into the project:
+
 ```bash
-ln -s ~/.scitex/orochi/agents/mamba/CLAUDE.md ~/proj/todo/.claude/CLAUDE.md
+ln -s ~/.scitex/orochi/shared/agents/mamba/src_CLAUDE.md \
+      ~/proj/todo/.claude/CLAUDE.md
 ```
 
 ### MCP Config (Auto-Generated)
@@ -227,15 +235,25 @@ spec:
       command: "/loop 30m Scan for stale issues"
 ```
 
-Launch: `scitex-orochi launch head mamba` or `scitex-agent-container start ~/.scitex/orochi/agents/mamba/mamba.yaml`
+Launch: `scitex-orochi launch head mamba` or
+`scitex-agent-container start ~/.scitex/orochi/shared/agents/mamba/mamba.yaml`
+(or `<host>/agents/mamba/mamba.yaml` for a host-specific concrete agent).
 
 ### Resolution Order
 
-`scitex-orochi launch head <name>` resolves YAML by:
-1. `~/.scitex/orochi/agents/<name>.yaml` (flat)
-2. `~/.scitex/orochi/agents/<name>/<name>.yaml` (subdirectory)
-3. `~/.scitex/orochi/agents/head-<name>.yaml`
-4. `./agents/<name>.yaml` (repo fallback)
+`scitex-orochi launch head <name>` searches each of these roots, in order
+(host override wins, then shared template, then legacy fallback):
+
+- `~/.scitex/orochi/<host>/agents/`
+- `~/.scitex/orochi/shared/agents/`
+- `~/.scitex/orochi/agents/` (legacy; DEPRECATED)
+
+Within each root, the first hit wins:
+1. `<root>/<name>.yaml` (flat — mainly for legacy layout)
+2. `<root>/<name>/<name>.yaml` (dir-per-agent)
+3. `<root>/head-<name>/head-<name>.yaml`
+4. `<root>/<name>-*/<name>-*.yaml` (machine-suffix; exactly one match)
+5. `./agents/<name>.yaml` (repo fallback — `examples/agents/`)
 
 ## Polling Mode (Fallback)
 

--- a/src/scitex_orochi/_skills/scitex-orochi/agent-deployment.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-deployment.md
@@ -188,9 +188,6 @@ layout (dotfiles commit `68bd1592`, see `~/.scitex/orochi/README.md`):
     └── ...
 ```
 
-The legacy flat `~/.scitex/orochi/agents/` layout is accepted as a
-fallback while hosts finish re-bootstrapping (DEPRECATED).
-
 For an agent that also needs its `CLAUDE.md` visible inside a working
 project directory, symlink the `src_CLAUDE.md` into the project:
 
@@ -242,14 +239,13 @@ Launch: `scitex-orochi launch head mamba` or
 ### Resolution Order
 
 `scitex-orochi launch head <name>` searches each of these roots, in order
-(host override wins, then shared template, then legacy fallback):
+(host override wins, then shared template):
 
 - `~/.scitex/orochi/<host>/agents/`
 - `~/.scitex/orochi/shared/agents/`
-- `~/.scitex/orochi/agents/` (legacy; DEPRECATED)
 
 Within each root, the first hit wins:
-1. `<root>/<name>.yaml` (flat — mainly for legacy layout)
+1. `<root>/<name>.yaml` (flat)
 2. `<root>/<name>/<name>.yaml` (dir-per-agent)
 3. `<root>/head-<name>/head-<name>.yaml`
 4. `<root>/<name>-*/<name>-*.yaml` (machine-suffix; exactly one match)

--- a/src/scitex_orochi/_skills/scitex-orochi/agent-health-check.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-health-check.md
@@ -139,7 +139,7 @@ This is a known open issue tracked as "Dev channel dialog auto-confirm."
 }
 ```
 
-These take effect on next agent restart. Each agent workspace (`~/.scitex/orochi/runtime/workspaces/<agent-name>/` under the post-68bd1592 layout; the legacy `~/.scitex/orochi/workspaces/<agent-name>/` is still read as a fallback during rollout) should have its own `.claude/settings.json`.
+These take effect on next agent restart. Each agent workspace (`~/.scitex/orochi/runtime/workspaces/<agent-name>/` under the post-68bd1592 layout) should have its own `.claude/settings.json`.
 
 **Prevention**: Use `scitex-orochi launch` (reads YAML flags properly) or rely on settings.json allowlists.
 

--- a/src/scitex_orochi/_skills/scitex-orochi/agent-health-check.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-health-check.md
@@ -139,7 +139,7 @@ This is a known open issue tracked as "Dev channel dialog auto-confirm."
 }
 ```
 
-These take effect on next agent restart. Each agent workspace (`~/.scitex/orochi/workspaces/<agent-name>/`) should have its own `.claude/settings.json`.
+These take effect on next agent restart. Each agent workspace (`~/.scitex/orochi/runtime/workspaces/<agent-name>/` under the post-68bd1592 layout; the legacy `~/.scitex/orochi/workspaces/<agent-name>/` is still read as a fallback during rollout) should have its own `.claude/settings.json`.
 
 **Prevention**: Use `scitex-orochi launch` (reads YAML flags properly) or rely on settings.json allowlists.
 

--- a/src/scitex_orochi/_skills/scitex-orochi/agent-self-evolution.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-self-evolution.md
@@ -11,7 +11,14 @@ Agents in the Orochi fleet learn from operational experience and propagate that 
 
 ### 1. CLAUDE.md Updates
 
-Each agent maintains a `CLAUDE.md` in their definition directory (`~/.scitex/orochi/agents/<agent-name>/CLAUDE.md`). Agents should update this file when they learn something that will be useful across sessions:
+Each agent maintains a `CLAUDE.md` in their definition directory — either
+`~/.scitex/orochi/shared/agents/<agent-name>/src_CLAUDE.md` (shared
+template, copied to `{workdir}/CLAUDE.md` at launch) or
+`~/.scitex/orochi/<host>/agents/<agent-name>/src_CLAUDE.md` (host-specific
+concrete agent). The legacy flat `~/.scitex/orochi/agents/<agent-name>/CLAUDE.md`
+layout is DEPRECATED but still accepted as a fallback. Agents should
+update this file when they learn something that will be useful across
+sessions:
 
 - New operational patterns (e.g., "media URLs need public hostname, not LAN IP")
 - Role clarifications from the operator
@@ -35,7 +42,12 @@ Knowledge that benefits the whole fleet goes into shared skills at `~/proj/scite
 
 ### 4. Private Skills (Per-Machine)
 
-Knowledge private to the local machine (not shipped) goes into `~/.scitex/orochi/skills/scitex-orochi-private/`. This directory is symlinked to `~/.claude/skills/scitex/scitex-orochi-private/` automatically by `scitex-dev skills export`.
+Knowledge private to the local machine (not shipped) goes into
+`~/.scitex/orochi/shared/skills/scitex-orochi-private/` (post-68bd1592
+canonical location; legacy `~/.scitex/orochi/skills/scitex-orochi-private/`
+still accepted). This directory is symlinked to
+`~/.claude/skills/scitex/scitex-orochi-private/` automatically by
+`scitex-dev skills export`.
 
 Convention for any package:
 ```
@@ -46,7 +58,11 @@ Where `<suffix>` is the package name minus `scitex-` (e.g. `orochi` for `scitex-
 
 ### 5. Workspace-Level Knowledge
 
-Per-agent workspace knowledge goes into `~/.scitex/orochi/agents/<agent-name>/CLAUDE.md`. Not shared fleet-wide.
+Per-agent workspace knowledge goes into the agent's definition dir —
+`~/.scitex/orochi/shared/agents/<agent-name>/src_CLAUDE.md` or
+`~/.scitex/orochi/<host>/agents/<agent-name>/src_CLAUDE.md` (or, during
+68bd1592 rollout, the legacy `~/.scitex/orochi/agents/<agent-name>/CLAUDE.md`).
+Not shared fleet-wide.
 
 ## Self-Improvement Flow
 

--- a/src/scitex_orochi/_skills/scitex-orochi/agent-self-evolution.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-self-evolution.md
@@ -15,10 +15,8 @@ Each agent maintains a `CLAUDE.md` in their definition directory — either
 `~/.scitex/orochi/shared/agents/<agent-name>/src_CLAUDE.md` (shared
 template, copied to `{workdir}/CLAUDE.md` at launch) or
 `~/.scitex/orochi/<host>/agents/<agent-name>/src_CLAUDE.md` (host-specific
-concrete agent). The legacy flat `~/.scitex/orochi/agents/<agent-name>/CLAUDE.md`
-layout is DEPRECATED but still accepted as a fallback. Agents should
-update this file when they learn something that will be useful across
-sessions:
+concrete agent). Agents should update this file when they learn something
+that will be useful across sessions:
 
 - New operational patterns (e.g., "media URLs need public hostname, not LAN IP")
 - Role clarifications from the operator
@@ -44,8 +42,7 @@ Knowledge that benefits the whole fleet goes into shared skills at `~/proj/scite
 
 Knowledge private to the local machine (not shipped) goes into
 `~/.scitex/orochi/shared/skills/scitex-orochi-private/` (post-68bd1592
-canonical location; legacy `~/.scitex/orochi/skills/scitex-orochi-private/`
-still accepted). This directory is symlinked to
+canonical location). This directory is symlinked to
 `~/.claude/skills/scitex/scitex-orochi-private/` automatically by
 `scitex-dev skills export`.
 
@@ -60,8 +57,7 @@ Where `<suffix>` is the package name minus `scitex-` (e.g. `orochi` for `scitex-
 
 Per-agent workspace knowledge goes into the agent's definition dir —
 `~/.scitex/orochi/shared/agents/<agent-name>/src_CLAUDE.md` or
-`~/.scitex/orochi/<host>/agents/<agent-name>/src_CLAUDE.md` (or, during
-68bd1592 rollout, the legacy `~/.scitex/orochi/agents/<agent-name>/CLAUDE.md`).
+`~/.scitex/orochi/<host>/agents/<agent-name>/src_CLAUDE.md`.
 Not shared fleet-wide.
 
 ## Self-Improvement Flow

--- a/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
@@ -75,7 +75,7 @@ Counter-pattern: treating "SSH succeeded + tmux returned 0" as "host has no sess
 
 ## Canonical reference implementation
 
-head-<host> owns the canonical implementation at `fleet_watch.sh` + `probe_remote.sh` (see msg#8098, 2026-04-13), producing JSON snapshots under `~/.scitex/orochi/fleet-watch/`. Fields:
+head-<host> owns the canonical implementation at `fleet_watch.sh` + `probe_remote.sh` (see msg#8098, 2026-04-13), producing JSON snapshots under `~/.scitex/orochi/runtime/fleet-watch/` (post-68bd1592 canonical path; the legacy `~/.scitex/orochi/fleet-watch/` is still read as a fallback during rollout). Fields:
 
 ```json
 {
@@ -202,7 +202,7 @@ Every fleet healer and fleet_watch-style loop must satisfy all of these before b
 - [ ] **Three-outcome schema**: SSH failure, command error, and command success are all distinguished — never collapse to a single "0" that means "unknown".
 - [ ] **Compound escalation gate**: no host is marked down on a single metric. Minimum compound condition = `ssh=down` **AND** (`claude_procs=0` **OR** `orochi_presence=absent`).
 - [ ] **Silent success**: routine all-green scans are written to a local log file only, never posted to any channel (see `fleet-communication-discipline.md` rule #6).
-- [ ] **Snapshot reuse**: before running a fresh probe, check whether head-<host>'s `fleet_watch.sh` already captured the same data in `~/.scitex/orochi/fleet-watch/`. If yes, read the snapshot instead.
+- [ ] **Snapshot reuse**: before running a fresh probe, check whether head-<host>'s `fleet_watch.sh` already captured the same data in `~/.scitex/orochi/runtime/fleet-watch/` (or the legacy `~/.scitex/orochi/fleet-watch/`). If yes, read the snapshot instead.
 - [ ] **Host-specific gotchas**:
   - primary workstation: confirm `ssh <host> 'bash -lc "env | grep TMUX"'` shows `TMUX_TMPDIR`.
   - Spartan: probe login1 only, never compute nodes. Respect `project_spartan_login_node` memory.
@@ -217,7 +217,7 @@ Tracked 2026-04-13. Agents responsible for each lane must update this list when 
 |---|---|---|---|
 | host-a (WSL) | worker-healer-<host-a> | ✅ 2026-04-13 (cron job 40c61ea4 / msg#8406) | `bash -lc`, compound gate, silent success verified |
 | host-b (primary workstation) | worker-healer-<host-b> | 🔄 in-progress (2026-04-13) | Owner: head-<host-b>. Canonical /loop prompt drafted by worker-skill-manager; head-<host-b> to apply. |
-| host-c (NAS/storage) | worker-healer-<host-c> | ⏳ pending (depends on fleet_watch snapshot reuse) | Owner: head-<host-c>. Consume `~/.scitex/orochi/fleet-watch/` instead of re-probing. |
+| host-c (NAS/storage) | worker-healer-<host-c> | ⏳ pending (depends on fleet_watch snapshot reuse) | Owner: head-<host-c>. Consume `~/.scitex/orochi/runtime/fleet-watch/` (or legacy `~/.scitex/orochi/fleet-watch/`) instead of re-probing. |
 | spartan | head-<host> (no mamba-healer yet) | ⏳ feasibility note only | Constraint: login1-only, never compute nodes. Probe must use `bash -lc`. |
 
 ## Per-lane issue templates
@@ -232,7 +232,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > 2. SSH flags as in skill doc.
 > 3. Compound escalation gate (SSH fail **AND** (claude=0 **OR** orochi absent)).
 > 4. Routine all-green: written to `~/.scitex/healer/last-scan.json`, **not** posted.
-> 5. Consume `~/.scitex/orochi/fleet-watch/` if head-<host> snapshot is available; fall back to own probe otherwise.
+> 5. Consume `~/.scitex/orochi/runtime/fleet-watch/` (or legacy `~/.scitex/orochi/fleet-watch/`) if head-<host> snapshot is available; fall back to own probe otherwise.
 >
 > **Done signal**: one-line post to #agent: `worker-healer-<host> adoption complete, job <id>`, then mark this row ✅ in `convention-connectivity-probe.md`.
 
@@ -240,7 +240,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > **Task**: Align `worker-healer-<host>` `/loop` with canonical pattern and switch it to **pure consumer** of its own `fleet_watch.sh` output (no duplicate probes).
 >
 > **Acceptance**:
-> 1. Healer reads `~/.scitex/orochi/fleet-watch/*.json` on every tick; no direct `ssh` calls.
+> 1. Healer reads `~/.scitex/orochi/runtime/fleet-watch/*.json` (or legacy `~/.scitex/orochi/fleet-watch/*.json`) on every tick; no direct `ssh` calls.
 > 2. Escalation decisions use the same compound gate as the canonical skill.
 > 3. Silent success (no routine posts).
 > 4. If the snapshot is older than 2× `fleet_watch` interval, escalate staleness once and stop probing until fresh.

--- a/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
@@ -75,7 +75,7 @@ Counter-pattern: treating "SSH succeeded + tmux returned 0" as "host has no sess
 
 ## Canonical reference implementation
 
-head-<host> owns the canonical implementation at `fleet_watch.sh` + `probe_remote.sh` (see msg#8098, 2026-04-13), producing JSON snapshots under `~/.scitex/orochi/runtime/fleet-watch/` (post-68bd1592 canonical path; the legacy `~/.scitex/orochi/fleet-watch/` is still read as a fallback during rollout). Fields:
+head-<host> owns the canonical implementation at `fleet_watch.sh` + `probe_remote.sh` (see msg#8098, 2026-04-13), producing JSON snapshots under `~/.scitex/orochi/runtime/fleet-watch/` (post-68bd1592 canonical path). Fields:
 
 ```json
 {
@@ -202,7 +202,7 @@ Every fleet healer and fleet_watch-style loop must satisfy all of these before b
 - [ ] **Three-outcome schema**: SSH failure, command error, and command success are all distinguished — never collapse to a single "0" that means "unknown".
 - [ ] **Compound escalation gate**: no host is marked down on a single metric. Minimum compound condition = `ssh=down` **AND** (`claude_procs=0` **OR** `orochi_presence=absent`).
 - [ ] **Silent success**: routine all-green scans are written to a local log file only, never posted to any channel (see `fleet-communication-discipline.md` rule #6).
-- [ ] **Snapshot reuse**: before running a fresh probe, check whether head-<host>'s `fleet_watch.sh` already captured the same data in `~/.scitex/orochi/runtime/fleet-watch/` (or the legacy `~/.scitex/orochi/fleet-watch/`). If yes, read the snapshot instead.
+- [ ] **Snapshot reuse**: before running a fresh probe, check whether head-<host>'s `fleet_watch.sh` already captured the same data in `~/.scitex/orochi/runtime/fleet-watch/`. If yes, read the snapshot instead.
 - [ ] **Host-specific gotchas**:
   - primary workstation: confirm `ssh <host> 'bash -lc "env | grep TMUX"'` shows `TMUX_TMPDIR`.
   - Spartan: probe login1 only, never compute nodes. Respect `project_spartan_login_node` memory.
@@ -217,7 +217,7 @@ Tracked 2026-04-13. Agents responsible for each lane must update this list when 
 |---|---|---|---|
 | host-a (WSL) | worker-healer-<host-a> | ✅ 2026-04-13 (cron job 40c61ea4 / msg#8406) | `bash -lc`, compound gate, silent success verified |
 | host-b (primary workstation) | worker-healer-<host-b> | 🔄 in-progress (2026-04-13) | Owner: head-<host-b>. Canonical /loop prompt drafted by worker-skill-manager; head-<host-b> to apply. |
-| host-c (NAS/storage) | worker-healer-<host-c> | ⏳ pending (depends on fleet_watch snapshot reuse) | Owner: head-<host-c>. Consume `~/.scitex/orochi/runtime/fleet-watch/` (or legacy `~/.scitex/orochi/fleet-watch/`) instead of re-probing. |
+| host-c (NAS/storage) | worker-healer-<host-c> | ⏳ pending (depends on fleet_watch snapshot reuse) | Owner: head-<host-c>. Consume `~/.scitex/orochi/runtime/fleet-watch/` instead of re-probing. |
 | spartan | head-<host> (no mamba-healer yet) | ⏳ feasibility note only | Constraint: login1-only, never compute nodes. Probe must use `bash -lc`. |
 
 ## Per-lane issue templates
@@ -232,7 +232,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > 2. SSH flags as in skill doc.
 > 3. Compound escalation gate (SSH fail **AND** (claude=0 **OR** orochi absent)).
 > 4. Routine all-green: written to `~/.scitex/healer/last-scan.json`, **not** posted.
-> 5. Consume `~/.scitex/orochi/runtime/fleet-watch/` (or legacy `~/.scitex/orochi/fleet-watch/`) if head-<host> snapshot is available; fall back to own probe otherwise.
+> 5. Consume `~/.scitex/orochi/runtime/fleet-watch/` if head-<host> snapshot is available; fall back to own probe otherwise.
 >
 > **Done signal**: one-line post to #agent: `worker-healer-<host> adoption complete, job <id>`, then mark this row ✅ in `convention-connectivity-probe.md`.
 
@@ -240,7 +240,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > **Task**: Align `worker-healer-<host>` `/loop` with canonical pattern and switch it to **pure consumer** of its own `fleet_watch.sh` output (no duplicate probes).
 >
 > **Acceptance**:
-> 1. Healer reads `~/.scitex/orochi/runtime/fleet-watch/*.json` (or legacy `~/.scitex/orochi/fleet-watch/*.json`) on every tick; no direct `ssh` calls.
+> 1. Healer reads `~/.scitex/orochi/runtime/fleet-watch/*.json` on every tick; no direct `ssh` calls.
 > 2. Escalation decisions use the same compound gate as the canonical skill.
 > 3. Silent success (no routine posts).
 > 4. If the snapshot is older than 2× `fleet_watch` interval, escalate staleness once and stop probing until fresh.

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
@@ -92,7 +92,9 @@ is agent-only territory. Use that freedom:
 
 - `worker-verifier-<host>` keeps a **persistent headed Chromium** session
   with a dedicated user profile at
-  `~/.scitex/orochi/verifier/chrome-profile/` so OAuth, mic, clipboard,
+  `~/.scitex/orochi/runtime/verifier/chrome-profile/` (post-68bd1592;
+  legacy `~/.scitex/orochi/verifier/chrome-profile/` still accepted) so
+  OAuth, mic, clipboard,
   and notification permissions persist across runs.
 - The browser window stays open 24/7 pointed at the production hub,
   acting as a live "human-eye" observer that watches for blur events,
@@ -102,7 +104,7 @@ is agent-only territory. Use that freedom:
   on page load and kept warm; verifier reads them on demand instead of
   asking the operator to paste anything.
 - Periodic screenshots (every ~5 minutes) are taken automatically and
-  archived in `~/.scitex/orochi/verifier/screenshots/` plus uploaded to
+  archived in `~/.scitex/orochi/runtime/verifier/screenshots/` (legacy `~/.scitex/orochi/verifier/screenshots/` still accepted) plus uploaded to
   `#operator` as visual pulse snapshots when something changes
   meaningfully — not every heartbeat.
 - Other macOS affordances are also fair game when they help fleet work:

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
@@ -92,10 +92,8 @@ is agent-only territory. Use that freedom:
 
 - `worker-verifier-<host>` keeps a **persistent headed Chromium** session
   with a dedicated user profile at
-  `~/.scitex/orochi/runtime/verifier/chrome-profile/` (post-68bd1592;
-  legacy `~/.scitex/orochi/verifier/chrome-profile/` still accepted) so
-  OAuth, mic, clipboard,
-  and notification permissions persist across runs.
+  `~/.scitex/orochi/runtime/verifier/chrome-profile/` (post-68bd1592) so
+  OAuth, mic, clipboard, and notification permissions persist across runs.
 - The browser window stays open 24/7 pointed at the production hub,
   acting as a live "human-eye" observer that watches for blur events,
   WS disconnects, focus theft, and regression screenshots — without any
@@ -104,7 +102,7 @@ is agent-only territory. Use that freedom:
   on page load and kept warm; verifier reads them on demand instead of
   asking the operator to paste anything.
 - Periodic screenshots (every ~5 minutes) are taken automatically and
-  archived in `~/.scitex/orochi/runtime/verifier/screenshots/` (legacy `~/.scitex/orochi/verifier/screenshots/` still accepted) plus uploaded to
+  archived in `~/.scitex/orochi/runtime/verifier/screenshots/` plus uploaded to
   `#operator` as visual pulse snapshots when something changes
   meaningfully — not every heartbeat.
 - Other macOS affordances are also fair game when they help fleet work:

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
@@ -109,7 +109,7 @@ bash/python, no Claude session on either host.
    - `~/proj/scitex-agent-container/src/scitex_agent_container/_skills/scitex-agent-container/` (public, canonical)
    - `~/proj/scitex-orochi/src/scitex_orochi/_skills/scitex-orochi/` (public, canonical)
    - `~/.scitex/agent-container/skills/scitex-agent-container-private/` (private per-machine, symlinked on export)
-   - `~/.scitex/orochi/shared/skills/scitex-orochi-private/` (private per-machine, symlinked on export; post-68bd1592 canonical location — legacy `~/.scitex/orochi/skills/` still read as fallback)
+   - `~/.scitex/orochi/shared/skills/scitex-orochi-private/` (private per-machine, symlinked on export; post-68bd1592 canonical location)
    - Convention: `~/.scitex/<suffix>/shared/skills/<package>-private/` → `~/.claude/skills/scitex/<package>-private/`
 2. **Git status** of the two shared locations. If dirty (uncommitted
    local edits), skip the export step for that repo and log the

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
@@ -109,14 +109,14 @@ bash/python, no Claude session on either host.
    - `~/proj/scitex-agent-container/src/scitex_agent_container/_skills/scitex-agent-container/` (public, canonical)
    - `~/proj/scitex-orochi/src/scitex_orochi/_skills/scitex-orochi/` (public, canonical)
    - `~/.scitex/agent-container/skills/scitex-agent-container-private/` (private per-machine, symlinked on export)
-   - `~/.scitex/orochi/skills/scitex-orochi-private/` (private per-machine, symlinked on export)
-   - Convention: `~/.scitex/<suffix>/skills/<package>-private/` → `~/.claude/skills/scitex/<package>-private/`
+   - `~/.scitex/orochi/shared/skills/scitex-orochi-private/` (private per-machine, symlinked on export; post-68bd1592 canonical location — legacy `~/.scitex/orochi/skills/` still read as fallback)
+   - Convention: `~/.scitex/<suffix>/shared/skills/<package>-private/` → `~/.claude/skills/scitex/<package>-private/`
 2. **Git status** of the two shared locations. If dirty (uncommitted
    local edits), skip the export step for that repo and log the
    skip — never clobber in-progress work.
 3. **Run** `scitex-dev skills export --clean` in each clean repo.
    Verify exit 0. On non-zero: write the full stderr to the log
-   and drop a touch-file `~/.scitex/orochi/skill-sync-daemon.fail`
+   and drop a touch-file `~/.scitex/orochi/runtime/skill-sync-daemon.fail`
    so the agent layer's healer-prober notices on next probe.
 4. **Frontmatter integrity scan.** Verify each `*.md` skill file
    in the two shared trees has a frontmatter block with `name:`
@@ -136,7 +136,7 @@ bash/python, no Claude session on either host.
    `~/.dotfiles/...`; both mirrors are equivalent because both
    read from the same canonical upstream repos via `git pull`.
 7. **Write one log line** to host-local
-   `~/.scitex/orochi/logs/skill-sync-daemon.log` with:
+   `~/.scitex/orochi/runtime/logs/skill-sync-daemon.log` with:
    `ISO8601 | host=<mba|nas> | tick=N | exported=<N> | drift-repaired=<N> | dedupe-flags=<N> | mirror-updated=<bool> | wall-time=<sec>`
 8. **No hub post.** Ever. State-change-only reporting is the
    agent layer's job (Track B worker reads the log via host-local
@@ -193,14 +193,14 @@ issues on demand.
 ### Failure handling
 
 - Non-zero exit from `scitex-dev skills export`: drop
-  host-local `~/.scitex/orochi/skill-sync-daemon.fail` touch-file,
+  host-local `~/.scitex/orochi/runtime/skill-sync-daemon.fail` touch-file,
   include full stderr in the log, continue the rest of the tick.
   Do **not** retry — an agent-layer worker should look at it.
 - Rsync failure: same pattern. Don't self-recover.
 - Filesystem scan error: log, skip the affected path, continue.
 
 Each host owns its own `.fail` touch-file in its own
-`~/.scitex/orochi/` so failures on one host don't block the
+`~/.scitex/orochi/runtime/` so failures on one host don't block the
 other. The Track B worker on primary host reads the local `.fail`
 directly and reads standby host's via SSH (or via a hub `fleet_report`
 endpoint if/when the daemon inventory gets aggregated centrally).
@@ -243,7 +243,7 @@ drift/dedupe candidates, curate taxonomy.
   candidate whether to merge (requires the operator or head-<host>
   sign-off), rename, or leave as-is with a note.
 - **Export failures** signaled by
-  `~/.scitex/orochi/skill-sync-daemon.fail` on either host —
+  `~/.scitex/orochi/runtime/skill-sync-daemon.fail` on either host —
   fetch the log, diagnose, clear the touch-file only after the
   root cause is fixed.
 
@@ -252,7 +252,7 @@ drift/dedupe candidates, curate taxonomy.
 Outside of query response, daemon-queue servicing, and the single
 startup announce to `#the operator`, the Track B worker is silent.
 No heartbeat. No "still idling". No "queues empty, nothing to
-do." Those go to `~/.scitex/orochi/logs/skill-manager-worker.log`
+do." Those go to `~/.scitex/orochi/runtime/logs/skill-manager-worker.log`
 (per head-<host> review, msg#11427 — explicit local log path).
 
 ### What Track B worker does **not** do

--- a/src/scitex_orochi/_skills/scitex-orochi/hpc-etiquette.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/hpc-etiquette.md
@@ -159,7 +159,7 @@ HPC quotas are **per-user inodes**, not just bytes. The 2026-04-14 NeuroVista ba
 - Never submit more than the site's per-user concurrent job limit. `squeue -u $USER` before submitting a batch.
 - Use the correct partition. `long` is for 90-day tunnels and stable services, `sapphire` for GPU work, `physical` for CPU. Misusing `long` for short jobs wastes the partition budget.
 - Release unused allocations via `scancel` when you are done. Do not leave an `salloc` shell open overnight "just in case".
-- `sbatch` jobs that are holders for long-running tunnels are allowed (see `hpc-spartan-startup-pattern.md`), but they must be single-purpose, documented, and tracked in `~/.scitex/orochi/scripts/`.
+- `sbatch` jobs that are holders for long-running tunnels are allowed (see `hpc-spartan-startup-pattern.md`), but they must be single-purpose, documented, and tracked in `~/.scitex/orochi/shared/scripts/` (post-68bd1592 canonical path; legacy `~/.scitex/orochi/scripts/` accepted during rollout).
 
 ## Login-node policy (Spartan-specific but generalizable)
 

--- a/src/scitex_orochi/_skills/scitex-orochi/hpc-etiquette.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/hpc-etiquette.md
@@ -159,7 +159,7 @@ HPC quotas are **per-user inodes**, not just bytes. The 2026-04-14 NeuroVista ba
 - Never submit more than the site's per-user concurrent job limit. `squeue -u $USER` before submitting a batch.
 - Use the correct partition. `long` is for 90-day tunnels and stable services, `sapphire` for GPU work, `physical` for CPU. Misusing `long` for short jobs wastes the partition budget.
 - Release unused allocations via `scancel` when you are done. Do not leave an `salloc` shell open overnight "just in case".
-- `sbatch` jobs that are holders for long-running tunnels are allowed (see `hpc-spartan-startup-pattern.md`), but they must be single-purpose, documented, and tracked in `~/.scitex/orochi/shared/scripts/` (post-68bd1592 canonical path; legacy `~/.scitex/orochi/scripts/` accepted during rollout).
+- `sbatch` jobs that are holders for long-running tunnels are allowed (see `hpc-spartan-startup-pattern.md`), but they must be single-purpose, documented, and tracked in `~/.scitex/orochi/shared/scripts/` (post-68bd1592 canonical path).
 
 ## Login-node policy (Spartan-specific but generalizable)
 

--- a/ts/mcp_channel.ts
+++ b/ts/mcp_channel.ts
@@ -131,8 +131,10 @@ const _deliveredIds = new Set<string | number>();
 // Registry heartbeat — thin pump.
 //
 // The sidecar shells out to
-//     ~/.scitex/orochi/scripts/agent_meta.py <agent>
-// which reads the live Claude Code session jsonl transcript and emits
+//     ~/.scitex/orochi/shared/scripts/agent_meta.py <agent>
+// (see src/agent_meta.ts — legacy flat path is a compat fallback during the
+// dotfiles 68bd1592 rollout) which reads the live Claude Code session jsonl
+// transcript and emits
 // claude-hud-style metadata (alive, subagents, context_pct, current_tool,
 // last_activity, model, ...) as a single JSON line. The resulting dict is
 // spread into the hub heartbeat payload.

--- a/ts/src/agent_meta.ts
+++ b/ts/src/agent_meta.ts
@@ -1,8 +1,10 @@
 /**
  * Agent metadata collection for heartbeat payloads.
  *
- * Shells out to `python3 ~/.scitex/orochi/scripts/agent_meta.py <agent>`
- * which introspects the local Claude Code session and returns JSON like:
+ * Shells out to `python3 ~/.scitex/orochi/shared/scripts/agent_meta.py <agent>`
+ * (with a legacy fallback to the old flat `scripts/` path during dotfiles
+ * 68bd1592 rollout — DEPRECATED, remove once every host is migrated.)
+ * The script introspects the local Claude Code session and returns JSON like:
  *   {
  *     "agent": "head-mba",
  *     "alive": true,
@@ -20,11 +22,25 @@
  *     values so the heartbeat shape stays stable.
  */
 import { execFile } from "child_process";
+import { existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { OROCHI_AGENT } from "./config.js";
 
-const SCRIPT_PATH = join(homedir(), ".scitex/orochi/scripts/agent_meta.py");
+// Canonical path (dotfiles commit 68bd1592, Phase A restructure): agent_meta.py
+// now lives under shared/scripts/. Fall back to the legacy flat path while
+// hosts finish re-bootstrapping. DEPRECATED: drop legacy branch after rollout.
+const _CANONICAL_SCRIPT_PATH = join(
+  homedir(),
+  ".scitex/orochi/shared/scripts/agent_meta.py",
+);
+const _LEGACY_SCRIPT_PATH = join(
+  homedir(),
+  ".scitex/orochi/scripts/agent_meta.py",
+);
+const SCRIPT_PATH = existsSync(_CANONICAL_SCRIPT_PATH)
+  ? _CANONICAL_SCRIPT_PATH
+  : _LEGACY_SCRIPT_PATH;
 const EXEC_TIMEOUT_MS = 5_000;
 
 export type AgentMeta = {

--- a/ts/src/agent_meta.ts
+++ b/ts/src/agent_meta.ts
@@ -1,9 +1,7 @@
 /**
  * Agent metadata collection for heartbeat payloads.
  *
- * Shells out to `python3 ~/.scitex/orochi/shared/scripts/agent_meta.py <agent>`
- * (with a legacy fallback to the old flat `scripts/` path during dotfiles
- * 68bd1592 rollout — DEPRECATED, remove once every host is migrated.)
+ * Shells out to `python3 ~/.scitex/orochi/shared/scripts/agent_meta.py <agent>`.
  * The script introspects the local Claude Code session and returns JSON like:
  *   {
  *     "agent": "head-mba",
@@ -22,25 +20,15 @@
  *     values so the heartbeat shape stays stable.
  */
 import { execFile } from "child_process";
-import { existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import { OROCHI_AGENT } from "./config.js";
 
-// Canonical path (dotfiles commit 68bd1592, Phase A restructure): agent_meta.py
-// now lives under shared/scripts/. Fall back to the legacy flat path while
-// hosts finish re-bootstrapping. DEPRECATED: drop legacy branch after rollout.
-const _CANONICAL_SCRIPT_PATH = join(
+// Canonical path (dotfiles commit 68bd1592, Phase A restructure).
+const SCRIPT_PATH = join(
   homedir(),
   ".scitex/orochi/shared/scripts/agent_meta.py",
 );
-const _LEGACY_SCRIPT_PATH = join(
-  homedir(),
-  ".scitex/orochi/scripts/agent_meta.py",
-);
-const SCRIPT_PATH = existsSync(_CANONICAL_SCRIPT_PATH)
-  ? _CANONICAL_SCRIPT_PATH
-  : _LEGACY_SCRIPT_PATH;
 const EXEC_TIMEOUT_MS = 5_000;
 
 export type AgentMeta = {

--- a/ts/src/tool_defs.ts
+++ b/ts/src/tool_defs.ts
@@ -326,7 +326,7 @@ export const TOOL_DEFS = [
   {
     name: "connectivity_matrix",
     description:
-      "Return the fleet 4×4 reachability matrix as JSON (todo#297 layer 3). Reads connectivity rows produced by the per-host fleet-watch producers (PR B) from $SCITEX_OROCHI_CONNECTIVITY_DIR (default ~/.scitex/orochi/runtime/fleet-watch/; falls back to the legacy ~/.scitex/orochi/fleet-watch/ during dotfiles 68bd1592 rollout) and merges them keyed by `from`. Each row is a single host's outbound view: {ts, from, from_hostname, to: {<peer>: {ok, rtt_ms, route, error?}}}. This is a thin read-only aggregator — it does NOT run ssh or measure RTT itself; the per-host producers handle that. Once #298 fleet_report endpoint lands, the same shape will be served from the hub DB without consumer changes.",
+      "Return the fleet 4×4 reachability matrix as JSON (todo#297 layer 3). Reads connectivity rows produced by the per-host fleet-watch producers (PR B) from $SCITEX_OROCHI_CONNECTIVITY_DIR (default ~/.scitex/orochi/runtime/fleet-watch/) and merges them keyed by `from`. Each row is a single host's outbound view: {ts, from, from_hostname, to: {<peer>: {ok, rtt_ms, route, error?}}}. This is a thin read-only aggregator — it does NOT run ssh or measure RTT itself; the per-host producers handle that. Once #298 fleet_report endpoint lands, the same shape will be served from the hub DB without consumer changes.",
     inputSchema: {
       type: "object" as const,
       properties: {},

--- a/ts/src/tool_defs.ts
+++ b/ts/src/tool_defs.ts
@@ -326,7 +326,7 @@ export const TOOL_DEFS = [
   {
     name: "connectivity_matrix",
     description:
-      "Return the fleet 4×4 reachability matrix as JSON (todo#297 layer 3). Reads connectivity rows produced by the per-host fleet-watch producers (PR B) from $SCITEX_OROCHI_CONNECTIVITY_DIR (default ~/.scitex/orochi/fleet-watch/) and merges them keyed by `from`. Each row is a single host's outbound view: {ts, from, from_hostname, to: {<peer>: {ok, rtt_ms, route, error?}}}. This is a thin read-only aggregator — it does NOT run ssh or measure RTT itself; the per-host producers handle that. Once #298 fleet_report endpoint lands, the same shape will be served from the hub DB without consumer changes.",
+      "Return the fleet 4×4 reachability matrix as JSON (todo#297 layer 3). Reads connectivity rows produced by the per-host fleet-watch producers (PR B) from $SCITEX_OROCHI_CONNECTIVITY_DIR (default ~/.scitex/orochi/runtime/fleet-watch/; falls back to the legacy ~/.scitex/orochi/fleet-watch/ during dotfiles 68bd1592 rollout) and merges them keyed by `from`. Each row is a single host's outbound view: {ts, from, from_hostname, to: {<peer>: {ok, rtt_ms, route, error?}}}. This is a thin read-only aggregator — it does NOT run ssh or measure RTT itself; the per-host producers handle that. Once #298 fleet_report endpoint lands, the same shape will be served from the hub DB without consumer changes.",
     inputSchema: {
       type: "object" as const,
       properties: {},

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -1044,7 +1044,14 @@ export async function handleRsyncStatus(args: {
 //
 // Source resolution priority:
 //   1. SCITEX_OROCHI_CONNECTIVITY_DIR env var (allows tests / overrides)
-//   2. ~/.scitex/orochi/fleet-watch/  (NAS-local cache, default)
+//   2. ~/.scitex/orochi/runtime/fleet-watch/  (NAS-local cache, canonical)
+//   3. ~/.scitex/orochi/fleet-watch/          (legacy flat layout; hosts not
+//                                              yet bootstrapped against the
+//                                              new runtime/ layout from
+//                                              dotfiles 68bd1592)
+//
+// The legacy fallback is DEPRECATED and can be removed once every host has
+// been re-bootstrapped against the runtime/ layout.
 //
 // File names: `connectivity.json` (legacy single-row from #297 PR B initial)
 // AND `connectivity-<host>.json` (multi-host pattern after Phase 2 fleet_report
@@ -1061,7 +1068,17 @@ function connectivityCacheDir(): string {
   const override = process.env.SCITEX_OROCHI_CONNECTIVITY_DIR;
   if (override && override.trim()) return override.trim();
   const home = process.env.HOME || "";
-  return pathJoin(home, ".scitex", "orochi", "fleet-watch");
+  // Prefer the canonical runtime/ layout; fall back to the legacy flat
+  // path if the runtime/ dir isn't present yet on this host (dotfiles
+  // 68bd1592 rollout). DEPRECATED: drop the legacy branch once every
+  // host has been re-bootstrapped.
+  const runtimeDir = pathJoin(home, ".scitex", "orochi", "runtime", "fleet-watch");
+  const legacyDir = pathJoin(home, ".scitex", "orochi", "fleet-watch");
+  if (existsSync(runtimeDir)) return runtimeDir;
+  if (existsSync(legacyDir)) return legacyDir;
+  // Neither exists yet — return the canonical path so errors point to
+  // the correct, expected location.
+  return runtimeDir;
 }
 
 interface ConnectivityRow {

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -1045,16 +1045,9 @@ export async function handleRsyncStatus(args: {
 // Source resolution priority:
 //   1. SCITEX_OROCHI_CONNECTIVITY_DIR env var (allows tests / overrides)
 //   2. ~/.scitex/orochi/runtime/fleet-watch/  (NAS-local cache, canonical)
-//   3. ~/.scitex/orochi/fleet-watch/          (legacy flat layout; hosts not
-//                                              yet bootstrapped against the
-//                                              new runtime/ layout from
-//                                              dotfiles 68bd1592)
 //
-// The legacy fallback is DEPRECATED and can be removed once every host has
-// been re-bootstrapped against the runtime/ layout.
-//
-// File names: `connectivity.json` (legacy single-row from #297 PR B initial)
-// AND `connectivity-<host>.json` (multi-host pattern after Phase 2 fleet_report
+// File names: `connectivity.json` (single-row from #297 PR B initial) AND
+// `connectivity-<host>.json` (multi-host pattern after Phase 2 fleet_report
 // landing). Both are surfaced when present so the tool keeps working through
 // the file → hub-DB migration without breaking consumers.
 //
@@ -1068,17 +1061,7 @@ function connectivityCacheDir(): string {
   const override = process.env.SCITEX_OROCHI_CONNECTIVITY_DIR;
   if (override && override.trim()) return override.trim();
   const home = process.env.HOME || "";
-  // Prefer the canonical runtime/ layout; fall back to the legacy flat
-  // path if the runtime/ dir isn't present yet on this host (dotfiles
-  // 68bd1592 rollout). DEPRECATED: drop the legacy branch once every
-  // host has been re-bootstrapped.
-  const runtimeDir = pathJoin(home, ".scitex", "orochi", "runtime", "fleet-watch");
-  const legacyDir = pathJoin(home, ".scitex", "orochi", "fleet-watch");
-  if (existsSync(runtimeDir)) return runtimeDir;
-  if (existsSync(legacyDir)) return legacyDir;
-  // Neither exists yet — return the canonical path so errors point to
-  // the correct, expected location.
-  return runtimeDir;
+  return pathJoin(home, ".scitex", "orochi", "runtime", "fleet-watch");
 }
 
 interface ConnectivityRow {


### PR DESCRIPTION
## Summary

Phase A.3 of the Orochi fleet restructure. Mirrors dotfiles commit `68bd1592` and scitex-agent-container PR #54. **Safe to merge after #54.**

Migrates every path reference in `scitex-orochi` to the canonical two-tier layout under `~/.scitex/orochi/`:

- **Definitions** → `shared/agents/<name>/<name>.yaml` (shared template) or `<host>/agents/<name>/<name>.yaml` (host-specific)
- **Runtime state** → `runtime/{workspaces,logs,fleet-watch,quota-telemetry,tmux-unstick-state,host-telemetry,verifier}/`
- Client scripts → `shared/scripts/`, private skills → `shared/skills/`

**Backward-compat removed (2026-04-17 refactor commit).** Per operator directive ("no backward compat needed; cleanliness is more important") every legacy fallback has been stripped. There are no live agents to protect during this prep/refactoring phase. Legacy flat paths (`~/.scitex/orochi/agents/`, `workspaces/`, `logs/`, `fleet-watch/`, `scripts/`, `skills/`, `tmux-unstick-state/`, `quota-telemetry/`, `host-telemetry/`, `verifier/`) are now **invisible**. Hosts MUST be bootstrapped against the `runtime/` + `shared/` skeleton before these paths resolve.

## Commits

- `refactor: migrate code paths to ~/.scitex/orochi/ runtime/shared layout (todo A.3)` — CLI, hub API, ts/ sidecar, fleet-watch scripts, setup-workspace, hub tests
- `refactor(deployment): runtime/shared layout in fleet scripts + launchd/systemd (todo A.3)` — tmux-unstick, agent-respawn, cloudflared-watchdog, logrotate, launchd plists, systemd unit, orochi-config.yaml / orochi-machines.yaml
- `docs: point skill docs + examples + README at ~/.scitex/orochi/ runtime/shared layout (todo A.3)` — README.md, examples/agents/*, _skills/scitex-orochi/*
- `refactor: drop all backward-compat fallbacks` — strip every "prefer runtime/, else legacy" branch from CLI, ts, fleet-watch, deployment scripts, hub comments, docs, and tests (-326/+95 lines).

## Canonical-only path matrix (post-cleanup)

| Surface | Canonical path |
|---|---|
| Agent YAML lookup (CLI) | `<host>/agents/`, then `shared/agents/` |
| Workspace creation | `runtime/workspaces/` |
| connectivity_matrix read | `runtime/fleet-watch/` |
| drift_check read | `runtime/fleet-watch/` |
| agent_meta.py lookup (ts) | `shared/scripts/agent_meta.py` |
| tmux-unstick log / state / PAUSED | `runtime/logs/`, `runtime/tmux-unstick-state/` |
| Hub restart (api.py) | `runtime/workspaces/` |
| fleet_watch.sh out-dir | `runtime/fleet-watch/` |
| host-telemetry-probe.sh | `runtime/host-telemetry/` |
| compact_actuator log | `runtime/fleet-watch/compact_actuator.log` |
| Example YAMLs | `shared/agents/<name>/<name>.yaml` |

## Test plan

- [x] `pytest tests/` — 30 passed, 1 skipped (DeepEval, pre-existing)
- [x] `python manage.py test hub` — 122/125 pass; 3 pre-existing failures (`workspace_dashboard` slug issue) unrelated to this PR
- [x] `python3 -m py_compile` for every touched `.py`
- [x] `bash -n` for every touched shell script
- [x] `bun build --target=bun` for touched ts files
- [x] Smoke-import `_launch_helpers` + `agent_cmd` — resolves real agents under `~/.scitex/orochi/shared/agents/` on the dev box
- [ ] (deferred — requires fleet access) End-to-end: `scitex-orochi launch head` on a post-68bd1592 host
- [ ] (deferred — requires fleet access) tmux-unstick.sh on spartan (runtime/ must exist — no fallback now)

## Notes

- Every host MUST be bootstrapped (`shared/scripts/bootstrap-host.sh` or dotfiles symlink) before CLI, hub restart, fleet_watch, tmux-unstick, and ts sidecar calls will resolve their paths. No silent fallback to the flat layout.
- No changes to `~/proj/scitex-agent-container` (handled by PR #54).
- No dotfiles changes (already shipped at `68bd1592`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
