### PR TITLE
feat(dashboard): workdir truncation + tool sequences + indicator hints

### DIFF
--- a/hub/static/hub/activity-tab.css
+++ b/hub/static/hub/activity-tab.css
@@ -302,6 +302,36 @@
   border: 1px solid #1f486b;
 }
 
+/* Tool-sequence chip — inline breadcrumb of the last N hook events.
+ * Uses a compact row layout so a 5-step chain fits on one line on
+ * normal card widths. */
+.activity-chip-tool-seq {
+  background: #14324a;
+  color: #8acdee;
+  border: 1px solid #1f486b;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  flex-wrap: wrap;
+}
+.activity-chip-tool-seq .activity-tool-step {
+  padding: 0 4px;
+}
+.activity-chip-tool-seq .activity-tool-sep {
+  color: #5a7b93;
+  padding: 0 1px;
+}
+
+/* Fresh-agent empty-state chip (registered but hasn't run any tools
+ * yet — makes the absence of tool/action data explicit instead of just
+ * showing nothing). */
+.activity-chip-idle-fresh {
+  background: #1a1a1a;
+  color: #888;
+  border: 1px dashed #3a3a3a;
+  font-style: italic;
+}
+
 @keyframes activity-pulse {
   0%,
   100% {

--- a/hub/static/hub/activity-tab.js
+++ b/hub/static/hub/activity-tab.js
@@ -885,33 +885,84 @@ function _renderActivityCards(agents, grid) {
         );
       }
       /* Pane-state chip (agent-container classifier result — running,
-       * y_n_prompt, auth_error, compose_pending, etc.). Available from
-       * /api/agents/<name>/detail but also surfaced in the registry row
-       * via agent_meta.py. Separate from liveness: liveness tracks the
-       * push channel's freshness, pane_state tracks what the LLM itself
-       * is doing. */
+       * y_n_prompt, auth_error, compose_pending, etc.). Each state has
+       * its own hover-hint explaining what it means. */
       var paneState = a.pane_state || "";
+      var PANE_STATE_HINTS = {
+        y_n_prompt:
+          "agent blocked on a yes/no prompt — approve or reject in the pane",
+        compose_pending_unsent:
+          "agent drafted a message but hasn't sent it yet",
+        auth_error: "claude-code auth expired — agent needs re-login",
+        mcp_broken: "MCP sidecar disconnected — tools unavailable",
+        stuck: "detected as stuck by the classifier — no progress",
+      };
       if (paneState && paneState !== "running") {
+        var paneHint =
+          PANE_STATE_HINTS[paneState] ||
+          "agent-container classifier: " + paneState;
         chips.push(
           '<span class="activity-chip activity-chip-pane-state activity-chip-pane-' +
             escapeHtml(paneState).replace(/[^a-z0-9_-]/gi, "") +
-            '" title="pane state">' +
+            '" title="' +
+            escapeHtml(paneHint) +
+            '">' +
             escapeHtml(paneState.replace(/_/g, " ")) +
             "</span>",
         );
       }
