### PR TITLE
fix(dashboard): UX polish + per-agent observability push

### DIFF
--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -704,9 +704,15 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             if not allowed:
                 return
         else:
-            # Group channels: existing subscription filter.
+            # Group channels: subscription filter. The previous form
+            # guarded this with `agent_channels and ...`, which meant an
+            # agent with no subscriptions received every group message
+            # (including GitHub CI notifications routed to #progress).
+            # Subscription is now strictly opt-in: no membership → no
+            # group receipt. Per-DM delivery is still governed by the
+            # DM-participant check above.
             agent_channels = getattr(self, "agent_meta", {}).get("channels", [])
-            if agent_channels and ch_name not in agent_channels:
+            if ch_name not in agent_channels:
                 return
         await self.send_json(
             {

--- a/hub/registry.py
+++ b/hub/registry.py
@@ -54,7 +54,16 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             "multiplexer": info.get("multiplexer", ""),
             "project": info.get("project", ""),
             "workdir": info.get("workdir", ""),
-            "channels": info.get("channels", []),
+            # Subscriptions are server-authoritative (ChannelMembership).
+            # Preserve prev.channels when a heartbeat omits the field so
+            # REST pushers (agent_meta.py) don't wipe subscriptions every
+            # 30s. A caller that really wants to clear channels must send
+            # "channels": [] explicitly.
+            "channels": (
+                list(info["channels"])
+                if isinstance(info.get("channels"), (list, tuple))
+                else prev.get("channels") or []
+            ),
             "claude_md": info.get("claude_md", "") or prev.get("claude_md", ""),
             "status": "online",
             "registered_at": prev.get("registered_at") or time.time(),

--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -369,6 +369,9 @@ function _renderAgentContent(grid) {
           _renderAgentContent(grid);
         });
       });
+    /* Re-apply Ctrl+K fuzzy filter after the innerHTML rewrite — see
+     * todo-tab.js rationale. */
+    if (typeof runFilter === "function") runFilter();
     return;
   }
 

