### PR TITLE
fix(client): widen CLAUDE.md / .mcp.json lookup for non-head agents (todo#53)

### DIFF
--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -178,7 +178,14 @@ function _updateChannelTopicBanner(ch) {
   } else if (membersBtn) {
     membersBtn.style.display = "none";
   }
-  banner.style.display = desc || ch ? "" : "none";
+  /* Banner visibility: only ever show on the Chat tab, even if a channel
+   * is selected. Other tabs (TODO, Agents, Machines, Files, Releases,
+   * Settings) share the same #channel-topic-banner element but must not
+   * render it — the banner is conceptually a chat-space header, not a
+   * global workspace header. See ywatanabe directive 2026-04-18 18:31. */
+  var _onChatTab =
+    typeof activeTab !== "undefined" ? activeTab === "chat" : true;
+  banner.style.display = _onChatTab && (desc || ch) ? "" : "none";
 }
 
 /* Channel members panel (todo#407) */

--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -906,48 +906,117 @@ def collect(agent: str) -> dict:
     # the heartbeat payload bounded; the viewer renders the truncated
     # body and links to the canonical file path for the rest.
     claude_md_full = ""
-    try:
-        cmd = Path(workspace) / "CLAUDE.md"
-        if cmd.is_file():
-            text = cmd.read_text()
-            for ln in text.splitlines():
-                ln_stripped = ln.strip()
-                if ln_stripped and not ln_stripped.startswith("```"):
-                    claude_md_head = ln_stripped[:120]
-                    break
-            claude_md_full = text[:10000]
-    except Exception:
-        pass
+
+    # todo#53: historically only head-* agents had a CLAUDE.md at
+    # `<workspace>/CLAUDE.md`. Other roles (healer / skill-manager /
+    # todo-manager / ...) either live under a legacy `mamba-<name>/`
+    # directory, use the user's global `~/.claude/CLAUDE.md`, or have
+    # the file placed in a nested `.claude/` folder. We now walk a
+    # prioritised candidate list so the detail view has content for
+    # every agent instead of only head.
+    def _claude_md_candidates(ws: str) -> list[Path]:
+        p = Path(ws) if ws else None
+        home = Path.home()
+        cands: list[Path] = []
+        if p is not None:
+            cands += [p / "CLAUDE.md", p / ".claude" / "CLAUDE.md"]
+            if p.parent.name == "workspaces":
+                # Legacy sibling directory: mamba-<role>-<host>/CLAUDE.md
+                cands.append(p.parent / f"mamba-{p.name}" / "CLAUDE.md")
+            # Project-level Claude config if the agent cwd is a git repo
+            try:
+                git_root = p
+                while git_root != git_root.parent and not (git_root / ".git").exists():
+                    git_root = git_root.parent
+                if (git_root / ".git").exists():
+                    cands.append(git_root / "CLAUDE.md")
+            except Exception:
+                pass
+        cands += [home / ".claude" / "CLAUDE.md", home / "CLAUDE.md"]
+        # Dedup preserving order.
+        seen: set[str] = set()
+        uniq: list[Path] = []
+        for c in cands:
+            key = str(c)
+            if key in seen:
+                continue
+            seen.add(key)
+            uniq.append(c)
+        return uniq
+
+    for cmd in _claude_md_candidates(workspace):
+        try:
+            if cmd.is_file():
+                text = cmd.read_text()
+                for ln in text.splitlines():
+                    ln_stripped = ln.strip()
+                    if ln_stripped and not ln_stripped.startswith("```"):
+                        claude_md_head = ln_stripped[:120]
+                        break
+                claude_md_full = text[:10000]
+                break
+        except Exception:
+            continue
 
     # .mcp.json full — for the per-agent page .mcp.json viewer
     # (todo#460). Tokens are redacted (env values containing TOKEN /
     # SECRET / KEY substrings). Truncated to 10000 chars.
     mcp_json_full = ""
