### PR TITLE
fix(mcp-channel): prefer env hostname over Node's hostname()

### DIFF
--- a/ts/mcp_channel.ts
+++ b/ts/mcp_channel.ts
@@ -207,7 +207,12 @@ async function pushRegistryHeartbeat(): Promise<void> {
     name: OROCHI_AGENT,
     agent_id: OROCHI_AGENT,
     role: process.env.SCITEX_OROCHI_ROLE || "agent",
-    machine: process.env.SCITEX_OROCHI_MACHINE || hostname() || "",
+    machine:
+      process.env.SCITEX_OROCHI_MACHINE ||
+      process.env.SCITEX_OROCHI_HOSTNAME ||
+      process.env.SCITEX_AGENT_CONTAINER_HOSTNAME ||
+      hostname() ||
+      "",
     multiplexer: process.env.SCITEX_OROCHI_MULTIPLEXER || "tmux",
   };
 
@@ -352,15 +357,21 @@ const conn = {
       } catch {}
 
       // Register with the hub
+      const _machine =
+        process.env.SCITEX_OROCHI_MACHINE ||
+        process.env.SCITEX_OROCHI_HOSTNAME ||
+        process.env.SCITEX_AGENT_CONTAINER_HOSTNAME ||
+        hostname() ||
+        "";
       _ws!.send(
         JSON.stringify({
           type: "register",
           sender: OROCHI_AGENT,
           payload: {
-            machine: hostname(),
+            machine: _machine,
             role: process.env.SCITEX_OROCHI_ROLE || "claude-code",
             model: OROCHI_MODEL,
-            agent_id: `${OROCHI_AGENT}@${hostname()}`,
+            agent_id: `${OROCHI_AGENT}@${_machine}`,
             icon: process.env.SCITEX_OROCHI_ICON || "",
             icon_emoji: process.env.SCITEX_OROCHI_ICON_EMOJI || "",
             icon_text: process.env.SCITEX_OROCHI_ICON_TEXT || "",


### PR DESCRIPTION
## Summary

Compute nodes on SLURM clusters have FQDN hostnames (`spartan-bm164.hpc.unimelb.edu.au`) which leaked into the dashboard's @machine labels through Node's `os.hostname()` syscall, bypassing the `SCITEX_OROCHI_MACHINE` env var that the status-push path already honoured.

Now both the WebSocket register path (line 358-374) and the HTTP status-push path (line 210-215) resolve machine via the same chain:

`SCITEX_OROCHI_MACHINE -> SCITEX_OROCHI_HOSTNAME -> SCITEX_AGENT_CONTAINER_HOSTNAME -> hostname()`

Pairs with dotfiles commit 3a426ca0 where spartan's pre_agent SLURM hook now sets `SCITEX_OROCHI_HOSTNAME=spartan` inside the job, so the agent registers as `@spartan` instead of `@spartan-bm164.hpc.unimelb.edu.au`.

## Test plan

- [x] Spartan compute node: agent reports `@spartan` after restart
- [ ] Other hosts: no regression (env var unset -> falls through to hostname() as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)