### PR TITLE
feat(dashboard): SSH-mesh width alignment + hover-sync with host cards

### DIFF
--- a/hub/static/hub/activity-tab.js
+++ b/hub/static/hub/activity-tab.js
@@ -1067,6 +1067,17 @@ function _renderActivityCards(agents, grid) {
         _activitySubTab = name;
         _applyActivitySubTab(window.__lastAgents || []);
       });
+      /* todo#51: bidirectional hover sync with SSH-mesh + res-cards. */
+      card.addEventListener("mouseenter", function () {
+        var host = card.getAttribute("data-machine");
+        if (host && typeof syncHostHover === "function")
+          syncHostHover(host, true);
+      });
+      card.addEventListener("mouseleave", function () {
+        var host = card.getAttribute("data-machine");
+        if (host && typeof syncHostHover === "function")
+          syncHostHover(host, false);
+      });
     },
   );
   /* Wire up copy buttons */

--- a/hub/static/hub/connectivity-map.css
+++ b/hub/static/hub/connectivity-map.css
@@ -5,7 +5,9 @@
   border: 1px solid #222;
   border-radius: 6px;
   padding: 12px;
-  margin: 16px;
+  /* todo#51: zero L/R margin so the mesh aligns with #resources-grid
+   * below (.todo-view already supplies 16px padding on both sides). */
+  margin: 0 0 12px 0;
 }
 
 .connectivity-header {
@@ -35,9 +37,18 @@
   border-radius: 10px;
   font-weight: 600;
 }
