### PR TITLE
fix(hub): include hostname_canonical in agent-detail endpoint (todo#55 follow-up)

### DIFF
--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -198,6 +198,9 @@ def api_agent_detail(request, name: str):
         "name": agent.get("name", name),
         "role": agent.get("role", ""),
         "machine": agent.get("machine", ""),
+        # todo#55: canonical FQDN reported by the heartbeat, displayed
+        # next to the short `machine` label in the detail header.
+        "hostname_canonical": agent.get("hostname_canonical", ""),
         "model": agent.get("model", ""),
         "uptime_seconds": uptime_seconds,
         "registered_at": agent.get("registered_at"),


### PR DESCRIPTION
## Problem
PR #215 added `hostname_canonical` to the `/api/agents/` list + registry but forgot the `/api/agents/<name>/detail/` payload (which hand-builds its own dict). Dashboard detail rendering still works today only because the JS falls back to `a.hostname_canonical` from the list row — direct API consumers of the detail endpoint see nothing.

## Fix
One-line addition to `hub/views/agent_detail.py`.

## Test plan
- Deploy
- `curl /api/agents/head-mba/detail/?token=...` — expect `hostname_canonical` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)