### PR TITLE
feat(hub): hub→agent JSON ping/pong + RT lamp (todo#46)

### DIFF
--- a/hub/consumers.py
+++ b/hub/consumers.py
@@ -1,10 +1,42 @@
 """WebSocket consumers for agent and dashboard connections."""
 
+import asyncio
 import logging
+import time
 from urllib.parse import parse_qs
 
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
+
+# Interval between hub→agent JSON pings. Agents echo back
+# {"type":"pong","payload":{"ts":<sent_ts>}} so the hub can compute
+# round-trip time and expose hub-side liveness on the Agents tab's PN
+# lamp (todo#46). Kept below the 30s heartbeat-stale threshold so a
+# drop is noticed by both ends before the registry marks offline.
+PING_INTERVAL_SECONDS = 25
+# Upper bound on a healthy RTT; above this the PN lamp degrades to yellow.
+RTT_WARN_MS = 500
+
+
+async def _hub_ping_loop(consumer: "AgentConsumer") -> None:
+    """Send periodic hub→agent JSON pings so hub-side liveness is tracked.
+
+    Runs for the lifetime of the WebSocket connection. Cancelled from
+    ``AgentConsumer.disconnect``. Exceptions other than ``CancelledError``
+    are logged and swallowed — a ping loop crash must not tear down the
+    whole consumer.
+    """
+    try:
+        while True:
+            await asyncio.sleep(PING_INTERVAL_SECONDS)
+            try:
+                await consumer.send_json({"type": "ping", "ts": time.time()})
+            except Exception:  # noqa: BLE001
+                log.exception("ping send failed for %s", consumer.agent_name)
+                return
+    except asyncio.CancelledError:
+        raise
+
 
 from hub.channel_acl import check_write_allowed
 from hub.models import (
@@ -314,7 +346,16 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         # System messages (connect/disconnect/register) removed from chat feed
         # — too noisy during restarts. Sidebar presence updates are sufficient.
 
+        # todo#46 — start hub→agent JSON ping loop so dashboard can show
+        # live RTT and flag hub-side drops without waiting for the 30s
+        # heartbeat-stale timeout.
+        self._ping_task = asyncio.create_task(_hub_ping_loop(self))
+
     async def disconnect(self, code):
+        # Stop the ping task first so we don't race with the WS close.
+        ping_task = getattr(self, "_ping_task", None)
+        if ping_task is not None:
+            ping_task.cancel()
         if hasattr(self, "workspace_group"):
             # scitex-orochi#144 fix path 4: drop only THIS connection from
             # the per-agent set, not the whole agent record. The agent only
@@ -479,6 +520,27 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
                     "channels": subs,
                 }
             )
+
+        elif msg_type == "pong":
+            # todo#46 — agent echoed our ping back. Compute round-trip
+            # time, stash on the registry, and broadcast to dashboard
+            # observers so the PN lamp lights up live.
+            payload = content.get("payload") or {}
+            sent_ts = payload.get("ts") or content.get("ts")
+            if isinstance(sent_ts, (int, float)):
+                rtt_ms = max(0.0, (time.time() - float(sent_ts)) * 1000.0)
+                from hub.registry import update_pong
+
+                update_pong(self.agent_name, rtt_ms)
+                await self.channel_layer.group_send(
+                    self.workspace_group,
+                    {
+                        "type": "agent.pong",
+                        "agent": self.agent_name,
+                        "rtt_ms": rtt_ms,
+                        "ts": time.time(),
+                    },
+                )
 
         elif msg_type == "heartbeat":
             # Store resource metrics from agent heartbeat
@@ -737,6 +799,10 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
 
     async def agent_info(self, event):
         """Handle agent.info from channel layer — ignore for agent sockets."""
+        pass
+
+    async def agent_pong(self, event):
+        """Handle agent.pong from channel layer — ignore for agent sockets."""
         pass
 
     async def system_message(self, event):
@@ -1145,6 +1211,17 @@ class DashboardConsumer(AsyncJsonWebsocketConsumer):
                 "agent": event["agent"],
                 "info": event.get("info", {}),
                 "metrics": event.get("metrics", {}),
+            }
+        )
+
+    async def agent_pong(self, event):
+        """Forward hub→agent pong RTT to dashboard WebSocket client (todo#46)."""
+        await self.send_json(
+            {
+                "type": "agent_pong",
+                "agent": event["agent"],
+                "rtt_ms": event.get("rtt_ms"),
+                "ts": event.get("ts"),
             }
         )
 

--- a/hub/registry.py
+++ b/hub/registry.py
@@ -415,6 +415,19 @@ def update_heartbeat(name: str, metrics: dict | None = None) -> None:
                 _agents[name]["metrics"] = metrics
 
 
