### PR TITLE
fix(tabs.js): don't force display:block on #activity-view

### DIFF
--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -69,7 +69,13 @@ function _activateTab(tab) {
     fetchWorkspaces();
   } else if (tab === "activity") {
     if (activityView) {
-      activityView.style.display = "block";
+      /* Clear the inline display:none set above and let the CSS rule
+       * (#activity-view.todo-view { display: flex }) take effect. An
+       * inline `display: block` here would override the flex container
+       * declaration, which breaks the flex chain and prevents
+       * `.activity-grid` from scrolling (its `overflow: auto` never has
+       * an upper bound to trigger against). See #200 for the CSS side. */
+      activityView.style.display = "";
       activityView.style.flex = "1";
     }
     if (typeof refreshActivityFromApi === "function") refreshActivityFromApi();


### PR DESCRIPTION
## Problem

After #200 set `#activity-view.todo-view { display: flex }` to fix the grid scroll, the grid still wouldn't scroll — because `tabs.js:72` then forces `activityView.style.display = 'block'` at tab-switch time, clobbering the CSS flex container declaration.

With `display: block`, `#activity-view` is no longer a flex container, so `.activity-grid` isn't a flex-child and doesn't get its height constrained by the parent. `overflow: auto` never has an upper bound to trigger against.

## Fix

Set `display: ''` (empty) instead, clearing the inline `display: none` from the top of the tab-switch loop and letting the stylesheet's `display: flex` apply. This matches the pattern `.messages` uses on the chat tab.

## Test plan

- [x] Agents tab: `.activity-grid` computed height clamped to viewport minus subtabs; scroll wheel works
- [x] Other tabs unaffected (only the activity branch changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)