### PR TITLE
feat(dashboard): fleet-core vs ad-hoc + pane-state / tool chips

### DIFF
--- a/hub/static/hub/activity-tab.css
+++ b/hub/static/hub/activity-tab.css
@@ -259,6 +259,49 @@
   opacity: 0.6;
 }
 
+/* Fleet-core agents (YAML-defined canonical roles). Slightly heavier
+ * left-border + a teal hairline on the top so core slots are scannable
+ * at a glance vs ad-hoc registrations. */
+.activity-card.activity-card-core {
+  border-left-width: 4px;
+  box-shadow: inset 0 1px 0 rgba(78, 205, 196, 0.18);
+}
+
+/* Fleet-core agents that went stale: render as a shadow so the slot is
+ * still visible (the user expects a head/healer to be present even
+ * when it's briefly down) but clearly not responsive. */
+.activity-card.activity-card-shadow {
+  opacity: 0.35;
+  filter: grayscale(0.6);
+  background: #0f0f0f;
+}
+
+/* Pane-state chip (stuck/y_n_prompt/auth_error/compose_pending). */
+.activity-chip-pane-state {
+  background: #3a1e1e;
+  color: #fca5a5;
+  border: 1px solid #6b2525;
+}
+.activity-chip-pane-y_n_prompt,
+.activity-chip-pane-compose_pending_unsent {
+  background: #3a2f10;
+  color: #fcd34d;
+  border-color: #6b5220;
+}
+.activity-chip-pane-auth_error,
+.activity-chip-pane-mcp_broken {
+  background: #3a1010;
+  color: #f87171;
+  border-color: #6b2020;
+}
+
+/* Tool-freshness chip (last LLM hook event). */
+.activity-chip-tool {
+  background: #14324a;
+  color: #8acdee;
+  border: 1px solid #1f486b;
+}
+
 @keyframes activity-pulse {
   0%,
   100% {

--- a/hub/static/hub/activity-tab.js
+++ b/hub/static/hub/activity-tab.js
@@ -772,6 +772,23 @@ function _renderActivityCards(agents, grid) {
     grid.innerHTML = '<p class="empty-notice">No agents connected.</p>';
     return;
   }
+  /* Visibility policy (ywatanabe msg 2026-04-18 17:00):
+   *  - Fleet-core agents (YAML-defined) are always shown, muted to a
+   *    shadow when stale/offline so their expected slot stays visible.
+   *  - Non-core registered agents are only shown while responsive;
+   *    they drop off when stale.
+   *  - Unregistered agents are not in the registry to begin with.
+   */
+  var isCore = typeof isFleetCoreAgent === "function" ? isFleetCoreAgent : null;
+  if (isCore) {
+    agents = agents.filter(function (a) {
+      return isCore(a) || !isAgentInactive(a);
+    });
+  }
+  if (!agents.length) {
+    grid.innerHTML = '<p class="empty-notice">No agents connected.</p>';
+    return;
+  }
   var summary = document.getElementById("activity-summary");
   var counts = { online: 0, idle: 0, stale: 0, offline: 0 };
   agents.forEach(function (a) {
@@ -867,6 +884,35 @@ function _renderActivityCards(agents, grid) {
             "%</span>",
         );
       }
+      /* Pane-state chip (agent-container classifier result — running,
+       * y_n_prompt, auth_error, compose_pending, etc.). Available from
+       * /api/agents/<name>/detail but also surfaced in the registry row
+       * via agent_meta.py. Separate from liveness: liveness tracks the
+       * push channel's freshness, pane_state tracks what the LLM itself
+       * is doing. */
+      var paneState = a.pane_state || "";
+      if (paneState && paneState !== "running") {
+        chips.push(
+          '<span class="activity-chip activity-chip-pane-state activity-chip-pane-' +
+            escapeHtml(paneState).replace(/[^a-z0-9_-]/gi, "") +
+            '" title="pane state">' +
+            escapeHtml(paneState.replace(/_/g, " ")) +
+            "</span>",
+        );
+      }
+      /* Tool freshness — proves the LLM is actually working (last hook
+       * event < N min ago), not just that its sidecar is heartbeating. */
+      var toolAgeSec = _secondsSinceIso(a.last_tool_at);
+      if (toolAgeSec != null && toolAgeSec < 3600) {
+        chips.push(
+          '<span class="activity-chip activity-chip-tool" ' +
+            'title="last tool call: ' +
+            escapeHtml(String(a.last_tool_name || "")) +
+            '">tool ' +
+            _formatIdle(toolAgeSec) +
+            "</span>",
+        );
+      }
       var chipsHtml =
         chips.length > 0
           ? '<div class="activity-chips">' + chips.join("") + "</div>"
@@ -882,10 +928,19 @@ function _renderActivityCards(agents, grid) {
         escapeHtml(copyPayload) +
         '">\uD83D\uDCCB</button>';
       var stuckClass = isStuck ? " activity-stuck" : "";
+      /* Fleet-core vs ad-hoc styling. Core agents that went stale are
+       * shadowed (muted) so their slot is still visible; ad-hoc stale
+       * agents were filtered out above. */
+      var core = typeof isFleetCoreAgent === "function" && isFleetCoreAgent(a);
+      var coreClass = core ? " activity-card-core" : "";
+      var shadowClass =
+        core && isAgentInactive(a) ? " activity-card-shadow" : "";
       return (
         '<div class="activity-card activity-' +
         liveness +
         stuckClass +
+        coreClass +
+        shadowClass +
         '" ' +
         'data-agent="' +
         escapeHtml(rawName) +

--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -877,6 +877,39 @@ function hostedAgentName(a) {
   return host ? name + "@" + host : name;
 }
 
+/* Fleet-core roles defined by YAML under ~/.scitex/orochi/shared/agents/
+ * (and the per-host overrides in spartan/agents/ etc.). These agents are
+ * launched canonically by `sac start --all` and are expected to be
+ * present on every applicable host. Non-core registered agents are
+ * ad-hoc — they should disappear from the dashboard once they go stale
+ * rather than stick around as zombie cards. */
+var FLEET_CORE_ROLES = [
+  "expert-scitex",
+  "fleet-lead",
+  "head",
+  "healer",
+  "quality-checker",
+  "skill-manager",
+  "synchronizer",
+  "todo-manager",
+];
+
+/* Return true if the agent matches a YAML-defined fleet-core role.
+ * Names register as "<role>" (singleton) or "<role>-<host>" (per-host);
+ * stripping the "-<host>" suffix gives the role, which we compare
+ * against FLEET_CORE_ROLES. */
+function isFleetCoreAgent(a) {
+  if (!a || !a.name) return false;
+  var name = String(a.name).split("@")[0];
+  var host = a.machine ? String(a.machine) : "";
+  if (host && name.length > host.length + 1 && name.endsWith("-" + host)) {
+    name = name.slice(0, -(host.length + 1));
+  }
+  return FLEET_CORE_ROLES.indexOf(name) !== -1;
+}
+window.isFleetCoreAgent = isFleetCoreAgent;
+window.FLEET_CORE_ROLES = FLEET_CORE_ROLES;
+
 function fuzzyMatch(query, text) {
   if (!query) return true;
   query = query.toLowerCase();

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="{% static 'hub/icons.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/settings.css' %}?v=104">
     <link rel="stylesheet" href="{% static 'hub/connectivity-map.css' %}?v=99">
-    <link rel="stylesheet" href="{% static 'hub/activity-tab.css' %}?v=122">
+    <link rel="stylesheet" href="{% static 'hub/activity-tab.css' %}?v=123">
     <link rel="stylesheet" href="{% static 'hub/files-tab.css' %}?v=103">
     <link rel="stylesheet" href="{% static 'hub/releases-tab.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/reactions.css' %}?v=115">
@@ -365,7 +365,7 @@
     </script>
     <script src="{% static 'hub/config.js' %}?v=117"></script>
     <script src="{% static 'hub/agent-icons.js' %}?v=99"></script>
-    <script src="{% static 'hub/app.js' %}?v=128"></script>
+    <script src="{% static 'hub/app.js' %}?v=129"></script>
     <script src="{% static 'hub/dms.js' %}?v=2"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
     <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>
@@ -379,7 +379,7 @@
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
     <script src="{% static 'hub/agents-tab.js' %}?v=101"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=99"></script>
-    <script src="{% static 'hub/activity-tab.js' %}?v=119"></script>
+    <script src="{% static 'hub/activity-tab.js' %}?v=120"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>
     <script src="{% static 'hub/upload.js' %}?v=111"></script>
     <script src="{% static 'hub/files-tab.js' %}?v=104"></script>


### PR DESCRIPTION
## Summary

Three observability changes to the Agents card grid:

1. **Fleet-core vs ad-hoc visibility** — YAML-defined canonical agents (head, healer, expert-scitex, fleet-lead, quality-checker, skill-manager, synchronizer, todo-manager) are always shown; stale ones render as a shadow (opacity 0.35, grayscale 0.6) so their slot is still visible. Non-core registered agents only render while responsive.

2. **pane-state chip** — surfaces the agent-container classifier result (y_n_prompt, compose_pending_unsent, auth_error, mcp_broken). Separate from liveness: liveness tracks the push channel's freshness, pane-state tracks what the LLM itself is doing.

3. **tool chip** — shows last hook event age (≤1h) so you can tell a heartbeating sidecar's LLM is actually doing work.

## Test plan
- [ ] head / healer show as shadow when their tmux is down
- [ ] ad-hoc scitex-haiku-int-* drops from the grid after it goes stale
- [ ] An agent stuck on a y/n prompt shows the pane-state chip even if heartbeats keep flowing
- [ ] tool chip age updates with hook events

🤖 Generated with [Claude Code](https://claude.com/claude-code)