### PR TITLE
fix(agents): harden CLAUDE.md scroll preservation (rAF + cache-bust)

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -494,9 +494,10 @@ function _renderAgentContent(grid) {
   /* Preserve scrollTop of long, user-scrolled panes across heartbeat-driven
    * re-renders. Without this the CLAUDE.md viewer (and .mcp.json viewer)
    * snaps to the top every poll tick — reported by ywatanabe 2026-04-18
-   * 20:45 ("sometimes it automatically scrolls up to the top"). We stash
-   * scrollTop by CSS class because there is only one detail card in the
-   * DOM at a time, so class alone is a stable key. */
+   * 20:45 / 21:02 ("sometimes it automatically scrolls up to the top").
+   * Restore is double-applied: synchronously after innerHTML, and again
+   * from rAF so the browser has a chance to finish layout on a long
+   * <pre> before we set its scroll offset. */
   var _preserveScrollClasses = [
     "agent-detail-claude-md",
     "agent-detail-mcp-json",
@@ -504,15 +505,21 @@ function _renderAgentContent(grid) {
   var _savedScrollTops = {};
   _preserveScrollClasses.forEach(function (cls) {
     var el = content.querySelector("." + cls);
-    if (el) _savedScrollTops[cls] = el.scrollTop;
+    if (el && el.scrollTop > 0) _savedScrollTops[cls] = el.scrollTop;
   });
   content.innerHTML = _renderAgentDetail(agent);
-  _preserveScrollClasses.forEach(function (cls) {
-    if (_savedScrollTops[cls] != null) {
-      var el = content.querySelector("." + cls);
-      if (el) el.scrollTop = _savedScrollTops[cls];
-    }
-  });
+  var _restoreScroll = function () {
+    _preserveScrollClasses.forEach(function (cls) {
+      if (_savedScrollTops[cls] != null) {
+        var el = content.querySelector("." + cls);
+        if (el) el.scrollTop = _savedScrollTops[cls];
+      }
+    });
+  };
+  _restoreScroll();
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(_restoreScroll);
+  }
   /* Scroll pane to bottom so latest output is visible */
   var pre = content.querySelector(".agent-detail-pane");
   if (pre) pre.scrollTop = pre.scrollHeight;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -377,7 +377,7 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=105"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=106"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=124"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>


### PR DESCRIPTION
Follow-up to #221. User still saw periodic snap-to-top. Two root causes: (1) synchronous scrollTop restore fires before the new <pre> has laid out, (2) ?v=105 stays cached by Cloudflare+browser for 4h. Re-run restore from rAF and bump to ?v=106. 🤖 Generated with [Claude Code](https://claude.com/claude-code)