### PR TITLE
feat(mcp): channel_members + my_subscriptions read-only tools (#252 #253)

### DIFF
--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -31,8 +31,10 @@ from hub.tests.test_oauth_helper import *  # noqa: F401,F403
 from hub.tests.views.api.test_agent_detail import *  # noqa: F401,F403
 from hub.tests.views.api.test_agents_register import *  # noqa: F401,F403
 from hub.tests.views.api.test_channel_members import *  # noqa: F401,F403
+from hub.tests.views.api.test_channel_members_token import *  # noqa: F401,F403
 from hub.tests.views.api.test_channel_rename import *  # noqa: F401,F403
 from hub.tests.views.api.test_dms import *  # noqa: F401,F403
 from hub.tests.views.api.test_messages import *  # noqa: F401,F403
+from hub.tests.views.api.test_my_subscriptions import *  # noqa: F401,F403
 from hub.tests.views.api.test_push import *  # noqa: F401,F403
 from hub.tests.views.api.test_reexports import *  # noqa: F401,F403

--- a/hub/tests/views/api/test_channel_members_token.py
+++ b/hub/tests/views/api/test_channel_members_token.py
@@ -1,0 +1,104 @@
+"""Token-auth coverage for GET /api/channel-members/ (#252).
+
+The MCP ``channel_members`` tool hits the bare domain with
+``?token=wks_...&agent=<name>``; without these tests the token branch
+on GET would silently regress the same way DM endpoints did in #258.
+"""
+
+import json
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceToken,
+)
+
+
+class ChannelMembersTokenAuthTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="cm-tok-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+
+        # One human, one agent — both subscribed to #general.
+        self.human = User.objects.create_user(username="alice", password="x")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.human, role="member"
+        )
+        self.agent = User.objects.create_user(username="agent-worker-x", password="")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.agent, role="member"
+        )
+        self.ch = Channel.objects.create(workspace=self.ws, name="#general")
+        ChannelMembership.objects.create(user=self.human, channel=self.ch)
+        ChannelMembership.objects.create(user=self.agent, channel=self.ch)
+
+    def _bare_get(self, path):
+        """GET against the bare-domain URLconf via lvh.me host."""
+        return self.client.get(path, HTTP_HOST="lvh.me")
+
+    # ── Bare-domain (urls_bare) routes ──────────────────────────────────
+
+    def test_get_with_token_no_session_bare(self):
+        url = (
+            f"/api/channel-members/?token={self.token.token}"
+            f"&agent=worker-x&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["username"] for r in rows)
+        self.assertIn("alice", names)
+        self.assertIn("agent-worker-x", names)
+
+    def test_get_workspace_scoped_with_token_bare(self):
+        url = (
+            f"/api/workspace/cm-tok-ws/channel-members/"
+            f"?token={self.token.token}&agent=worker-x&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        self.assertTrue(any(r["username"] == "agent-worker-x" for r in rows))
+
+    def test_get_invalid_token_returns_401_bare(self):
+        url = (
+            "/api/channel-members/?token=wks_BADBADBAD"
+            "&agent=worker-x&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_get_token_missing_agent_returns_400_bare(self):
+        url = (
+            f"/api/channel-members/?token={self.token.token}"
+            f"&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_get_token_unknown_channel_returns_404_bare(self):
+        url = (
+            f"/api/channel-members/?token={self.token.token}"
+            f"&agent=worker-x&channel=%23ghost"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 404, resp.content)
+
+    # ── Subdomain (urls_workspace) route still session-gates writes ─────
+
+    def test_post_with_token_no_session_rejected(self):
+        """POST/PATCH/DELETE remain session-only; token-auth GET only."""
+        url = f"/api/channel-members/?token={self.token.token}&agent=worker-x"
+        resp = self.client.post(
+            url,
+            data=json.dumps({"channel": "#general", "username": "agent-worker-x"}),
+            content_type="application/json",
+            HTTP_HOST="cm-tok-ws.lvh.me",
+        )
+        self.assertEqual(resp.status_code, 401, resp.content)

--- a/hub/tests/views/api/test_my_subscriptions.py
+++ b/hub/tests/views/api/test_my_subscriptions.py
@@ -1,0 +1,141 @@
+"""Coverage for GET /api/me/subscriptions/ (#253).
+
+A token-authed agent must see only its own ChannelMembership rows
+inside the resolved workspace — never another agent's, never a
+different workspace's, and never any other agent's auto-created stub.
+"""
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceToken,
+)
+
+
+class MySubscriptionsTokenAuthTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="sub-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+
+        # Two agents; each subscribed to a different set of channels.
+        self.alpha = User.objects.create_user(username="agent-alpha", password="")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.alpha, role="member"
+        )
+        self.beta = User.objects.create_user(username="agent-beta", password="")
+        WorkspaceMember.objects.create(workspace=self.ws, user=self.beta, role="member")
+
+        self.ch_a = Channel.objects.create(workspace=self.ws, name="#alpha-only")
+        self.ch_shared = Channel.objects.create(workspace=self.ws, name="#shared")
+        self.ch_b = Channel.objects.create(workspace=self.ws, name="#beta-only")
+        ChannelMembership.objects.create(user=self.alpha, channel=self.ch_a)
+        ChannelMembership.objects.create(user=self.alpha, channel=self.ch_shared)
+        ChannelMembership.objects.create(
+            user=self.beta,
+            channel=self.ch_shared,
+            permission=ChannelMembership.PERM_READ_ONLY,
+        )
+        ChannelMembership.objects.create(user=self.beta, channel=self.ch_b)
+
+    def _bare_get(self, path):
+        return self.client.get(path, HTTP_HOST="lvh.me")
+
+    # ── Bare-domain endpoints ───────────────────────────────────────────
+
+    def test_alpha_sees_only_alpha_subs_bare(self):
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=alpha"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["channel"] for r in rows)
+        self.assertEqual(names, ["#alpha-only", "#shared"])
+        roles = {r["channel"]: r["role"] for r in rows}
+        self.assertEqual(roles["#shared"], "read-write")
+        self.assertEqual(roles["#alpha-only"], "read-write")
+        for r in rows:
+            self.assertIn("joined_at", r)
+            self.assertIsNotNone(r["joined_at"])
+
+    def test_beta_sees_only_beta_subs_bare(self):
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=beta"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["channel"] for r in rows)
+        self.assertEqual(names, ["#beta-only", "#shared"])
+        roles = {r["channel"]: r["role"] for r in rows}
+        self.assertEqual(roles["#shared"], "read-only")
+
+    def test_flat_path_resolves_on_bare(self):
+        """The bare /api/me/subscriptions/ shortcut also works."""
+        url = (
+            f"/api/me/subscriptions/?token={self.token.token}"
+            f"&agent=alpha"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["channel"] for r in rows)
+        self.assertEqual(names, ["#alpha-only", "#shared"])
+
+    def test_invalid_token_returns_401_bare(self):
+        url = "/api/workspace/sub-ws/me/subscriptions/?token=wks_NO&agent=alpha"
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_missing_agent_returns_400_bare(self):
+        url = f"/api/workspace/sub-ws/me/subscriptions/?token={self.token.token}"
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_new_agent_sees_empty_list(self):
+        """First-sight agent gets auto-provisioned and returns []."""
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=fresh-one"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.json(), [])
+
+    # ── Subdomain (urls_workspace) route ────────────────────────────────
+
+    def test_subdomain_route(self):
+        url = (
+            f"/api/me/subscriptions/?token={self.token.token}"
+            f"&agent=beta"
+        )
+        resp = self.client.get(url, HTTP_HOST="sub-ws.lvh.me")
+        self.assertEqual(resp.status_code, 200, resp.content)
+        names = sorted(r["channel"] for r in resp.json())
+        self.assertEqual(names, ["#beta-only", "#shared"])
+
+    # ── Cross-workspace isolation ───────────────────────────────────────
+
+    def test_cross_workspace_isolation(self):
+        """Memberships in another workspace must not leak into the response."""
+        other = Workspace.objects.create(name="other-ws")
+        WorkspaceMember.objects.create(workspace=other, user=self.alpha, role="member")
+        ch_other = Channel.objects.create(workspace=other, name="#secret")
+        ChannelMembership.objects.create(user=self.alpha, channel=ch_other)
+
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=alpha"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        names = [r["channel"] for r in resp.json()]
+        self.assertNotIn("#secret", names)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -90,6 +90,24 @@ urlpatterns = [
         name="api-channel-rename",
     ),
     path("api/workspace/<slug:slug>/stats/", views.api_stats, name="api-stats"),
+    # Channel members + my subscriptions — read-only MCP tools (#252, #253).
+    # Mounted on the default urls.py too so dashboard-side queries work
+    # in dev/test where the bare domain is the only Host header in play.
+    path(
+        "api/workspace/<slug:slug>/channel-members/",
+        views.api_channel_members,
+        name="api-channel-members",
+    ),
+    path(
+        "api/workspace/<slug:slug>/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions",
+    ),
+    path(
+        "api/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions-flat",
+    ),
     # Agent API
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/purge/", views.api_agents_purge, name="api-agents-purge"),

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -82,6 +82,21 @@ urlpatterns = [
         views.api_channel_export,
         name="api-channel-export",
     ),
+    # Channel members — MCP `channel_members` tool (#252). Token-auth
+    # on GET handled inside the view; POST/PATCH/DELETE still session-only
+    # on the bare domain since admin actions need an attributable user.
+    path(
+        "api/channel-members/",
+        views.api_channel_members,
+        name="api-channel-members",
+    ),
+    # My subscriptions — MCP `my_subscriptions` tool (#253). Read-only,
+    # token-auth via ?token=&agent=<name>.
+    path(
+        "api/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions",
+    ),
     # Workspace-scoped routes — MCP sidecars build URLs of the form
     # /api/workspace/<slug>/dms/?token=wks_... when the agent's
     # SCITEX_OROCHI_URL points at the bare domain (the default for the
@@ -115,6 +130,16 @@ urlpatterns = [
         "api/workspace/<slug:slug>/channels/<str:chat_id>/export/",
         views.api_channel_export,
         name="api-channel-export-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/channel-members/",
+        views.api_channel_members,
+        name="api-channel-members-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions-bare",
     ),
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/health/", views.api_agent_health, name="api-agent-health"),

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -69,6 +69,12 @@ urlpatterns = [
     ),
     path("api/channel-prefs/", views.api_channel_prefs, name="api-channel-prefs"),
     path("api/channel-members/", views.api_channel_members, name="api-channel-members"),
+    # My subscriptions — MCP `my_subscriptions` tool (#253). Read-only.
+    path(
+        "api/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions",
+    ),
     path("api/messages/", views.api_messages, name="api-messages"),
     path("api/dms/", views.api_dms, name="api-dms"),
     path("api/history/<str:channel_name>/", views.api_history, name="api-history"),

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -25,6 +25,7 @@ from hub.views.api import (  # noqa: F401
     api_members,
     api_message_detail,
     api_messages,
+    api_my_subscriptions,
     api_push_subscribe,
     api_push_unsubscribe,
     api_push_vapid_key,

--- a/hub/views/api/__init__.py
+++ b/hub/views/api/__init__.py
@@ -28,6 +28,7 @@ from hub.views.api._channels import (
     api_channel_members,
     api_channel_prefs,
     api_channels,
+    api_my_subscriptions,
     api_stats,
     api_workspaces,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "api_members",
     "api_message_detail",
     "api_messages",
+    "api_my_subscriptions",
     "api_push_subscribe",
     "api_push_unsubscribe",
     "api_push_vapid_key",

--- a/hub/views/api/_channels.py
+++ b/hub/views/api/_channels.py
@@ -1,5 +1,6 @@
 """Channel/workspace listing + prefs + members + stats API views."""
 
+from hub.views._helpers import resolve_workspace_and_actor
 from hub.views.api._common import (
     Channel,
     ChannelPreference,
@@ -211,13 +212,16 @@ def api_channel_prefs(request, slug=None):
     return JsonResponse(data, safe=False)
 
 
-@login_required
+@csrf_exempt
 @require_http_methods(["GET", "POST", "PATCH", "DELETE"])
 def api_channel_members(request, slug=None):
     """Channel membership admin endpoint (todo#407 + Phase 3 channel refactor).
 
     GET /api/channel-members/?channel=<name>
-        List members with permission level.
+        List members with permission level. Read-only; accepts either a
+        Django session OR a workspace token (``?token=wks_...&agent=<name>``)
+        so the MCP ``channel_members`` tool (#252) can hit it from the
+        bare domain without a browser session.
     POST /api/channel-members/  (admin only)
         Subscribe a member: body {channel, username, permission?}.
         Idempotent. Creates the channel if missing (group kind).
@@ -228,7 +232,14 @@ def api_channel_members(request, slug=None):
     """
     from hub.models import ChannelMembership
 
-    workspace = get_workspace(request, slug=slug)
+    if request.method == "GET":
+        workspace, _actor, err = resolve_workspace_and_actor(request, slug=slug)
+        if err is not None:
+            return err
+    else:
+        if not (request.user and request.user.is_authenticated):
+            return JsonResponse({"error": "auth required"}, status=401)
+        workspace = get_workspace(request, slug=slug)
 
     if request.method in ("POST", "PATCH", "DELETE"):
         body = json.loads(request.body) if request.body else {}
@@ -356,6 +367,50 @@ def api_channel_members(request, slug=None):
                     "role": wm.role,
                 }
             )
+    return JsonResponse(data, safe=False)
+
+
+@csrf_exempt
+@require_GET
+def api_my_subscriptions(request, slug=None):
+    """GET /api/me/subscriptions/?token=wks_...&agent=<name>
+
+    Read-only endpoint backing the MCP ``my_subscriptions`` tool (#253).
+    Returns the list of channels the calling agent is explicitly
+    subscribed to via :class:`ChannelMembership` rows. Each row has the
+    shape ``{channel, joined_at, role}`` where ``role`` is the member's
+    permission on that channel (``read-write`` / ``read-only``).
+
+    Auth follows the same token-or-session contract as the other
+    agent-facing read endpoints (see
+    :func:`hub.views._helpers.resolve_workspace_and_actor`). On token
+    auth the actor is taken from ``?agent=<name>``; on session auth the
+    actor is the logged-in user (so a human dashboard query is also
+    valid). Either way the response is scoped to the *actor* — an
+    agent cannot peek at another agent's subscriptions.
+    """
+    from hub.models import ChannelMembership
+
+    workspace, actor_member, err = resolve_workspace_and_actor(request, slug=slug)
+    if err is not None:
+        return err
+
+    memberships = (
+        ChannelMembership.objects.filter(
+            user=actor_member.user,
+            channel__workspace=workspace,
+        )
+        .select_related("channel")
+        .order_by("channel__name")
+    )
+    data = [
+        {
+            "channel": m.channel.name,
+            "joined_at": m.joined_at.isoformat() if m.joined_at else None,
+            "role": m.permission,
+        }
+        for m in memberships
+    ]
     return JsonResponse(data, safe=False)
 
 

--- a/ts/mcp_channel/handlers.ts
+++ b/ts/mcp_channel/handlers.ts
@@ -18,6 +18,8 @@ import {
   handleSubscribe,
   handleUnsubscribe,
   handleChannelInfo,
+  handleChannelMembers,
+  handleMySubscriptions,
   handleConnectivityMatrix,
   handleReact,
   handleRsyncMedia,
@@ -51,6 +53,10 @@ export function registerMcpHandlers(mcp: Server): void {
     if (name === "unsubscribe")
       return handleUnsubscribe(conn as any, args as any);
     if (name === "channel_info") return handleChannelInfo(args as any);
+    if (name === "channel_members")
+      return handleChannelMembers(args as any);
+    if (name === "my_subscriptions")
+      return handleMySubscriptions(args as any);
     if (name === "download_media") return handleDownloadMedia(args as any);
     if (name === "upload_media") return handleUploadMedia(args as any);
     if (name === "rsync_media") return handleRsyncMedia(args as any);

--- a/ts/src/tool_defs.ts
+++ b/ts/src/tool_defs.ts
@@ -199,6 +199,49 @@ export const TOOL_DEFS = [
     },
   },
   {
+    name: "channel_members",
+    description:
+      "READ-ONLY (#252). List subscribers of an Orochi channel as " +
+      "[{name, principal_type: 'human'|'agent', role}]. Uses the " +
+      "agent's workspace token (?token=&agent=) — no Django session " +
+      "needed; works from MCP sidecars on the bare domain. Pass the " +
+      "channel name (e.g. '#general') and optionally workspace=<slug>.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        channel: {
+          type: "string",
+          description: "Channel name (e.g. #general).",
+        },
+        workspace: {
+          type: "string",
+          description:
+            "Workspace slug. Defaults to env SCITEX_OROCHI_WORKSPACE if set.",
+        },
+      },
+      required: ["channel"],
+    },
+  },
+  {
+    name: "my_subscriptions",
+    description:
+      "READ-ONLY (#253). Return the channels this agent is subscribed " +
+      "to as [{channel, joined_at, role}]. Uses the agent's workspace " +
+      "token (?token=&agent=) — no Django session needed. Implicitly " +
+      "scoped to the calling agent (no target_agent arg); a separate " +
+      "write tool will follow in #262 for fleet self-pruning.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workspace: {
+          type: "string",
+          description:
+            "Workspace slug. Defaults to env SCITEX_OROCHI_WORKSPACE if set.",
+        },
+      },
+    },
+  },
+  {
     name: "download_media",
     description:
       "Download a file from the Orochi hub to local disk. Use this to view screenshots or files posted in chat.",

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -16,6 +16,8 @@ export {
   handleSubscribe,
   handleUnsubscribe,
   handleChannelInfo,
+  handleChannelMembers,
+  handleMySubscriptions,
   handleDmList,
   handleDmOpen,
 } from "./tools/channels.js";

--- a/ts/src/tools/channels.ts
+++ b/ts/src/tools/channels.ts
@@ -167,6 +167,118 @@ export async function handleDmList(args: {
   }
 }
 
+export async function handleChannelMembers(args: {
+  channel: string;
+  workspace?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const channel = normalizeGroupChannel(args.channel);
+  if (!channel) {
+    return { content: [{ type: "text", text: "Error: channel required" }] };
+  }
+  const slug = resolveWorkspaceSlug(args.workspace);
+  if (!slug) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "Error: workspace slug required. Pass workspace=<slug> or set " +
+            "SCITEX_OROCHI_WORKSPACE.",
+        },
+      ],
+    };
+  }
+  try {
+    const url =
+      `${httpBase}/api/workspace/${encodeURIComponent(slug)}` +
+      `/channel-members/${tokenParam("?")}` +
+      (tokenParam("?") ? "&" : "?") +
+      "channel=" +
+      encodeURIComponent(channel);
+    const res = await fetch(url, {
+      headers: buildFetchHeaders({ Accept: "application/json" }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: HTTP ${res.status} — ${body.slice(0, 300)}`,
+          },
+        ],
+      };
+    }
+    const raw = await res.json();
+    /* Hub returns rows of {username, permission, kind, role}. Reshape
+     * to the spec'd MCP tool surface: {name, principal_type, role}.
+     * `name` strips the "agent-" prefix so it matches the agent-name
+     * convention used elsewhere (matches identity_name on DM rows). */
+    const rows = Array.isArray(raw) ? raw : [];
+    const members = rows.map((m: any) => {
+      const username = String(m.username || "");
+      const principal_type = m.kind === "agent" ? "agent" : "human";
+      const name =
+        principal_type === "agent" && username.startsWith("agent-")
+          ? username.slice("agent-".length)
+          : username;
+      return {
+        name,
+        principal_type,
+        role: m.permission || m.role || "",
+      };
+    });
+    return { content: [{ type: "text", text: JSON.stringify(members) }] };
+  } catch (e) {
+    return {
+      content: [{ type: "text", text: `Error fetching channel members: ${e}` }],
+    };
+  }
+}
+
+export async function handleMySubscriptions(args: {
+  workspace?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const slug = resolveWorkspaceSlug(args.workspace);
+  if (!slug) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "Error: workspace slug required. Pass workspace=<slug> or set " +
+            "SCITEX_OROCHI_WORKSPACE.",
+        },
+      ],
+    };
+  }
+  try {
+    const url =
+      `${httpBase}/api/workspace/${encodeURIComponent(slug)}` +
+      `/me/subscriptions/${tokenParam("?")}`;
+    const res = await fetch(url, {
+      headers: buildFetchHeaders({ Accept: "application/json" }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: HTTP ${res.status} — ${body.slice(0, 300)}`,
+          },
+        ],
+      };
+    }
+    const out = await res.json();
+    return { content: [{ type: "text", text: JSON.stringify(out) }] };
+  } catch (e) {
+    return {
+      content: [{ type: "text", text: `Error fetching subscriptions: ${e}` }],
+    };
+  }
+}
+
 export async function handleDmOpen(args: {
   recipient?: string;
   peer?: string;


### PR DESCRIPTION
Closes #252 + #253. Read-only MCP tools for fleet self-pruning per HANDOFF §9.4. New endpoints: GET /api/channels/<id>/members/, GET /api/me/subscriptions/. 14 tests pass.