### PR TITLE
feat(pane): Follow toggle + Expand-state persistence (todo#47 tier 4-read)

### DIFF
--- a/hub/static/hub/activity-tab.js
+++ b/hub/static/hub/activity-tab.js
@@ -9,6 +9,13 @@ var _paneShowRaw = false; /* false = strip ANSI (clean), true = raw */
  * text, redacted MCP). Mirrors _agentDetailCache in agents-tab.js. */
 var _activityDetailCache = {};
 var _activityDetailInflight = {};
+/* todo#47 — Pane view state survives heartbeat-driven re-renders
+ * (Expand stays expanded, Follow keeps polling). One agent follows
+ * at a time; sub-tab switch or hidden document auto-stops. */
+var _activityPaneExpanded = {}; /* name -> bool */
+var _activityFollowAgent = null;
+var _activityFollowTimer = null;
+var ACTIVITY_FOLLOW_INTERVAL_MS = 3000;
 
 async function _fetchActivityDetail(name) {
   if (!name || name === "overview") return;
@@ -82,7 +89,13 @@ function _renderActivitySubTabBar(agents) {
     function (e) {
       var btn = e.target.closest(".agent-subtab");
       if (!btn) return;
-      _activitySubTab = btn.getAttribute("data-actsubtab");
+      var nextTab = btn.getAttribute("data-actsubtab");
+      /* todo#47 — switching away cancels Follow so we don't keep
+       * polling an agent the user can no longer see. */
+      if (_activityFollowAgent && _activityFollowAgent !== nextTab) {
+        _stopActivityFollow();
+      }
+      _activitySubTab = nextTab;
       _applyActivitySubTab(agents);
     },
     { once: true },
@@ -98,7 +111,12 @@ function _bindActivitySubTabBar(agents) {
   newBar.addEventListener("click", function (e) {
     var btn = e.target.closest(".agent-subtab");
     if (!btn) return;
-    _activitySubTab = btn.getAttribute("data-actsubtab");
+    var nextTab = btn.getAttribute("data-actsubtab");
+    /* todo#47 — switching away cancels Follow */
+    if (_activityFollowAgent && _activityFollowAgent !== nextTab) {
+      _stopActivityFollow();
+    }
+    _activitySubTab = nextTab;
     /* If selected agent no longer in list, fall back */
     if (
       _activitySubTab !== "overview" &&
@@ -287,6 +305,7 @@ function _renderActivityAgentDetail(a, grid) {
   a = Object.assign({}, a, {
     claude_md: d.claude_md || a.claude_md || a.claude_md_head || "",
     pane_tail_block: d.pane_text || a.pane_tail_block || a.pane_tail || "",
+    pane_text_full: d.pane_text_full || "",
   });
   var liveness = a.liveness || a.status || "online";
   var livenessColors = {
@@ -450,17 +469,69 @@ function _renderActivityAgentDetail(a, grid) {
         escapeHtml(a.current_task || a.last_message_preview) +
         "</div>"
       : "";
-  /* Terminal pane — with Raw/Clean toggle */
-  var paneContent = pane ? (_paneShowRaw ? pane : _stripAnsi(pane)) : "";
+  /* Terminal pane — Raw/Clean + todo#47 Refresh / Copy / Follow /
+   * Expand. Expand only renders when pane_text_full is available
+   * (newer agent_meta.py push); older agents just see the short
+   * tail. Follow polls /detail every 3 s for a live-tail feel. */
+  var paneFull = a.pane_text_full || "";
+  var paneFullAvailable = !!paneFull;
+  var _isFollowing = _activityFollowAgent === a.name;
+  var _isExpanded = !!_activityPaneExpanded[a.name] && paneFullAvailable;
+  var paneSource = _isExpanded ? paneFull : pane || "";
+  var paneContent = paneSource
+    ? _paneShowRaw
+      ? paneSource
+      : _stripAnsi(paneSource)
+    : "";
   var paneHtml =
     '<div class="agent-detail-pane-wrap">' +
     '<div class="agent-detail-pane-label-row">' +
     '<span class="agent-detail-pane-label">Terminal output</span>' +
+    '<span class="agent-detail-pane-controls">' +
+    (paneFullAvailable
+      ? '<button type="button" class="agent-detail-pane-btn' +
+        (_isExpanded ? " agent-detail-pane-btn-on" : "") +
+        '" data-act-pane-action="expand" data-agent="' +
+        escapeHtml(a.name) +
+        '" title="' +
+        (_isExpanded
+          ? "Show short pane (~10 lines)"
+          : "Show ~500-line scrollback") +
+        '">' +
+        (_isExpanded ? "Collapse" : "Expand") +
+        "</button>"
+      : "") +
+    '<button type="button" class="agent-detail-pane-btn" ' +
+    'data-act-pane-action="refresh" data-agent="' +
+    escapeHtml(a.name) +
+    '" title="Force re-fetch of detail">Refresh</button>' +
+    '<button type="button" class="agent-detail-pane-btn' +
+    (_isFollowing ? " agent-detail-pane-btn-on" : "") +
+    '" data-act-pane-action="follow" data-agent="' +
+    escapeHtml(a.name) +
+    '" title="' +
+    (_isFollowing
+      ? "Stop live-tail polling"
+      : "Poll /detail every " +
+        ACTIVITY_FOLLOW_INTERVAL_MS / 1000 +
+        "s for a live-tail feel") +
+    '">' +
+    (_isFollowing ? "Following" : "Follow") +
+    "</button>" +
+    '<button type="button" class="agent-detail-pane-btn" ' +
+    'data-act-pane-action="copy" data-agent="' +
+    escapeHtml(a.name) +
+    '" title="Copy pane text to clipboard">Copy</button>' +
     '<button class="pane-raw-toggle" id="pane-raw-toggle" title="Toggle raw/clean terminal output">' +
     (_paneShowRaw ? "Raw" : "Clean") +
     "</button>" +
+    "</span>" +
     "</div>" +
-    '<pre class="agent-detail-pane" id="agent-detail-pane-content">' +
+    '<pre class="agent-detail-pane" id="agent-detail-pane-content" data-agent="' +
+    escapeHtml(a.name) +
+    '" data-pane-view="' +
+    (_isExpanded ? "full" : "short") +
+    '">' +
     (paneContent
       ? escapeHtml(paneContent)
       : '<span class="muted-cell">No terminal output available</span>') +
@@ -564,7 +635,9 @@ function _renderActivityAgentDetail(a, grid) {
   /* Scroll pane to bottom */
   var pre = grid.querySelector(".agent-detail-pane");
   if (pre) pre.scrollTop = pre.scrollHeight;
-  /* Wire Raw/Clean toggle */
+  /* Wire Raw/Clean toggle. When Expand is active, the toggle re-renders
+   * against pane_text_full so raw/clean applies to the full scrollback
+   * too — otherwise Raw would silently fall back to the short tail. */
   var toggleBtn = grid.querySelector("#pane-raw-toggle");
   if (toggleBtn) {
     toggleBtn.addEventListener("click", function () {
@@ -572,11 +645,9 @@ function _renderActivityAgentDetail(a, grid) {
       toggleBtn.textContent = _paneShowRaw ? "Raw" : "Clean";
       var paneEl = grid.querySelector("#agent-detail-pane-content");
       if (paneEl) {
-        var rawPaneContent = pane
-          ? _paneShowRaw
-            ? pane
-            : _stripAnsi(pane)
-          : "";
+        var useFull = paneEl.getAttribute("data-pane-view") === "full";
+        var src = useFull ? paneFull : pane || "";
+        var rawPaneContent = src ? (_paneShowRaw ? src : _stripAnsi(src)) : "";
         paneEl.innerHTML = rawPaneContent
           ? escapeHtml(rawPaneContent)
           : '<span class="muted-cell">No terminal output available</span>';
@@ -584,7 +655,134 @@ function _renderActivityAgentDetail(a, grid) {
       }
     });
   }
+  _bindActivityPaneControls(grid, a.name, pane, paneFull);
   _bindActivityChannelControls(grid, a.name);
+}
+
+/* todo#47 — Refresh / Copy / Follow / Expand for the Agents-tab pane.
+ * Expand state + Follow state live in module vars so heartbeat-driven
+ * re-renders preserve them. */
+function _bindActivityPaneControls(grid, name, pane, paneFull) {
+  grid
+    .querySelectorAll('[data-act-pane-action="refresh"]')
+    .forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        ev.preventDefault();
+        btn.disabled = true;
+        var original = btn.textContent;
+        btn.textContent = "Refreshing…";
+        delete _activityDetailCache[name];
+        _fetchActivityDetail(name);
+        setTimeout(function () {
+          btn.disabled = false;
+          btn.textContent = original;
+        }, 1500);
+      });
+    });
+  grid
+    .querySelectorAll('[data-act-pane-action="copy"]')
+    .forEach(function (btn) {
+      btn.addEventListener("click", async function (ev) {
+        ev.preventDefault();
+        var pre = grid.querySelector("#agent-detail-pane-content");
+        var text = pre ? pre.textContent || "" : "";
+        try {
+          await navigator.clipboard.writeText(text);
+          var original = btn.textContent;
+          btn.textContent = "Copied";
+          setTimeout(function () {
+            btn.textContent = original;
+          }, 1200);
+        } catch (err) {
+          alert("Copy failed: " + err.message);
+        }
+      });
+    });
+  grid
+    .querySelectorAll('[data-act-pane-action="expand"]')
+    .forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        ev.preventDefault();
+        var pre = grid.querySelector("#agent-detail-pane-content");
+        if (!pre) return;
+        var view = pre.getAttribute("data-pane-view") || "short";
+        var nextView = view === "short" ? "full" : "short";
+        var src = nextView === "full" ? paneFull : pane || "";
+        var body = src ? (_paneShowRaw ? src : _stripAnsi(src)) : "";
+        pre.innerHTML = body
+          ? escapeHtml(body)
+          : '<span class="muted-cell">No terminal output available</span>';
+        pre.setAttribute("data-pane-view", nextView);
+        if (nextView === "full") {
+          _activityPaneExpanded[name] = true;
+          btn.textContent = "Collapse";
+          btn.classList.add("agent-detail-pane-btn-on");
+          btn.setAttribute("title", "Show short pane (~10 lines)");
+        } else {
+          _activityPaneExpanded[name] = false;
+          btn.textContent = "Expand";
+          btn.classList.remove("agent-detail-pane-btn-on");
+          btn.setAttribute("title", "Show ~500-line scrollback");
+        }
+        pre.scrollTop = pre.scrollHeight;
+      });
+    });
+  grid
+    .querySelectorAll('[data-act-pane-action="follow"]')
+    .forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        ev.preventDefault();
+        if (_activityFollowAgent === name) {
+          _stopActivityFollow();
+        } else {
+          _startActivityFollow(name);
+        }
+      });
+    });
+}
+
+function _stopActivityFollow() {
+  if (_activityFollowTimer != null) {
+    clearInterval(_activityFollowTimer);
+    _activityFollowTimer = null;
+  }
+  _activityFollowAgent = null;
+  document
+    .querySelectorAll('[data-act-pane-action="follow"]')
+    .forEach(function (b) {
+      b.classList.remove("agent-detail-pane-btn-on");
+      b.textContent = "Follow";
+      b.setAttribute(
+        "title",
+        "Poll /detail every " +
+          ACTIVITY_FOLLOW_INTERVAL_MS / 1000 +
+          "s for a live-tail feel",
+      );
+    });
+}
+
+function _startActivityFollow(name) {
+  _stopActivityFollow();
+  _activityFollowAgent = name;
+  document
+    .querySelectorAll(
+      '[data-act-pane-action="follow"][data-agent="' + name + '"]',
+    )
+    .forEach(function (b) {
+      b.classList.add("agent-detail-pane-btn-on");
+      b.textContent = "Following";
+      b.setAttribute("title", "Stop live-tail polling");
+    });
+  _activityFollowTimer = setInterval(function () {
+    if (!_activityFollowAgent) return;
+    if (typeof document !== "undefined" && document.hidden) return;
+    if (_activitySubTab !== _activityFollowAgent) {
+      _stopActivityFollow();
+      return;
+    }
+    delete _activityDetailCache[_activityFollowAgent];
+    _fetchActivityDetail(_activityFollowAgent);
+  }, ACTIVITY_FOLLOW_INTERVAL_MS);
 }
 
 async function _activityChannelRequest(method, agent, channel) {

--- a/hub/static/hub/agents-tab.js
+++ b/hub/static/hub/agents-tab.js
@@ -6,6 +6,12 @@ var _selectedAgentTab = "overview"; /* "overview" or agent name */
 var _lastAgentsData = []; /* cached for sub-tab renders */
 var _agentDetailCache = {}; /* name -> last /detail response */
 var _agentDetailInflight = {}; /* name -> bool (in-flight guard) */
+/* todo#47 — pane view state survives heartbeat-driven re-renders so
+ * Expand and Follow don't reset every poll. */
+var _paneExpanded = {}; /* name -> bool */
+var _followAgent = null; /* name currently in follow mode (only one) */
+var _followTimer = null; /* setInterval handle */
+var FOLLOW_INTERVAL_MS = 3000;
 
 /* Fetch the full per-agent detail payload (todo#420).
  *
@@ -78,7 +84,13 @@ function _bindSubTabBar(grid) {
   bar.addEventListener("click", function (e) {
     var btn = e.target.closest(".agent-subtab");
     if (!btn) return;
-    _selectedAgentTab = btn.getAttribute("data-subtab");
+    var nextTab = btn.getAttribute("data-subtab");
+    /* todo#47 — any agent switch (including → overview) cancels Follow
+     * so we're not polling an agent the user can no longer see. */
+    if (_followAgent && _followAgent !== nextTab) {
+      _stopFollow();
+    }
+    _selectedAgentTab = nextTab;
     /* Re-render content area only, not the whole tab (preserve scroll) */
     _renderAgentContent(grid);
   });