+def update_pong(name: str, rtt_ms: float) -> None:
+    """Record a hub→agent pong's RTT so the PN lamp goes live (todo#46).
+
+    Stores both the RTT and the pong timestamp — the dashboard treats
+    a stale ``last_pong_ts`` as "no recent pong" independent of the RTT
+    value, so an agent that stops responding is visibly degraded.
+    """
+    with _lock:
+        if name in _agents:
+            _agents[name]["last_pong_ts"] = time.time()
+            _agents[name]["last_rtt_ms"] = float(rtt_ms)
+
+
 def register_connection(name: str, conn_id: str) -> int:
     """Track a new WebSocket connection for ``name``.
 
@@ -630,6 +643,16 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                     if hb_ts
                     else None
                 ),
+                # todo#46 — hub→agent ping RTT. last_pong_ts is what the
+                # dashboard checks to decide whether the PN lamp is live.
+                "last_pong_ts": (
+                    datetime.fromtimestamp(
+                        a["last_pong_ts"], tz=timezone.utc
+                    ).isoformat()
+                    if a.get("last_pong_ts")
+                    else None
+                ),
+                "last_rtt_ms": a.get("last_rtt_ms"),
                 "last_action": (
                     datetime.fromtimestamp(action_ts, tz=timezone.utc).isoformat()
                     if action_ts

--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -796,6 +796,61 @@ function _buildIndicatorLamps(a, d) {
       liveness +
       " (online <2m · idle 2–10m · stale >10m · offline no push)",
   });
+
+  // todo#46 — Hub→agent round-trip ping lamp (RT). last_pong_ts is an
+  // ISO8601 string from the agent detail / agents projection; treat
+  // missing-or-stale-beyond-60s as "no signal" (gray). RTT color
+  // thresholds: <=250ms teal, <=1000ms amber, >1000ms red.
+  var pongIso = d.last_pong_ts || a.last_pong_ts || null;
+  var rttMs = d.last_rtt_ms;
+  if (typeof rttMs !== "number") rttMs = a.last_rtt_ms;
+  var pongAgeSec = null;
+  if (pongIso) {
+    var pongDate = new Date(pongIso);
+    if (!isNaN(pongDate.getTime())) {
+      pongAgeSec = Math.max(0, (Date.now() - pongDate.getTime()) / 1000);
+    }
+  }
+  var rtColor;
+  var rtTitle;
+  if (pongAgeSec === null || pongAgeSec > 60) {
+    rtColor = "#888";
+    rtTitle = "Hub ping RTT · no recent pong — hub→agent channel may be stuck";
+  } else if (typeof rttMs !== "number") {
+    rtColor = "#888";
+    rtTitle = "Hub ping RTT · pong received but no RTT sample";
+  } else if (rttMs <= 250) {
+    rtColor = "#4ecdc4";
+    rtTitle =
+      "Hub ping RTT · " +
+      Math.round(rttMs) +
+      " ms (last pong " +
+      Math.round(pongAgeSec) +
+      "s ago)";
+  } else if (rttMs <= 1000) {
+    rtColor = "#ffd93d";
+    rtTitle =
+      "Hub ping RTT · " +
+      Math.round(rttMs) +
+      " ms — slow (last pong " +
+      Math.round(pongAgeSec) +
+      "s ago)";
+  } else {
+    rtColor = "#ef4444";
+    rtTitle =
+      "Hub ping RTT · " +
+      Math.round(rttMs) +
+      " ms — very slow (last pong " +
+      Math.round(pongAgeSec) +
+      "s ago)";
+  }
+  lamps.push({
+    key: "rtt",
+    color: rtColor,
+    label: "RT",
+    title: rtTitle,
+  });
+
   var paneState = d.pane_state || a.pane_state || "";
   var paneOk = ["", "running", "idle", "unknown"];
   var paneStuck = [

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -377,7 +377,7 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=106"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=107"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=125"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>

--- a/hub/tests.py
+++ b/hub/tests.py
@@ -2153,6 +2153,28 @@ class AgentDetailApiTest(TestCase):
         self.assertIn("hostname_canonical", data2)
         self.assertEqual(data2["hostname_canonical"], "")
 
+    def test_ping_pong_fields_exposed(self):
+        """todo#46: detail endpoint must expose last_pong_ts / last_rtt_ms
+        once update_pong has been called, and must always include the
+        keys (as None) when no pong has been received yet."""
+        self._register()
+        # Fresh registration: fields present but null.
+        data = self._get().json()
+        self.assertIn("last_pong_ts", data)
+        self.assertIn("last_rtt_ms", data)
+        self.assertIsNone(data["last_pong_ts"])
+        self.assertIsNone(data["last_rtt_ms"])
+
+        # After a pong: last_rtt_ms is the float we recorded, last_pong_ts
+        # is an ISO8601 string close to "now".
+        from hub.registry import update_pong
+
+        update_pong("alpha", 42.5)
+        data2 = self._get().json()
+        self.assertAlmostEqual(data2["last_rtt_ms"], 42.5, places=3)
+        self.assertIsNotNone(data2["last_pong_ts"])
+        self.assertIn("T", data2["last_pong_ts"])  # ISO8601 marker
+
     def test_event_log_shortcuts_projected(self):
         """The hook-event / action_store shortcuts the frontend reads
         for the Last tool / Last MCP / Last action rows must always be

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -206,6 +206,11 @@ def api_agent_detail(request, name: str):
         "registered_at": agent.get("registered_at"),
         "last_action_ts": agent.get("last_action"),
         "last_heartbeat": agent.get("last_heartbeat"),
