### PR TITLE
fix(activity-tab): preserve CLAUDE.md scroll (real fix)

### DIFF
--- a/hub/static/hub/activity-tab.js
+++ b/hub/static/hub/activity-tab.js
@@ -526,6 +526,21 @@ function _renderActivityAgentDetail(a, grid) {
     d.background_tasks || [],
     d.tool_counts || {},
   );
+  /* Preserve scrollTop of long, user-scrolled panes across heartbeat-driven
+   * re-renders. Without this the CLAUDE.md viewer (and .mcp.json viewer)
+   * snaps to the top every poll tick — reported by ywatanabe 2026-04-18
+   * 20:45 / 21:02 / 21:13 on the *Agents* tab (which this file renders,
+   * despite its historical name of "activity-tab"). Mirrors the fix in
+   * agents-tab.js (PR #221, #222). */
+  var _preserveScrollClasses = [
+    "agent-detail-claude-md",
+    "agent-detail-mcp-json",
+  ];
+  var _savedScrollTops = {};
+  _preserveScrollClasses.forEach(function (cls) {
+    var el = grid.querySelector("." + cls);
+    if (el && el.scrollTop > 0) _savedScrollTops[cls] = el.scrollTop;
+  });
   grid.innerHTML =
     '<div class="agent-detail-view">' +
     headerHtml +
@@ -534,6 +549,18 @@ function _renderActivityAgentDetail(a, grid) {
     splitHtml +
     hooksHtml +
     "</div>";
+  var _restoreScroll = function () {
+    _preserveScrollClasses.forEach(function (cls) {
+      if (_savedScrollTops[cls] != null) {
+        var el = grid.querySelector("." + cls);
+        if (el) el.scrollTop = _savedScrollTops[cls];
+      }
+    });
+  };
+  _restoreScroll();
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(_restoreScroll);
+  }
   /* Scroll pane to bottom */
   var pre = grid.querySelector(".agent-detail-pane");
   if (pre) pre.scrollTop = pre.scrollHeight;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -379,7 +379,7 @@
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
     <script src="{% static 'hub/agents-tab.js' %}?v=106"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
-    <script src="{% static 'hub/activity-tab.js' %}?v=124"></script>
+    <script src="{% static 'hub/activity-tab.js' %}?v=125"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>
     <script src="{% static 'hub/upload.js' %}?v=112"></script>
     <script src="{% static 'hub/files-tab.js' %}?v=104"></script>


### PR DESCRIPTION
PRs #221/#222 targeted agents-tab.js but the Agents button has data-tab=activity and loads activity-tab.js. User kept seeing snap because the fix was in a file the tab doesn't render. Mirror the rAF save/restore in activity-tab.js and bump cache ?v=124→?v=125. 🤖 Generated with Claude Code