### PR TITLE
fix(dashboard): collapse redundant FQDN on Machine row (todo#58)

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -112,14 +112,26 @@ function _renderAgentDetail(a) {
     }
     return { display: raw, tooltip: "" };
   }
-  /* todo#55: canonical FQDN for the Machine row. When the agent pushes
-   * one AND it differs from the short label, the UI renders
-   * "<label> (<fqdn>)". When identical or empty, the short label alone. */
+  /* todo#55/#58: canonical FQDN for the Machine row. Render
+   * "<label> (<fqdn>)" only when the FQDN adds real information beyond
+   * the short label. Drops redundant suffixes like ".local" /
+   * ".localdomain" / ".lan" / ".home.arpa" that macOS and WSL attach to
+   * their mDNS names — those contribute nothing (ywatanabe msg 2026-04-18
+   * "2" flagged the duplication for the 7 ywata-note-win agents whose
+   * FQDN was just the short label + ".localdomain"). */
   var machineCanonical = d.hostname_canonical || a.hostname_canonical || "";
-  var machineDisplay =
-    machineCanonical && machineCanonical !== machine
-      ? machine + " (" + machineCanonical + ")"
-      : machine;
+  function _fqdnAddsInfo(short, fqdn) {
+    if (!fqdn) return false;
+    if (fqdn === short) return false;
+    var redundantSuffixes = [".local", ".localdomain", ".lan", ".home.arpa"];
+    for (var i = 0; i < redundantSuffixes.length; i++) {
+      if (fqdn === short + redundantSuffixes[i]) return false;
+    }
+    return true;
+  }
+  var machineDisplay = _fqdnAddsInfo(machine, machineCanonical)
+    ? machine + " (" + machineCanonical + ")"
+    : machine;
   var modelClean = _cleanModel(d.model || a.model || "");
   var ctxPct = d.context_pct != null ? d.context_pct : a.context_pct;
   var currentTask = d.current_task || a.current_task || "";
@@ -185,9 +197,11 @@ function _renderAgentDetail(a) {
     [
       "Machine",
       machineDisplay,
-      machineCanonical && machineCanonical !== machine
+      _fqdnAddsInfo(machine, machineCanonical)
         ? "short label · canonical FQDN reported by the heartbeat"
-        : "hostname the agent is running on (short label — no FQDN reported)",
+        : machineCanonical
+          ? "FQDN is just the short label + redundant mDNS suffix; hidden"
+          : "hostname the agent is running on (short label — no FQDN reported)",
     ],
     [
       "Model",

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -377,7 +377,7 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=104"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=105"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=123"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>


### PR DESCRIPTION
## Summary
Agents on ywata-note-win rendered their Machine row as ``ywata-note-win (ywata-note-win.localdomain)`` — the parenthetical carries zero new information (just an mDNS resolver suffix).

Now drop the FQDN parenthetical when it's the short label, OR the short label plus one of ``.local`` / ``.localdomain`` / ``.lan`` / ``.home.arpa``. ``mba → Yusukes-MacBook-Air.local`` and ``nas → DXP480TPLUS-994`` still render in full because those FQDNs genuinely differ.

## Test plan
- Deploy, reload the Agents tab
- ywata-note-win agents: Machine row shows just ``ywata-note-win``
- head-mba: still shows ``mba (Yusukes-MacBook-Air.local)``
- head-nas: still shows ``nas (DXP480TPLUS-994)``

🤖 Generated with [Claude Code](https://claude.com/claude-code)