### PR TITLE
fix(activity-grid): claim remaining vertical space so grid scrolls

### DIFF
--- a/hub/static/hub/activity-tab.css
+++ b/hub/static/hub/activity-tab.css
@@ -154,6 +154,12 @@
 #activity-view.todo-view {
   display: flex;
   flex-direction: column;
+  /* Must claim remaining vertical space inside `.main` (itself flex-col).
+   * Without flex: 1 + min-height: 0, the view sizes to content height and
+   * activity-grid's `overflow: auto` never triggers — the grid just grows
+   * past the viewport bottom, making it unscrollable (2026-04-18). */
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
   padding: 0;
 }


### PR DESCRIPTION
## Problem

On the Agents tab overview, the agent-card grid (div#activity-grid.activity-grid) couldn't scroll: its computed height was 1688px in a ~900px viewport. Scrolling had no effect because the grid was as tall as its content, not clipped to viewport.

Element Inspector debug on 2026-04-17 22:38 UTC confirmed:
- `.activity-grid` computed `overflow: auto` ✓
- `height: 1687.94px` ✗ (should be viewport-bound)
- `scrollTop: 0, scrollLeft: 0`

## Root cause

`#activity-view.todo-view` is a flex-child of `.main` (`display: flex; flex-direction: column`) but didn't have `flex: 1`. Without that, it sized to content height instead of filling the available viewport, so `.activity-grid`'s `overflow: auto` never had an upper bound to trigger against.

## Fix

Add `flex: 1; min-height: 0` to `#activity-view.todo-view`, matching the pattern already applied to sibling views (`.messages` uses the same flex-column chain and scrolls correctly).

## Test plan

- [x] Computed height of `.activity-grid` should equal viewport height minus subtab bar after this change
- [ ] Scroll wheel / trackpad scroll works inside the grid
- [ ] Detail view (`.activity-grid-detail`) unaffected (rule targets `:not(.activity-grid-detail)` separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)