### PR TITLE
feat(dashboard): drag-and-drop agent → channel subscribe/unsubscribe

### DIFF
--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -736,6 +736,115 @@ function _addDragAndDrop(container, section) {
   });
 }
 
+/* ── todo#49: agent ↔ channel subscription DnD helpers ── */
+function _agentHasChannel(channelsCsv, channel) {
+  if (!channel) return false;
+  var norm = channel.charAt(0) === "#" ? channel : "#" + channel;
+  var bare = channel.charAt(0) === "#" ? channel.slice(1) : channel;
+  var list = String(channelsCsv || "")
+    .split(",")
+    .map(function (s) {
+      return s.trim();
+    })
+    .filter(Boolean);
+  for (var i = 0; i < list.length; i++) {
+    var v = list[i];
+    if (v === channel || v === norm || v === bare || v === "#" + bare)
+      return true;
+  }
+  return false;
+}
+
+function _setChannelDropHint(el, text) {
+  var hint = el.querySelector(".ch-hint");
+  if (!hint) {
+    hint = document.createElement("span");
+    hint.className = "ch-hint";
+    el.appendChild(hint);
+  }
+  hint.textContent = text;
+}
+
+function _agentDjangoUsername(name) {
+  /* Mirrors hub/views/api.py: re.sub(r"[^a-zA-Z0-9_.\-]", "-", name) */
+  if (!name) return "";
+  var safe = String(name).replace(/[^a-zA-Z0-9_.\-]/g, "-");
+  return "agent-" + safe;
+}
+
+function _showMiniToast(text, kind) {
+  var el = document.getElementById("orochi-mini-toast");
+  if (!el) {
+    el = document.createElement("div");
+    el.id = "orochi-mini-toast";
+    document.body.appendChild(el);
+  }
+  el.className = "";
+  if (kind) el.classList.add(kind);
+  el.textContent = text;
+  /* force reflow so transition re-fires when toast shown twice in a row */
+  void el.offsetWidth;
+  el.classList.add("visible");
+  if (el._hideTimer) clearTimeout(el._hideTimer);
+  el._hideTimer = setTimeout(function () {
+    el.classList.remove("visible");
+  }, 2200);
+}
+
+function _toggleAgentChannelSubscription(agentName, channel, subscribe) {
+  var username = _agentDjangoUsername(agentName);
+  if (!username || !channel) return;
+  var method = subscribe ? "POST" : "DELETE";
+  var body = JSON.stringify({ channel: channel, username: username });
+  var url = apiUrl("/api/channel-members/");
+  fetch(url, {
+    method: method,
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCsrfToken(),
+    },
+    body: body,
+  })
+    .then(function (res) {
+      if (!res.ok) {
+        return res
+          .json()
+          .catch(function () {
+            return { error: res.status };
+          })
+          .then(function (j) {
+            var msg =
+              (j && j.error) || "HTTP " + res.status + " — check permissions";
+            _showMiniToast(
+              (subscribe ? "Subscribe failed: " : "Unsubscribe failed: ") + msg,
+              "err",
+            );
+            throw new Error(msg);
+          });
+      }
+      return res.json();
+    })
+    .then(function () {
+      _showMiniToast(
+        (subscribe ? "Subscribed " : "Unsubscribed ") +
+          agentName +
+          (subscribe ? " → " : " ← ") +
+          channel,
+        "ok",
+      );
+      /* Registry heartbeat takes up to ~2s to re-propagate agent.channels;
+       * force an immediate refresh so the UI reflects the change and a
+       * subsequent drag sees the latest subscription state. */
+      if (typeof fetchAgentsThrottled === "function") {
+        fetchAgentsThrottled();
+      } else if (typeof fetchAgents === "function") {
+        fetchAgents();
+      }
+    })
+    .catch(function (_) {});
+}
+
 var cachedAgentNames = [];
 var historyLoaded = false;
 var knownMessageKeys = {};
