### PR TITLE
feat(agents-tab): live-refresh detail view on info/pong (todo#47 read-only tier)

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -629,6 +629,22 @@ function _invalidateAgentDetail(name) {
   _fetchAgentDetail(name);
 }
 
+/* todo#47 — live read-only pane tier.
+ *
+ * Exported entry point called by app.js on every `agent_info` /
+ * `agent_pong` WebSocket event. If the dashboard is currently showing
+ * the detail tab for *this* agent, re-fetch detail so the pane_tail /
+ * RTT / last_action surfaces refresh within seconds instead of waiting
+ * for the user to re-click. No-op when the user is on the Overview tab
+ * or looking at a different agent — avoids hammering the API with
+ * unrelated heartbeats. */
+function onAgentInfoEvent(name) {
+  if (!name) return;
+  if (_selectedAgentTab !== name) return;
+  _invalidateAgentDetail(name);
+}
+window.onAgentInfoEvent = onAgentInfoEvent;
+
 /* ── Overview HTML builder (extracted from renderAgentsTab) ─────────── */
 function _buildOverviewHtml(agents) {
   var machineMap = {};

--- a/hub/static/hub/app.js
+++ b/hub/static/hub/app.js
@@ -1282,11 +1282,23 @@ function handleMessage(msg) {
     msg.type === "presence_change" ||
     msg.type === "status_update" ||
     msg.type === "agent_presence" ||
-    msg.type === "agent_info"
+    msg.type === "agent_info" ||
+    msg.type === "agent_pong"
   ) {
     fetchAgentsThrottled();
     fetchStatsThrottled();
     fetchResources();
+    /* todo#47 — if the Agents tab currently has a detail view open
+     * for the agent that just sent an info/pong, invalidate that
+     * view's cache so pane_tail / RTT / last_action refresh live. */
+    if (
+      (msg.type === "agent_info" ||
+        msg.type === "agent_pong" ||
+        msg.type === "agent_presence") &&
+      typeof window.onAgentInfoEvent === "function"
+    ) {
+      window.onAgentInfoEvent(msg.agent);
+    }
   } else if (msg.type === "reaction_update") {
     if (typeof handleReactionUpdate === "function") handleReactionUpdate(msg);
   } else if (msg.type === "thread_reply") {

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -365,7 +365,7 @@
     </script>
     <script src="{% static 'hub/config.js' %}?v=117"></script>
     <script src="{% static 'hub/agent-icons.js' %}?v=100"></script>
-    <script src="{% static 'hub/app.js' %}?v=131"></script>
+    <script src="{% static 'hub/app.js' %}?v=132"></script>
     <script src="{% static 'hub/dms.js' %}?v=2"></script>
     <script src="{% static 'hub/workspace-dropdown.js' %}?v=99"></script>
     <script src="{% static 'hub/resources-tab.js' %}?v=100"></script>
@@ -377,7 +377,7 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=107"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=108"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=125"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>


### PR DESCRIPTION
## Summary

First increment on todo#47. Lands a *read-only* live pane: when the Agents tab has an agent detail tab open, it auto-refreshes as heartbeats and pongs arrive, so pane_tail, the new RT lamp (todo#46), last_action, and other detail-only surfaces stay current without the user re-clicking.

No PTY, no xterm.js, no auth surface — that stays for a future increment.

## Why this cut

- The underlying data already flows: agents push pane_tail_block in every heartbeat, and todo#46 added pong broadcasts. The detail endpoint exposes all of it.
- The gap is purely the dashboard keeping its rendered view fresh. Scoping this to "only the currently-open detail tab" keeps it cheap — heartbeats for other agents don't fire the re-fetch.

## Changes

- `hub/static/hub/agents-tab.js` — new `onAgentInfoEvent(name)` exported on `window`. If `_selectedAgentTab === name`, invalidate the detail cache and re-fetch.
- `hub/static/hub/app.js` — WS dispatch now also fires on `agent_pong`; hands off to `window.onAgentInfoEvent(msg.agent)`.
- `hub/templates/hub/dashboard.html` — `app.js?v=132`, `agents-tab.js?v=108`.

## Verify after deploy

1. Open Agents tab → click any online agent card.
2. Watch the pane_tail block. Next time the agent heartbeats (~30s), it should update without manual refresh.
3. Watch the **RT** lamp tooltip (shipped in #227). It should update its "last pong Xs ago" within ~25s tick.
4. Click Overview — no extra network traffic should fire on heartbeats (confirm in devtools).

## Follow-ups (not in this PR)

- Manual "Refresh pane" button in the detail header.
- Dedicated `/api/agents/<name>/pane/full/` endpoint for longer capture-pane scrollback.
- xterm.js interactive tier (needs auth model first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)