### PR TITLE
fix(ts): ping-echo in canonical ts/mcp_channel.ts (todo#46 bugfix)

### DIFF
--- a/ts/mcp_channel.ts
+++ b/ts/mcp_channel.ts
@@ -391,6 +391,29 @@ const conn = {
         _dbg(`ws recv: ${raw.slice(0, 200)}`);
         const msg = JSON.parse(raw);
 
+        // todo#46 — hub→agent JSON ping. Echo original ts back so the
+        // hub can compute RTT and light the Agents-tab RT lamp. Keep
+        // this branch first so ping handling is not blocked by any
+        // later message-type routing.
+        if (msg.type === "ping") {
+          const sentTs =
+            typeof msg.ts === "number"
+              ? msg.ts
+              : typeof msg?.payload?.ts === "number"
+                ? msg.payload.ts
+                : null;
+          if (sentTs !== null) {
+            try {
+              _ws!.send(
+                JSON.stringify({ type: "pong", payload: { ts: sentTs } }),
+              );
+            } catch (_) {
+              /* socket already closing — ignore */
+            }
+          }
+          return;
+        }
+
         // Thread replies and reaction updates -> rewrite to message type
         if (msg.type === "thread_reply") {
           const parentId = msg.parent_id ?? msg.parent ?? "?";


### PR DESCRIPTION
## Summary

Fixes a latent bug in #227: the ping-echo branch was added to `src/scitex_orochi/_ts/mcp_channel.ts`, but agents run `ts/mcp_channel.ts` (resolved via `_agent_container_bridge/mcp.py`'s `pkg_file.parent.parent.parent / "ts" / "mcp_channel.ts"`). The two files have diverged, so #227's TS edit was effectively dead code for production.

This PR adds the same ping-echo branch to the canonical runtime file. The hub-side logic, registry, API, and RT lamp shipped in #227/#228 are correct — only the agent-side echo was in the wrong file.

## Verify

After merge + agent MCP sidecar restart:

```bash
curl -s "https://scitex-lab.scitex-orochi.com/api/agents/?token=wks_..." \
  | python3 -c "import sys,json; [print(a['name'], a['last_rtt_ms']) for a in json.load(sys.stdin) if a['status']=='online']"
# Should show non-None rtt_ms values within 25s per agent.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)