### PR TITLE
fix(hub/auth): drop client-supplied channels in register frame (#251)

### DIFF
--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -17,13 +17,20 @@ from ._helpers import _load_agent_channel_subs, _persist_agent_subscription
 
 
 async def handle_register(consumer, content):
-    """Hydrate channel subscriptions + agent metadata, then announce."""
+    """Hydrate channel subscriptions + agent metadata, then announce.
+
+    Subscription state is sourced **only** from the persisted
+    ``ChannelMembership`` rows. Client-supplied ``channels`` arrays in the
+    register frame (``content["channels"]`` / ``payload["channels"]``) are
+    **ignored** — accepting them would let any agent opt itself into any
+    channel by self-declaration, bypassing the ACL gate on subscribe.
+    Fix for scitex-orochi#251 (private-channel delivery leak).
+    """
     payload = content.get("payload", {})
-    legacy_channels = list(content.get("channels") or payload.get("channels", []) or [])
     persisted = await _load_agent_channel_subs(
         consumer.workspace_id, consumer.agent_name
     )
-    channels = list(dict.fromkeys([*persisted, *legacy_channels]))
+    channels = list(persisted)
     # Spec v3 §3.1 — DM channels auto-subscribed at connect must also
     # appear in agent_meta["channels"] so the chat_message filter
     # forwards DM events.


### PR DESCRIPTION
## Summary

Closes #251 — ACL bypass where agents could self-declare into private channels by including a `channels` array in the WebSocket register frame.

## The bug

`hub/consumers/_agent_handlers.py::handle_register` previously merged client-supplied channel names with the persisted ChannelMembership rows:

```python
legacy_channels = list(content.get("channels") or payload.get("channels", []) or [])
persisted = await _load_agent_channel_subs(...)
channels = list(dict.fromkeys([*persisted, *legacy_channels]))   # ← bypass
```

Result: an agent could post into `#ywatanabe` (private) just by sending `"channels": ["#ywatanabe"]` at register time, without going through the subscribe ACL gate.

## The fix

Source channels **only** from persisted ChannelMembership. Drop the client-supplied array silently.

## Compatibility

If any agent today relies on declaring channels via register frame, it will lose those subscriptions until they're created via the subscribe REST/MCP path. That migration is one call per channel and is the correct path anyway.

## Test plan

- [x] Existing test suite green (no test was asserting the legacy-merge behavior — it was a security hole, not a feature).
- [ ] Manual: deploy + verify agents see only their persisted memberships in dashboard.

Generated with Claude Code