@@ -308,30 +320,62 @@ function _renderAgentDetail(a) {
     "</div>" +
     "</div>";
 
-  // todo#47 — Terminal output controls: Refresh / Copy / (optional)
-  // Expand. Expand only appears when the newer agent_meta.py push
-  // delivered pane_text_full. Buttons are data-hooked per-agent so
-  // multiple stacked detail panels don't collide.
+  // todo#47 — Terminal output controls: Refresh / Copy / Follow /
+  // (optional) Expand. Expand only appears when the newer
+  // agent_meta.py push delivered pane_text_full. Follow polls /detail
+  // every 3s for a live-tail feel. Buttons are data-hooked per-agent
+  // so multiple stacked detail panels don't collide.
+  var _isFollowing = _followAgent === a.name;
+  var _isExpanded = _paneExpanded[a.name] && paneFullAvailable;
   var paneLabel =
     'Terminal output <span class="agent-detail-pane-source">(' +
     escapeHtml(paneSource) +
     ")</span>" +
     '<span class="agent-detail-pane-controls">' +
     (paneFullAvailable
-      ? '<button type="button" class="agent-detail-pane-btn" ' +
-        'data-action="expand-pane" data-agent="' +
+      ? '<button type="button" class="agent-detail-pane-btn' +
+        (_isExpanded ? " agent-detail-pane-btn-on" : "") +
+        '" data-action="expand-pane" data-agent="' +
         escapeHtml(a.name) +
-        '" title="Show ~500-line scrollback">Expand</button>'
+        '" title="' +
+        (_isExpanded
+          ? "Show short pane (~10 lines)"
+          : "Show ~500-line scrollback") +
+        '">' +
+        (_isExpanded ? "Collapse" : "Expand") +
+        "</button>"
       : "") +
     '<button type="button" class="agent-detail-pane-btn" ' +
     'data-action="refresh-pane" data-agent="' +
     escapeHtml(a.name) +
     '" title="Force re-fetch of detail (pane + RTT + last action)">Refresh</button>' +
+    '<button type="button" class="agent-detail-pane-btn' +
+    (_isFollowing ? " agent-detail-pane-btn-on" : "") +
+    '" data-action="follow-pane" data-agent="' +
+    escapeHtml(a.name) +
+    '" title="' +
+    (_isFollowing
+      ? "Stop live-tail polling"
+      : "Poll /detail every " +
+        FOLLOW_INTERVAL_MS / 1000 +
+        "s for a live-tail feel") +
+    '">' +
+    (_isFollowing ? "Following" : "Follow") +
+    "</button>" +
     '<button type="button" class="agent-detail-pane-btn" ' +
     'data-action="copy-pane" data-agent="' +
     escapeHtml(a.name) +
     '" title="Copy pane text to clipboard">Copy</button>' +
     "</span>";
+  // Initial view honors preserved _paneExpanded so heartbeat re-renders
+  // don't snap the user back to the short view.
+  var _initialView = _isExpanded ? "full" : "short";
+  var _initialBody = _isExpanded
+    ? paneFull
+    : pane ||
+      '<span class="muted-cell">No terminal output available (pane_text_source=' +
+        paneSource +
+        ")</span>";
   var paneHtml =
     '<div class="agent-detail-pane-wrap">' +
     '<div class="agent-detail-pane-label">' +
@@ -343,9 +387,11 @@ function _renderAgentDetail(a) {
     escapeHtml(pane || "") +
     '" data-pane-full="' +
     escapeHtml(paneFull) +
-    '" data-pane-view="short">' +
-    (pane
-      ? escapeHtml(pane)
+    '" data-pane-view="' +
+    _initialView +
+    '">' +
+    (_isExpanded || pane
+      ? escapeHtml(_initialBody)
       : '<span class="muted-cell">No terminal output available (pane_text_source=' +
         escapeHtml(paneSource) +
         ")</span>") +
@@ -593,20 +639,22 @@ function _renderAgentContent(grid) {
  * button itself so there's no ambiguity when multiple agents are
  * stacked in the DOM. */
 function _bindPaneControls(content) {
-  content.querySelectorAll('[data-action="refresh-pane"]').forEach(function (btn) {
-    btn.addEventListener("click", function (ev) {
-      ev.preventDefault();
-      var name = btn.getAttribute("data-agent") || "";
-      if (!name) return;
-      btn.disabled = true;
-      btn.textContent = "Refreshing…";
-      _invalidateAgentDetail(name);
-      setTimeout(function () {
-        btn.disabled = false;
-        btn.textContent = "Refresh";
-      }, 1500);
+  content
+    .querySelectorAll('[data-action="refresh-pane"]')
+    .forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        ev.preventDefault();
+        var name = btn.getAttribute("data-agent") || "";
+        if (!name) return;
+        btn.disabled = true;
+        btn.textContent = "Refreshing…";
+        _invalidateAgentDetail(name);
+        setTimeout(function () {
+          btn.disabled = false;
+          btn.textContent = "Refresh";
+        }, 1500);
+      });
     });
-  });
   content.querySelectorAll('[data-action="copy-pane"]').forEach(function (btn) {
     btn.addEventListener("click", async function (ev) {
       ev.preventDefault();
@@ -631,29 +679,97 @@ function _bindPaneControls(content) {
   // todo#47 — Expand / Collapse between short and full scrollback.
   // The full pane is stashed on data-pane-full so no network round-
   // trip is needed to toggle. data-pane-view tracks which is shown.
-  content.querySelectorAll('[data-action="expand-pane"]').forEach(function (btn) {
-    btn.addEventListener("click", function (ev) {
-      ev.preventDefault();
-      var name = btn.getAttribute("data-agent") || "";
-      if (!name) return;
-      var pre = content.querySelector(
-        '.agent-detail-pane[data-agent="' + name + '"]',
-      );
-      if (!pre) return;
-      var view = pre.getAttribute("data-pane-view") || "short";
-      if (view === "short") {
-        pre.textContent = pre.getAttribute("data-pane-full") || "";
-        pre.setAttribute("data-pane-view", "full");
-        btn.textContent = "Collapse";
-        btn.setAttribute("title", "Show short pane (~10 lines)");
-      } else {
-        pre.textContent = pre.getAttribute("data-pane-short") || "";
-        pre.setAttribute("data-pane-view", "short");
-        btn.textContent = "Expand";
-        btn.setAttribute("title", "Show ~500-line scrollback");
-      }
+  // State is mirrored into _paneExpanded so heartbeat-driven re-renders
+  // don't snap the user back to the short view.
+  content
+    .querySelectorAll('[data-action="expand-pane"]')
+    .forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        ev.preventDefault();
+        var name = btn.getAttribute("data-agent") || "";
+        if (!name) return;
+        var pre = content.querySelector(
+          '.agent-detail-pane[data-agent="' + name + '"]',
+        );
+        if (!pre) return;
+        var view = pre.getAttribute("data-pane-view") || "short";
+        if (view === "short") {
+          pre.textContent = pre.getAttribute("data-pane-full") || "";
+          pre.setAttribute("data-pane-view", "full");
+          btn.textContent = "Collapse";
+          btn.classList.add("agent-detail-pane-btn-on");
+          btn.setAttribute("title", "Show short pane (~10 lines)");
+          _paneExpanded[name] = true;
+          pre.scrollTop = pre.scrollHeight;
+        } else {
+          pre.textContent = pre.getAttribute("data-pane-short") || "";
+          pre.setAttribute("data-pane-view", "short");
+          btn.textContent = "Expand";
+          btn.classList.remove("agent-detail-pane-btn-on");
+          btn.setAttribute("title", "Show ~500-line scrollback");
+          _paneExpanded[name] = false;
+        }
+      });
     });
-  });
+  // todo#47 — Follow: poll /detail every FOLLOW_INTERVAL_MS for a
+  // live-tail feel. Only one agent can follow at a time; switching
+  // agents or toggling off clears the timer. Hidden tab pauses so we
+  // don't keep hammering when the dashboard is in a background tab.
+  content
+    .querySelectorAll('[data-action="follow-pane"]')
+    .forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        ev.preventDefault();
+        var name = btn.getAttribute("data-agent") || "";
+        if (!name) return;
+        if (_followAgent === name) {
+          _stopFollow();
+        } else {
+          _startFollow(name);
+        }
+      });
+    });
+}
+
+function _stopFollow() {
+  if (_followTimer != null) {
+    clearInterval(_followTimer);
+    _followTimer = null;
+  }
+  _followAgent = null;
+  document
+    .querySelectorAll('[data-action="follow-pane"]')
+    .forEach(function (b) {
+      b.classList.remove("agent-detail-pane-btn-on");
+      b.textContent = "Follow";
+      b.setAttribute(
+        "title",
+        "Poll /detail every " +
+          FOLLOW_INTERVAL_MS / 1000 +
+          "s for a live-tail feel",
+      );
+    });
+}
+
+function _startFollow(name) {
+  _stopFollow();
+  _followAgent = name;
+  document
+    .querySelectorAll('[data-action="follow-pane"][data-agent="' + name + '"]')
+    .forEach(function (b) {
+      b.classList.add("agent-detail-pane-btn-on");
+      b.textContent = "Following";
+      b.setAttribute("title", "Stop live-tail polling");
+    });
+  _followTimer = setInterval(function () {
+    if (!_followAgent) return;
+    if (typeof document !== "undefined" && document.hidden) return;
+    if (_selectedAgentTab !== _followAgent) {
+      _stopFollow();
+      return;
+    }
+    _invalidateAgentDetail(_followAgent);
+  }, FOLLOW_INTERVAL_MS);
 }
 
 /* ── Channel subscription controls (Phase 3) ────────────────────────── */

--- a/hub/static/hub/components.css
+++ b/hub/static/hub/components.css
@@ -899,3 +899,17 @@
   opacity: 0.5;
   cursor: wait;
 }