-.conn-pill-ok { background: rgba(78, 205, 196, 0.2); color: #4ecdc4; }
-.conn-pill-fail { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
-.conn-source { font-size: 10px; color: #555; }
+.conn-pill-ok {
+  background: rgba(78, 205, 196, 0.2);
+  color: #4ecdc4;
+}
+.conn-pill-fail {
+  background: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+}
+.conn-source {
+  font-size: 10px;
+  color: #555;
+}
 
 .connectivity-svg {
   display: block;
@@ -47,11 +58,25 @@
 }
 
 .conn-node circle {
-  transition: stroke 0.15s, fill 0.15s;
+  transition:
+    stroke 0.15s,
+    fill 0.15s,
+    stroke-width 0.15s;
 }
-.conn-node:hover circle {
+.conn-node[data-host-name] {
+  cursor: pointer;
+}
+.conn-node:hover circle,
+.conn-node.mesh-hl circle {
   fill: #1a1a1a;
   stroke: #88e6dd;
+  stroke-width: 3;
+}
+/* todo#51: bidirectional hover sync between SSH-mesh ↔ cards */
+.res-card.mesh-hl,
+.activity-card.mesh-hl {
+  border-color: #88e6dd !important;
+  box-shadow: 0 0 0 2px rgba(136, 230, 221, 0.25);
 }
 .conn-node-label {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -64,7 +89,9 @@
 
 /* Bastion cloud nodes (outer ring) */
 .conn-node-bastion rect {
-  transition: fill 0.15s, stroke 0.15s;
+  transition:
+    fill 0.15s,
+    stroke 0.15s;
 }
 .conn-node-bastion:hover rect {
   fill: rgba(78, 205, 196, 0.2);
@@ -82,4 +109,7 @@
 }
 
 /* Pending badge pill */
-.conn-pill-pending { background: rgba(245, 158, 11, 0.2); color: #f59e0b; }
+.conn-pill-pending {
+  background: rgba(245, 158, 11, 0.2);
+  color: #f59e0b;
+}

--- a/hub/static/hub/connectivity-map.js
+++ b/hub/static/hub/connectivity-map.js
@@ -3,9 +3,38 @@
 
 var connectivityCache = null;
 
+/* todo#51: bidirectional hover sync across SSH-mesh, res-cards,
+ * activity-cards. Any DOM element with data-host-name / data-machine
+ * matching `host` gets `.mesh-hl`; removed on `off`. Exposed globally so
+ * activity-tab.js and resources-tab.js can call it without a circular
+ * require. */
+function syncHostHover(host, on) {
+  if (!host) return;
+  var selectors = [
+    '.conn-node[data-host-name="' + host + '"]',
+    '.res-card[data-host-name="' + host + '"]',
+    '.activity-card[data-machine="' + host + '"]',
+  ];
+  selectors.forEach(function (sel) {
+    var els;
+    try {
+      els = document.querySelectorAll(sel);
+    } catch (e) {
+      return;
+    }
+    els.forEach(function (el) {
+      if (on) el.classList.add("mesh-hl");
+      else el.classList.remove("mesh-hl");
+    });
+  });
+}
+window.syncHostHover = syncHostHover;
+
 async function fetchConnectivity() {
   try {
-    var res = await fetch(apiUrl("/api/connectivity/"), { credentials: "same-origin" });
+    var res = await fetch(apiUrl("/api/connectivity/"), {
+      credentials: "same-origin",
+    });
     if (!res.ok) return;
     connectivityCache = await res.json();
     renderConnectivityMap();
@@ -18,8 +47,12 @@ async function fetchConnectivity() {
 function _layoutNodes(nodes, cx, cy, innerRadius, outerRadius) {
   var positions = {};
   if (nodes.length === 0) return positions;
-  var machines = nodes.filter(function (n) { return n.type !== "bastion"; });
-  var bastions = nodes.filter(function (n) { return n.type === "bastion"; });
+  var machines = nodes.filter(function (n) {
+    return n.type !== "bastion";
+  });
+  var bastions = nodes.filter(function (n) {
+    return n.type === "bastion";
+  });
   var mCount = machines.length;
 
   /* Machine nodes: evenly around inner ring */
@@ -63,9 +96,20 @@ function _edgePath(p1, p2, offsetSign) {
   var midx = (p1.x + p2.x) / 2 + nx * off * 4;
   var midy = (p1.y + p2.y) / 2 + ny * off * 4;
   /* Quadratic bezier so the arrow direction is visually distinct */
-  return "M " + (p1.x + nx * off) + " " + (p1.y + ny * off) +
-         " Q " + midx + " " + midy +
-         " " + (p2.x + nx * off) + " " + (p2.y + ny * off);
+  return (
+    "M " +
+    (p1.x + nx * off) +
+    " " +
+    (p1.y + ny * off) +
+    " Q " +
+    midx +
+    " " +
+    midy +
+    " " +
+    (p2.x + nx * off) +
+    " " +
+    (p2.y + ny * off)
+  );
 }
 
 function renderConnectivityMap() {
@@ -75,11 +119,17 @@ function renderConnectivityMap() {
   var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
   var container = document.getElementById("connectivity-map");
   if (!container) return;
-  if (!connectivityCache || !connectivityCache.nodes || connectivityCache.nodes.length === 0) {
+  if (
+    !connectivityCache ||
+    !connectivityCache.nodes ||
+    connectivityCache.nodes.length === 0
+  ) {
     container.innerHTML = '<p class="empty-notice">No connectivity data.</p>';
     if (inputHasFocus && document.activeElement !== msgInput) {
       msgInput.focus();
-      try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+      try {
+        msgInput.setSelectionRange(savedStart, savedEnd);
+      } catch (_) {}
     }
     return;
   }
@@ -96,33 +146,49 @@ function renderConnectivityMap() {
   var positions = _layoutNodes(nodes, cx, cy, innerRadius, outerRadius);
 
   /* Pair up bidirectional edges so we can offset them */
-  var edgeKey = function (e) { return e.source + "→" + e.target; };
+  var edgeKey = function (e) {
+    return e.source + "→" + e.target;
+  };
   var seen = {};
 
   var svgParts = [];
   svgParts.push(
-    '<svg class="connectivity-svg" viewBox="0 0 ' + W + ' ' + H + '" width="100%" height="' + H + '">'
+    '<svg class="connectivity-svg" viewBox="0 0 ' +
+      W +
+      " " +
+      H +
+      '" width="100%" height="' +
+      H +
+      '">',
   );
   /* Definitions: arrowhead markers */
   svgParts.push(
-    '<defs>' +
-    '<marker id="arrow-ok" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">' +
-    '<path d="M 0 0 L 10 5 L 0 10 z" fill="#4ecdc4"/></marker>' +
-    '<marker id="arrow-fail" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">' +
-    '<path d="M 0 0 L 10 5 L 0 10 z" fill="#ef4444"/></marker>' +
-    '<marker id="arrow-pending" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">' +
-    '<path d="M 0 0 L 10 5 L 0 10 z" fill="#f59e0b"/></marker>' +
-    '</defs>'
+    "<defs>" +
+      '<marker id="arrow-ok" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">' +
+      '<path d="M 0 0 L 10 5 L 0 10 z" fill="#4ecdc4"/></marker>' +
+      '<marker id="arrow-fail" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">' +
+      '<path d="M 0 0 L 10 5 L 0 10 z" fill="#ef4444"/></marker>' +
+      '<marker id="arrow-pending" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">' +
+      '<path d="M 0 0 L 10 5 L 0 10 z" fill="#f59e0b"/></marker>' +
+      "</defs>",
   );
   /* Separate machine vs bastion nodes */
-  var machineNodes = nodes.filter(function (n) { return n.type !== "bastion"; });
-  var bastionNodes = nodes.filter(function (n) { return n.type === "bastion"; });
+  var machineNodes = nodes.filter(function (n) {
+    return n.type !== "bastion";
+  });
+  var bastionNodes = nodes.filter(function (n) {
+    return n.type === "bastion";
+  });
   /* Separate bastion-anchor edges from machine-to-machine edges */
   var bastionAnchorEdges = edges.filter(function (e) {
-    return e.source.indexOf("bastion") === 0 || e.target.indexOf("bastion") === 0;
+    return (
+      e.source.indexOf("bastion") === 0 || e.target.indexOf("bastion") === 0
+    );
   });
   var machineEdges = edges.filter(function (e) {
-    return e.source.indexOf("bastion") !== 0 && e.target.indexOf("bastion") !== 0;
+    return (
+      e.source.indexOf("bastion") !== 0 && e.target.indexOf("bastion") !== 0
+    );
   });
 
   /* Draw bastion anchor edges (dashed, thin) first */
@@ -130,13 +196,26 @@ function renderConnectivityMap() {
     var p1 = positions[e.source];
     var p2 = positions[e.target];
     if (!p1 || !p2) return;
-    var color = e.status === "ok" ? "#4ecdc4" : e.status === "pending" ? "#f59e0b" : "#ef4444";
+    var color =
+      e.status === "ok"
+        ? "#4ecdc4"
+        : e.status === "pending"
+          ? "#f59e0b"
+          : "#ef4444";
     var d = "M " + p1.x + " " + p1.y + " L " + p2.x + " " + p2.y;
     svgParts.push(
-      '<path d="' + d + '" stroke="' + color + '" stroke-width="1" fill="none" ' +
-      'stroke-dasharray="3 3" opacity="0.5">' +
-      '<title>' + escapeHtml(e.source) + ' ↔ ' + escapeHtml(e.target) + ' (CF tunnel)</title>' +
-      '</path>'
+      '<path d="' +
+        d +
+        '" stroke="' +
+        color +
+        '" stroke-width="1" fill="none" ' +
+        'stroke-dasharray="3 3" opacity="0.5">' +
+        "<title>" +
+        escapeHtml(e.source) +
+        " ↔ " +
+        escapeHtml(e.target) +
+        " (CF tunnel)</title>" +
+        "</path>",
     );
   });
 
@@ -155,11 +234,25 @@ function renderConnectivityMap() {
     var dash = e.status === "ok" ? "" : 'stroke-dasharray="4 4"';
     var marker = e.status === "ok" ? "url(#arrow-ok)" : "url(#arrow-fail)";
     svgParts.push(
-      '<path d="' + d + '" stroke="' + color + '" stroke-width="1.5" fill="none" ' +
-      dash + ' marker-end="' + marker + '" opacity="0.75">' +
-      '<title>' + escapeHtml(e.source) + ' → ' + escapeHtml(e.target) +
-      ' (' + escapeHtml(e.status) + ', ' + escapeHtml(e.method) + ')</title>' +
-      '</path>'
+      '<path d="' +
+        d +
+        '" stroke="' +
+        color +
+        '" stroke-width="1.5" fill="none" ' +
+        dash +
+        ' marker-end="' +
+        marker +
+        '" opacity="0.75">' +
+        "<title>" +
+        escapeHtml(e.source) +
+        " → " +
+        escapeHtml(e.target) +
+        " (" +
+        escapeHtml(e.status) +
+        ", " +
+        escapeHtml(e.method) +
+        ")</title>" +
+        "</path>",
     );
   });
 
@@ -172,15 +265,38 @@ function renderConnectivityMap() {
     var fill = isPending ? "rgba(245,158,11,0.12)" : "rgba(78,205,196,0.10)";
     svgParts.push(
       '<g class="conn-node conn-node-bastion">' +
-      '<rect x="' + (p.x - bastionR) + '" y="' + (p.y - bastionR * 0.7) + '" ' +
-      'width="' + (bastionR * 2) + '" height="' + (bastionR * 1.4) + '" rx="8" ry="8" ' +
-      'fill="' + fill + '" stroke="' + stroke + '" stroke-width="1.5" ' +
-      (isPending ? 'stroke-dasharray="4 2"' : '') + '/>' +
-      '<text x="' + p.x + '" y="' + (p.y + 3) + '" text-anchor="middle" ' +
-      'class="conn-node-label conn-bastion-label">' +
-      '☁ ' + escapeHtml(n.label.replace('bastion-', '')) + '</text>' +
-      '<title>' + escapeHtml(n.label) + ' — ' + escapeHtml(n.role || "") + '</title>' +
-      '</g>'
+        '<rect x="' +
+        (p.x - bastionR) +
+        '" y="' +
+        (p.y - bastionR * 0.7) +
+        '" ' +
+        'width="' +
+        bastionR * 2 +
+        '" height="' +
+        bastionR * 1.4 +
+        '" rx="8" ry="8" ' +
+        'fill="' +
+        fill +
+        '" stroke="' +
+        stroke +
+        '" stroke-width="1.5" ' +
+        (isPending ? 'stroke-dasharray="4 2"' : "") +
+        "/>" +
+        '<text x="' +
+        p.x +
+        '" y="' +
+        (p.y + 3) +
+        '" text-anchor="middle" ' +
+        'class="conn-node-label conn-bastion-label">' +
+        "☁ " +
+        escapeHtml(n.label.replace("bastion-", "")) +
+        "</text>" +
+        "<title>" +
+        escapeHtml(n.label) +
+        " — " +
+        escapeHtml(n.role || "") +
+        "</title>" +
+        "</g>",
     );
   });
 
@@ -188,43 +304,108 @@ function renderConnectivityMap() {
   machineNodes.forEach(function (n) {
     var p = positions[n.id];
     if (!p) return;
+    /* todo#51: data-host-name lets hover-sync find the node from res-card
+     * and activity-card mouseenter handlers. Use n.id (matches .res-card
+     * data-host-name and .activity-card data-machine). */
     svgParts.push(
-      '<g class="conn-node">' +
-      '<circle cx="' + p.x + '" cy="' + p.y + '" r="' + nodeR + '" ' +
-      'fill="#141414" stroke="#4ecdc4" stroke-width="2"/>' +
-      '<text x="' + p.x + '" y="' + (p.y + 4) + '" text-anchor="middle" ' +
-      'class="conn-node-label">' + escapeHtml(n.label) + '</text>' +
-      '<title>' + escapeHtml(n.label) + ' — ' + escapeHtml(n.role || "") + '</title>' +
-      '</g>'
+      '<g class="conn-node" data-host-name="' +
+        escapeHtml(n.id) +
+        '">' +
+        '<circle cx="' +
+        p.x +
+        '" cy="' +
+        p.y +
+        '" r="' +
+        nodeR +
+        '" ' +
+        'fill="#141414" stroke="#4ecdc4" stroke-width="2"/>' +
+        '<text x="' +
+        p.x +
+        '" y="' +
+        (p.y + 4) +
+        '" text-anchor="middle" ' +
+        'class="conn-node-label">' +
+        escapeHtml(n.label) +
+        "</text>" +
+        "<title>" +
+        escapeHtml(n.label) +
+        " — " +
+        escapeHtml(n.role || "") +
+        "</title>" +
+        "</g>",
     );
   });
   svgParts.push("</svg>");
 
   /* Build the legend + summary */
-  var okCount = edges.filter(function (e) { return e.status === "ok"; }).length;
-  var failCount = edges.filter(function (e) { return e.status === "fail"; }).length;
-  var pendingCount = edges.filter(function (e) { return e.status === "pending"; }).length;
-  var bastionLive = nodes.filter(function (n) { return n.type === "bastion" && n.status !== "pending"; }).length;
-  var bastionTotal = nodes.filter(function (n) { return n.type === "bastion"; }).length;
+  var okCount = edges.filter(function (e) {
+    return e.status === "ok";
+  }).length;
+  var failCount = edges.filter(function (e) {
+    return e.status === "fail";
+  }).length;
+  var pendingCount = edges.filter(function (e) {
+    return e.status === "pending";
+  }).length;
+  var bastionLive = nodes.filter(function (n) {
+    return n.type === "bastion" && n.status !== "pending";
+  }).length;
+  var bastionTotal = nodes.filter(function (n) {
+    return n.type === "bastion";
+  }).length;
   var srcLabel = connectivityCache.source === "live" ? "live" : "static";
-  var pendingPill = pendingCount > 0
-    ? '<span class="conn-pill conn-pill-pending">☁ ' + bastionLive + '/' + bastionTotal + ' CF tunnels</span>'
-    : '<span class="conn-pill conn-pill-ok">☁ ' + bastionLive + '/' + bastionTotal + ' CF tunnels</span>';
+  var pendingPill =
+    pendingCount > 0
+      ? '<span class="conn-pill conn-pill-pending">☁ ' +
+        bastionLive +
+        "/" +
+        bastionTotal +
+        " CF tunnels</span>"
+      : '<span class="conn-pill conn-pill-ok">☁ ' +
+        bastionLive +
+        "/" +
+        bastionTotal +
+        " CF tunnels</span>";
   var html =
     '<div class="connectivity-header">' +
     '<span class="connectivity-title">SSH mesh</span>' +
     '<span class="connectivity-summary">' +
     pendingPill +
-    '<span class="conn-pill conn-pill-ok">' + okCount + ' links ok</span>' +
-    (failCount ? '<span class="conn-pill conn-pill-fail">' + failCount + ' blocked</span>' : '') +
-    '<span class="conn-source">(' + escapeHtml(srcLabel) + ')</span>' +
-    '</span>' +
-    '</div>' +
+    '<span class="conn-pill conn-pill-ok">' +
+    okCount +
+    " links ok</span>" +
+    (failCount
+      ? '<span class="conn-pill conn-pill-fail">' +
+        failCount +
+        " blocked</span>"
+      : "") +
+    '<span class="conn-source">(' +
+    escapeHtml(srcLabel) +
+    ")</span>" +
+    "</span>" +
+    "</div>" +
     svgParts.join("");
   container.innerHTML = html;
+  /* todo#51: after innerHTML swap, re-attach hover handlers on each
+   * machine node. Delegation via the SVG root is awkward because the
+   * event target is the inner <circle> or <text>. */
+  Array.prototype.forEach.call(
+    container.querySelectorAll(".conn-node[data-host-name]"),
+    function (g) {
+      var host = g.getAttribute("data-host-name");
+      g.addEventListener("mouseenter", function () {
+        syncHostHover(host, true);
+      });
+      g.addEventListener("mouseleave", function () {
+        syncHostHover(host, false);
+      });
+    },
+  );
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
-    try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+    try {
+      msgInput.setSelectionRange(savedStart, savedEnd);
+    } catch (_) {}
   }
 }
 

--- a/hub/static/hub/resources-tab.js
+++ b/hub/static/hub/resources-tab.js
@@ -51,12 +51,16 @@ function donutHtml(label, percent) {
     return (
       '<div class="res-donut">' +
       '<svg class="res-donut-svg" viewBox="0 0 64 64" width="64" height="64">' +
-      '<circle class="res-donut-bg" cx="32" cy="32" r="' + radius + '" ' +
+      '<circle class="res-donut-bg" cx="32" cy="32" r="' +
+      radius +
+      '" ' +
       'fill="none" stroke="#1f1f1f" stroke-width="8"/>' +
       '<text x="32" y="36" text-anchor="middle" class="res-donut-text res-donut-unknown">\u2014</text>' +
-      '</svg>' +
-      '<div class="res-donut-label">' + label + '</div>' +
-      '</div>'
+      "</svg>" +
+      '<div class="res-donut-label">' +
+      label +
+      "</div>" +
+      "</div>"
     );
   }
   var color = p > 80 ? "#ef4444" : p > 60 ? "#f59e0b" : "#4ecdc4";
@@ -64,17 +68,31 @@ function donutHtml(label, percent) {
   return (
     '<div class="res-donut">' +
     '<svg class="res-donut-svg" viewBox="0 0 64 64" width="64" height="64">' +
-    '<circle class="res-donut-bg" cx="32" cy="32" r="' + radius + '" ' +
+    '<circle class="res-donut-bg" cx="32" cy="32" r="' +
+    radius +
+    '" ' +
     'fill="none" stroke="#1f1f1f" stroke-width="8"/>' +
-    '<circle class="res-donut-fg" cx="32" cy="32" r="' + radius + '" ' +
-    'fill="none" stroke="' + color + '" stroke-width="8" ' +
-    'stroke-dasharray="' + circumference.toFixed(2) + '" ' +
-    'stroke-dashoffset="' + offset.toFixed(2) + '" ' +
+    '<circle class="res-donut-fg" cx="32" cy="32" r="' +
+    radius +
+    '" ' +
+    'fill="none" stroke="' +
+    color +
+    '" stroke-width="8" ' +
+    'stroke-dasharray="' +
+    circumference.toFixed(2) +
+    '" ' +
+    'stroke-dashoffset="' +
+    offset.toFixed(2) +
+    '" ' +
     'stroke-linecap="round" transform="rotate(-90 32 32)"/>' +
-    '<text x="32" y="36" text-anchor="middle" class="res-donut-text">' + p + '%</text>' +
-    '</svg>' +
-    '<div class="res-donut-label">' + label + '</div>' +
-    '</div>'
+    '<text x="32" y="36" text-anchor="middle" class="res-donut-text">' +
+    p +
+    "%</text>" +
+    "</svg>" +
+    '<div class="res-donut-label">' +
+    label +
+    "</div>" +
+    "</div>"
   );
 }
 
@@ -91,7 +109,9 @@ function renderResources() {
     container.innerHTML = '<p class="empty-notice">No reports yet</p>';
     if (inputHasFocus && document.activeElement !== msgInput) {
       msgInput.focus();
-      try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+      try {
+        msgInput.setSelectionRange(savedStart, savedEnd);
+      } catch (_) {}
     }
     return;
   }
@@ -143,7 +163,9 @@ function renderResources() {
     .join("");
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
-    try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+    try {
+      msgInput.setSelectionRange(savedStart, savedEnd);
+    } catch (_) {}
   }
 }
 
@@ -158,7 +180,9 @@ function renderResourcesTab() {
     grid.innerHTML = '<p class="empty-notice">No resource reports yet.</p>';
     if (inputHasFocus && document.activeElement !== msgInput) {
       msgInput.focus();
-      try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+      try {
+        msgInput.setSelectionRange(savedStart, savedEnd);
+      } catch (_) {}
     }
     return;
   }
@@ -167,10 +191,21 @@ function renderResourcesTab() {
     el.addEventListener("click", function () {
       addTag("host", el.getAttribute("data-host-name"));
     });
+    /* todo#51: bidirectional hover-sync with SSH-mesh + activity cards. */
+    el.addEventListener("mouseenter", function () {
+      if (typeof syncHostHover === "function")
+        syncHostHover(el.getAttribute("data-host-name"), true);
+    });
+    el.addEventListener("mouseleave", function () {
+      if (typeof syncHostHover === "function")
+        syncHostHover(el.getAttribute("data-host-name"), false);
+    });
   });
   if (inputHasFocus && document.activeElement !== msgInput) {
     msgInput.focus();
-    try { msgInput.setSelectionRange(savedStart, savedEnd); } catch (_) {}
+    try {
+      msgInput.setSelectionRange(savedStart, savedEnd);
+    } catch (_) {}
   }
 }
 
@@ -237,7 +272,10 @@ function buildResourceCard(k) {
   if (d.gpu && d.gpu.length > 0) {
     var gpuRow = '<div class="res-donut-row">';
     d.gpu.forEach(function (g, i) {
-      gpuRow += donutHtml("GPU" + (d.gpu.length > 1 ? (i + 1) : ""), g.utilization_percent || 0);
+      gpuRow += donutHtml(
+        "GPU" + (d.gpu.length > 1 ? i + 1 : ""),
+        g.utilization_percent || 0,
+      );
     });
     gpuRow += "</div>";
     html += gpuRow;
@@ -287,7 +325,13 @@ async function fetchResources() {
       var r = entry.resources || {};
       /* Don't overwrite richer WS data with empty REST metrics (#337) */
       var existing = resourceData[agentName];
-      if (existing && !existing._api && (r.mem_used_percent || 0) === 0 && (existing.memory || {}).percent > 0) return;
+      if (
+        existing &&
+        !existing._api &&
+        (r.mem_used_percent || 0) === 0 &&
+        (existing.memory || {}).percent > 0
+      )
+        return;
       resourceData[agentName] = {
         hostname: _friendlyMachine(entry.machine || agentName),
         agent: agentName,

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="{% static 'hub/resources.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/icons.css' %}?v=99">
     <link rel="stylesheet" href="{% static 'hub/settings.css' %}?v=104">
-    <link rel="stylesheet" href="{% static 'hub/connectivity-map.css' %}?v=99">
+    <link rel="stylesheet" href="{% static 'hub/connectivity-map.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/activity-tab.css' %}?v=125">
     <link rel="stylesheet" href="{% static 'hub/files-tab.css' %}?v=103">
     <link rel="stylesheet" href="{% static 'hub/releases-tab.css' %}?v=100">
@@ -362,7 +362,7 @@
     <script src="{% static 'hub/app.js' %}?v=131"></script>
     <script src="{% static 'hub/dms.js' %}?v=2"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
-    <script src="{% static 'hub/resources-tab.js' %}?v=99"></script>
+    <script src="{% static 'hub/resources-tab.js' %}?v=100"></script>
     <script src="{% static 'hub/todo-tab.js' %}?v=107"></script>
     <script src="{% static 'hub/workspaces-tab.js' %}?v=99"></script>
     <script src="{% static 'hub/chat.js' %}?v=121"></script>
@@ -372,8 +372,8 @@
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
     <script src="{% static 'hub/agents-tab.js' %}?v=102"></script>
-    <script src="{% static 'hub/connectivity-map.js' %}?v=99"></script>
-    <script src="{% static 'hub/activity-tab.js' %}?v=122"></script>
+    <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
+    <script src="{% static 'hub/activity-tab.js' %}?v=123"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>
     <script src="{% static 'hub/upload.js' %}?v=111"></script>
     <script src="{% static 'hub/files-tab.js' %}?v=104"></script>


### PR DESCRIPTION
## Summary
- Mesh container now aligns with the `#resources-grid` cards below (removed the extra 16px L/R margin)
- Hovering an SSH-mesh node, a `.res-card`, or an `.activity-card` highlights all three (`.mesh-hl` class, brighter border + subtle halo)
- Works across tabs: mesh and res-cards live in the Machines tab, activity cards in the Agents tab — each render path installs its own listener and uses the shared `window.syncHostHover(host, on)` helper

## Notes
- Host key: `.conn-node[data-host-name=<n.id>]` / `.res-card[data-host-name]` / `.activity-card[data-machine]`. They already use the same string (hostname like `mba`, `ywata-note-win`). Flagged during exploration — no normalization needed.
- Connectivity-map diff is mostly Prettier re-formatting of prior string concatenations — actual behaviour change is just the added data attribute + mouseenter/leave listeners.

## Test plan
- [ ] Hover a node in Machines tab → node stroke thickens + matching `.res-card` border glows
- [ ] Hover a `.res-card` → matching SSH-mesh node highlights
- [ ] Switch to Agents tab, hover an `.activity-card` → visible halo on that card (mesh is invisible in this tab, so cross-tab highlight is invisible but does not error)
- [ ] Mesh visually flush with the card grid beneath it (no double inset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)