### PR TITLE
fix(agent-meta): forward hook-event ring buffer to hub (#187 / #59)

### DIFF
--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -132,6 +132,46 @@ def read_oauth_metadata(claude_json_path=None) -> dict:
     return result
 
 
+_HOOK_EVENT_KEYS = (
+    "recent_tools",
+    "recent_prompts",
+    "tool_counts",
+    "last_tool_name",
+    "last_tool_at",
+    "last_mcp_tool_name",
+    "last_mcp_tool_at",
+    "last_action_name",
+    "last_action_at",
+    "last_action_outcome",
+    "last_action_elapsed_s",
+    "p95_elapsed_s_by_action",
+)
+
+
+def _collect_hook_events(agent: str) -> dict:
+    """Read hook-event ring-buffer summary via scitex-agent-container.
+
+    scitex-orochi todo#187 / #59: the per-agent Last tool / Last MCP /
+    Last action rows stay empty because this heartbeat script never
+    pulled these fields from the hook-event ring buffer. Shell-out is
+    short-lived (<1 s) and bounded by ``timeout``; on any failure we
+    return an empty dict so the rest of the heartbeat still flows.
+    """
+    try:
+        proc = subprocess.run(
+            ["scitex-agent-container", "status", agent, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if proc.returncode != 0:
+            return {}
+        data = json.loads(proc.stdout or "{}")
+    except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
+        return {}
+    return {k: data[k] for k in _HOOK_EVENT_KEYS if k in data}
+
+
 def detect_multiplexer(agent: str) -> str:
     """Return 'tmux', 'screen', or '' if not found."""
     if (
@@ -1158,6 +1198,10 @@ def collect(agent: str) -> dict:
         # stuck-prompt text. Computed from pane_tail_block_clean below.
         "pane_state": _classify_pane_state(pane_tail_block_clean, pane),
         "stuck_prompt_text": _extract_stuck_prompt(pane_tail_block_clean, pane),
+        # scitex-orochi #187 / #59 — hook-event ring buffer summary
+        # from scitex-agent-container. Unpacked as top-level keys so
+        # push_all()'s whitelist can forward each one verbatim.
+        **_collect_hook_events(agent),
         "runtime": "claude-code",
         "version": os.environ.get("SCITEX_OROCHI_AGENT_META_VERSION", "0.1"),
         # Machine resource snapshot (todo#329 — Machines tab populate).
@@ -1337,6 +1381,24 @@ def push_all(url=None, token=None) -> int:
                 "pane_tail_full": meta.get("pane_tail_full", ""),
                 "pane_state": meta.get("pane_state", ""),
                 "stuck_prompt_text": meta.get("stuck_prompt_text", ""),
+                # scitex-orochi #187 / #59 — forward the hook-event
+                # ring buffer summary so the Agents tab's Last tool /
+                # Last MCP / Last action rows populate. Without this,
+                # collect() gathers them but the whitelist drops them
+                # before they reach the hub (same trap as #232 for
+                # pane_tail_full).
+                "recent_tools": meta.get("recent_tools") or [],
+                "recent_prompts": meta.get("recent_prompts") or [],
+                "tool_counts": meta.get("tool_counts") or {},
+                "last_tool_name": meta.get("last_tool_name") or "",
+                "last_tool_at": meta.get("last_tool_at") or "",
+                "last_mcp_tool_name": meta.get("last_mcp_tool_name") or "",
+                "last_mcp_tool_at": meta.get("last_mcp_tool_at") or "",
+                "last_action_name": meta.get("last_action_name") or "",
+                "last_action_at": meta.get("last_action_at") or "",
+                "last_action_outcome": meta.get("last_action_outcome") or "",
+                "last_action_elapsed_s": meta.get("last_action_elapsed_s"),
+                "p95_elapsed_s_by_action": meta.get("p95_elapsed_s_by_action") or {},
             }
             # todo#265: merge OAuth account public metadata into the
             # heartbeat payload. All 9 keys are whitelist-extracted

--- a/scripts/client/agent_meta.py
+++ b/scripts/client/agent_meta.py
@@ -145,6 +145,13 @@ _HOOK_EVENT_KEYS = (
     "last_action_outcome",
     "last_action_elapsed_s",
     "p95_elapsed_s_by_action",
+    # scitex-orochi #132 — subagent activity. agent_calls is the
+    # projected Agent/Task tool-invocation ring buffer; subagents is
+    # the in-flight list with descriptions; background_tasks is
+    # run_in_background Bash calls.
+    "agent_calls",
+    "background_tasks",
+    "subagents",
 )
 
 
@@ -1399,6 +1406,12 @@ def push_all(url=None, token=None) -> int:
                 "last_action_outcome": meta.get("last_action_outcome") or "",
                 "last_action_elapsed_s": meta.get("last_action_elapsed_s"),
                 "p95_elapsed_s_by_action": meta.get("p95_elapsed_s_by_action") or {},
+                # scitex-orochi #132 — subagent activity for the
+                # Agents tab AGENT CALLS / BACKGROUND TASKS panels
+                # and the active-subagent badge.
+                "agent_calls": meta.get("agent_calls") or [],
+                "background_tasks": meta.get("background_tasks") or [],
+                "subagents": meta.get("subagents") or [],
             }
             # todo#265: merge OAuth account public metadata into the
             # heartbeat payload. All 9 keys are whitelist-extracted


### PR DESCRIPTION
## Summary
- Root-cause fix for #187 sub-issue 1: \"Agents tab shows everyone as 'not moving'\". Last tool / Last MCP / Last action were blank on every agent because the push script in \`scripts/client/agent_meta.py\` never pulled the hook-event ring buffer from \`scitex-agent-container status --json\`.
- Mirror of the PR #232 fix pattern (pane_tail_full was in collect() but dropped by push_all whitelist). collect() and push_all maintain independent field lists; the whitelist is the bottleneck.

## Change
1. New \`_collect_hook_events(agent)\` helper — 5s-bounded shell-out to \`scitex-agent-container status <agent> --json\`, returns the 12 whitelisted keys (\`recent_tools\`, \`recent_prompts\`, \`tool_counts\`, \`last_tool_name/at\`, \`last_mcp_tool_name/at\`, \`last_action_name/at/outcome/elapsed_s\`, \`p95_elapsed_s_by_action\`). Empty dict on any failure.
2. Unpacked into collect()'s return dict (\`**_collect_hook_events(agent)\`).
3. Added all 12 keys to push_all()'s wire whitelist.

Hub-side \`api_agents_register\` already reads these fields from the POST body (hub/views/api.py:1887–1906), and \`register_agent\` already has prev-preserve semantics for them (hub/registry.py:155–219). No hub changes needed.

## Test plan
Verified end-to-end on local ywata-note-win fleet:
- [x] Fired manual \`scitex-agent-container hook-event pretool --agent head-ywata-note-win\` — ring buffer captures the event.
- [x] Ran \`agent_meta.py --push\` manually → 9 agents pushed, 200 OK.
- [x] \`fetch('/api/agents/registry')\` returns for head-ywata-note-win:
  - recent_tools=7, last_tool_name='Bash', last_tool_at populated
  - tool_counts={'Read':2,'Agent':2,'Bash':3}
- [x] Dashboard screenshot: \"Last tool: 6m ago (Bash)\" now populates, Recent Tools panel shows 7 events with input previews (Bash — echo test, Bash — long build, Agent — scan fleet, Read — /etc/hosts, …).

## Deploy
Hosts pick up the fix on next \`git pull\` of scitex-orochi. The launchd/systemd daemons respawn agent_meta.py within ~30s and the first heartbeat after that carries the hook fields. No hub restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)