### PR TITLE
fix(registry): preserve last_pong_ts/last_rtt_ms on re-register (todo#46)

### DIFF
--- a/hub/registry.py
+++ b/hub/registry.py
@@ -81,6 +81,12 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             "subagents": list(prev.get("subagents") or []),
             "health": prev.get("health") or {},
             "metrics": prev.get("metrics") or {},
+            # todo#46 — preserve ping/pong state across re-registers
+            # (heartbeat, WS reconnect). Without this, every heartbeat
+            # wiped last_pong_ts/last_rtt_ms back to absent, so the RT
+            # lamp flickered to gray 1× per 30s heartbeat cycle.
+            "last_pong_ts": prev.get("last_pong_ts"),
+            "last_rtt_ms": prev.get("last_rtt_ms"),
             # Extended process/runtime metadata pushed by agent_meta.py --push.
             # Optional; absent for legacy WS-only agents.
             "pid": info.get("pid") or prev.get("pid") or 0,


### PR DESCRIPTION
## Summary

Bugfix for #227. \`register_agent\` rebuilds the agent dict on every heartbeat or WS reconnect, and fields not explicitly preserved from \`prev\` get dropped. The \`last_pong_ts\` / \`last_rtt_ms\` fields weren't on the preserve list, so every 30s heartbeat wiped them — making the RT lamp flicker to gray roughly once per cycle even for healthy agents.

## Verify after merge + hub redeploy

Watch the fleet API over ~2 minutes — RTT should stay populated continuously for any agent that echoes pong, not flap with the heartbeat cadence:

\`\`\`bash
while true; do
  curl -s "https://scitex-lab.scitex-orochi.com/api/agents/?token=wks_..." \\
    | python3 -c "import sys,json; d=json.load(sys.stdin); lives=sum(1 for a in d if a.get('last_rtt_ms')); print(f'{lives}/15 live')"
  sleep 15
done
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)