### PR TITLE
feat(dashboard): Ctrl+K filter on Agents cards + ★ fleet-core marker

### DIFF
--- a/hub/static/hub/activity-tab.css
+++ b/hub/static/hub/activity-tab.css
@@ -332,6 +332,17 @@
   font-style: italic;
 }
 
+/* Star marker for fleet-core agents. Placed between the status dot and
+ * the name so the visual hierarchy is: liveness → role → identity. */
+.activity-core-star {
+  color: #fbbf24;
+  font-size: 12px;
+  margin-right: 2px;
+}
+.activity-card-shadow .activity-core-star {
+  color: #574019;
+}
+
 @keyframes activity-pulse {
   0%,
   100% {

--- a/hub/static/hub/activity-tab.js
+++ b/hub/static/hub/activity-tab.js
@@ -1016,6 +1016,9 @@ function _renderActivityCards(agents, grid) {
         '" title="' +
         escapeHtml(livenessHint) +
         '"></span>' +
+        (core
+          ? '<span class="activity-core-star" title="fleet-core role (YAML-defined, always shown)">\u2605</span>'
+          : "") +
         '<span class="activity-name" style="color:' +
         color +
         '">' +
@@ -1042,6 +1045,11 @@ function _renderActivityCards(agents, grid) {
       );
     })
     .join("");
+  /* Re-apply Ctrl+K fuzzy filter after innerHTML rewrite (mirrors
+   * todo-tab / agents-tab / files-tab behaviour). Without this, typing
+   * "head" on Chat then switching to Agents shows all agents until you
+   * retype. */
+  if (typeof runFilter === "function") runFilter();
   /* Click card -> switch to that agent's sub-tab (Shift/Ctrl/Cmd keeps
    * the legacy addTag filter behaviour so power users are not
    * surprised). Copy button and other inline controls stop propagation. */

--- a/hub/static/hub/filter.js
+++ b/hub/static/hub/filter.js
@@ -426,4 +426,16 @@ function filterSidebarElements(qWords, allTags) {
           ? ""
           : "none";
     });
+  /* Agents tab activity-card grid (what "Agents" actually renders —
+   * the data-tab="activity" view). Previously Ctrl+K only filtered
+   * table rows in the legacy agents-tab overview, not these cards. */
+  document
+    .querySelectorAll("#activity-grid .activity-card")
+    .forEach(function (el) {
+      var text = el.textContent;
+      el.style.display =
+        _matchAllWords(qWords, text) && matchesAllTags(allTags, text)
+          ? ""
+          : "none";
+    });
 }

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="{% static 'hub/icons.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/settings.css' %}?v=104">
     <link rel="stylesheet" href="{% static 'hub/connectivity-map.css' %}?v=99">
-    <link rel="stylesheet" href="{% static 'hub/activity-tab.css' %}?v=124">
+    <link rel="stylesheet" href="{% static 'hub/activity-tab.css' %}?v=125">
     <link rel="stylesheet" href="{% static 'hub/files-tab.css' %}?v=103">
     <link rel="stylesheet" href="{% static 'hub/releases-tab.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/reactions.css' %}?v=115">
@@ -369,11 +369,11 @@
     <script src="{% static 'hub/mention.js' %}?v=101"></script>
     <script src="{% static 'hub/settings-tab.js' %}?v=104"></script>
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
-    <script src="{% static 'hub/filter.js' %}?v=100"></script>
+    <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
     <script src="{% static 'hub/agents-tab.js' %}?v=102"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=99"></script>
-    <script src="{% static 'hub/activity-tab.js' %}?v=121"></script>
+    <script src="{% static 'hub/activity-tab.js' %}?v=122"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>
     <script src="{% static 'hub/upload.js' %}?v=111"></script>
     <script src="{% static 'hub/files-tab.js' %}?v=104"></script>


### PR DESCRIPTION
## Summary
- **Agents tab fuzzy filter** — Ctrl+K now filters `#activity-grid .activity-card` (previously only the legacy table).
- **Filter survives tab re-render** — `runFilter()` re-applied after activity-tab innerHTML rewrite.
- **★ marker on fleet-core cards** — canonical roles (head, healer, etc.) get an amber star before the name; it dims on stale/shadow cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)