--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -58,14 +58,20 @@ function setCurrentChannel(ch) {
   } catch (_) {}
   /* Update textarea placeholder to show active channel — msg#9368.
    * In multi-select mode (ch=null), keep showing the last active channel
-   * so the user knows where their message will be posted (#9694). */
+   * so the user knows where their message will be posted (#9694).
+   * DMs use a friendly "@<other>" label instead of the raw
+   * "dm:agent:X|human:Y" channel string. */
   try {
     var inp = document.getElementById("msg-input");
     if (inp) {
       var targetCh = ch || lastActiveChannel;
-      inp.placeholder = targetCh
-        ? "Message #" + targetCh.replace(/^#/, "") + "\u2026"
-        : "Type a message\u2026";
+      if (targetCh && targetCh.indexOf("dm:") === 0) {
+        inp.placeholder = "Message " + _dmFriendlyLabel(targetCh) + "\u2026";
+      } else {
+        inp.placeholder = targetCh
+          ? "Message #" + targetCh.replace(/^#/, "") + "\u2026"
+          : "Type a message\u2026";
+      }
     }
   } catch (_) {}
   /* Update composer target indicator (todo#364) */
@@ -74,6 +80,26 @@ function setCurrentChannel(ch) {
    * or last active when in all-channels mode */
   _updateChannelTopicBanner(ch || lastActiveChannel);
 }
+
+/* Friendly-label for a dm:<principal>|<principal> channel. Strips the
+ * "dm:" prefix, splits on "|", drops the self principal when known, and
+ * strips "agent:"/"human:" type prefixes so the result is "@name" (or
+ * "@a, @b" when the self principal can't be determined). */
+function _dmFriendlyLabel(ch) {
+  if (!ch || ch.indexOf("dm:") !== 0) return ch || "";
+  var parts = ch.substring(3).split("|");
+  var self = window.__orochiUserName ? "human:" + window.__orochiUserName : "";
+  var others = parts.filter(function (p) {
+    return p && p !== self;
+  });
+  if (others.length === 0) others = parts;
+  return others
+    .map(function (p) {
+      return "@" + p.replace(/^(agent:|human:)/, "");
+    })
+    .join(", ");
+}
+window._dmFriendlyLabel = _dmFriendlyLabel;
 
 function _updateComposerTarget(ch, isReply, replyMsgId) {
   try {
@@ -88,8 +114,7 @@ function _updateComposerTarget(ch, isReply, replyMsgId) {
       el.firstChild.nodeValue = "";
     } else if (ch && ch.startsWith("dm:")) {
       el.classList.add("is-dm");
-      var parts = ch.replace("dm:", "").split("|");
-      nameEl.textContent = "\u2192 @" + (parts[1] || parts[0]) + " (DM)";
+      nameEl.textContent = "\u2192 " + _dmFriendlyLabel(ch) + " (DM)";
       el.firstChild.nodeValue = "";
     } else {
       nameEl.textContent = ch || "#general";

--- a/hub/static/hub/dms.js
+++ b/hub/static/hub/dms.js
@@ -37,9 +37,7 @@
     if (others.length === 0) return "";
     var t = others[0].type === "agent" ? "agent" : "human";
     var label = t === "agent" ? "AI" : "U";
-    return (
-      '<span class="dm-principal-badge ' + t + '">' + label + "</span>"
-    );
+    return '<span class="dm-principal-badge ' + t + '">' + label + "</span>";
   }
 
   function renderDms(rows) {
@@ -75,20 +73,19 @@
           if (!ch) return;
           /* Mirror the channel-link pattern from chat.js:1547 and the
            * #channels click handler in app.js:920. */
-          if (
-            typeof currentChannel !== "undefined" &&
-            currentChannel === ch
-          ) {
+          if (typeof currentChannel !== "undefined" && currentChannel === ch) {
             if (typeof setCurrentChannel === "function")
               setCurrentChannel(null);
             if (typeof loadHistory === "function") loadHistory();
           } else {
-            if (typeof setCurrentChannel === "function")
-              setCurrentChannel(ch);
+            if (typeof setCurrentChannel === "function") setCurrentChannel(ch);
             if (typeof loadChannelHistory === "function")
               loadChannelHistory(ch);
           }
-          if (typeof addTag === "function") addTag("channel", ch);
+          /* Do NOT push a channel:<raw-dm-name> filter tag — DM routing
+           * already goes through setCurrentChannel() above, and the raw
+           * "dm:agent:X|human:Y" string surfaced in a filter chip is
+           * unreadable (msg 082849 screenshot). */
           fetchDms();
           if (typeof fetchStats === "function") fetchStats();
         });
@@ -187,8 +184,7 @@
       return c.label.toLowerCase().indexOf(q) !== -1;
     });
     if (filtered.length === 0) {
-      container.innerHTML =
-        '<div class="dm-modal-empty">No matches</div>';
+      container.innerHTML = '<div class="dm-modal-empty">No matches</div>';
       return;
     }
     container.innerHTML = filtered
@@ -240,9 +236,8 @@
       var ch = row && row.name;
       if (ch) {
         if (typeof setCurrentChannel === "function") setCurrentChannel(ch);
-        if (typeof loadChannelHistory === "function")
-          loadChannelHistory(ch);
-        if (typeof addTag === "function") addTag("channel", ch);
+        if (typeof loadChannelHistory === "function") loadChannelHistory(ch);
+        /* Intentionally no addTag("channel", ch) — see click handler above. */
         if (typeof fetchStats === "function") fetchStats();
       }
     } catch (e) {
@@ -297,14 +292,18 @@
       if (e.key === "Escape") closeModal();
       /* Focus trap for a11y (#262) */
       if (e.key === "Tab" && modal && !modal.hidden) {
-        var focusable = modal.querySelectorAll('input, button, [tabindex]:not([tabindex="-1"])');
+        var focusable = modal.querySelectorAll(
+          'input, button, [tabindex]:not([tabindex="-1"])',
+        );
         if (focusable.length === 0) return;
         var first = focusable[0];
         var last = focusable[focusable.length - 1];
         if (e.shiftKey && document.activeElement === first) {
-          e.preventDefault(); last.focus();
+          e.preventDefault();
+          last.focus();
         } else if (!e.shiftKey && document.activeElement === last) {
-          e.preventDefault(); first.focus();
+          e.preventDefault();
+          first.focus();
         }
       }
     });

--- a/hub/static/hub/files-tab.js
+++ b/hub/static/hub/files-tab.js
@@ -532,6 +532,8 @@ function renderFilesGrid() {
     },
     { once: true },
   );
