### PR TITLE
fix(dashboard): activity-tab parity with agents-tab FQDN + synthetic cleanup (todo#55/#56/#58)

### DIFF
--- a/hub/static/hub/activity-tab.js
+++ b/hub/static/hub/activity-tab.js
@@ -326,10 +326,33 @@ function _renderActivityAgentDetail(a, grid) {
     var d = Math.floor(v / 86400);
     return d + "d " + Math.round((v % 86400) / 3600) + "h";
   }
+  /* todo#55/#56/#58: collapse redundant FQDN suffixes and hide
+   * <synthetic>-style model placeholders, mirroring the same polish on
+   * the Agents tab detail card. */
+  var _machine = a.machine || "?";
+  var _fqdn = a.hostname_canonical || "";
+  var _redundant = [".local", ".localdomain", ".lan", ".home.arpa"];
+  var _fqdnUseful = _fqdn && _fqdn !== _machine;
+  if (_fqdnUseful) {
+    for (var _i = 0; _i < _redundant.length; _i++) {
+      if (_fqdn === _machine + _redundant[_i]) {
+        _fqdnUseful = false;
+        break;
+      }
+    }
+  }
+  var _machineDisplay = _fqdnUseful ? _machine + " (" + _fqdn + ")" : _machine;
+  var _rawModel = a.model || "";
+  var _modelDisplay =
+    _rawModel.length > 2 &&
+    _rawModel.charAt(0) === "<" &&
+    _rawModel.charAt(_rawModel.length - 1) === ">"
+      ? "—"
+      : _rawModel || "-";
   var metaFields = [
     ["Role", a.role || "agent"],
-    ["Machine", a.machine || "?"],
-    ["Model", a.model || "-"],
+    ["Machine", _machineDisplay],
+    ["Model", _modelDisplay],
     ["Multiplexer", a.multiplexer || "-"],
     ["PID", a.pid || "-"],
     ["Liveness", liveness],

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -379,7 +379,7 @@
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
     <script src="{% static 'hub/agents-tab.js' %}?v=105"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
-    <script src="{% static 'hub/activity-tab.js' %}?v=123"></script>
+    <script src="{% static 'hub/activity-tab.js' %}?v=124"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>
     <script src="{% static 'hub/upload.js' %}?v=112"></script>
     <script src="{% static 'hub/files-tab.js' %}?v=104"></script>


### PR DESCRIPTION
## Summary
Mirror the FQDN collapse and <synthetic> model cleanup into activity-tab.js (Agents tab). Prior PRs #217 and #219 only touched agents-tab.js detail view.

## Test plan
- Reload Agents tab → ywata-note-win cards show Machine as just `ywata-note-win`
- head-mba card Model shows `—` instead of `<synthetic>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)