### PR TITLE
fix(client): resolve canonical hostname sensibly on macOS (todo#55)

### DIFF
--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -52,6 +52,35 @@ if not log.handlers:
     )
 
 
+def _resolve_canonical_hostname() -> str:
+    """Best-effort canonical hostname for dashboard display (todo#55).
+
+    On Linux ``socket.getfqdn()`` usually returns a sensible
+    ``host.example.com``. On macOS (and some containers) it can return the
+    IPv6 loopback PTR — e.g. ``1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0
+    .0.0.0.0.0.0.0.0.0.0.ip6.arpa`` — which is worse than useless. In that
+    case we prefer ``socket.gethostname()`` which returns the user-meaningful
+    ``*.local`` / ``*.localdomain`` name the user recognises.
+    """
+    try:
+        fqdn = (socket.getfqdn() or "").strip()
+    except Exception:
+        fqdn = ""
+    try:
+        short = (socket.gethostname() or "").strip()
+    except Exception:
+        short = ""
+    looks_bogus = (
+        not fqdn
+        or fqdn.endswith(".arpa")
+        or fqdn == "localhost"
+        or fqdn == "localhost.localdomain"
+    )
+    if looks_bogus:
+        return short
+    return fqdn
+
+
 def read_oauth_metadata(claude_json_path=None) -> dict:
     """Return Claude Code OAuth account public metadata (todo#265).
 
@@ -1083,11 +1112,14 @@ def collect(agent: str) -> dict:
         "project": project,
         "machine": machine,
         # todo#55: canonical FQDN for display next to the short machine
-        # label in the dashboard (e.g. "spartan (spartan.hpc.unimelb.edu.au)").
-        # socket.getfqdn() returns the short name when no reverse DNS is
-        # configured, in which case the dashboard simply shows the short
-        # label once.
-        "hostname_canonical": (socket.getfqdn() or "").strip(),
+        # label in the dashboard (e.g. "spartan (spartan.hpc.unimelb.edu.au)",
+        # "mba (Yusukes-MacBook-Air.local)").
+        # _resolve_canonical_hostname() prefers socket.getfqdn() on Linux but
+        # falls back to socket.gethostname() on macOS, where getfqdn() often
+        # resolves the IPv6 loopback PTR to `1.0.0.0...ip6.arpa` instead of
+        # the user-meaningful `*.local` name. The dashboard collapses to the
+        # short label when canonical is empty or identical.
+        "hostname_canonical": _resolve_canonical_hostname(),
         "skills_loaded": skills_loaded,
         "mcp_servers": mcp_servers,
         "claude_md_head": claude_md_head,


### PR DESCRIPTION
## Summary

Agents tab renders just `mba` instead of `mba (Yusukes-MacBook-Air.local)` because `socket.getfqdn()` on macOS returns the IPv6 loopback PTR (`1.0.0.0…ip6.arpa`) rather than a user-meaningful name. The hub then hides it and collapses to the short label.

Replace the direct `socket.getfqdn()` call in `scripts/client/agent_meta.py` with a small `_resolve_canonical_hostname()` helper that prefers `getfqdn()` on Linux (correct) but falls back to `gethostname()` when the result looks bogus (ends in `.arpa`, empty, `localhost`).

## Test plan

- [x] `_resolve_canonical_hostname()` returns `Yusukes-MacBook-Air.local` on mba
- [x] `_resolve_canonical_hostname()` returns `ywata-note-win.localdomain` on ywata-note-win
- [x] No regression for Linux boxes with real `.hpc.unimelb.edu.au` FQDNs
- [ ] Re-heartbeat head-mba → Agents tab shows `mba (Yusukes-MacBook-Air.local)`

## Risks

- Zero — helper is contained, behaviour is additive, display-only field

🤖 Generated with [Claude Code](https://claude.com/claude-code)