### PR TITLE
feat(hub/observability): 4th echo-roundtrip indicator end-to-end (#259)

### DIFF
--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -23,6 +23,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 
 from ._agent_handlers import (
+    handle_echo_pong,
     handle_heartbeat,
     handle_pong,
     handle_register,
@@ -30,6 +31,7 @@ from ._agent_handlers import (
     handle_subscription,
     handle_task_update,
 )
+from ._echo import _hub_echo_loop
 from ._groups import _hub_ping_loop, _sanitize_group, log
 from ._helpers import (
     _ensure_agent_member,
@@ -123,12 +125,19 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         # live RTT and flag hub-side drops without waiting for the 30s
         # heartbeat-stale timeout.
         self._ping_task = asyncio.create_task(_hub_ping_loop(self))
+        # #259 — start hub→agent echo round-trip loop. Independent task
+        # so a transport hiccup in one loop can't starve the other.
+        # Cancelled in disconnect() alongside _ping_task.
+        self._echo_task = asyncio.create_task(_hub_echo_loop(self))
 
     async def disconnect(self, code):
         # Stop the ping task first so we don't race with the WS close.
         ping_task = getattr(self, "_ping_task", None)
         if ping_task is not None:
             ping_task.cancel()
+        echo_task = getattr(self, "_echo_task", None)
+        if echo_task is not None:
+            echo_task.cancel()
         if hasattr(self, "workspace_group"):
             # scitex-orochi#144 fix path 4: drop only THIS connection from
             # the per-agent set, not the whole agent record. The agent only
@@ -173,6 +182,8 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             )
         elif msg_type == "pong":
             await handle_pong(self, content)
+        elif msg_type == "echo_pong":
+            await handle_echo_pong(self, content)
         elif msg_type == "heartbeat":
             await handle_heartbeat(self, content)
         elif msg_type == "task_update":

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -157,6 +157,33 @@ async def handle_pong(consumer, content):
         )
 
 
+async def handle_echo_pong(consumer, content):
+    """Lookup the nonce, compute RTT, update echo registry fields (#259).
+
+    The hub publisher (in ``_echo._hub_echo_loop``) keeps a per-consumer
+    ``_echo_inflight`` dict mapping nonce -> sent_at. A matching
+    ``echo_pong`` frame yields the round-trip time and triggers
+    ``update_echo_pong``, which is what flips the 4th LED green.
+
+    Unknown nonces are dropped silently — they happen naturally on
+    reconnects (publisher state is per-consumer, lost on disconnect)
+    and shouldn't disturb the dashboard or log noise.
+    """
+    nonce = content.get("nonce")
+    if not isinstance(nonce, str) or not nonce:
+        return
+    inflight = getattr(consumer, "_echo_inflight", None)
+    if not inflight:
+        return
+    sent_at = inflight.pop(nonce, None)
+    if sent_at is None:
+        return
+    rtt_ms = max(0.0, (time.time() - float(sent_at)) * 1000.0)
+    from hub.registry import update_echo_pong
+
+    update_echo_pong(consumer.agent_name, rtt_ms)
+
+
 async def handle_heartbeat(consumer, content):
     """Persist resource metrics + optional narrative fields, then broadcast."""
     payload = content.get("payload", {})

--- a/hub/consumers/_echo.py
+++ b/hub/consumers/_echo.py
@@ -1,0 +1,120 @@
+"""Hub→agent echo round-trip publisher loop (#259, indicator #4).
+
+Periodically sends a `{"type":"echo","nonce":"<uuid>"}` frame to every
+connected agent. The agent's MCP-channel WebSocket client auto-replies
+with `{"type":"echo_pong","nonce":"<same>","ts":<unix>}` (handled at
+the WS-client layer — *not* a Claude round-trip).
+
+The hub measures round-trip time, records ``last_echo_rtt_ms`` +
+``last_echo_ok_ts`` + ``last_nonce_echo_at`` on the agent's registry
+entry. The Agents-tab LED renderer (``renderAgentLeds`` in
+``hub/static/hub/agent-badge.js``) reads ``last_nonce_echo_at`` and
+flips the 4th LED from grey-dashed "pending" to green / yellow / red
+based on age, with no further frontend changes.
+
+Cadence is configurable via the ``OROCHI_ECHO_INTERVAL_SECONDS``
+environment variable (default 30s — matched to the existing
+``_hub_ping_loop`` cadence so a complete loss is noticed by both
+indicators within one cycle, not two).
+
+Backward-compatible: agents that never echo back keep functioning
+(their 4th LED stays grey-pending). We never disconnect on a missing
+echo. Unknown nonces in inbound ``echo_pong`` frames are dropped
+silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+import uuid
+
+log = logging.getLogger("orochi.consumers")
+
+
+def _read_interval_seconds() -> int:
+    """Read the publisher cadence from the environment (default 30s).
+
+    Constrained to a sane range — we don't want a misconfigured env
+    var to flood the WS or, conversely, push the cadence above the
+    LED's "stale" threshold (90s) and make every agent appear yellow.
+    """
+    raw = os.environ.get("OROCHI_ECHO_INTERVAL_SECONDS", "30")
+    try:
+        v = int(raw)
+    except (TypeError, ValueError):
+        v = 30
+    if v < 5:
+        v = 5
+    if v > 60:
+        v = 60
+    return v
+
+
+ECHO_INTERVAL_SECONDS = _read_interval_seconds()
+
+# Bound on the per-agent in-flight nonce dict. Each entry is small
+# (uuid + float) but unbounded growth would be a slow leak if an agent
+# never replies. The cap is deliberately ~10× the expected steady-state
+# in-flight count so transient bursts (network hiccups) don't evict
+# legitimate replies.
+MAX_INFLIGHT_NONCES = 32
+
+# Drop nonces older than this many seconds — we'll never accept a pong
+# that took longer than this anyway, and stale entries are pure noise
+# in the in-flight dict.
+NONCE_EXPIRY_SECONDS = 120
+
+
+def _prune_expired(inflight: dict[str, float], now: float) -> None:
+    """Remove entries older than NONCE_EXPIRY_SECONDS from inflight dict."""
+    expired = [
+        nonce
+        for nonce, sent_at in inflight.items()
+        if now - sent_at > NONCE_EXPIRY_SECONDS
+    ]
+    for n in expired:
+        inflight.pop(n, None)
+
+
+async def _hub_echo_loop(consumer) -> None:
+    """Send periodic ``{"type":"echo","nonce":"<uuid>"}`` frames.
+
+    Runs for the lifetime of the WebSocket connection. Cancelled from
+    ``AgentConsumer.disconnect``. Exceptions other than
+    ``CancelledError`` are logged and swallowed so a publisher crash
+    cannot tear down the consumer (matches ``_hub_ping_loop`` semantics).
+
+    The per-consumer in-flight nonce dict (``_echo_inflight``) is
+    initialised lazily here so the consumer's ``__init__`` doesn't need
+    to know about it. It's read by ``handle_echo_pong`` to compute RTT.
+    """
+    if not hasattr(consumer, "_echo_inflight"):
+        consumer._echo_inflight = {}
+    inflight: dict[str, float] = consumer._echo_inflight
+
+    try:
+        while True:
+            await asyncio.sleep(ECHO_INTERVAL_SECONDS)
+            now = time.time()
+            _prune_expired(inflight, now)
+            # If we've hit the cap, evict the oldest entry so a single
+            # silent agent can't permanently lock new probes out.
+            if len(inflight) >= MAX_INFLIGHT_NONCES:
+                oldest = min(inflight, key=inflight.get)
+                inflight.pop(oldest, None)
+
+            nonce = uuid.uuid4().hex
+            inflight[nonce] = now
+            try:
+                await consumer.send_json({"type": "echo", "nonce": nonce})
+            except Exception:  # noqa: BLE001
+                log.exception(
+                    "echo send failed for %s",
+                    getattr(consumer, "agent_name", "?"),
+                )
+                return
+    except asyncio.CancelledError:
+        raise

--- a/hub/registry/__init__.py
+++ b/hub/registry/__init__.py
@@ -31,6 +31,7 @@ from ._heartbeat import (
     set_health,
     set_subagent_count,
     set_subagents,
+    update_echo_pong,
     update_heartbeat,
     update_pong,
 )
@@ -76,6 +77,7 @@ __all__ = [
     # Heartbeat / activity / health setters
     "update_heartbeat",
     "update_pong",
+    "update_echo_pong",
     "mark_activity",
     "set_current_task",
     "set_subagents",

--- a/hub/registry/_heartbeat.py
+++ b/hub/registry/_heartbeat.py
@@ -145,3 +145,29 @@ def update_pong(name: str, rtt_ms: float) -> None:
         if name in _agents:
             _agents[name]["last_pong_ts"] = time.time()
             _agents[name]["last_rtt_ms"] = float(rtt_ms)
+
+
+def update_echo_pong(name: str, rtt_ms: float) -> None:
+    """Record an agent's echo round-trip pong (#259, indicator #4).
+
+    Sets three fields:
+
+    - ``last_echo_rtt_ms`` — most recent echo RTT in milliseconds.
+    - ``last_echo_ok_ts``  — wall time of the most recent successful
+      echo (unix seconds, float). Used by the API/payload layer.
+    - ``last_nonce_echo_at`` — ISO-8601 string of the same instant,
+      consumed directly by the Agents-tab LED renderer
+      (``renderAgentLeds`` reads ``a.last_nonce_echo_at``).
+
+    All three are written atomically so a partial update can't leave
+    the LED rendering off a fresher timestamp than the RTT it cites.
+    """
+    from datetime import datetime, timezone
+
+    now = time.time()
+    iso_now = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+    with _lock:
+        if name in _agents:
+            _agents[name]["last_echo_rtt_ms"] = float(rtt_ms)
+            _agents[name]["last_echo_ok_ts"] = now
+            _agents[name]["last_nonce_echo_at"] = iso_now

--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -129,6 +129,20 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                     else None
                 ),
                 "last_rtt_ms": a.get("last_rtt_ms"),
+                # #259 — 4th-indicator (Remote / nonce-echo) round-trip
+                # data for the dashboard. ``last_nonce_echo_at`` is the
+                # field the LED renderer reads (already wired in
+                # agent-badge.js); the other two surface RTT + raw unix
+                # timestamp for tooling and the per-agent detail page.
+                "last_nonce_echo_at": a.get("last_nonce_echo_at"),
+                "last_echo_rtt_ms": a.get("last_echo_rtt_ms"),
+                "last_echo_ok_ts": (
+                    datetime.fromtimestamp(
+                        a["last_echo_ok_ts"], tz=timezone.utc
+                    ).isoformat()
+                    if a.get("last_echo_ok_ts")
+                    else None
+                ),
                 "last_action": (
                     datetime.fromtimestamp(action_ts, tz=timezone.utc).isoformat()
                     if action_ts

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -138,6 +138,18 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             # lamp flickered to gray 1× per 30s heartbeat cycle.
             "last_pong_ts": prev.get("last_pong_ts"),
             "last_rtt_ms": prev.get("last_rtt_ms"),
+            # #259 — preserve echo round-trip state across re-registers.
+            # Same prev-preserve pitfall as the ping/pong fields above:
+            # if these were dropped on every heartbeat, the 4th LED
+            # (Remote/echo) would flicker to grey-pending at the
+            # heartbeat cadence even when the echo path is live. The
+            # fields are written by ``update_echo_pong()`` (in
+            # ``_heartbeat.py``) when an ``echo_pong`` frame lands, and
+            # are surfaced in the API by ``_payload.get_agents()`` /
+            # ``hub/views/agent_detail.py``.
+            "last_echo_rtt_ms": prev.get("last_echo_rtt_ms"),
+            "last_echo_ok_ts": prev.get("last_echo_ok_ts"),
+            "last_nonce_echo_at": prev.get("last_nonce_echo_at"),
             # Extended process/runtime metadata pushed by agent_meta.py --push.
             # Optional; absent for legacy WS-only agents.
             "pid": info.get("pid") or prev.get("pid") or 0,

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -23,6 +23,7 @@ from hub.tests.models.test_messaging import *  # noqa: F401,F403
 from hub.tests.models.test_reexports import *  # noqa: F401,F403
 from hub.tests.registry.test_active_sessions import *  # noqa: F401,F403
 from hub.tests.registry.test_canonical_metadata import *  # noqa: F401,F403
+from hub.tests.registry.test_echo_indicator import *  # noqa: F401,F403
 from hub.tests.registry.test_heartbeat import *  # noqa: F401,F403
 from hub.tests.registry.test_reexports import *  # noqa: F401,F403
 from hub.tests.test_auth import *  # noqa: F401,F403

--- a/hub/tests/registry/test_echo_indicator.py
+++ b/hub/tests/registry/test_echo_indicator.py
@@ -1,0 +1,198 @@
+"""Tests for the 4th liveness indicator — echo round-trip (#259).
+
+Covers the registry-side contract for the new echo fields:
+
+  - ``update_echo_pong(name, rtt_ms)`` populates the three fields
+    (``last_echo_rtt_ms`` / ``last_echo_ok_ts`` / ``last_nonce_echo_at``)
+    atomically.
+  - The prev-preserve list in ``register_agent`` keeps those fields
+    across re-registers / heartbeats that omit them, so the 4th LED
+    doesn't flicker grey-pending each cycle (per the prev-preserve
+    pitfall memory).
+  - ``GET /api/agents/<name>/detail/`` surfaces the new fields in the
+    response so the dashboard's per-agent detail panel can display
+    them without a second round-trip.
+"""
+
+import json
+import time
+
+from django.test import Client, TestCase
+
+from hub.models import Workspace, WorkspaceToken
+
+
+class UpdateEchoPongRegistryTests(TestCase):
+    """Verify the registry setter writes all three fields atomically."""
+
+    def setUp(self):
+        from hub.registry import _agents, _connections
+
+        _agents.clear()
+        _connections.clear()
+        self.ws = Workspace.objects.create(name="echo-test-ws")
+
+    def _seed_agent(self, name="echo-agent"):
+        from hub.registry import register_agent
+
+        register_agent(
+            name,
+            self.ws.id,
+            {
+                "agent_id": name,
+                "machine": "MBA",
+                "role": "head",
+            },
+        )
+
+    def test_update_echo_pong_sets_all_three_fields(self):
+        from hub.registry import _agents, update_echo_pong
+
+        self._seed_agent()
+        before = time.time()
+        update_echo_pong("echo-agent", 42.5)
+        after = time.time()
+
+        a = _agents["echo-agent"]
+        self.assertEqual(a["last_echo_rtt_ms"], 42.5)
+        self.assertIsNotNone(a["last_echo_ok_ts"])
+        self.assertGreaterEqual(a["last_echo_ok_ts"], before)
+        self.assertLessEqual(a["last_echo_ok_ts"], after)
+        # The ISO timestamp consumed by renderAgentLeds must be set
+        # — this is the field the LED renderer pins on.
+        self.assertIsInstance(a["last_nonce_echo_at"], str)
+        self.assertTrue(a["last_nonce_echo_at"].endswith("+00:00"))
+
+    def test_update_echo_pong_unknown_agent_is_silent_noop(self):
+        """An echo_pong for an unknown agent must not raise / corrupt state."""
+        from hub.registry import _agents, update_echo_pong
+
+        update_echo_pong("never-registered", 17.0)
+        self.assertNotIn("never-registered", _agents)
+
+    def test_register_agent_preserves_echo_fields_across_heartbeat(self):
+        """A subsequent register/heartbeat that omits echo fields must NOT
+        wipe them. This is the prev-preserve pitfall — without it, every
+        heartbeat would flicker the 4th LED to grey-pending."""
+        from hub.registry import _agents, register_agent, update_echo_pong
+
+        self._seed_agent()
+        update_echo_pong("echo-agent", 55.0)
+        snapshot = {
+            "last_echo_rtt_ms": _agents["echo-agent"]["last_echo_rtt_ms"],
+            "last_echo_ok_ts": _agents["echo-agent"]["last_echo_ok_ts"],
+            "last_nonce_echo_at": _agents["echo-agent"]["last_nonce_echo_at"],
+        }
+
+        # Simulate a re-register (e.g. WS reconnect) that doesn't carry
+        # the echo fields — they must survive.
+        register_agent(
+            "echo-agent",
+            self.ws.id,
+            {
+                "agent_id": "echo-agent",
+                "machine": "MBA",
+                "role": "head",
+            },
+        )
+
+        a = _agents["echo-agent"]
+        self.assertEqual(a["last_echo_rtt_ms"], snapshot["last_echo_rtt_ms"])
+        self.assertEqual(a["last_echo_ok_ts"], snapshot["last_echo_ok_ts"])
+        self.assertEqual(a["last_nonce_echo_at"], snapshot["last_nonce_echo_at"])
+
+    def test_get_agents_payload_surfaces_echo_fields(self):
+        """The dashboard read path (get_agents) must include the echo
+        fields so the LED renderer can consume ``last_nonce_echo_at``."""
+        from hub.registry import get_agents, update_echo_pong
+
+        self._seed_agent()
+        update_echo_pong("echo-agent", 33.0)
+        payload = next(
+            a for a in get_agents(workspace_id=self.ws.id) if a["name"] == "echo-agent"
+        )
+        self.assertIn("last_nonce_echo_at", payload)
+        self.assertIn("last_echo_rtt_ms", payload)
+        self.assertIn("last_echo_ok_ts", payload)
+        self.assertEqual(payload["last_echo_rtt_ms"], 33.0)
+        self.assertIsNotNone(payload["last_nonce_echo_at"])
+        self.assertTrue(payload["last_echo_ok_ts"].endswith("+00:00"))
+
+    def test_get_agents_payload_echo_fields_absent_when_never_set(self):
+        """Agents that have never echoed back should report None for the
+        echo fields — the LED renderer treats None as grey-pending."""
+        from hub.registry import get_agents
+
+        self._seed_agent()
+        payload = next(
+            a for a in get_agents(workspace_id=self.ws.id) if a["name"] == "echo-agent"
+        )
+        self.assertIsNone(payload["last_nonce_echo_at"])
+        self.assertIsNone(payload["last_echo_rtt_ms"])
+        self.assertIsNone(payload["last_echo_ok_ts"])
+
+
+class AgentDetailEchoFieldsTests(TestCase):
+    """End-to-end: register → update_echo_pong → GET /api/agents/<n>/detail/."""
+
+    def setUp(self):
+        from hub.registry import _agents, _connections
+
+        _agents.clear()
+        _connections.clear()
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="echo-detail-ws")
+        self.token = WorkspaceToken.objects.create(
+            workspace=self.ws, label="echo-test"
+        )
+
+    def _post_register(self, name="echo-agent"):
+        return self.client.post(
+            "/api/agents/register/",
+            data=json.dumps(
+                {
+                    "token": self.token.token,
+                    "name": name,
+                    "machine": "MBA",
+                    "role": "head",
+                }
+            ),
+            content_type="application/json",
+        )
+
+    def _get_detail(self, name):
+        return self.client.get(
+            f"/api/agents/{name}/detail/",
+            data={"token": self.token.token},
+        )
+
+    def test_detail_api_surfaces_echo_fields_after_pong(self):
+        from hub.registry import update_echo_pong
+
+        self._post_register("echo-agent")
+        update_echo_pong("echo-agent", 77.7)
+
+        resp = self._get_detail("echo-agent")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("last_nonce_echo_at", data)
+        self.assertIn("last_echo_rtt_ms", data)
+        self.assertIn("last_echo_ok_ts", data)
+        self.assertEqual(data["last_echo_rtt_ms"], 77.7)
+        self.assertIsNotNone(data["last_nonce_echo_at"])
+
+    def test_detail_api_echo_fields_default_when_never_pong(self):
+        """An agent that registered but never echoed back must have the
+        new fields present (not missing keys) and set to None — the
+        dashboard relies on the keys existing for its grey-pending
+        rendering."""
+        self._post_register("echo-agent")
+        resp = self._get_detail("echo-agent")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("last_nonce_echo_at", data)
+        self.assertIn("last_echo_rtt_ms", data)
+        self.assertIn("last_echo_ok_ts", data)
+        self.assertIsNone(data["last_nonce_echo_at"])
+        self.assertIsNone(data["last_echo_rtt_ms"])
+        self.assertIsNone(data["last_echo_ok_ts"])

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -247,6 +247,14 @@ def api_agent_detail(request, name: str):
         # by latency).
         "last_pong_ts": agent.get("last_pong_ts"),
         "last_rtt_ms": agent.get("last_rtt_ms"),
+        # #259 — 4th indicator (Remote / nonce-echo round-trip).
+        # ``last_nonce_echo_at`` is the field the agent-badge LED
+        # renderer consumes (already wired in agent-badge.js); the
+        # other two surface RTT + raw unix timestamp for the per-agent
+        # detail page tooling.
+        "last_nonce_echo_at": agent.get("last_nonce_echo_at"),
+        "last_echo_rtt_ms": agent.get("last_echo_rtt_ms"),
+        "last_echo_ok_ts": agent.get("last_echo_ok_ts"),
         "liveness": agent.get("liveness") or agent.get("status") or "unknown",
         "claude_md": redact_secrets(agent.get("claude_md") or ""),
         # todo#460: serve the workspace .mcp.json for the Agents tab viewer.

--- a/ts/mcp_channel/dispatch.ts
+++ b/ts/mcp_channel/dispatch.ts
@@ -148,6 +148,31 @@ export async function handleWsMessage(
       return;
     }
 
+    // scitex-orochi#259 — 4th liveness indicator (Remote / nonce-echo
+    // round-trip). The hub publishes `{type:echo,nonce}` to every
+    // connected agent; we auto-respond at the WS layer with
+    // `{type:echo_pong,nonce,ts}`. NO Claude round-trip — this is a
+    // sidecar-level pure handler, identical in spirit to the ping/pong
+    // branch above. The hub matches the nonce against its in-flight
+    // dict to compute RTT and flips the 4th LED green.
+    if (msg.type === "echo") {
+      const nonce = typeof msg.nonce === "string" ? msg.nonce : null;
+      if (nonce) {
+        try {
+          ws.send(
+            JSON.stringify({
+              type: "echo_pong",
+              nonce,
+              ts: Date.now() / 1000,
+            }),
+          );
+        } catch (_) {
+          /* socket already closing — ignore */
+        }
+      }
+      return;
+    }
+
     // Thread replies and reaction updates -> rewrite to message type
     if (msg.type === "thread_reply") {
       const parentId = msg.parent_id ?? msg.parent ?? "?";


### PR DESCRIPTION
## Summary

Implements the publisher / responder loop for the 4th liveness LED ("Remote / nonce-echo") that has been rendering as a grey-dashed "pending" placeholder since the dashboard polish session. Closes #259.

- **Hub publisher** (`hub/consumers/_echo.py`): per-WS task emits `{type:echo,nonce:<uuid>}` every 30s (cadence configurable via `OROCHI_ECHO_INTERVAL_SECONDS`, bounded 5..60s), tracks in-flight nonces in a per-consumer dict with bounded size + expiry pruning.
- **Hub responder handler** (`handle_echo_pong` in `_agent_handlers.py`): looks up nonce, computes RTT, calls new `update_echo_pong(name, rtt_ms)` setter. Unknown nonces dropped silently.
- **Registry**: new `update_echo_pong` writes `last_echo_rtt_ms`, `last_echo_ok_ts`, and `last_nonce_echo_at` (the ISO field the LED renderer pins on) atomically. All three added to the prev-preserve list per the prev-preserve pitfall memory so the 4th LED won't flicker grey-pending on every heartbeat.
- **API surface**: `get_agents` payload + `GET /api/agents/<name>/detail/` expose the three fields.
- **TS sidecar responder** (`ts/mcp_channel/dispatch.ts`): adds an `echo` branch that auto-replies with `{type:echo_pong,nonce,ts}` at the WS layer. Pure handler, no Claude round-trip — same shape as the existing `ping`/`pong` branch.

The dashboard's LED renderer (`renderAgentLeds` in `agent-badge.js`) already reads `a.last_nonce_echo_at`; no frontend bundle rebuild needed — placeholder flips to green/yellow/red on real data automatically.

Backward-compat: agents that don't echo back keep functioning (4th LED stays grey); we never disconnect on a missing echo. Legacy MCP sidecars without the new `echo` handler still register and heartbeat normally.

## Test plan

- [x] `python manage.py test hub.tests.UpdateEchoPongRegistryTests hub.tests.AgentDetailEchoFieldsTests` — 7/7 pass
- [x] Setter atomicity, unknown-agent silent no-op
- [x] prev-preserve survives a heartbeat that omits the echo fields
- [x] `get_agents` + `/api/agents/<name>/detail/` surface the new fields (and default to None when never set)
- [x] Registry `__all__` updated; existing reexport tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)