+        # todo#46 — hub→agent ping RTT. Dashboard drives the PN lamp
+        # off `last_pong_ts` (live when fresh) and `last_rtt_ms` (color
+        # by latency).
+        "last_pong_ts": agent.get("last_pong_ts"),
+        "last_rtt_ms": agent.get("last_rtt_ms"),
         "liveness": agent.get("liveness") or agent.get("status") or "unknown",
         "claude_md": redact_secrets(agent.get("claude_md") or ""),
         # todo#460: serve the workspace .mcp.json for the Agents tab viewer.

--- a/src/scitex_orochi/_ts/mcp_channel.ts
+++ b/src/scitex_orochi/_ts/mcp_channel.ts
@@ -77,6 +77,23 @@ Orochi is a real-time communication hub for AI agents across different machines.
 const conn = new OrochiConnection(async (raw: string) => {
   try {
     const msg = JSON.parse(raw);
+
+    // todo#46 — hub→agent JSON ping. Echo the original ts back so the
+    // hub can compute RTT. Keep the branch first so ping handling is
+    // not blocked by any later message-type routing.
+    if (msg.type === "ping") {
+      const sentTs =
+        typeof msg.ts === "number"
+          ? msg.ts
+          : typeof msg?.payload?.ts === "number"
+            ? msg.payload.ts
+            : null;
+      if (sentTs !== null) {
+        conn.send(JSON.stringify({ type: "pong", payload: { ts: sentTs } }));
+      }
+      return;
+    }
+
     if (msg.type !== "message") return;
 
     const payload = msg.payload || {};


### PR DESCRIPTION
## Summary

Closes todo#46. Bidirectional liveness: the hub now sends a periodic JSON ping to each connected agent, the TS bridge echoes it back, and a new **RT** lamp on the Agents tab shows round-trip time in real time.

Before this, the dashboard could only infer agent→hub health from heartbeat freshness (HB lamp). If the hub→agent direction of a WebSocket went stuck (e.g. `send()` buffering without error), the dashboard would happily show "online" until the 30s stale timeout.

## Changes

- **`hub/consumers.py`**: `_hub_ping_loop` coroutine launched on `connect`, cancelled on `disconnect`. Sends `{"type":"ping","ts":<float>}` every 25s. New `pong` branch in `receive_json` computes RTT, stores it via `update_pong`, broadcasts `agent.pong`. `AgentConsumer` handler is a no-op; `DashboardConsumer.agent_pong` forwards to the browser as `{"type":"agent_pong","agent":..., "rtt_ms":..., "ts":...}`.
- **`hub/registry.py`**: `update_pong(name, rtt_ms)` + `last_pong_ts` / `last_rtt_ms` fields in `get_agents()` projection.
- **`hub/views/agent_detail.py`**: exposes both fields on `/api/agents/<name>/detail/`.
- **`hub/static/hub/agents-tab.js`**: new **RT** lamp between HB and PN. Gray when no pong within 60s, teal ≤250ms, amber ≤1000ms, red >1000ms. Tooltip shows RTT and pong-age.
- **`hub/templates/hub/dashboard.html`**: `agents-tab.js?v=107` cache-bust.
- **`src/scitex_orochi/_ts/mcp_channel.ts`**: echoes `ping` back as `pong` with original ts.

## Tests

- New `test_ping_pong_fields_exposed` pins projection: keys present & None before any pong; after `update_pong("alpha", 42.5)` the detail API returns `last_rtt_ms=42.5` and an ISO8601 `last_pong_ts`.
- Full `AgentDetailApiTest` suite (11 tests) passes.

## Verify manually after deploy

1. Open `/` in the browser, go to Agents tab.
2. Hover any online agent card — RT lamp tooltip should show `Hub ping RTT · <N> ms (last pong <M>s ago)` within 25s.
3. Break an agent (`docker kill orochi-server-stable` on its side) — within 60s the RT lamp should turn gray ("no recent pong — hub→agent channel may be stuck") while HB may still be green until the heartbeat window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)