### PR TITLE
feat(hub/dashboard): agent detail pane shows canonical heartbeat metadata (#261)

### DIFF
--- a/hub/frontend/src/activity-tab/detail.ts
+++ b/hub/frontend/src/activity-tab/detail.ts
@@ -103,9 +103,37 @@ export function _renderActivityAgentDetail(a, grid) {
     _rawModel.charAt(_rawModel.length - 1) === ">"
       ? "—"
       : _rawModel || "-";
+  /* #257 + #261: surface the canonical heartbeat metadata. See the
+   * matching block in hub/static/hub/activity-tab/detail.js. */
+  var _launchSigil = {
+    "sac": "🤖 sac",
+    "sac-ssh": "🛰 sac-ssh",
+    "sbatch": "💼 sbatch",
+    "manual-tmux": "👤 tmux",
+    "manual-direct": "👤 direct",
+    "unknown": "?",
+  };
+  var _launchDisplay = a.launch_method
+    ? (_launchSigil[a.launch_method] || a.launch_method)
+    : "-";
+  var _instanceShort = a.instance_id
+    ? String(a.instance_id).slice(0, 8) + "…"
+    : "-";
+  var _proxyDisplay = a.is_proxy
+    ? "yes (rank " + (a.priority_rank != null ? a.priority_rank : "?") + ")"
+    : (a.priority_rank === 0 ? "no (primary)" : "-");
+  var _priorityListDisplay = (a.priority_list && a.priority_list.length)
+    ? a.priority_list.join(" → ")
+    : "-";
   var metaFields = [
     ["Role", a.role || "agent"],
     ["Machine", _machineDisplay],
+    ["Hostname", a.hostname || "-"],
+    ["Uname", a.uname || "-"],
+    ["Instance", _instanceShort],
+    ["Launch", _launchDisplay],
+    ["Proxy?", _proxyDisplay],
+    ["Priority list", _priorityListDisplay],
     ["Model", _modelDisplay],
     ["Multiplexer", a.multiplexer || "-"],
     ["PID", a.pid || "-"],

--- a/hub/static/hub/activity-tab/detail.js
+++ b/hub/static/hub/activity-tab/detail.js
@@ -95,9 +95,44 @@ function _renderActivityAgentDetail(a, grid) {
     _rawModel.charAt(_rawModel.length - 1) === ">"
       ? "—"
       : _rawModel || "-";
+  /* #257 + #261: surface the canonical heartbeat metadata so humans
+   * scanning the detail pane can verify "where am I really running"
+   * at a glance. `Hostname` is the live hostname(1); distinct from
+   * `Machine` (the YAML config label). `Instance` truncates the UUID
+   * to 8 chars (full UUID is in dev tools). `Launch` renders as a
+   * sigil so sac vs manual is obvious. Empty fields collapse to "-"
+   * for legacy agents that haven't been upgraded yet. */
+  var _launchSigil = {
+    "sac": "🤖 sac",
+    "sac-ssh": "🛰 sac-ssh",
+    "sbatch": "💼 sbatch",
+    "manual-tmux": "👤 tmux",
+    "manual-direct": "👤 direct",
+    "unknown": "?",
+  };
+  var _launchDisplay = a.launch_method
+    ? (_launchSigil[a.launch_method] || a.launch_method)
+    : "-";
+  var _instanceShort = a.instance_id
+    ? String(a.instance_id).slice(0, 8) + "…"
+    : "-";
+  var _proxyDisplay = a.is_proxy
+    ? "yes (rank " + (a.priority_rank != null ? a.priority_rank : "?") + ")"
+    : (a.priority_rank === 0 ? "no (primary)" : "-");
+  var _priorityListDisplay = (a.priority_list && a.priority_list.length)
+    ? a.priority_list.join(" → ")
+    : "-";
   var metaFields = [
     ["Role", a.role || "agent"],
     ["Machine", _machineDisplay],
+    /* Live hostname(1). When this disagrees with Machine, the agent
+     * yaml is misconfigured (or the agent moved hosts). */
+    ["Hostname", a.hostname || "-"],
+    ["Uname", a.uname || "-"],
+    ["Instance", _instanceShort],
+    ["Launch", _launchDisplay],
+    ["Proxy?", _proxyDisplay],
+    ["Priority list", _priorityListDisplay],
     ["Model", _modelDisplay],
     ["Multiplexer", a.multiplexer || "-"],
     ["PID", a.pid || "-"],


### PR DESCRIPTION
## Summary

Closes the agent-detail-pane half of #261 — surfaces the new heartbeat metadata fields from #257 in the per-agent detail pane.

New rows in the meta-fields list:

- **Hostname** — live `hostname(1)` of the running process
- **Uname** — `uname -a` output  
- **Instance** — UUID truncated to 8 chars
- **Launch** — sigil + label (sac / tmux / sbatch / direct)
- **Proxy?** — yes (rank N) or no (primary)
- **Priority list** — host: list joined with arrows

Empty fields collapse to `-` for legacy agents whose heartbeat hasn't been upgraded yet (no agent-container PR yet).

## Mirroring

Updated in BOTH places:
- `hub/static/hub/activity-tab/detail.js` (legacy classic-script copy)
- `hub/frontend/src/activity-tab/detail.ts` (TS bundle source — what dashboard.html actually loads since the ts-migration-v2 merge)

Bundle rebuilt: `orochi-2ZAbXD3Z.js` (698 KB / 158 KB gzip).

## Test plan

- [x] Bundle builds clean.
- [ ] Manual: deploy + open per-agent detail pane on dashboard, confirm new rows render. For legacy agents, all 6 new rows should show `-`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)