### PR TITLE
feat(hub): show canonical FQDN next to short machine label (todo#55)

### DIFF
--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -381,6 +381,10 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
                 "agent_id": payload.get("agent_id", self.agent_name),
                 "project": payload.get("project", ""),
                 "machine": payload.get("machine", ""),
+                # todo#55: canonical FQDN from the heartbeat (via
+                # `hostname -f`). Display-only — `machine` stays the
+                # short join key.
+                "hostname_canonical": payload.get("hostname_canonical", ""),
                 "role": payload.get("role", ""),
                 "model": payload.get("model", ""),
                 "workdir": payload.get("workdir", ""),

--- a/hub/registry.py
+++ b/hub/registry.py
@@ -49,6 +49,12 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             "workspace_id": workspace_id,
             "agent_id": info.get("agent_id", name),
             "machine": info.get("machine", ""),
+            # todo#55: canonical FQDN reported by the heartbeat via
+            # `socket.getfqdn()`. Display-only — the short `machine` field
+            # remains the join key for cards/channels. Preserved across
+            # heartbeats that omit the field (older clients).
+            "hostname_canonical": info.get("hostname_canonical", "")
+            or prev.get("hostname_canonical", ""),
             "role": info.get("role", ""),
             "model": info.get("model", ""),
             "multiplexer": info.get("multiplexer", ""),
@@ -597,6 +603,10 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "name": a["name"],
                 "agent_id": a.get("agent_id", a["name"]),
                 "machine": a.get("machine", ""),
+                # todo#55: FQDN / canonical hostname for display next to
+                # the short machine label. Empty string = older client
+                # that didn't push this field.
+                "hostname_canonical": a.get("hostname_canonical", ""),
                 "role": a.get("role", ""),
                 "model": a.get("model", ""),
                 "multiplexer": a.get("multiplexer", ""),

--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -96,6 +96,14 @@ function _renderAgentDetail(a) {
   var statusColor = livenessColor(liveness);
   var role = d.role || a.role || "agent";
   var machine = d.machine || a.machine || "?";
+  /* todo#55: canonical FQDN for the Machine row. When the agent pushes
+   * one AND it differs from the short label, the UI renders
+   * "<label> (<fqdn>)". When identical or empty, the short label alone. */
+  var machineCanonical = d.hostname_canonical || a.hostname_canonical || "";
+  var machineDisplay =
+    machineCanonical && machineCanonical !== machine
+      ? machine + " (" + machineCanonical + ")"
+      : machine;
   var model = d.model || a.model || "-";
   var ctxPct = d.context_pct != null ? d.context_pct : a.context_pct;
   var currentTask = d.current_task || a.current_task || "";
@@ -158,7 +166,13 @@ function _renderAgentDetail(a) {
    * middle-truncated). */
   var metaFields = [
     ["Role", role, "declared agent role (head / healer / expert-scitex / ...)"],
-    ["Machine", machine, "canonical hostname the agent is running on"],
+    [
+      "Machine",
+      machineDisplay,
+      machineCanonical && machineCanonical !== machine
+        ? "short label · canonical FQDN reported by the heartbeat"
+        : "hostname the agent is running on (short label — no FQDN reported)",
+    ],
     ["Model", model, "Claude model id the agent is running against"],
     [
       "Multiplexer",

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -377,7 +377,7 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=102"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=103"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=123"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>

--- a/hub/views/api.py
+++ b/hub/views/api.py
@@ -1813,6 +1813,8 @@ def api_agents_register(request):
         info={
             "agent_id": body.get("agent_id") or name,
             "machine": body.get("machine", ""),
+            # todo#55: canonical FQDN (socket.getfqdn()) from the heartbeat.
+            "hostname_canonical": body.get("hostname_canonical", ""),
             "role": body.get("role", "agent"),
             "model": body.get("model", ""),
             "workdir": body.get("workdir", ""),

--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -1072,6 +1072,12 @@ def collect(agent: str) -> dict:
         "workdir": workspace,
         "project": project,
         "machine": machine,
+        # todo#55: canonical FQDN for display next to the short machine
+        # label in the dashboard (e.g. "spartan (spartan.hpc.unimelb.edu.au)").
+        # socket.getfqdn() returns the short name when no reverse DNS is
+        # configured, in which case the dashboard simply shows the short
+        # label once.
+        "hostname_canonical": (socket.getfqdn() or "").strip(),
         "skills_loaded": skills_loaded,
         "mcp_servers": mcp_servers,
         "claude_md_head": claude_md_head,
@@ -1229,6 +1235,7 @@ def push_all(url=None, token=None) -> int:
                 "agent_id": meta["agent"],
                 "role": "agent",
                 "machine": meta.get("machine", ""),
+                "hostname_canonical": meta.get("hostname_canonical", ""),
                 "model": meta.get("model", ""),
                 "multiplexer": meta.get("multiplexer", ""),
                 "project": meta.get("project", ""),

--- a/src/scitex_orochi/_ts/src/connection.ts
+++ b/src/scitex_orochi/_ts/src/connection.ts
@@ -3,8 +3,30 @@
  */
 import WebSocket from "ws";
 import { hostname } from "os";
+import { execSync } from "child_process";
 import { OROCHI_AGENT, OROCHI_MODEL, buildWsUrl, maskUrl } from "./config.js";
 import { getSystemMetrics } from "./metrics.js";
+
+// todo#55: canonical FQDN for display next to the short machine label
+// ("spartan (spartan.hpc.unimelb.edu.au)"). os.hostname() in Node returns
+// the SHORT hostname on every platform we care about, so shell out to
+// `hostname -f` once per process and cache. Falls back to the short
+// label on hosts with no reverse DNS so the UI degrades gracefully.
+let _canonicalHostname: string | null = null;
+function canonicalHostname(): string {
+  if (_canonicalHostname !== null) return _canonicalHostname;
+  try {
+    _canonicalHostname = execSync("hostname -f", {
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_500,
+    })
+      .toString()
+      .trim();
+  } catch {
+    _canonicalHostname = hostname();
+  }
+  return _canonicalHostname;
+}
 
 // ---------------------------------------------------------------------------
 // Connection state
@@ -156,6 +178,8 @@ export class OrochiConnection {
         sender: OROCHI_AGENT,
         payload: {
           machine: hostname(),
+          // todo#55: canonical FQDN for display next to the short label.
+          hostname_canonical: canonicalHostname(),
           role: "claude-code",
           model: OROCHI_MODEL,
           agent_id: `${OROCHI_AGENT}@${hostname()}`,


### PR DESCRIPTION
## Summary
Agent detail + heartbeat plumbing now carries a `hostname_canonical` field end-to-end. The Machine row renders as ``<short> (<fqdn>)`` when the two differ; otherwise just the short label (no visible regression for hosts with no reverse DNS).

## Wiring
- **Clients**
  - ``scripts/client/agent_meta.py`` (legacy push) → ``socket.getfqdn()``
  - ``src/scitex_orochi/_ts/src/connection.ts`` (WS sidecar) → ``execSync("hostname -f")`` with fallback to ``os.hostname()``, memoised per process.
- **Server**
  - ``hub/consumers.py`` ``AgentConsumer.handle_register`` stores ``payload["hostname_canonical"]`` on ``agent_meta``.
  - ``hub/views/api.py`` ``api_agents_register`` reads ``body["hostname_canonical"]``.
  - ``hub/registry.py`` ``register_agent`` persists it (preserved across heartbeats) and ``get_agents`` projects it.
- **Frontend** ``hub/static/hub/agents-tab.js`` renders ``machineDisplay`` + a contextual tooltip.

## Backward compatibility
Older clients that don't push ``hostname_canonical`` produce the legacy short-label-only display. No other fields touched.

## Test plan
- Deploy, wait one heartbeat
- Expect ``curl /api/agents/`` to include ``hostname_canonical`` for any agent that pushed a heartbeat after deploy
- Dashboard per-agent Machine row shows "spartan (spartan.hpc.unimelb.edu.au)" once that agent re-registers

🤖 Generated with [Claude Code](https://claude.com/claude-code)