### PR TITLE
fix(hub/auth): expose workspace-scoped routes on bare domain + accept token auth (#258 #254)

### DIFF
--- a/hub/tests/views/api/test_dms.py
+++ b/hub/tests/views/api/test_dms.py
@@ -213,6 +213,141 @@ class DmRestApiTest(TestCase):
         self.assertEqual(resp.status_code, 201, resp.content)
 
 
+# ── Token-auth on workspace-scoped routes (issues #258 + #254) ──────────
+
+
+class DmTokenAuthTest(TestCase):
+    """MCP sidecars hit the bare domain with ``?token=wks_...&agent=<name>``.
+
+    These tests pin the token-auth path independently of any Django session
+    cookie so the regression that took out ``dm_open`` / ``dm_list`` /
+    ``channel_info`` cannot reappear silently.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="tok-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+        self.bob = User.objects.create_user(username="bob", password="x")
+        WorkspaceMember.objects.create(workspace=self.ws, user=self.bob)
+
+    def test_post_dms_with_token_no_session(self):
+        """POST /api/workspace/<slug>/dms/?token=...&agent=... opens a DM."""
+        url = (
+            f"/api/workspace/tok-ws/dms/"
+            f"?token={self.token.token}&agent=mamba-foo"
+        )
+        resp = self.client.post(
+            url,
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        # Canonical channel name with both principals.
+        self.assertIn("agent:mamba-foo", data["name"])
+        self.assertIn("human:bob", data["name"])
+        # The synthetic agent user was auto-provisioned as a member.
+        self.assertTrue(
+            User.objects.filter(username="agent-mamba-foo").exists(),
+            "token branch must auto-provision the agent's User row",
+        )
+        self.assertTrue(
+            WorkspaceMember.objects.filter(
+                workspace=self.ws, user__username="agent-mamba-foo"
+            ).exists(),
+            "token branch must auto-provision the WorkspaceMember row",
+        )
+
+    def test_get_dms_with_token_no_session(self):
+        url_post = (
+            f"/api/workspace/tok-ws/dms/?token={self.token.token}&agent=mamba-foo"
+        )
+        self.client.post(
+            url_post,
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        resp = self.client.get(url_post)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()["dms"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["other_participants"][0]["identity_name"], "bob")
+
+    def test_dms_token_invalid_returns_401(self):
+        resp = self.client.post(
+            "/api/workspace/tok-ws/dms/?token=wks_BADBADBAD&agent=mamba-foo",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_dms_token_missing_agent_returns_400(self):
+        resp = self.client.post(
+            f"/api/workspace/tok-ws/dms/?token={self.token.token}",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_channels_get_with_token_no_session(self):
+        """GET /api/channels/?token=...&name=#X — the channel_info path.
+
+        Hits ``lvh.me`` (a bare-domain alias the middleware recognizes) so
+        the request is dispatched against ``hub.urls_bare`` — which is
+        exactly what MCP sidecars do when they call
+        ``https://scitex-orochi.com/api/channels/?...``. Without the
+        bare-domain route added in this PR the call 404s.
+        """
+        Channel.objects.create(workspace=self.ws, name="#general")
+        resp = self.client.get(
+            f"/api/channels/?token={self.token.token}&name=%23general",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        names = [c["name"] for c in data]
+        self.assertIn("#general", names)
+
+    def test_channels_get_invalid_token_returns_401(self):
+        resp = self.client.get(
+            "/api/channels/?token=wks_BADBADBAD", HTTP_HOST="lvh.me"
+        )
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_workspace_scoped_channels_with_token(self):
+        """GET /api/workspace/<slug>/channels/?token=... resolves on bare domain."""
+        Channel.objects.create(workspace=self.ws, name="#proj-x")
+        resp = self.client.get(
+            f"/api/workspace/tok-ws/channels/?token={self.token.token}",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        names = [c["name"] for c in resp.json()]
+        self.assertIn("#proj-x", names)
+
+    def test_workspace_scoped_dms_resolves_on_bare_domain(self):
+        """POST /api/workspace/<slug>/dms/?token=... on the bare domain works.
+
+        Pin for issue #258 — the exact MCP request shape that previously
+        404'd in production because the route wasn't mounted in
+        ``hub.urls_bare``.
+        """
+        resp = self.client.post(
+            (
+                f"/api/workspace/tok-ws/dms/"
+                f"?token={self.token.token}&agent=mamba-foo"
+            ),
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        self.assertIn("agent:mamba-foo", data["name"])
+        self.assertIn("human:bob", data["name"])
+
+
 # ── Web Push (todo#263) ─────────────────────────────────────────────────
 
 from unittest.mock import MagicMock, patch

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -72,6 +72,50 @@ urlpatterns = [
         views.api_message_detail,
         name="api-message-detail",
     ),
+    # Channel info — MCP `channel_info` tool hits this on the bare
+    # domain (issue #254). Token-auth on GET handled inside the view.
+    path("api/channels/", views.api_channels, name="api-channels"),
+    # Channel export — MCP `export_channel` tool. Already accepts
+    # ?token= internally; just needs a route on the bare domain.
+    path(
+        "api/channels/<str:chat_id>/export/",
+        views.api_channel_export,
+        name="api-channel-export",
+    ),
+    # Workspace-scoped routes — MCP sidecars build URLs of the form
+    # /api/workspace/<slug>/dms/?token=wks_... when the agent's
+    # SCITEX_OROCHI_URL points at the bare domain (the default for the
+    # production hub). Without these the DM tool, channel listing,
+    # history fetch, and per-channel export 404 (issue #258 root cause).
+    # The slug kwarg is consumed by ``get_workspace`` /
+    # ``resolve_workspace_and_actor`` so the same view function works on
+    # both the subdomain (`request.workspace` set by middleware) and the
+    # bare domain (slug from URL).
+    path(
+        "api/workspace/<slug:slug>/dms/",
+        views.api_dms,
+        name="api-dms-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/channels/",
+        views.api_channels,
+        name="api-channels-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/messages/",
+        views.api_messages,
+        name="api-messages-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/history/<str:channel_name>/",
+        views.api_history,
+        name="api-history-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/channels/<str:chat_id>/export/",
+        views.api_channel_export,
+        name="api-channel-export-bare",
+    ),
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/health/", views.api_agent_health, name="api-agent-health"),
     # Per-agent single-screen detail payload (todo#420 MVP).

--- a/hub/views/_helpers.py
+++ b/hub/views/_helpers.py
@@ -1,7 +1,7 @@
 """Shared helpers for hub views."""
 
 from django.conf import settings
-from django.http import Http404
+from django.http import Http404, JsonResponse
 
 
 def workspace_url(workspace_name, path="/"):
@@ -38,3 +38,115 @@ def get_workspace(request, slug=None):
         except Workspace.DoesNotExist:
             raise Http404(f"Workspace {slug!r} not found")
     raise Http404("No workspace context")
+
+
+def resolve_workspace_and_actor(request, slug=None):
+    """Token-or-session auth helper for agent-callable workspace API views.
+
+    Returns a 3-tuple ``(workspace, actor_member, error_response)``:
+
+    - On Django session auth: ``actor_member`` is the
+      :class:`hub.models.WorkspaceMember` for ``request.user`` in the
+      resolved workspace; ``error_response`` is ``None``.
+    - On workspace-token auth (``?token=wks_...``): the workspace is
+      resolved from the token. The actor is taken from the
+      ``?agent=<name>`` query param (matching the convention used by
+      ``ts/src/config.ts::buildWsUrl`` so MCP sidecars only need to
+      forward what they already pass on the WS handshake). If no
+      ``?agent=`` is supplied, the actor falls back to the request body
+      keys ``agent`` / ``sender`` / ``reactor`` (mirrors the pattern in
+      :func:`hub.views.api._reactions.api_reactions`). The synthetic
+      ``agent-<name>`` Django user + :class:`hub.models.WorkspaceMember`
+      is created on first sight so an agent that just registered can
+      open a DM without a separate provisioning step.
+    - On any failure: returns ``(None, None, JsonResponse(...))`` with
+      a populated 401/404 error.
+
+    Why this exists: the ``@login_required`` decorator that previously
+    gated ``api_dms`` etc. doesn't see workspace tokens, so MCP sidecars
+    hitting ``https://scitex-orochi.com/api/workspace/<slug>/dms/?token=
+    wks_...`` were 302-redirected to ``/signin``. Centralizing the
+    branching here keeps the call sites declarative — the view says
+    "I need a workspace and an actor" and the helper picks the right
+    auth path. Spec v3.1 §4.1 still routes message *sends* through the
+    WS path; this helper is for non-write surfaces (DM list/open,
+    channel info, history) where REST is the only option.
+    """
+    import json as _json
+
+    from django.contrib.auth import get_user_model
+
+    from hub.models import WorkspaceMember, WorkspaceToken
+
+    token_str = (
+        request.GET.get("token") or (request.POST.get("token") if request.POST else None)
+    )
+
+    # ── Session path ────────────────────────────────────────────────
+    if not token_str:
+        if not (request.user and request.user.is_authenticated):
+            return None, None, JsonResponse({"error": "auth required"}, status=401)
+        try:
+            workspace = get_workspace(request, slug=slug)
+        except Http404 as exc:
+            return None, None, JsonResponse({"error": str(exc)}, status=404)
+        member = (
+            WorkspaceMember.objects.filter(workspace=workspace, user=request.user)
+            .select_related("user")
+            .first()
+        )
+        if member is None:
+            return (
+                None,
+                None,
+                JsonResponse({"error": "not a workspace member"}, status=403),
+            )
+        return workspace, member, None
+
+    # ── Token path ──────────────────────────────────────────────────
+    try:
+        wt = WorkspaceToken.objects.select_related("workspace").get(token=token_str)
+    except WorkspaceToken.DoesNotExist:
+        return None, None, JsonResponse({"error": "invalid token"}, status=401)
+    workspace = wt.workspace
+
+    # Actor identity. For agent calls the canonical source is the
+    # ``?agent=<name>`` query param; falling back to body keys matches
+    # the heterogeneous shapes existing endpoints already accept.
+    agent_name = (request.GET.get("agent") or "").strip()
+    if not agent_name and request.body:
+        try:
+            body = _json.loads(request.body or b"{}")
+            agent_name = (
+                body.get("agent")
+                or body.get("sender")
+                or body.get("reactor")
+                or ""
+            ).strip()
+        except (_json.JSONDecodeError, ValueError):
+            agent_name = ""
+    if not agent_name:
+        return (
+            None,
+            None,
+            JsonResponse(
+                {"error": "agent identity required (pass ?agent=<name>)"},
+                status=400,
+            ),
+        )
+
+    User = get_user_model()
+    username = f"agent-{agent_name}"
+    user, _ = User.objects.get_or_create(
+        username=username,
+        defaults={
+            "email": f"{username}@agents.orochi.local",
+            "is_active": True,
+        },
+    )
+    member, _ = WorkspaceMember.objects.get_or_create(
+        user=user,
+        workspace=workspace,
+        defaults={"role": "member"},
+    )
+    return workspace, member, None

--- a/hub/views/api/_channels.py
+++ b/hub/views/api/_channels.py
@@ -6,6 +6,7 @@ from hub.views.api._common import (
     JsonResponse,
     Workspace,
     WorkspaceMember,
+    WorkspaceToken,
     async_to_sync,
     csrf_exempt,
     get_channel_layer,
@@ -44,13 +45,37 @@ def api_workspaces(request):
 
 
 @csrf_exempt
-@login_required
 @require_http_methods(["GET", "PATCH"])
 def api_channels(request, slug=None):
     """GET /api/channels/ — list channels in current workspace.
     PATCH /api/channels/?name=<channel> — update channel description (topic).
+
+    Auth: Django session OR workspace token (``?token=wks_...``). The
+    token branch supports the MCP ``channel_info`` tool which hits the
+    bare domain — see issue #254 / #258 for the original outage. PATCH
+    still requires a logged-in human (token-auth has no notion of "who
+    edited the topic").
     """
-    workspace = get_workspace(request, slug=slug)
+    # GET supports token auth (read-only); PATCH still requires session
+    # because we attribute the edit to a Django user for audit.
+    if request.method == "GET":
+        token_str = request.GET.get("token")
+        if token_str:
+            try:
+                wt = WorkspaceToken.objects.select_related("workspace").get(
+                    token=token_str
+                )
+                workspace = wt.workspace
+            except WorkspaceToken.DoesNotExist:
+                return JsonResponse({"error": "invalid token"}, status=401)
+        elif request.user and request.user.is_authenticated:
+            workspace = get_workspace(request, slug=slug)
+        else:
+            return JsonResponse({"error": "auth required"}, status=401)
+    else:
+        if not (request.user and request.user.is_authenticated):
+            return JsonResponse({"error": "auth required"}, status=401)
+        workspace = get_workspace(request, slug=slug)
 
     if request.method == "PATCH":
         body = json.loads(request.body)

--- a/hub/views/api/_dms.py
+++ b/hub/views/api/_dms.py
@@ -1,5 +1,6 @@
 """Direct-message helpers + ``/api/dms/`` view (spec v3 §4)."""
 
+from hub.views._helpers import resolve_workspace_and_actor
 from hub.views.api._common import (
     Channel,
     DMParticipant,
@@ -9,10 +10,8 @@ from hub.views.api._common import (
     async_to_sync,
     csrf_exempt,
     get_channel_layer,
-    get_workspace,
     json,
     log,
-    login_required,
     require_http_methods,
 )
 
@@ -201,24 +200,19 @@ def _dm_row(channel, current_member):
     }
 
 
-@login_required
 @csrf_exempt
 @require_http_methods(["GET", "POST"])
 def api_dms(request, slug=None):
     """GET/POST /api/workspace/<slug>/dms/ — list or create 1:1 DMs.
 
-    Spec v3 §4. The current authenticated principal is resolved via
-    ``WorkspaceMember`` for ``request.user`` in the active workspace.
+    Spec v3 §4. Auth is either a Django session OR a workspace token
+    (``?token=wks_...&agent=<name>``) — see
+    :func:`hub.views._helpers.resolve_workspace_and_actor`. MCP sidecars
+    on the bare domain rely on the token branch (issue #258 root cause).
     """
-    workspace = get_workspace(request, slug=slug)
-
-    current_member = (
-        WorkspaceMember.objects.filter(workspace=workspace, user=request.user)
-        .select_related("user")
-        .first()
-    )
-    if current_member is None:
-        return JsonResponse({"error": "not a workspace member"}, status=403)
+    workspace, current_member, err = resolve_workspace_and_actor(request, slug=slug)
+    if err is not None:
+        return err
 
     if request.method == "GET":
         my_dm_channel_ids = DMParticipant.objects.filter(


### PR DESCRIPTION
## Summary
- MCP sidecars hit the bare domain (`scitex-orochi.com`) but `hub/urls_bare.py` was missing `/api/workspace/<slug>/dms/`, `/api/channels/`, and friends — `dm_open` / `dm_list` / `channel_info` all 404'd in production.
- `api_dms` was gated by `@login_required` which doesn't honor `?token=wks_...`, so even after routing was fixed the call would 302 to `/signin`.
- This PR adds a single `resolve_workspace_and_actor()` helper that accepts either a Django session or `?token=...&agent=<name>` (auto-provisioning the synthetic `agent-<name>` User + WorkspaceMember on first sight, mirroring `hub/views/auth.py`), uses it in `api_dms`, and gives `api_channels` GET a parallel token-aware branch. The bare URLConf gets the missing routes.

## Routes added to `hub/urls_bare.py`
- `GET/PATCH /api/channels/`
- `GET /api/channels/<chat_id>/export/`
- `GET/POST /api/workspace/<slug>/dms/`
- `GET/PATCH /api/workspace/<slug>/channels/`
- `GET/POST /api/workspace/<slug>/messages/`
- `GET /api/workspace/<slug>/history/<channel_name>/`
- `GET /api/workspace/<slug>/channels/<chat_id>/export/`

## Auth changes
- New `hub.views._helpers.resolve_workspace_and_actor()` — central token-or-session resolver.
- `api_dms` now uses the helper; `@login_required` removed.
- `api_channels` GET accepts `?token=wks_...`; PATCH still requires a session (audit attribution).

## Test plan
- [x] `python manage.py test hub.tests.views.api.test_dms` — 17/17 pass.
- [x] `python manage.py test hub.tests` — 176/176 pass (3 pre-existing skips).
- [x] New `DmTokenAuthTest` class adds 8 cases covering:
  - POST `/api/workspace/<slug>/dms/?token=...&agent=...` (no Django session)
  - GET `/api/workspace/<slug>/dms/?token=...&agent=...`
  - Invalid token → 401, missing `agent` → 400
  - GET `/api/channels/?token=...&name=...` on `lvh.me` (bare URLConf)
  - GET `/api/workspace/<slug>/channels/?token=...` on `lvh.me`
  - End-to-end DM open via bare-domain routing pin (`HTTP_HOST=lvh.me`)

Closes #258
Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)