+  /* Re-apply Ctrl+K fuzzy filter after innerHTML rewrite (see todo-tab.js). */
+  if (typeof runFilter === "function") runFilter();
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
     try {

--- a/hub/static/hub/filter.js
+++ b/hub/static/hub/filter.js
@@ -5,7 +5,9 @@
 /* mention.js redefines fuzzyMatch() to return a numeric score where
  * -1 means no match. In JS -1 is truthy, so all boolean filter checks
  * would pass regardless of match. _fm() wraps with >= 0 check. */
-var _fm = function (query, text) { return fuzzyMatch(query, text) >= 0; };
+var _fm = function (query, text) {
+  return fuzzyMatch(query, text) >= 0;
+};
 
 var filterInput = document.getElementById("filter-input");
 var filterTagsEl = document.getElementById("filter-tags");
@@ -101,7 +103,9 @@ function renderTags() {
     .join("");
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
-    try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+    try {
+      msgInput.setSelectionRange(savedStart, savedEnd);
+    } catch (_) {}
   }
 }
 
@@ -174,7 +178,9 @@ function showSuggestions(items) {
   filterSuggestEl.classList.add("visible");
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
-    try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+    try {
+      msgInput.setSelectionRange(savedStart, savedEnd);
+    } catch (_) {}
   }
 }
 
@@ -188,7 +194,9 @@ function hideSuggestions() {
   suggestIndex = -1;
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
-    try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+    try {
+      msgInput.setSelectionRange(savedStart, savedEnd);
+    } catch (_) {}
   }
 }
 