-    try:
-        mcp_path = Path(workspace) / ".mcp.json"
-        if mcp_path.is_file():
+
+    # todo#53: same fallback logic for .mcp.json so non-head agents also
+    # populate the MCP viewer.
+    def _mcp_json_candidates(ws: str) -> list[Path]:
+        p = Path(ws) if ws else None
+        home = Path.home()
+        cands: list[Path] = []
+        if p is not None:
+            cands += [p / ".mcp.json"]
+            if p.parent.name == "workspaces":
+                cands.append(p.parent / f"mamba-{p.name}" / ".mcp.json")
+            try:
+                git_root = p
+                while git_root != git_root.parent and not (git_root / ".git").exists():
+                    git_root = git_root.parent
+                if (git_root / ".git").exists():
+                    cands.append(git_root / ".mcp.json")
+            except Exception:
+                pass
+        cands += [home / ".mcp.json"]
+        seen: set[str] = set()
+        uniq: list[Path] = []
+        for c in cands:
+            key = str(c)
+            if key in seen:
+                continue
+            seen.add(key)
+            uniq.append(c)
+        return uniq
+
+    def _redact_secrets(obj):
+        if isinstance(obj, dict):
+            out = {}
+            for k, v in obj.items():
+                if isinstance(v, str) and any(
+                    tag in k.upper() for tag in ("TOKEN", "SECRET", "KEY", "PASSWORD")
+                ):
+                    out[k] = "***REDACTED***"
+                else:
+                    out[k] = _redact_secrets(v)
+            return out
+        if isinstance(obj, list):
+            return [_redact_secrets(x) for x in obj]
+        return obj
+
+    for mcp_path in _mcp_json_candidates(workspace):
+        try:
+            if not mcp_path.is_file():
+                continue
             doc = json.loads(mcp_path.read_text())
-
-            def _redact_secrets(obj):
-                if isinstance(obj, dict):
-                    out = {}
-                    for k, v in obj.items():
-                        if isinstance(v, str) and any(
-                            tag in k.upper()
-                            for tag in ("TOKEN", "SECRET", "KEY", "PASSWORD")
-                        ):
-                            out[k] = "***REDACTED***"
-                        else:
-                            out[k] = _redact_secrets(v)
-                    return out
-                if isinstance(obj, list):
-                    return [_redact_secrets(x) for x in obj]
-                return obj
-
             redacted = _redact_secrets(doc)
             mcp_json_full = json.dumps(redacted, indent=2)[:10000]
-    except Exception:
-        pass
+            break
+        except Exception:
+            continue
 
     return {
         "agent": agent,


### PR DESCRIPTION
## Problem
Per-agent detail view shows a populated CLAUDE.md only for ``head-*`` agents. For every other role the panel is empty even though the user has a ``~/.claude/CLAUDE.md`` and the legacy ``mamba-<role>-<host>/CLAUDE.md`` that should clearly be surfaced.

Root cause: ``agent_meta.py`` probed a single path (``<workspace>/CLAUDE.md``) and no fallback. Only ``head-*`` workspaces happened to get provisioned with that file.

## Fix
Walk a prioritised candidate list and use the first hit:
1. ``<workspace>/CLAUDE.md``
2. ``<workspace>/.claude/CLAUDE.md``
3. Legacy sibling ``<workspace-parent>/mamba-<name>/CLAUDE.md``
4. Nearest enclosing git-root ``CLAUDE.md``
5. ``~/.claude/CLAUDE.md`` (user-global fallback)
6. ``~/CLAUDE.md``

Same cascade for ``.mcp.json``. Still truncated to 10 000 chars + redacts TOKEN / SECRET / KEY / PASSWORD keys. Backward-compatible — head agents hit candidate #1 and behave exactly as before.

## Test plan
- [ ] Merge, pull on each fleet host, restart agent loops
- [ ] Curl ``/api/agents/?token=...`` — every registered agent now has ``len(claude_md) > 0``
- [ ] Dashboard detail view shows CLAUDE.md content for healer / skill-manager / todo-manager / synchronizer / expert-scitex

🤖 Generated with [Claude Code](https://claude.com/claude-code)