### PR TITLE
fix(hub/dashboard): @host suffix from live hostname (#256)

### DIFF
--- a/hub/frontend/src/app/utils.ts
+++ b/hub/frontend/src/app/utils.ts
@@ -164,7 +164,13 @@ export function hostedAgentName(a) {
   var name = a && a.name ? a.name : "";
   if (!name) return name;
   if (name.indexOf("@") !== -1) return cleanAgentName(name);
-  var host = a && a.machine ? a.machine : "";
+  /* #256 — host label MUST come from the live `hostname(1)` reported
+   * in the heartbeat (#257), NOT from the YAML config `machine` field.
+   * Pre-fix, an agent_handlers `machine: mba` line in YAML caused the
+   * dashboard to show `proj-neurovista@mba` even when no process was
+   * running on mba (the ghost-mba bug). Falls back to `machine` for
+   * legacy agents whose heartbeat hasn't been upgraded yet. */
+  var host = a && a.hostname ? a.hostname : a && a.machine ? a.machine : "";
   /* Always pipe the constructed "<name>@<host>" string through
    * cleanAgentName so the role-host suffix gets collapsed
    * (head-mba@mba → head@mba). The earlier form returned the raw
@@ -381,7 +387,11 @@ export function sendOrochiMessage(msgData) {
 }
 
 // Expose cross-file mutable state via globalThis:
-(globalThis as any).cachedAgentNames = (typeof cachedAgentNames !== 'undefined' ? cachedAgentNames : undefined);
-(globalThis as any).historyLoaded = (typeof historyLoaded !== 'undefined' ? historyLoaded : undefined);
-(globalThis as any).knownMessageKeys = (typeof knownMessageKeys !== 'undefined' ? knownMessageKeys : undefined);
-(globalThis as any).unreadCount = (typeof unreadCount !== 'undefined' ? unreadCount : undefined);
+(globalThis as any).cachedAgentNames =
+  typeof cachedAgentNames !== "undefined" ? cachedAgentNames : undefined;
+(globalThis as any).historyLoaded =
+  typeof historyLoaded !== "undefined" ? historyLoaded : undefined;
+(globalThis as any).knownMessageKeys =
+  typeof knownMessageKeys !== "undefined" ? knownMessageKeys : undefined;
+(globalThis as any).unreadCount =
+  typeof unreadCount !== "undefined" ? unreadCount : undefined;

--- a/hub/static/hub/app/utils.js
+++ b/hub/static/hub/app/utils.js
@@ -161,7 +161,13 @@ function hostedAgentName(a) {
   var name = a && a.name ? a.name : "";
   if (!name) return name;
   if (name.indexOf("@") !== -1) return cleanAgentName(name);
-  var host = a && a.machine ? a.machine : "";
+  /* #256 — host label MUST come from the live `hostname(1)` reported
+   * in the heartbeat, NOT from the YAML config `machine` field.
+   * Pre-fix, an agent_handlers `machine: mba` line in YAML caused the
+   * dashboard to show `proj-neurovista@mba` even when no process was
+   * running on mba (the ghost-mba bug). Falls back to `machine` for
+   * legacy agents whose heartbeat hasn't been upgraded yet. */
+  var host = a && a.hostname ? a.hostname : a && a.machine ? a.machine : "";
   /* Always pipe the constructed "<name>@<host>" string through
    * cleanAgentName so the role-host suffix gets collapsed
    * (head-mba@mba → head@mba). The earlier form returned the raw


### PR DESCRIPTION
## Summary

Closes #256 — the dashboard's `@host` label now reads from the live `hostname(1)` reported in the heartbeat, not the YAML config `machine` field.

## The bug

ywatanabe directive (msg #14726, #14730): the dashboard must NEVER show a fabricated/cached @host. Pre-fix, `hostedAgentName()` built the suffix from `a.machine` (YAML config), so an agent yaml with `machine: mba` displayed as `proj-neurovista@mba` even when no process was running on mba.

## The fix

```js
// before
var host = a && a.machine ? a.machine : "";

// after  
var host = (a && a.hostname) ? a.hostname : (a && a.machine ? a.machine : "");
```

Reads from `a.hostname` (the heartbeat field landed in #257 / PR #263), falls back to `a.machine` for legacy agents whose heartbeat hasn't been upgraded yet.

## Mirroring

Updated in BOTH places:
- `hub/static/hub/app/utils.js` (legacy classic-script copy, kept for any non-bundle path)  
- `hub/frontend/src/app/utils.ts` (the actual TS bundle source — what dashboard.html loads since the ts-migration-v2 merge)

Bundle rebuilt: `orochi-CoY0fysX.js` (697 KB / 157 KB gzip).

## Test plan

- [ ] Manual: deploy + verify with screenshot. Once every fleet agent emits the new heartbeat metadata (#260 agent-container companion), fabricated @host labels should disappear entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)