### PR TITLE
fix(agents): preserve CLAUDE.md / .mcp.json scroll across re-renders

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -491,7 +491,28 @@ function _renderAgentContent(grid) {
       '" not found.</p>';
     return;
   }
+  /* Preserve scrollTop of long, user-scrolled panes across heartbeat-driven
+   * re-renders. Without this the CLAUDE.md viewer (and .mcp.json viewer)
+   * snaps to the top every poll tick — reported by ywatanabe 2026-04-18
+   * 20:45 ("sometimes it automatically scrolls up to the top"). We stash
+   * scrollTop by CSS class because there is only one detail card in the
+   * DOM at a time, so class alone is a stable key. */
+  var _preserveScrollClasses = [
+    "agent-detail-claude-md",
+    "agent-detail-mcp-json",
+  ];
+  var _savedScrollTops = {};
+  _preserveScrollClasses.forEach(function (cls) {
+    var el = content.querySelector("." + cls);
+    if (el) _savedScrollTops[cls] = el.scrollTop;
+  });
   content.innerHTML = _renderAgentDetail(agent);
+  _preserveScrollClasses.forEach(function (cls) {
+    if (_savedScrollTops[cls] != null) {
+      var el = content.querySelector("." + cls);
+      if (el) el.scrollTop = _savedScrollTops[cls];
+    }
+  });
   /* Scroll pane to bottom so latest output is visible */
   var pre = content.querySelector(".agent-detail-pane");
   if (pre) pre.scrollTop = pre.scrollHeight;


### PR DESCRIPTION
## Summary

Reported by @ywatanabe1989 2026-04-18 20:45:
> sometimes it automatically scrolls up to the top

On every heartbeat poll the Agents tab does `content.innerHTML = _renderAgentDetail(agent)` in `agents-tab.js`, which tears out and rebuilds every `<pre>` inside the detail card. Scroll position on the new element starts at 0 — so the CLAUDE.md viewer (and the `.mcp.json` viewer) jumps back to the top while you're mid-read.

Fix: capture `scrollTop` for `.agent-detail-claude-md` and `.agent-detail-mcp-json` immediately before the `innerHTML` replacement and restore it immediately after. The existing auto-scroll-to-bottom for `.agent-detail-pane` (terminal output) is preserved.

## Test plan

- [x] Lint clean
- [ ] Open Agents tab → head-mba → scroll CLAUDE.md halfway down → wait for heartbeat poll → scroll stays put
- [ ] Open .mcp.json `<details>` → scroll halfway → poll → scroll stays put
- [ ] Terminal output pane still snaps to bottom on fresh output

## Risks

- Zero — pure DOM state preservation. If a future scrollable pane is added to the detail card, add its CSS class to `_preserveScrollClasses`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)