### PR TITLE
feat(agents-tab): Refresh + Copy buttons on pane viewer (todo#47 next tier)

### DIFF
--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -302,16 +302,33 @@ function _renderAgentDetail(a) {
     "</div>" +
     "</div>";
 
+  // todo#47 — Terminal output controls: Refresh forces a fresh
+  // /detail fetch (useful when heartbeats are paused or the user
+  // wants a synchronous read). Copy dumps the raw text to the
+  // clipboard. Both are data-hooked so the click handlers can find
+  // them without relying on fragile closures.
   var paneLabel =
     'Terminal output <span class="agent-detail-pane-source">(' +
     escapeHtml(paneSource) +
-    ")</span>";
+    ")</span>" +
+    '<span class="agent-detail-pane-controls">' +
+    '<button type="button" class="agent-detail-pane-btn" ' +
+    'data-action="refresh-pane" data-agent="' +
+    escapeHtml(a.name) +
+    '" title="Force re-fetch of detail (pane + RTT + last action)">Refresh</button>' +
+    '<button type="button" class="agent-detail-pane-btn" ' +
+    'data-action="copy-pane" data-agent="' +
+    escapeHtml(a.name) +
+    '" title="Copy full pane text to clipboard">Copy</button>' +
+    "</span>";
   var paneHtml =
     '<div class="agent-detail-pane-wrap">' +
     '<div class="agent-detail-pane-label">' +
     paneLabel +
     "</div>" +
-    '<pre class="agent-detail-pane">' +
+    '<pre class="agent-detail-pane" data-agent="' +
+    escapeHtml(a.name) +
+    '">' +
     (pane
       ? escapeHtml(pane)
       : '<span class="muted-cell">No terminal output available (pane_text_source=' +
@@ -552,6 +569,50 @@ function _renderAgentContent(grid) {
   }
 
   _bindChannelControls(content);
+  _bindPaneControls(content);
+}
+
+/* todo#47 — wire Refresh / Copy buttons in the pane viewer. Refresh
+ * invalidates the detail cache and re-renders; Copy dumps pane text
+ * to the clipboard. Both are scoped per-agent via data-agent on the
+ * button itself so there's no ambiguity when multiple agents are
+ * stacked in the DOM. */
+function _bindPaneControls(content) {
+  content.querySelectorAll('[data-action="refresh-pane"]').forEach(function (btn) {
+    btn.addEventListener("click", function (ev) {
+      ev.preventDefault();
+      var name = btn.getAttribute("data-agent") || "";
+      if (!name) return;
+      btn.disabled = true;
+      btn.textContent = "Refreshing…";
+      _invalidateAgentDetail(name);
+      setTimeout(function () {
+        btn.disabled = false;
+        btn.textContent = "Refresh";
+      }, 1500);
+    });
+  });
+  content.querySelectorAll('[data-action="copy-pane"]').forEach(function (btn) {
+    btn.addEventListener("click", async function (ev) {
+      ev.preventDefault();
+      var name = btn.getAttribute("data-agent") || "";
+      if (!name) return;
+      var pre = content.querySelector(
+        '.agent-detail-pane[data-agent="' + name + '"]',
+      );
+      var text = pre ? pre.textContent || "" : "";
+      try {
+        await navigator.clipboard.writeText(text);
+        var original = btn.textContent;
+        btn.textContent = "Copied";
+        setTimeout(function () {
+          btn.textContent = original;
+        }, 1200);
+      } catch (err) {
+        alert("Copy failed: " + err.message);
+      }
+    });
+  });
 }
 
 /* ── Channel subscription controls (Phase 3) ────────────────────────── */

--- a/hub/static/hub/components.css
+++ b/hub/static/hub/components.css
@@ -871,3 +871,31 @@
   font-size: 10px;
   margin-left: 4px;
 }
+
+/* todo#47 — Refresh/Copy buttons in the terminal-output label row.
+ * Low-visual-weight pill buttons so the pane itself stays dominant. */
+.agent-detail-pane-controls {
+  float: right;
+  display: inline-flex;
+  gap: 4px;
+}
+.agent-detail-pane-btn {
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  padding: 2px 8px;
+  background: transparent;
+  color: #666;
+  border: 1px solid #ccc;
+  border-radius: 10px;
+  cursor: pointer;
+}
+.agent-detail-pane-btn:hover:not(:disabled) {
+  color: #4ecdc4;
+  border-color: #4ecdc4;
+}
+.agent-detail-pane-btn:disabled {
+  opacity: 0.5;
+  cursor: wait;
+}

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -9,7 +9,7 @@
     <link rel="manifest" href="{% static 'hub/manifest.json' %}">
     <link rel="apple-touch-icon" href="{% static 'hub/orochi-icon.png' %}">
     <link rel="stylesheet" href="{% static 'hub/style.css' %}?v=125">
-    <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=103">
+    <link rel="stylesheet" href="{% static 'hub/components.css' %}?v=104">
     <link rel="stylesheet" href="{% static 'hub/todo-tab.css' %}?v=105">
     <link rel="stylesheet" href="{% static 'hub/attachments.css' %}?v=100">
     <link rel="stylesheet" href="{% static 'hub/responsive.css' %}?v=99">
@@ -377,7 +377,7 @@
     <script src="{% static 'hub/emoji-picker.js' %}?v=99"></script>
     <script src="{% static 'hub/filter.js' %}?v=101"></script>
     <script src="{% static 'hub/blockers.js' %}?v=1"></script>
-    <script src="{% static 'hub/agents-tab.js' %}?v=108"></script>
+    <script src="{% static 'hub/agents-tab.js' %}?v=109"></script>
     <script src="{% static 'hub/connectivity-map.js' %}?v=100"></script>
     <script src="{% static 'hub/activity-tab.js' %}?v=125"></script>
     <script src="{% static 'hub/viz-tab.js' %}?v=4"></script>


### PR DESCRIPTION
## Summary

Adds two low-visual-weight pill buttons to the agent detail pane viewer's label row:

- **Refresh**: forces a synchronous re-fetch of `/api/agents/<name>/detail/`. Useful when heartbeats are paused (MCP sidecar restarting) or when the user wants guaranteed-fresh output instead of waiting for the auto-refresh tick.
- **Copy**: dumps the full pane text to the clipboard.

No agent-side or backend changes — reuses the `_invalidateAgentDetail` path already in place from #228.

## Context

- #228 landed live auto-refresh when heartbeats arrive.
- This PR adds the on-demand / manual refresh lever that complements the auto-refresh.
- Follow-ups: full-capture scrollback endpoint (needs agent-side change to `agent_meta.py`) and xterm.js interactive tier (needs auth model).

## Verify

1. Open Agents tab → click an agent → pane section now has `Refresh` and `Copy` buttons.
2. Click `Refresh` while agent is heartbeating — pane updates; button briefly becomes "Refreshing…".
3. Click `Copy` — button briefly becomes "Copied"; pane text is on clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)