### PR TITLE
fix(agent-meta): include pane_tail_full in --push whitelist (todo#47)

### DIFF
--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -557,7 +557,9 @@ def collect(agent: str) -> dict:
     pane_tail = ""  # last interesting single line (legacy field)
     pane_tail_block = ""  # last ~10 interesting lines (raw — keeps channel inbound for WS-alive proof)
     pane_tail_block_clean = ""  # same as block but stripped of channel inbound (for stuck-detection / state classifier)
-    pane_tail_full = ""  # up to 500 filtered lines, trimmed to 32 KB (todo#47 web-terminal tier)
+    pane_tail_full = (
+        ""  # up to 500 filtered lines, trimmed to 32 KB (todo#47 web-terminal tier)
+    )
 
     def _is_channel_inbound_line(s: str) -> bool:
         """ywatanabe msg#10657 / #10677: incoming Orochi channel pushes
@@ -1330,6 +1332,9 @@ def push_all(url=None, token=None) -> int:
                 "mcp_servers": list(meta.get("mcp_servers") or []),
                 "pane_tail": meta.get("pane_tail", ""),
                 "pane_tail_block": meta.get("pane_tail_block", ""),
+                # todo#47 — full scrollback for the "Expand" toggle in
+                # the agent detail pane viewer.
+                "pane_tail_full": meta.get("pane_tail_full", ""),
                 "pane_state": meta.get("pane_state", ""),
                 "stuck_prompt_text": meta.get("stuck_prompt_text", ""),
             }


### PR DESCRIPTION
## Summary

One-line fix. #231 added \`pane_tail_full\` to \`collect()\` output but \`push_all()\` rebuilds a whitelist payload that didn't include the field — so it was silently dropped before reaching the hub.

Symptom: hub detail API returned \`pane_text_full=""\` on every agent even after the launchd \`agent-meta-push\` job was respawned. \"agent_meta pushed healer-mba ctx=...\" log lines looked normal while the new field was being filtered one hop earlier.

Hub-side acceptance + registry + projection all verified OK since #231 merged.

## Verify after merge + agent pull

\`\`\`bash
curl -s \"https://scitex-lab.scitex-orochi.com/api/agents/healer-mba/detail/?token=wks_...\" \\
  | python3 -c \"import sys,json; d=json.load(sys.stdin); print(len(d.get('pane_text_full') or ''))\"
# Should print non-zero bytes within one heartbeat cycle (30-45s) of the script refresh.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)