### PR TITLE
feat(dashboard): multi-lamp connectivity bank + <synthetic> model fallback (todo#56, #57)

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -96,6 +96,22 @@ function _renderAgentDetail(a) {
   var statusColor = livenessColor(liveness);
   var role = d.role || a.role || "agent";
   var machine = d.machine || a.machine || "?";
+  /* todo#56: some transcripts surface <synthetic> / <none> / <compact>
+   * placeholder tokens for model when the assistant turn was synthesised
+   * (e.g. after /compact). Show a dash with the raw token in the tooltip
+   * instead of exposing the placeholder verbatim in the detail card. */
+  function _cleanModel(m) {
+    if (!m) return { display: "-", tooltip: "" };
+    var raw = String(m);
+    if (
+      raw.length > 2 &&
+      raw.charAt(0) === "<" &&
+      raw.charAt(raw.length - 1) === ">"
+    ) {
+      return { display: "—", tooltip: "heartbeat reported " + raw };
+    }
+    return { display: raw, tooltip: "" };
+  }
   /* todo#55: canonical FQDN for the Machine row. When the agent pushes
    * one AND it differs from the short label, the UI renders
    * "<label> (<fqdn>)". When identical or empty, the short label alone. */
@@ -104,7 +120,7 @@ function _renderAgentDetail(a) {
     machineCanonical && machineCanonical !== machine
       ? machine + " (" + machineCanonical + ")"
       : machine;
-  var model = d.model || a.model || "-";
+  var modelClean = _cleanModel(d.model || a.model || "");
   var ctxPct = d.context_pct != null ? d.context_pct : a.context_pct;
   var currentTask = d.current_task || a.current_task || "";
   var channels = d.channel_subs || a.channels || [];
@@ -173,7 +189,11 @@ function _renderAgentDetail(a) {
         ? "short label · canonical FQDN reported by the heartbeat"
         : "hostname the agent is running on (short label — no FQDN reported)",
     ],
-    ["Model", model, "Claude model id the agent is running against"],
+    [
+      "Model",
+      modelClean.display,
+      modelClean.tooltip || "Claude model id the agent is running against",
+    ],
     [
       "Multiplexer",
       multiplexer || "-",
@@ -248,9 +268,7 @@ function _renderAgentDetail(a) {
   var headerHtml =
     '<div class="agent-detail-header">' +
     '<div class="agent-detail-header-line">' +
-    '<span class="status-dot-inline" style="background:' +
-    statusColor +
-    '"></span>' +
+    _renderIndicatorLamps(a, d) +
     '<span class="agent-detail-header-title">' +
     escapeHtml(a.name) +
     "</span>" +
@@ -715,6 +733,100 @@ function livenessColor(liveness) {
     default:
       return "#888";
   }
+}
+
+/* todo#57: multi-lamp connectivity indicator bank on the detail header.
+ * Instead of one status dot, surface the independent signals the user
+ * needs to triage a broken agent: heartbeat freshness, pane classifier,
+ * MCP sidecar, and explicit health. Each lamp renders as a 10px dot
+ * with a hover tooltip explaining what it tracks and the current state
+ * value. Gray = no signal reported (distinct from red = bad signal). */
+function _buildIndicatorLamps(a, d) {
+  var lamps = [];
+  var liveness =
+    d.liveness || a.liveness || (isAgentInactive(a) ? "offline" : "online");
+  lamps.push({
+    key: "heartbeat",
+    color: livenessColor(liveness),
+    label: "HB",
+    title:
+      "Heartbeat freshness · " +
+      liveness +
+      " (online <2m · idle 2–10m · stale >10m · offline no push)",
+  });
+  var paneState = d.pane_state || a.pane_state || "";
+  var paneOk = ["", "running", "idle", "unknown"];
+  var paneStuck = [
+    "y_n_prompt",
+    "auth_error",
+    "mcp_broken",
+    "compose_pending_unsent",
+    "stuck",
+  ];
+  var paneColor = "#888";
+  if (paneOk.indexOf(paneState) !== -1) paneColor = "#4ecdc4";
+  else if (paneStuck.indexOf(paneState) !== -1) paneColor = "#ef4444";
+  else paneColor = "#ffd93d";
+  lamps.push({
+    key: "pane",
+    color: paneColor,
+    label: "PN",
+    title:
+      "Pane classifier · " +
+      (paneState || "(no classification)") +
+      " — red=stuck / amber=unusual / teal=ok / gray=no signal",
+  });
+  var mcpServers = d.mcp_servers || a.mcp_servers || [];
+  var mcpColor = mcpServers.length > 0 ? "#4ecdc4" : "#888";
+  lamps.push({
+    key: "mcp",
+    color: mcpColor,
+    label: "MCP",
+    title:
+      "MCP sidecar · " +
+      (mcpServers.length > 0
+        ? mcpServers.length + " server(s) connected"
+        : "(none reported — sidecar may be down)"),
+  });
+  var health = (d.health || a.health || {}).status || "";
+  var healthColor;
+  if (!health) healthColor = "#888";
+  else if (health === "healthy" || health === "ok") healthColor = "#4ecdc4";
+  else if (health === "degraded" || health === "warn") healthColor = "#ffd93d";
+  else healthColor = "#ef4444";
+  lamps.push({
+    key: "health",
+    color: healthColor,
+    label: "HL",
+    title:
+      "Self-reported health · " +
+      (health || "(none reported)") +
+      " — teal=healthy / amber=degraded / red=unhealthy / gray=no signal",
+  });
+  return lamps;
+}
+
+function _renderIndicatorLamps(a, d) {
+  var lamps = _buildIndicatorLamps(a, d);
+  return (
+    '<span class="agent-detail-lamps" role="status">' +
+    lamps
+      .map(function (l) {
+        return (
+          '<span class="agent-detail-lamp" data-lamp="' +
+          escapeHtml(l.key) +
+          '" title="' +
+          escapeHtml(l.title) +
+          '"><span class="agent-detail-lamp-dot" style="background:' +
+          l.color +
+          '"></span><span class="agent-detail-lamp-label">' +
+          escapeHtml(l.label) +
+          "</span></span>"
+        );
+      })
+      .join("") +
+    "</span>"
+  );
 }
 
 /* todo#418: pane_state badge — maps classifier label to display color+icon.

--- a/hub/static/hub/components.css
+++ b/hub/static/hub/components.css
@@ -635,6 +635,38 @@
   align-items: center;
   gap: 10px;
 }
+/* todo#57: multi-lamp connectivity indicator bank */
+.agent-detail-lamps {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 6px;
+  background: #0f0f0f;
+  border: 1px solid #2a2a2a;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+.agent-detail-lamp {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  cursor: help;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: #888;
+  line-height: 1;
+}
+.agent-detail-lamp-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 3px currentColor;
+}
+.agent-detail-lamp-label {
+  font-weight: 600;
+}
 .agent-detail-header-title {
   font-weight: 600;
   color: #4ecdc4;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -9,7 +9,7 @@
     <link rel="manifest" href="{% static 'hub/manifest.json' %}">
     <link rel="apple-touch-icon" href="{% static 'hub/orochi-icon.png' %}">
     <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=125">
-    <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=102">
+    <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=103">
     <link rel="stylesheet" href="{% static 'hub/todo-tab.css' %}?v=105">
     <link rel="stylesheet" href="{% static 'hub/attachments.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/responsive.css' %}?v=99">
@@ -377,7 +377,7 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=103"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=104"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=123"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>

--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -1059,10 +1059,20 @@ def collect(agent: str) -> dict:
         "model": (
             model
             if model and not model.startswith("<")
+            # Linux-only: peek at /proc/<pid>/environ for the real
+            # model env the runtime set at spawn.
             else (
                 _read_process_env(
                     pid, ("SCITEX_AGENT_CONTAINER_MODEL", "SCITEX_OROCHI_MODEL")
                 )
+                # Darwin fallback: /proc doesn't exist. Check the pusher's
+                # own env — on mba the tmux launcher exports
+                # SCITEX_OROCHI_MODEL before spawning both claude and the
+                # heartbeat helper, so they share the same env. Without
+                # this the heartbeat keeps pushing "<synthetic>" (incident:
+                # head-mba detail card, ywatanabe msg 2026-04-18 20:09).
+                or os.environ.get("SCITEX_AGENT_CONTAINER_MODEL", "").strip()
+                or os.environ.get("SCITEX_OROCHI_MODEL", "").strip()
                 or model
             )
         ),


### PR DESCRIPTION
## Summary
1. **Multi-lamp connectivity bank** on the agent detail header, replacing the single status dot. Four labeled lamps — HB (heartbeat), PN (pane classifier), MCP (sidecar), HL (health). Each has a hover tooltip explaining the layer and the current state. Red = broken, amber = degraded, teal = ok, gray = no signal.
2. **`<synthetic>` Model row cleanup**: any angle-bracketed placeholder token (`<synthetic>`, `<compact>`, `<none>`) renders as an em-dash, with the raw token moved to the tooltip.
3. **Darwin model fallback**: `agent_meta.py` now also reads `os.environ` for `SCITEX_AGENT_CONTAINER_MODEL` / `SCITEX_OROCHI_MODEL` when `/proc/<pid>/environ` is unavailable (macOS). Fixes head-mba which had been pushing `<synthetic>` ever since the transcript compaction path stopped setting a real model label.

## Incident that motivated this
- User: "it says synthetic" (head-mba detail card)
- User: "indicator LED should not be a single one but should have MULTIPLE INDICATOR LAMPS to show different levels of connectivity check"

## Test plan
- [ ] Deploy
- [ ] Reload the Agents tab, open any agent's detail card → four lamps in the header; hover each → tooltip
- [ ] head-mba Model row shows `—` with "heartbeat reported <synthetic>" tooltip until the next agent_meta.py push, then flips to a real model id
- [ ] agents with no MCP servers show the MCP lamp gray (not green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)