+/* todo#47 — active/engaged state for toggle buttons (Follow, Expand).
+ * Teal fill matches the hover color and the RT lamp so the "this is
+ * live-updating" cue is consistent across the viewer. */
+.agent-detail-pane-btn-on,
+.agent-detail-pane-btn.agent-detail-pane-btn-on {
+  background: #4ecdc4;
+  border-color: #4ecdc4;
+  color: #fff;
+}
+.agent-detail-pane-btn-on:hover:not(:disabled) {
+  background: #3db5ac;
+  border-color: #3db5ac;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- **Follow** toggle on the agent-detail pane: polls /detail every 3 s so you see a live-tail of the agent's terminal without needing to click Refresh.
- **Expand** state now survives heartbeat-driven re-renders — no more snapping back to the short pane every 3 s. Lives in a module var (`_activityPaneExpanded`).
- Ports **Refresh / Copy / Expand** from the legacy `agents-tab.js` path into `activity-tab.js`, which is what actually renders the Agents tab today.
- Shared `.agent-detail-pane-btn-on` CSS makes active toggles match the RT-lamp teal.

## Design notes
- Read-only tier 4: no bidirectional keystroke path, so no auth/session design work is blocked on this PR.
- Only one agent follows at a time; sub-tab switch or `document.hidden` auto-stops the timer.
- The Raw/Clean toggle now re-renders against `pane_text_full` when Expand is on, so Raw doesn't silently fall back to the short tail.
- `agents-tab.js` kept in lockstep (still referenced by `dashboard.html`).

## Test plan
Verified live on `scitex-lab.scitex-orochi.com` via playwright, head-mba sub-tab:
- [x] Expand: button text flips to Collapse, `-btn-on` class applied, pane view=full, paneLen 620 chars (vs short)
- [x] Follow: 2 `/detail/` fetches in ~6 s while Following — 3 s cadence holds
- [x] Expand survived 2 Follow-driven re-renders
- [x] Switching to Overview clears `_activityFollowAgent` and the timer
- [x] `node --check activity-tab.js` clean
- [x] Deployed via docker-cp-via-SSH-stdin + Cloudflare purge; served md5 matches local

🤖 Generated with [Claude Code](https://claude.com/claude-code)