-      /* Tool freshness — proves the LLM is actually working (last hook
-       * event < N min ago), not just that its sidecar is heartbeating. */
-      var toolAgeSec = _secondsSinceIso(a.last_tool_at);
-      if (toolAgeSec != null && toolAgeSec < 3600) {
+      /* Tool sequence — last N hook events as breadcrumb chips. Proves
+       * the LLM is actually working (distinct from liveness, which only
+       * tracks the sidecar's heartbeat). Falls back to the single
+       * last_tool_name when the recent_tools ring buffer isn't
+       * populated yet. */
+      var recentTools = Array.isArray(a.recent_tools) ? a.recent_tools : [];
+      if (recentTools.length) {
+        var seqChips = recentTools
+          .slice(-5)
+          .map(function (t) {
+            var nm = String((t && (t.name || t.tool)) || "?");
+            var when = (t && (t.ts || t.at)) || "";
+            var age = _secondsSinceIso(when);
+            var ageStr = age != null ? " · " + _formatIdle(age) : "";
+            return (
+              '<span class="activity-tool-step" title="' +
+              escapeHtml(nm + ageStr) +
+              '">' +
+              escapeHtml(nm) +
+              "</span>"
+            );
+          })
+          .join('<span class="activity-tool-sep">\u203A</span>');
         chips.push(
-          '<span class="activity-chip activity-chip-tool" ' +
-            'title="last tool call: ' +
-            escapeHtml(String(a.last_tool_name || "")) +
-            '">tool ' +
-            _formatIdle(toolAgeSec) +
+          '<span class="activity-chip activity-chip-tool-seq" ' +
+            'title="last ' +
+            recentTools.slice(-5).length +
+            ' tool calls (oldest → newest)">' +
+            seqChips +
             "</span>",
         );
+      } else {
+        var toolAgeSec = _secondsSinceIso(a.last_tool_at);
+        if (toolAgeSec != null && toolAgeSec < 3600) {
+          chips.push(
+            '<span class="activity-chip activity-chip-tool" ' +
+              'title="last tool call: ' +
+              escapeHtml(String(a.last_tool_name || "")) +
+              '">tool ' +
+              _formatIdle(toolAgeSec) +
+              "</span>",
+          );
+        } else if (!task && !preview) {
+          /* Brand-new agent with no activity yet — explicit empty-state
+           * so the absence is intentional, not a data gap. */
+          chips.push(
+            '<span class="activity-chip activity-chip-idle-fresh" ' +
+              'title="agent registered but has not run any tools yet">' +
+              "awaiting first action" +
+              "</span>",
+          );
+        }
       }
       var chipsHtml =
         chips.length > 0
@@ -935,6 +986,16 @@ function _renderActivityCards(agents, grid) {
       var coreClass = core ? " activity-card-core" : "";
       var shadowClass =
         core && isAgentInactive(a) ? " activity-card-shadow" : "";
+      var LIVENESS_HINTS = {
+        online: "active — heartbeat <2 min ago",
+        idle: "idle — heartbeat 2–10 min ago",
+        stale: "stale — heartbeat >10 min ago (probably stuck)",
+        offline: "disconnected — no sidecar heartbeat",
+      };
+      var livenessHint = LIVENESS_HINTS[liveness] || liveness;
+      var coreHint = core
+        ? "fleet-core role (always visible, shadowed when stale)"
+        : "ad-hoc registration (hidden when stale)";
       return (
         '<div class="activity-card activity-' +
         liveness +
@@ -944,10 +1005,16 @@ function _renderActivityCards(agents, grid) {
         '" ' +
         'data-agent="' +
         escapeHtml(rawName) +
+        '" data-machine="' +
+        escapeHtml(a.machine || "") +
+        '" title="' +
+        escapeHtml(coreHint) +
         '">' +
         '<div class="activity-card-header">' +
         '<span class="activity-status-dot activity-dot-' +
         liveness +
+        '" title="' +
+        escapeHtml(livenessHint) +
         '"></span>' +
         '<span class="activity-name" style="color:' +
         color +
@@ -955,7 +1022,9 @@ function _renderActivityCards(agents, grid) {
         name +
         "</span>" +
         copyBtn +
-        '<span class="activity-liveness">' +
+        '<span class="activity-liveness" title="' +
+        escapeHtml(livenessHint) +
+        '">' +
         _livenessLabel(liveness) +
         (idleStr ? " · " + idleStr : "") +
         "</span>" +

--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -140,30 +140,90 @@ function _renderAgentDetail(a) {
     if (reset) s += " (resets " + reset + ")";
     return s;
   }
+  /* Smart middle-truncation for long paths (e.g. workdirs). Keep the
+   * first and last segments readable and drop the middle so the cell
+   * doesn't steal a full row. Full path goes into the title tooltip. */
+  function _smartTruncatePath(p, max) {
+    if (!p) return p;
+    var home = /^\/home\/[^/]+/;
+    var display = String(p).replace(home, "~");
+    if (display.length <= max) return display;
+    var head = Math.floor((max - 1) / 2);
+    var tail = max - 1 - head;
+    return display.slice(0, head) + "\u2026" + display.slice(-tail);
+  }
+  /* [label, value, tooltip] — tooltip optional. The detail-meta-grid
+   * renderer below writes the tooltip onto the <span> so hovering a
+   * cell reveals the full value (critical for workdir paths that get
+   * middle-truncated). */
   var metaFields = [
-    ["Role", role],
-    ["Machine", machine],
-    ["Model", model],
-    ["Multiplexer", multiplexer || "-"],
-    ["PID", pid || "-"],
-    ["Liveness", liveness],
-    ["Context", ctxPct != null ? Number(ctxPct).toFixed(1) + "%" : "-"],
-    ["5h quota", _fmtQuota(q5, q5Reset)],
-    ["7d quota", _fmtQuota(q7, q7Reset)],
+    ["Role", role, "declared agent role (head / healer / expert-scitex / ...)"],
+    ["Machine", machine, "canonical hostname the agent is running on"],
+    ["Model", model, "Claude model id the agent is running against"],
+    [
+      "Multiplexer",
+      multiplexer || "-",
+      "tmux / screen session hosting the agent process",
+    ],
+    ["PID", pid || "-", "host-side process id of the claude-code binary"],
+    [
+      "Liveness",
+      liveness,
+      "push-freshness: online <2m, idle 2–10m, stale >10m, offline disconnected",
+    ],
+    [
+      "Context",
+      ctxPct != null ? Number(ctxPct).toFixed(1) + "%" : "-",
+      "context-window usage reported by claude-hud",
+    ],
+    [
+      "5h quota",
+      _fmtQuota(q5, q5Reset),
+      "rolling 5-hour Claude usage quota consumed",
+    ],
+    [
+      "7d quota",
+      _fmtQuota(q7, q7Reset),
+      "rolling 7-day Claude usage quota consumed",
+    ],
     [
       "Subagents (" + (subagentCount != null ? subagentCount : 0) + ")",
       subagentCount != null ? String(subagentCount) : "-",
+      "active Agent-tool subagents spawned by this agent",
     ],
-    ["Uptime", d.uptime_seconds != null ? _fmtDuration(d.uptime_seconds) : "-"],
-    ["Idle", idleSec != null ? _fmtDuration(idleSec) : "-"],
-    ["Workdir", workdir || "-"],
-    ["Registered", registeredAt || "-"],
-    ["Last heartbeat", lastHeartbeat || "-"],
+    [
+      "Uptime",
+      d.uptime_seconds != null ? _fmtDuration(d.uptime_seconds) : "-",
+      "time since this agent first registered",
+    ],
+    [
+      "Idle",
+      idleSec != null ? _fmtDuration(idleSec) : "-",
+      "time since this agent last reported activity",
+    ],
+    [
+      "Workdir",
+      _smartTruncatePath(workdir, 40) || "-",
+      workdir || "(no workdir reported)",
+    ],
+    [
+      "Registered",
+      registeredAt || "-",
+      "iso timestamp of the first register heartbeat",
+    ],
+    [
+      "Last heartbeat",
+      lastHeartbeat || "-",
+      "iso timestamp of the most recent push",
+    ],
   ];
   var metaHtml = metaFields
     .map(function (f) {
+      var tip = f[2] ? ' title="' + escapeHtml(String(f[2])) + '"' : "";
       return (
-        "<span><strong>" +
+        "<span" +
+        tip +
+        "><strong>" +
         escapeHtml(f[0]) +
         ":</strong>" +
         escapeHtml(String(f[1])) +

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="{% static 'hub/icons.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/settings.css' %}?v=104">
     <link rel="stylesheet" href="{% static 'hub/connectivity-map.css' %}?v=99">
-    <link rel="stylesheet" href="{% static 'hub/activity-tab.css' %}?v=123">
+    <link rel="stylesheet" href="{% static 'hub/activity-tab.css' %}?v=124">
     <link rel="stylesheet" href="{% static 'hub/files-tab.css' %}?v=103">
     <link rel="stylesheet" href="{% static 'hub/releases-tab.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/reactions.css' %}?v=115">
@@ -377,9 +377,9 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=100"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=101"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=102"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=99"></script>
-    <script src="{% static 'hub/activity-tab.js' %}?v=120"></script>
+    <script src="{% static 'hub/activity-tab.js' %}?v=121"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>
     <script src="{% static 'hub/upload.js' %}?v=111"></script>
     <script src="{% static 'hub/files-tab.js' %}?v=104"></script>


### PR DESCRIPTION
## Summary

Addresses ywatanabe feedback 2026-04-18 17:00–17:06:

- **Workdir smart truncation** — middle-ellipsis at 40 chars, full path on hover. Detail meta cells gain explanatory tooltips.
- **Tool sequence chips** — render `recent_tools` ring buffer as a breadcrumb (tool1 › tool2 › tool3 …) instead of a single "last tool" chip.
- **Fresh-agent empty-state** — `awaiting first action` chip for agents that registered but haven't run any tools yet.
- **Pane-state chip hover hints** — each classifier state (y_n_prompt / compose_pending_unsent / auth_error / mcp_broken) gets a verbose tooltip.
- **Status-dot + liveness-label tooltips** — explain the <2m / 2–10m / >10m thresholds.
- **Fleet-core hover hint** — explains the shadow vs hidden policy.
- **data-machine attribute** added to activity-card for the upcoming ssh-mesh hover-sync work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)