### PR TITLE
fix(mcp-channel): model + multiplexer in register payload

### DIFF
--- a/ts/mcp_channel.ts
+++ b/ts/mcp_channel.ts
@@ -371,6 +371,7 @@ const conn = {
             machine: _machine,
             role: process.env.SCITEX_OROCHI_ROLE || "claude-code",
             model: OROCHI_MODEL,
+            multiplexer: process.env.SCITEX_OROCHI_MULTIPLEXER || "tmux",
             agent_id: `${OROCHI_AGENT}@${_machine}`,
             icon: process.env.SCITEX_OROCHI_ICON || "",
             icon_emoji: process.env.SCITEX_OROCHI_ICON_EMOJI || "",

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -12,7 +12,14 @@ export const OROCHI_AGENT =
 // MCP tools, REST API, or web UI. Agents register with no channels and
 // pick up their memberships from the server. No env var.
 export const OROCHI_TOKEN = process.env.SCITEX_OROCHI_TOKEN || "";
-export const OROCHI_MODEL = process.env.SCITEX_OROCHI_MODEL || "unknown";
+// Model label: prefer orochi-namespaced var, fall back to sac's namespace
+// (which is what the generic scitex-agent-container auto-injects since the
+// orochi-agnostic refactor). Either should be set by the agent's YAML or
+// pre_agent hook.
+export const OROCHI_MODEL =
+  process.env.SCITEX_OROCHI_MODEL ||
+  process.env.SCITEX_AGENT_CONTAINER_MODEL ||
+  "unknown";
 
 // WSS support: SCITEX_OROCHI_URL overrides host/port with a full URL (ws:// or wss://)
 // Examples:


### PR DESCRIPTION
## Summary

After the sac purity refactor (scitex-agent-container#56), the dashboard showed `Model: unknown` and `Multiplexer: -` for agents using the new SlurmRuntime path. Two small fixes:

1. **`ts/src/config.ts`** — `OROCHI_MODEL` now falls back through `SCITEX_OROCHI_MODEL → SCITEX_AGENT_CONTAINER_MODEL → "unknown"`. sac auto-injects the sac-namespace var since the purity refactor (it used to inject `SCITEX_OROCHI_MODEL` but that leaked orochi into sac's core).

2. **`ts/mcp_channel.ts` WebSocket register payload** — add `multiplexer: process.env.SCITEX_OROCHI_MULTIPLEXER || "tmux"`. The HTTP status-push path already had it; mirroring fixes first-connect rendering on the dashboard card.

Pairs with scitex-orochi#197 (hostname fix).

## Test plan

- [x] head-spartan dashboard card: Machine `@spartan`, Model `opus[1m]`, Multiplexer `tmux` after restart
- [ ] Other hosts: no regression (env var unset → falls through as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)