@@ -269,13 +277,19 @@ function runFilter() {
       " " +
       (content ? content.textContent : "");
     /* Each keyword must match independently (AND logic) */
-    var show = qWords.length === 0 || qWords.every(function (w) {
-      return _fm(w, text);
-    });
+    var show =
+      qWords.length === 0 ||
+      qWords.every(function (w) {
+        return _fm(w, text);
+      });
     if (show && allTags.length > 0) {
       /* Group agent tags for OR (union) logic; other tags stay AND */
-      var agentTags = allTags.filter(function (t) { return t.type === "agent"; });
-      var otherTags = allTags.filter(function (t) { return t.type !== "agent"; });
+      var agentTags = allTags.filter(function (t) {
+        return t.type === "agent";
+      });
+      var otherTags = allTags.filter(function (t) {
+        return t.type !== "agent";
+      });
       if (agentTags.length > 0) {
         var senderText = (sender ? sender.textContent : "").toLowerCase();
         show = agentTags.some(function (tag) {
@@ -297,9 +311,8 @@ function runFilter() {
     }
     /* Skip single-channel filter when multi-select is active (#366):
      * applyFeedFilter() handles multi-channel visibility in that case. */
-    var _multiActive = document.querySelectorAll(
-      "#channels .channel-item.selected",
-    ).length >= 2;
+    var _multiActive =
+      document.querySelectorAll("#channels .channel-item.selected").length >= 2;
     if (show && currentChannel && !_multiActive) {
       show = el.getAttribute("data-channel") === currentChannel;
     }
@@ -307,7 +320,11 @@ function runFilter() {
   });
   document.querySelectorAll(".todo-item").forEach(function (el) {
     var text = el.textContent;
-    var show = qWords.length === 0 || qWords.every(function (w) { return _fm(w, text); });
+    var show =
+      qWords.length === 0 ||
+      qWords.every(function (w) {
+        return _fm(w, text);
+      });
     if (show && allTags.length > 0) {
       show = allTags.every(function (tag) {
         var val = tag.value.toLowerCase();
@@ -329,33 +346,84 @@ function runFilter() {
 }
 
 function _matchAllWords(words, text) {
-  return words.length === 0 || words.every(function (w) { return _fm(w, text); });
+  return (
+    words.length === 0 ||
+    words.every(function (w) {
+      return _fm(w, text);
+    })
+  );
 }
 
 function filterSidebarElements(qWords, allTags) {
   document.querySelectorAll("#agents .agent-card").forEach(function (el) {
     var text = el.textContent;
     el.style.display =
-      _matchAllWords(qWords, text) && matchesAllTags(allTags, text) ? "" : "none";
+      _matchAllWords(qWords, text) && matchesAllTags(allTags, text)
+        ? ""
+        : "none";
   });
   document.querySelectorAll("#channels .channel-item").forEach(function (el) {
     var text = el.textContent;
     el.style.display =
-      _matchAllWords(qWords, text) && matchesAllTags(allTags, text) ? "" : "none";
+      _matchAllWords(qWords, text) && matchesAllTags(allTags, text)
+        ? ""
+        : "none";
   });
   document.querySelectorAll("#resources .res-card").forEach(function (el) {
     var text = el.textContent;
     el.style.display =
-      _matchAllWords(qWords, text) && matchesAllTags(allTags, text) ? "" : "none";
+      _matchAllWords(qWords, text) && matchesAllTags(allTags, text)
+        ? ""
+        : "none";
   });
   document.querySelectorAll("#agents-grid .agent-card").forEach(function (el) {
     var text = el.textContent;
     el.style.display =
-      _matchAllWords(qWords, text) && matchesAllTags(allTags, text) ? "" : "none";
+      _matchAllWords(qWords, text) && matchesAllTags(allTags, text)
+        ? ""
+        : "none";
   });
   document.querySelectorAll("#resources-grid .res-card").forEach(function (el) {
     var text = el.textContent;
     el.style.display =
-      _matchAllWords(qWords, text) && matchesAllTags(allTags, text) ? "" : "none";
+      _matchAllWords(qWords, text) && matchesAllTags(allTags, text)
+        ? ""
+        : "none";
   });
+  /* Agents tab: per-agent table rows in the overview sub-tab. The paired
+   * .agent-pane-row / .claude-md-detail siblings must follow the parent
+   * agent-row's visibility so we don't leave orphaned pane previews
+   * behind after a filter. */
+  document
+    .querySelectorAll("#agent-tab-content tr.agent-row")
+    .forEach(function (el) {
+      var text = el.textContent;
+      var show = _matchAllWords(qWords, text) && matchesAllTags(allTags, text);
+      el.style.display = show ? "" : "none";
+      var sib = el.nextElementSibling;
+      while (
+        sib &&
+        (sib.classList.contains("agent-pane-row") ||
+          sib.classList.contains("claude-md-detail"))
+      ) {
+        if (!show) {
+          sib.style.display = "none";
+        } else if (sib.classList.contains("agent-pane-row")) {
+          sib.style.display = "";
+        }
+        /* claude-md-detail keeps whatever the toggle button set (display:none
+         * when collapsed, table-row when expanded) — don't clobber it. */
+        sib = sib.nextElementSibling;
+      }
+    });
+  /* Files tab rows. */
+  document
+    .querySelectorAll("#files-view tr.files-list-row")
+    .forEach(function (el) {
+      var text = el.textContent;
+      el.style.display =
+        _matchAllWords(qWords, text) && matchesAllTags(allTags, text)
+          ? ""
+          : "none";
+    });
 }

--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -12,6 +12,7 @@ function _activateTab(tab) {
   var messagesEl = document.getElementById("messages");
   var inputBar = document.querySelector(".input-bar");
   var todoView = document.getElementById("todo-view");
+  var vizView = document.getElementById("viz-view");
   var resourcesView = document.getElementById("resources-view");
   var agentsTabView = document.getElementById("agents-tab-view");
   var workspacesView = document.getElementById("workspaces-view");
@@ -26,6 +27,7 @@ function _activateTab(tab) {
   var membersPanel = document.getElementById("channel-members-panel");
   if (membersPanel) membersPanel.style.display = "none";
   todoView.style.display = "none";
+  if (vizView) vizView.style.display = "none";
   resourcesView.style.display = "none";
   agentsTabView.style.display = "none";
   workspacesView.style.display = "none";
@@ -33,7 +35,7 @@ function _activateTab(tab) {
   if (filesView) filesView.style.display = "none";
   if (releasesView) releasesView.style.display = "none";
   if (settingsView) settingsView.style.display = "none";
-  if (tab !== "todo" && typeof stopVizTab === "function") stopVizTab();
+  if (tab !== "viz" && typeof stopVizTab === "function") stopVizTab();
   if (tab === "chat") {
     messagesEl.style.display = "";
     inputBar.style.display = "";
@@ -65,6 +67,12 @@ function _activateTab(tab) {
     todoView.style.display = "block";
     todoView.style.flex = "1";
     fetchTodoList();
+  } else if (tab === "viz") {
+    if (vizView) {
+      vizView.style.display = "block";
+      vizView.style.flex = "1";
+    }
+    if (typeof renderVizTab === "function") renderVizTab();
   } else if (tab === "agents-tab") {
     agentsTabView.style.display = "block";
     agentsTabView.style.flex = "1";

--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -37,12 +37,22 @@ function _activateTab(tab) {
   if (tab === "chat") {
     messagesEl.style.display = "";
     inputBar.style.display = "";
+    /* Restore the channel-topic banner on re-entry to Chat. The block at
+     * the top of _activateTab hides it unconditionally; we only want that
+     * when leaving chat, not when returning. Without this line the banner
+     * vanishes after the first tab switch. Banner content already tracks
+     * the textarea target (see app.js _updateChannelTopicBanner). */
+    if (topicBanner) topicBanner.style.display = "";
     /* Always default-focus the compose input when the chat tab is shown.
      * Per ywatanabe spec (msg 5470, 2026-04-12): the compose textarea is
      * the primary action target on the chat tab, so the user should never
      * have to click into it manually after switching tabs or reloading.
      * Defer with rAF so the layout has settled (display:'' just changed). */
     requestAnimationFrame(function () {
+      /* Snap to bottom whenever chat is shown — initial load + every
+       * tab-switch back to chat. Layout may not be final until after the
+       * rAF tick, so scroll here (not synchronously). */
+      messagesEl.scrollTop = messagesEl.scrollHeight;
       var input = document.getElementById("msg-input");
       if (input) {
         input.focus();

--- a/hub/static/hub/todo-tab.js
+++ b/hub/static/hub/todo-tab.js
@@ -277,38 +277,11 @@ function _updateTodoBtnCounts(issues) {
   });
 }
 
-/* List / Viz mode toggle inside the TODO tab. List is the default;
- * clicking Viz swaps the todo-grid panel for the viz-content panel and
- * calls renderVizTab() (defined in viz-tab.js). */
-var _todoMode = "list";
-
-function _applyTodoMode() {
-  var grid = document.getElementById("todo-grid");
-  var viz = document.getElementById("viz-content");
-  var stateBar = document.getElementById("todo-state-filter");
-  if (_todoMode === "viz") {
-    if (grid) grid.classList.add("todo-viz-hidden");
-    if (viz) viz.classList.remove("todo-viz-hidden");
-    if (stateBar) stateBar.classList.add("todo-viz-hidden");
-    if (typeof renderVizTab === "function") renderVizTab();
-  } else {
-    if (grid) grid.classList.remove("todo-viz-hidden");
-    if (viz) viz.classList.add("todo-viz-hidden");
-    if (stateBar) stateBar.classList.remove("todo-viz-hidden");
-    if (typeof stopVizTab === "function") stopVizTab();
-  }
-  document.querySelectorAll(".todo-mode-btn").forEach(function (b) {
-    b.classList.toggle("active", b.getAttribute("data-mode") === _todoMode);
-  });
-}
+/* Viz is now a top-level tab (tabs.js handles its own show/hide and
+ * calls renderVizTab()); the in-TODO List/Viz mode switcher was removed
+ * so this module no longer owns viz lifecycle. */
 
 document.addEventListener("DOMContentLoaded", function () {
-  document.querySelectorAll(".todo-mode-btn").forEach(function (btn) {
-    btn.addEventListener("click", function () {
-      _todoMode = btn.getAttribute("data-mode") || "list";
-      _applyTodoMode();
-    });
-  });
   document.querySelectorAll(".todo-state-btn").forEach(function (btn) {
     btn.addEventListener("click", function (e) {
       var g = btn.getAttribute("data-group");

--- a/hub/static/hub/todo-tab.js
+++ b/hub/static/hub/todo-tab.js
@@ -463,6 +463,11 @@ function _renderTodoFromCache(issues) {
   attachTodoEvents(container);
   _backgroundFillDetails(container);
   _updateLastFetchedLabel(_todoCacheTs.all || _todoCacheTs.open || Date.now());
+  /* Re-apply any active filter-input query — the innerHTML rewrite above
+   * wiped the display:none state runFilter() had previously set. Without
+   * this, typing "todo#418" on the Chat tab then switching to TODO shows
+   * every issue. */
+  if (typeof runFilter === "function") runFilter();
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
     try {

--- a/hub/static/hub/viz-tab.js
+++ b/hub/static/hub/viz-tab.js
@@ -13,11 +13,27 @@
 /* globals apiUrl, escapeHtml */
 
 var _vizPollTimer = null;
+/* Cache the most recent stats payload so tab re-activation paints
+ * instantly from memory while a background refetch runs. Without this
+ * every tab switch waits on /api/todo/stats/ (which hits GitHub and is
+ * perceptibly slow). */
+var _vizCachedData = null;
+var _vizCachedAt = 0;
+var _VIZ_FRESH_MS = 60_000;
 
 function renderVizTab() {
-  fetchVizPayload();
+  var container = document.getElementById("viz-content");
+  if (container && _vizCachedData) {
+    /* Instant paint from cache — user sees the chart before the network
+     * call returns. */
+    _renderVizPayload(_vizCachedData, container);
+  }
+  /* Refetch if the cache is older than the poll interval. */
+  if (Date.now() - _vizCachedAt > _VIZ_FRESH_MS) {
+    fetchVizPayload();
+  }
   if (_vizPollTimer) clearInterval(_vizPollTimer);
-  _vizPollTimer = setInterval(fetchVizPayload, 60_000);
+  _vizPollTimer = setInterval(fetchVizPayload, _VIZ_FRESH_MS);
 }
 
 function stopVizTab() {
@@ -35,17 +51,25 @@ async function fetchVizPayload() {
       credentials: "same-origin",
     });
     if (!res.ok) {
-      container.innerHTML =
-        '<p class="empty-notice">Failed to load stats (HTTP ' +
-        res.status +
-        ").</p>";
+      /* Don't clobber a cached chart on a transient 5xx — show the
+       * error only when we have nothing on screen. */
+      if (!_vizCachedData) {
+        container.innerHTML =
+          '<p class="empty-notice">Failed to load stats (HTTP ' +
+          res.status +
+          ").</p>";
+      }
       return;
     }
     var data = await res.json();
+    _vizCachedData = data;
+    _vizCachedAt = Date.now();
     _renderVizPayload(data, container);
   } catch (e) {
-    container.innerHTML =
-      '<p class="empty-notice">Error: ' + escapeHtml(String(e)) + "</p>";
+    if (!_vizCachedData) {
+      container.innerHTML =
+        '<p class="empty-notice">Error: ' + escapeHtml(String(e)) + "</p>";
+    }
   }
 }
 

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -99,6 +99,7 @@
             <div class="tab-bar">
                 <button class="tab-btn active" data-tab="chat">Chat</button>
                 <button class="tab-btn" data-tab="todo">TODO</button>
+                <button class="tab-btn" data-tab="viz">Viz</button>
                 <button class="tab-btn" data-tab="activity">Agents</button>
                 <button class="tab-btn" data-tab="resources">Machines</button>
                 <button class="tab-btn" data-tab="files">Files</button>
@@ -143,10 +144,6 @@
             <div id="messages" class="messages"></div>
             <div id="todo-view" class="todo-view" style="display:none">
                 <!-- hook-bypass: inline-style -->
-                <div class="todo-mode-filter">
-                    <button type="button" class="todo-mode-btn active" data-mode="list">List</button>
-                    <button type="button" class="todo-mode-btn" data-mode="viz">Viz</button>
-                </div>
                 <div class="todo-state-filter" id="todo-state-filter">
                     <button type="button" class="todo-state-btn active" data-group="all">All</button>
                     <button type="button" class="todo-state-btn" data-group="high-priority">High</button>
@@ -160,7 +157,10 @@
                           title="Last fetched from GitHub"></span>
                 </div>
                 <div id="todo-grid" class="todo-grid"></div>
-                <div id="viz-content" class="viz-content todo-viz-hidden"></div>
+            </div>
+            <div id="viz-view" class="todo-view" style="display:none">
+                <!-- hook-bypass: inline-style -->
+                <div id="viz-content" class="viz-content"></div>
             </div>
             <div id="agents-tab-view" class="todo-view" style="display:none">
                 <div id="agents-grid" class="todo-grid"></div>
@@ -369,7 +369,7 @@
     <script src="{% static 'hub/dms.js' %}?v=2"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
     <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>
-    <script src="{% static 'hub/todo-tab.js' %}?v=105"></script>
+    <script src="{% static 'hub/todo-tab.js' %}?v=106"></script>
     <script src="{% static 'hub/workspaces-tab.js' %}?v=99"></script>
     <script src="{% static 'hub/chat.js' %}?v=121"></script>
     <script src="{% static 'hub/mention.js' %}?v=101"></script>
@@ -380,7 +380,7 @@
     <script src="{% static 'hub/agents-tab.js' %}?v=101"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=99"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=119"></script>
-    <script src="{% static 'hub/viz-tab.js' %}?v=2"></script>
+    <script src="{% static 'hub/viz-tab.js' %}?v=3"></script>
     <script src="{% static 'hub/upload.js' %}?v=111"></script>
     <script src="{% static 'hub/files-tab.js' %}?v=104"></script>
     <script src="{% static 'hub/releases-tab.js' %}?v=100"></script>
@@ -389,7 +389,7 @@
     <script src="{% static 'hub/sketch.js' %}?v=99"></script>
     <script src="{% static 'hub/webcam.js' %}?v=1"></script>
     <script src="{% static 'hub/voice-input.js' %}?v=126"></script>
-    <script src="{% static 'hub/tabs.js' %}?v=105"></script>
+    <script src="{% static 'hub/tabs.js' %}?v=106"></script>
     <script src="{% static 'hub/init.js' %}?v=99"></script>
     <script src="{% static 'hub/sw-register.js' %}?v=99"></script>
     <script src="{% static 'hub/push.js' %}?v=99"></script>

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -365,31 +365,31 @@
     </script>
     <script src="{% static 'hub/config.js' %}?v=117"></script>
     <script src="{% static 'hub/agent-icons.js' %}?v=99"></script>
-    <script src="{% static 'hub/app.js' %}?v=126"></script>
-    <script src="{% static 'hub/dms.js' %}?v=1"></script>
+    <script src="{% static 'hub/app.js' %}?v=127"></script>
+    <script src="{% static 'hub/dms.js' %}?v=2"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
     <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>
-    <script src="{% static 'hub/todo-tab.js' %}?v=104"></script>
+    <script src="{% static 'hub/todo-tab.js' %}?v=105"></script>
     <script src="{% static 'hub/workspaces-tab.js' %}?v=99"></script>
     <script src="{% static 'hub/chat.js' %}?v=121"></script>
     <script src="{% static 'hub/mention.js' %}?v=101"></script>
     <script src="{% static 'hub/settings-tab.js' %}?v=104"></script>
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
-    <script src="{% static 'hub/filter.js' %}?v=99"></script>
+    <script src="{% static 'hub/filter.js' %}?v=100"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=100"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=101"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=99"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=119"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=2"></script>
     <script src="{% static 'hub/upload.js' %}?v=111"></script>
-    <script src="{% static 'hub/files-tab.js' %}?v=103"></script>
+    <script src="{% static 'hub/files-tab.js' %}?v=104"></script>
     <script src="{% static 'hub/releases-tab.js' %}?v=100"></script>
     <script src="{% static 'hub/reactions.js' %}?v=107"></script>
     <script src="{% static 'hub/threads.js' %}?v=122"></script>
     <script src="{% static 'hub/sketch.js' %}?v=99"></script>
     <script src="{% static 'hub/webcam.js' %}?v=1"></script>
     <script src="{% static 'hub/voice-input.js' %}?v=126"></script>
-    <script src="{% static 'hub/tabs.js' %}?v=104"></script>
+    <script src="{% static 'hub/tabs.js' %}?v=105"></script>
     <script src="{% static 'hub/init.js' %}?v=99"></script>
     <script src="{% static 'hub/sw-register.js' %}?v=99"></script>
     <script src="{% static 'hub/push.js' %}?v=99"></script>

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -629,6 +629,26 @@ class DMConsumerRoutingTest(TestCase):
         self.assertEqual(len(consumer._sent), 1)
         self.assertEqual(consumer._sent[0]["channel"], "#general")
 
+    def test_agent_chat_message_no_subs_receives_no_group(self):
+        """Opt-in subscription: an agent with zero channels must not receive
+        group broadcasts (the previous `agent_channels and ...` guard
+        short-circuited the filter and let every group message through,
+        which caused GitHub CI notifications routed to #progress to reach
+        healer-ywata-note-win even though it was only subscribed to
+        #general).
+        """
+        from asgiref.sync import async_to_sync
+
+        consumer = self._make_agent_consumer(self.mem_alice.id, agent_channels=[])
+        event = {
+            "type": "chat.message",
+            "sender": "github",
+            "channel": "#progress",
+            "text": "CI success",
+        }
+        async_to_sync(consumer.chat_message)(event)
+        self.assertEqual(consumer._sent, [])
+
     # ------------------------------------------------------------------
     # DashboardConsumer.chat_message — confidentiality filter
     # ------------------------------------------------------------------

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -1764,11 +1764,47 @@ def api_agents_register(request):
     if not name:
         return JsonResponse({"error": "name required"}, status=400)
 
+    # Hydrate the agent's channel subscriptions from the DB (the
+    # ChannelMembership table is the source of truth, matching the WS
+    # register flow). Previously this endpoint hard-coded a
+    # ["#general"] default on every heartbeat, which forced every new
+    # agent to join #general even when the dashboard user wanted
+    # subscriptions to be opt-in.
+    #
+    # A caller that explicitly sends "channels" (legacy REST clients)
+    # is honored for backward-compat; otherwise we use whatever the DB
+    # has, which may be an empty list for a brand-new agent.
+    import re as _re
+
+    from django.contrib.auth.models import User as _User
+
+    from hub.models import ChannelMembership as _ChannelMembership
     from hub.registry import (
         mark_activity,
         register_agent,
         set_current_task,
         update_heartbeat,
+    )
+
+    _safe_name = _re.sub(r"[^a-zA-Z0-9_.\-]", "-", name)
+    _agent_username = f"agent-{_safe_name}"
+    _persisted_channels: list[str] = []
+    try:
+        _agent_user = _User.objects.get(username=_agent_username)
+        _persisted_channels = [
+            m.channel.name
+            for m in _ChannelMembership.objects.filter(
+                user=_agent_user,
+                channel__workspace_id=wt.workspace_id,
+            ).select_related("channel")
+        ]
+    except _User.DoesNotExist:
+        _persisted_channels = []
+    _legacy_channels = body.get("channels")
+    _effective_channels = (
+        list(_legacy_channels)
+        if isinstance(_legacy_channels, list)
+        else _persisted_channels
     )
 
     register_agent(
@@ -1780,7 +1816,7 @@ def api_agents_register(request):
             "role": body.get("role", "agent"),
             "model": body.get("model", ""),
             "workdir": body.get("workdir", ""),
-            "channels": body.get("channels") or ["#general"],
+            "channels": _effective_channels,
             # todo#213: claude-hud-style process/runtime metadata pushed by
             # mamba-healer-mba's agent_meta.py --push loop.
             "multiplexer": body.get("multiplexer", ""),

--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -1174,6 +1174,17 @@ def push_all(url=None, token=None) -> int:
                 "runtime": meta.get("runtime", ""),
                 "current_task": meta.get("current_task", ""),
                 "channels": ["#general"],
+                # Observability fields for the per-agent detail view
+                # (/api/agents/<name>/detail/). Without these the hub
+                # shows empty CLAUDE.md / .mcp.json / terminal output
+                # panels even though the agent collects them locally.
+                "claude_md": meta.get("claude_md", ""),
+                "mcp_json": meta.get("mcp_json", ""),
+                "mcp_servers": list(meta.get("mcp_servers") or []),
+                "pane_tail": meta.get("pane_tail", ""),
+                "pane_tail_block": meta.get("pane_tail_block", ""),
+                "pane_state": meta.get("pane_state", ""),
+                "stuck_prompt_text": meta.get("stuck_prompt_text", ""),
             }
             # todo#265: merge OAuth account public metadata into the
             # heartbeat payload. All 9 keys are whitelist-extracted

--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -1173,7 +1173,10 @@ def push_all(url=None, token=None) -> int:
                 "version": meta.get("version", ""),
                 "runtime": meta.get("runtime", ""),
                 "current_task": meta.get("current_task", ""),
-                "channels": ["#general"],
+                # Intentionally no "channels" key. Subscriptions are
+                # server-authoritative (ChannelMembership rows); heartbeats
+                # must not clobber them. New agents start with no
+                # subscriptions — the user opts in via the dashboard.
                 # Observability fields for the per-agent detail view
                 # (/api/agents/<name>/detail/). Without these the hub
                 # shows empty CLAUDE.md / .mcp.json / terminal output


### PR DESCRIPTION
## Summary

- **Chat UX** (`tabs.js`): restore the channel-topic banner and snap `#messages` to bottom when re-entering the Chat tab
- **Fuzzy filter** (`filter.js` + per-tab renderers): extend the Ctrl+K fuzzy filter to Agents-tab rows and Files-tab rows, and re-apply after each `innerHTML` rewrite so tab switches don't reset the query
- **DM display** (`app.js` + `dms.js`): friendly `@<other>` placeholder + drop the unreadable `channel:dm:agent:X|human:Y` filter chip
- **Per-agent observability** (`scripts/client/agent_meta.py`): forward `claude_md`, `mcp_json`, `mcp_servers`, `pane_tail[_block]`, `pane_state`, `stuck_prompt_text` into the `/api/agents/register/` heartbeat so the per-agent detail view actually populates

## Test plan
- [ ] hub redeployed on mba
- [ ] `curl …/api/agents/head-nas/detail/?token=…` returns non-empty `claude_md` and `mcp_json` after agent_meta.py rolled to nas
- [ ] Ctrl+K "todo" hides non-matching rows in TODO, Agents, Files tabs
- [ ] Switching tabs and returning to Chat leaves #messages scrolled to bottom and the topic banner visible
- [ ] Opening a DM shows "Message @head-spartan…" placeholder, no `channel:dm:…` filter tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)