@@ -1381,12 +1490,16 @@ async function fetchAgents() {
         var statusClassCompact = liveness === "online" ? "online" : "offline";
         var tooltip =
           (a.agent_id || a.name) + " (" + (a.machine || "unknown") + ")";
+        /* todo#49: draggable agent cards — drop on channel to subscribe */
+        var chList = Array.isArray(a.channels) ? a.channels.join(",") : "";
         return (
           '<div class="agent-card sidebar-compact' +
           (inactive ? " inactive" : "") +
           '" data-agent-name="' +
           escapeHtml(a.name) +
-          '" title="' +
+          '" data-agent-channels="' +
+          escapeHtml(chList) +
+          '" draggable="true" title="' +
           escapeHtml(tooltip) +
           '">' +
           '<span class="agent-status ' +
@@ -1405,6 +1518,35 @@ async function fetchAgents() {
         /* Restore .selected from before re-render (#274 Part 2) */
         var elName = el.getAttribute("data-agent-name");
         if (elName && prevSelectedAgents[elName]) el.classList.add("selected");
+        /* todo#49: drag agent card onto a channel to subscribe / unsubscribe. */
+        el.addEventListener("dragstart", function (ev) {
+          var n = el.getAttribute("data-agent-name") || "";
+          var chs = el.getAttribute("data-agent-channels") || "";
+          el.classList.add("agent-dragging");
+          try {
+            ev.dataTransfer.effectAllowed = "link";
+            ev.dataTransfer.setData("application/x-orochi-agent", n);
+            ev.dataTransfer.setData("text/plain", n);
+            /* Carry current subscriptions so the drop handler can render
+             * add/remove affordance without an extra fetch. */
+            ev.dataTransfer.setData("application/x-orochi-agent-channels", chs);
+          } catch (e) {}
+          window.__orochiDragAgent = { name: n, channels: chs };
+        });
+        el.addEventListener("dragend", function () {
+          el.classList.remove("agent-dragging");
+          window.__orochiDragAgent = null;
+          document
+            .querySelectorAll(
+              ".channel-item.drop-target-agent-add,.channel-item.drop-target-agent-remove",
+            )
+            .forEach(function (t) {
+              t.classList.remove("drop-target-agent-add");
+              t.classList.remove("drop-target-agent-remove");
+              var hint = t.querySelector(".ch-hint");
+              if (hint) hint.remove();
+            });
+        });
         el.addEventListener("click", function (ev) {
           if (ev.target.closest(".pin-btn")) return; /* handled separately */
           if (ev.target.closest(".kill-btn")) return; /* handled separately */
@@ -1694,6 +1836,52 @@ async function fetchStats() {
       }
       /* Context menu */
       _addChannelContextMenu(el);
+      /* todo#49: accept agent-card drops to toggle subscription. */
+      el.addEventListener("dragover", function (ev) {
+        var drag = window.__orochiDragAgent;
+        if (!drag || !drag.name) return;
+        ev.preventDefault();
+        ev.dataTransfer.dropEffect = "link";
+        var ch = el.getAttribute("data-channel") || "";
+        var subscribed = _agentHasChannel(drag.channels, ch);
+        if (subscribed) {
+          el.classList.add("drop-target-agent-remove");
+          el.classList.remove("drop-target-agent-add");
+          _setChannelDropHint(el, "drop to unsubscribe");
+        } else {
+          el.classList.add("drop-target-agent-add");
+          el.classList.remove("drop-target-agent-remove");
+          _setChannelDropHint(el, "drop to subscribe");
+        }
+      });
+      el.addEventListener("dragleave", function () {
+        el.classList.remove("drop-target-agent-add");
+        el.classList.remove("drop-target-agent-remove");
+        var hint = el.querySelector(".ch-hint");
+        if (hint) hint.remove();
+      });
+      el.addEventListener("drop", function (ev) {
+        var agentName =
+          (ev.dataTransfer &&
+            ev.dataTransfer.getData("application/x-orochi-agent")) ||
+          (window.__orochiDragAgent && window.__orochiDragAgent.name) ||
+          "";
+        if (!agentName) return;
+        ev.preventDefault();
+        ev.stopPropagation();
+        var ch = el.getAttribute("data-channel") || "";
+        var chs =
+          (ev.dataTransfer &&
+            ev.dataTransfer.getData("application/x-orochi-agent-channels")) ||
+          (window.__orochiDragAgent && window.__orochiDragAgent.channels) ||
+          "";
+        var subscribed = _agentHasChannel(chs, ch);
+        el.classList.remove("drop-target-agent-add");
+        el.classList.remove("drop-target-agent-remove");
+        var hint = el.querySelector(".ch-hint");
+        if (hint) hint.remove();
+        _toggleAgentChannelSubscription(agentName, ch, !subscribed);
+      });
       el.addEventListener("click", function (ev) {
         if (
           ev.target.classList.contains("ch-star") ||

--- a/hub/static/hub/style.css
+++ b/hub/static/hub/style.css
@@ -2289,6 +2289,63 @@ a.chat-link:hover {
   border-top: 2px solid #4af;
 }
 
+/* ── Drag-and-drop agent ↔ channel subscription (todo#49) ── */
+.agent-card[draggable="true"] {
+  cursor: grab;
+}
+.agent-card.agent-dragging {
+  opacity: 0.5;
+  background: #0d1a28 !important;
+}
+.channel-item.drop-target-agent-add {
+  outline: 2px solid #22c55e;
+  outline-offset: -2px;
+  background: rgba(34, 197, 94, 0.12) !important;
+}
+.channel-item.drop-target-agent-remove {
+  outline: 2px solid #f59e0b;
+  outline-offset: -2px;
+  background: rgba(245, 158, 11, 0.12) !important;
+}
+.channel-item .ch-hint {
+  margin-left: auto;
+  font-size: 11px;
+  color: #93c5fd;
+  opacity: 0.9;
+  padding-left: 4px;
+}
+#orochi-mini-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  background: #1f2937;
+  color: #e5e7eb;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  z-index: 99999;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transition: opacity 0.18s;
+  pointer-events: none;
+  max-width: 80vw;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#orochi-mini-toast.visible {
+  opacity: 1;
+}
+#orochi-mini-toast.ok {
+  border-color: #22c55e;
+}
+#orochi-mini-toast.err {
+  border-color: #ef4444;
+  color: #fecaca;
+}
+
 /* Mermaid diagram container */
 .mermaid-container {
   margin: 8px 0;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -8,7 +8,7 @@
           content="black-translucent">
     <link rel="manifest" href="{% static 'hub/manifest.json' %}">
     <link rel="apple-touch-icon" href="{% static 'hub/orochi-icon.png' %}">
-    <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=123">
+    <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=124">
     <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=102">
     <link rel="stylesheet" href="{% static 'hub/todo-tab.css' %}?v=105">
     <link rel="stylesheet" href="{% static 'hub/attachments.css' %}?v=100">
@@ -359,7 +359,7 @@
     </script>
     <script src="{% static 'hub/config.js' %}?v=117"></script>
     <script src="{% static 'hub/agent-icons.js' %}?v=99"></script>
-    <script src="{% static 'hub/app.js' %}?v=130"></script>
+    <script src="{% static 'hub/app.js' %}?v=131"></script>
     <script src="{% static 'hub/dms.js' %}?v=2"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
     <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>


### PR DESCRIPTION
## Summary
- Drag an agent card from the sidebar onto a channel row to toggle subscription
- Visual affordance while hovering: green outline + "drop to subscribe" if not a member, amber + "drop to unsubscribe" if already a member
- Reuses existing `/api/channel-members/` endpoint (`POST` to subscribe, `DELETE` to unsubscribe); uses session + CSRF
- Forces `fetchAgentsThrottled()` after success so the agent's `channels` attribute refreshes within the next poll

## Notes
- Admin/superuser only (that's the existing endpoint's auth)
- The agent's raw server-side `a.name` is converted to the Django username with the same regex as `hub/views/api.py:_safe_name` (`[^a-zA-Z0-9_.\-]` → `-`, prefixed with `agent-`)
- `window.__orochiDragAgent` bridges dragstart → drop for browsers that drop the `application/x-orochi-agent` MIME payload during dragover
- Existing `_addDragAndDrop` (channel reorder) is untouched: that path keys off `_dndState`, while the new drop listeners key off `window.__orochiDragAgent` — no cross-contamination

## Test plan
- [ ] Drag a registered agent onto `#general` → toast "Subscribed …", agent sidebar re-renders, agent now receives messages posted to `#general`
- [ ] Drag the same agent onto `#general` again → toast "Unsubscribed …"
- [ ] Drag a channel-item itself (its existing `draggable="true"` for reorder) → behaves as before, no subscribe toast
- [ ] Non-admin user: drop still fires but toast shows "permission denied"

🤖 Generated with [Claude Code](https://claude.com/claude-code)