### PR TITLE
feat(hub/registry): singleton cardinality enforcement (#255)

### DIFF
--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -138,6 +138,16 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         echo_task = getattr(self, "_echo_task", None)
         if echo_task is not None:
             echo_task.cancel()
+        # scitex-orochi#255 — drop per-channel identity tracking so a
+        # future challenger doesn't compare against this dead channel.
+        # Safe even when handle_register never recorded the channel
+        # (token-rejected connect, missing register frame).
+        try:
+            from hub.registry import clear_connection_identity
+
+            clear_connection_identity(self.channel_name)
+        except Exception:
+            pass
         if hasattr(self, "workspace_group"):
             # scitex-orochi#144 fix path 4: drop only THIS connection from
             # the per-agent set, not the whole agent record. The agent only
@@ -232,6 +242,41 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
                 "metadata": event.get("metadata", {}),
             }
         )
+
+    # --- scitex-orochi#255 singleton eviction handler -------------------
+
+    async def singleton_evict(self, event):
+        """Evict this WS because another process won the singleton race.
+
+        The challenger's register handler dispatched a ``singleton.evict``
+        event addressed to this exact channel via the channel layer. We
+        send a final error frame so the agent process logs *why* it is
+        being closed (rather than seeing a bare WS close), then close
+        with the configured code/reason so reconnect loops can branch
+        on it (don't auto-reconnect when the close reason is
+        ``duplicate_identity`` — exit cleanly instead).
+        """
+        from ._agent_handlers import (
+            DUPLICATE_IDENTITY_CLOSE_CODE,
+            DUPLICATE_IDENTITY_REASON,
+        )
+
+        code = event.get("code", DUPLICATE_IDENTITY_CLOSE_CODE)
+        reason = event.get("reason", DUPLICATE_IDENTITY_REASON)
+        try:
+            await self.send_json(
+                {
+                    "type": "error",
+                    "code": reason,
+                    "message": (
+                        "another process holds this agent identity with an "
+                        "older start_ts_unix; closing this connection"
+                    ),
+                }
+            )
+        except Exception:
+            pass
+        await self.close(code=code)
 
     # --- channel-layer events ignored on the agent socket ----------------
 

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -12,8 +12,14 @@ import time
 
 from hub.models import normalize_channel_name
 
-from ._groups import _sanitize_group
+from ._groups import _sanitize_group, log
 from ._helpers import _load_agent_channel_subs, _persist_agent_subscription
+
+# WebSocket close code reserved for "this WS got evicted because another
+# process holds the same agent identity". Custom 4xxx range is allowed
+# by RFC 6455; 4409 mirrors HTTP 409 Conflict for readability.
+DUPLICATE_IDENTITY_CLOSE_CODE = 4409
+DUPLICATE_IDENTITY_REASON = "duplicate_identity"
 
 
 async def handle_register(consumer, content):
@@ -25,8 +31,44 @@ async def handle_register(consumer, content):
     **ignored** — accepting them would let any agent opt itself into any
     channel by self-declaration, bypassing the ACL gate on subscribe.
     Fix for scitex-orochi#251 (private-channel delivery leak).
+
+    scitex-orochi#255 — singleton cardinality enforcement runs FIRST. If
+    a sibling channel already holds this ``agent_name`` and reports a
+    different ``instance_id``, we run the decision rule and either:
+
+      - close THIS connection (incumbent wins) with code 4409 and reason
+        ``"duplicate_identity"``; OR
+      - close the OTHER connection (challenger wins) via the channel
+        layer and proceed with the normal register flow.
+
+    Legacy clients that don't report ``instance_id``/``start_ts_unix`` in
+    the register frame fall through to the pre-#255 permissive
+    multi-connection behavior with a logged WARNING (no regression for
+    older agent_meta.py installs).
     """
     payload = content.get("payload", {})
+
+    # ── #255 singleton enforcement ───────────────────────────────────
+    challenger_instance_id = (payload.get("instance_id") or "").strip()
+    raw_challenger_ts = payload.get("start_ts_unix")
+    try:
+        challenger_start_ts_unix = (
+            float(raw_challenger_ts) if raw_challenger_ts is not None else None
+        )
+    except (TypeError, ValueError):
+        challenger_start_ts_unix = None
+
+    closed_self = await _enforce_singleton(
+        consumer,
+        challenger_instance_id=challenger_instance_id,
+        challenger_start_ts_unix=challenger_start_ts_unix,
+    )
+    if closed_self:
+        # We sent the close — abort the register flow so we don't write
+        # a half-registered identity into the registry.
+        return
+    # ── /#255 ────────────────────────────────────────────────────────
+
     persisted = await _load_agent_channel_subs(
         consumer.workspace_id, consumer.agent_name
     )
@@ -57,11 +99,27 @@ async def handle_register(consumer, content):
         "multiplexer": payload.get("multiplexer", ""),
         "channels": channels,
         "claude_md": payload.get("claude_md", ""),
+        # #257 canonical heartbeat metadata — pass through so the
+        # registry's prev-preserve logic can store the per-process
+        # identity. Without these, singleton enforcement on a future
+        # second register frame can't find an incumbent identity.
+        "instance_id": challenger_instance_id,
+        "start_ts_unix": challenger_start_ts_unix,
     }
 
-    from hub.registry import register_agent
+    from hub.registry import register_agent, set_connection_identity
 
     register_agent(consumer.agent_name, consumer.workspace_id, consumer.agent_meta)
+    # Track per-channel identity so a future challenger can be compared
+    # against this connection (#255). Safe no-op when instance_id is
+    # empty — list_sibling_channels still emits the entry but
+    # decide_singleton_winner falls through to legacy permissive mode.
+    set_connection_identity(
+        channel_name=consumer.channel_name,
+        agent_name=consumer.agent_name,
+        instance_id=challenger_instance_id,
+        start_ts_unix=challenger_start_ts_unix,
+    )
 
     await consumer.channel_layer.group_send(
         consumer.workspace_group,
@@ -73,6 +131,128 @@ async def handle_register(consumer, content):
     )
 
     await consumer.send_json({"type": "registered", "channels": channels})
+
+
+async def _enforce_singleton(
+    consumer,
+    challenger_instance_id: str,
+    challenger_start_ts_unix: float | None,
+) -> bool:
+    """Apply the #255 singleton decision rule for ``consumer``'s register frame.
+
+    Returns ``True`` when this connection (the challenger) was closed
+    and the caller should abort the register flow. Returns ``False``
+    when either no conflict was detected or the incumbent was evicted
+    (this consumer keeps the claim and registration should proceed).
+    """
+    from hub.registry import (
+        decide_singleton_winner,
+        list_sibling_channels,
+        record_singleton_conflict,
+    )
+
+    siblings = list_sibling_channels(
+        consumer.agent_name, exclude=consumer.channel_name
+    )
+    if not siblings:
+        return False
+
+    # Compare against EACH sibling so a third-comer doesn't accidentally
+    # admit itself by colluding with a stale half-disconnected sibling.
+    for sib in siblings:
+        outcome = decide_singleton_winner(
+            incumbent_instance_id=sib.get("instance_id") or "",
+            incumbent_start_ts_unix=sib.get("start_ts_unix"),
+            challenger_instance_id=challenger_instance_id,
+            challenger_start_ts_unix=challenger_start_ts_unix,
+        )
+        if outcome == "incumbent" and (
+            not sib.get("instance_id") or not challenger_instance_id
+        ):
+            # Legacy permissive mode — at least one side can't enforce.
+            # Log for visibility but admit both connections.
+            log.warning(
+                "Singleton check skipped for agent %s — legacy client "
+                "(missing instance_id). Allowing concurrent connections; "
+                "upgrade agent_meta.py to enable enforcement.",
+                consumer.agent_name,
+            )
+            continue
+        if outcome == "incumbent" and sib.get(
+            "instance_id"
+        ) == challenger_instance_id:
+            # Same process re-registering (transient WS reconnect).
+            # Not a conflict — let the new connection register and
+            # naturally supersede the stale sibling.
+            continue
+        if outcome == "incumbent":
+            # Strict-mode incumbent wins → close THIS connection.
+            record_singleton_conflict(
+                name=consumer.agent_name,
+                winner_instance_id=sib.get("instance_id") or "",
+                loser_instance_id=challenger_instance_id,
+                winner_start_ts_unix=sib.get("start_ts_unix"),
+                loser_start_ts_unix=challenger_start_ts_unix,
+                outcome="incumbent",
+            )
+            try:
+                await consumer.send_json(
+                    {
+                        "type": "error",
+                        "code": DUPLICATE_IDENTITY_REASON,
+                        "message": (
+                            "another process already holds this agent "
+                            "identity (older start_ts_unix wins)"
+                        ),
+                        "winner_instance_id": sib.get("instance_id") or "",
+                    }
+                )
+            except Exception:
+                pass
+            await consumer.close(code=DUPLICATE_IDENTITY_CLOSE_CODE)
+            return True
+        # outcome == "challenger" → evict the sibling.
+        record_singleton_conflict(
+            name=consumer.agent_name,
+            winner_instance_id=challenger_instance_id,
+            loser_instance_id=sib.get("instance_id") or "",
+            winner_start_ts_unix=challenger_start_ts_unix,
+            loser_start_ts_unix=sib.get("start_ts_unix"),
+            outcome="challenger",
+        )
+        await _evict_sibling(consumer, sib.get("channel_name", ""))
+    return False
+
+
+async def _evict_sibling(consumer, sibling_channel_name: str) -> None:
+    """Send a force-close hint to a sibling consumer over the channel layer.
+
+    Django Channels lets us address a single consumer by its
+    ``channel_name``. We deliver a custom event whose ``type`` maps to
+    the consumer's ``singleton_evict`` handler (defined on
+    ``AgentConsumer``); that handler then performs the WebSocket close.
+    Best-effort — if the sibling is already gone the channel layer just
+    drops the message and the next heartbeat-stale sweep finishes the
+    cleanup.
+    """
+    if not sibling_channel_name:
+        return
+    try:
+        await consumer.channel_layer.send(
+            sibling_channel_name,
+            {
+                "type": "singleton.evict",
+                "reason": DUPLICATE_IDENTITY_REASON,
+                "code": DUPLICATE_IDENTITY_CLOSE_CODE,
+            },
+        )
+    except Exception as e:
+        log.warning(
+            "Failed to evict sibling %s for agent %s: %s",
+            sibling_channel_name,
+            consumer.agent_name,
+            e,
+        )
 
 
 async def handle_subscription(consumer, content, subscribe: bool):

--- a/hub/frontend/src/agents-tab/detail.ts
+++ b/hub/frontend/src/agents-tab/detail.ts
@@ -208,6 +208,44 @@ export function _renderAgentDetail(a) {
       );
     })
     .join("");
+  // scitex-orochi#255 — duplicate-identity warning banner. Surfaces
+  // when the most recent singleton-conflict event for this agent is
+  // within the hub's window (last hour). The detail endpoint fades
+  // the field to null after the window expires so this branch falls
+  // off automatically — no client-side timer.
+  var dupEvent = d.last_duplicate_identity_event || null;
+  var dupWarnHtml = "";
+  if (dupEvent && dupEvent.ts) {
+    var ageSec = Math.max(
+      0,
+      Math.round((Date.now() - dupEvent.ts * 1000) / 1000),
+    );
+    var ageLabel =
+      ageSec < 60
+        ? ageSec + "s ago"
+        : ageSec < 3600
+          ? Math.round(ageSec / 60) + "m ago"
+          : Math.round(ageSec / 3600) + "h ago";
+    var winnerShort = (dupEvent.winner_instance_id || "?").slice(0, 8);
+    var loserShort = (dupEvent.loser_instance_id || "?").slice(0, 8);
+    dupWarnHtml =
+      '<div class="agent-detail-dup-warn" role="alert" title="' +
+      escapeHtml(
+        "Two processes claimed this agent name. The hub closed the loser " +
+          "with WebSocket close code 4409 (duplicate_identity).",
+      ) +
+      '">' +
+      "\u26A0\uFE0F duplicate identity detected " +
+      escapeHtml(ageLabel) +
+      " \u2014 winner=" +
+      escapeHtml(winnerShort) +
+      ", loser=" +
+      escapeHtml(loserShort) +
+      " (" +
+      escapeHtml(dupEvent.outcome || "incumbent") +
+      ")" +
+      "</div>";
+  }
   var headerHtml =
     '<div class="agent-detail-header">' +
     '<div class="agent-detail-header-line">' +
@@ -226,6 +264,7 @@ export function _renderAgentDetail(a) {
     '">DM</button>' +
     "</span>" +
     "</div>" +
+    dupWarnHtml +
     '<div class="agent-detail-meta-grid">' +
     metaHtml +
     "</div>" +

--- a/hub/registry/__init__.py
+++ b/hub/registry/__init__.py
@@ -37,21 +37,31 @@ from ._heartbeat import (
 )
 from ._payload import get_agents, get_online_count
 from ._register import (
+    clear_connection_identity,
+    decide_singleton_winner,
+    get_connection_identity,
+    get_recent_singleton_event,
+    list_sibling_channels,
     purge_agent,
     purge_all_offline,
+    record_singleton_conflict,
     register_agent,
     register_connection,
+    set_connection_identity,
     unregister_agent,
     unregister_connection,
 )
 from ._store import (
     HEARTBEAT_TIMEOUT_S,
+    SINGLETON_EVENT_WINDOW_S,
     STALE_PURGE_S,
     _active_session_count,
     _agents,
     _cleanup_locked,
+    _connection_identity,
     _connections,
     _lock,
+    _singleton_events,
     active_session_count,
     log,
 )
@@ -60,6 +70,8 @@ __all__ = [
     # Storage primitives (also imported by tests + a few views directly)
     "_agents",
     "_connections",
+    "_connection_identity",
+    "_singleton_events",
     "_lock",
     "_active_session_count",
     "_cleanup_locked",
@@ -67,6 +79,7 @@ __all__ = [
     "log",
     "HEARTBEAT_TIMEOUT_S",
     "STALE_PURGE_S",
+    "SINGLETON_EVENT_WINDOW_S",
     # Registration / connection lifecycle
     "register_agent",
     "unregister_agent",
@@ -74,6 +87,14 @@ __all__ = [
     "unregister_connection",
     "purge_agent",
     "purge_all_offline",
+    # Singleton enforcement (#255)
+    "set_connection_identity",
+    "clear_connection_identity",
+    "get_connection_identity",
+    "list_sibling_channels",
+    "decide_singleton_winner",
+    "record_singleton_conflict",
+    "get_recent_singleton_event",
     # Heartbeat / activity / health setters
     "update_heartbeat",
     "update_pong",

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -8,7 +8,16 @@ flicker every heartbeat (regression hazard).
 
 import time
 
-from ._store import _active_session_count, _agents, _connections, _lock
+from ._store import (
+    SINGLETON_EVENT_WINDOW_S,
+    _active_session_count,
+    _agents,
+    _connection_identity,
+    _connections,
+    _lock,
+    _singleton_events,
+    log,
+)
 
 
 def register_agent(name: str, workspace_id: int, info: dict) -> None:
@@ -460,3 +469,210 @@ def purge_agent(name: str) -> bool:
             del _agents[name]
             return True
         return False
+
+
+# ── scitex-orochi#255 — singleton cardinality enforcement ────────────
+#
+# The two-process race that motivated #255: when sac (or a human) starts
+# a second copy of an agent that already has a live WS, both processes
+# claim the same ``SCITEX_OROCHI_AGENT`` identity. Pre-#255 behaviour
+# admitted both — they then fought for the heartbeat slot, the dashboard
+# flickered between their states, and DM routing was racy. Post-#255 the
+# hub picks one winner and closes the loser with WebSocket close code
+# 4409 / reason ``duplicate_identity`` so the loser exits cleanly.
+#
+# Decision rule (HANDOFF.md §3 #3 + ywatanabe msg #14757):
+#
+#   1. Need *both* sides to report ``instance_id`` AND ``start_ts_unix``
+#      to enforce — legacy clients that report neither fall through to
+#      the permissive "allow both" behaviour with a logged WARNING (no
+#      regression for older agent_meta.py installs).
+#   2. Same ``instance_id``: not a conflict — same process re-registering
+#      after a transient WS reconnect. Treat as incumbent-wins (no-op).
+#   3. Different ``instance_id`` AND both have ``start_ts_unix``: the
+#      OLDER ``start_ts_unix`` wins. Original process keeps its claim.
+#   4. Tie (equal ``start_ts_unix``) or one side missing the field:
+#      incumbent wins (don't disrupt the running process).
+
+
+def set_connection_identity(
+    channel_name: str,
+    agent_name: str,
+    instance_id: str | None,
+    start_ts_unix: float | None,
+) -> None:
+    """Remember the per-process identity behind ``channel_name``.
+
+    Called from the register-frame handler so that when a *future* second
+    register frame arrives under the same ``agent_name`` we can compare
+    its ``(instance_id, start_ts_unix)`` against every currently-live
+    sibling channel and decide who survives.
+
+    Lookup direction is channel→identity (not name→identity) because
+    ``_agents[name]`` only ever stores ONE process's identity at a time;
+    the per-channel map is what lets us close the right WebSocket when
+    the challenger wins.
+    """
+    if not channel_name or not agent_name:
+        return
+    with _lock:
+        _connection_identity[channel_name] = {
+            "agent": agent_name,
+            "instance_id": instance_id or "",
+            "start_ts_unix": (
+                float(start_ts_unix) if start_ts_unix is not None else None
+            ),
+        }
+
+
+def clear_connection_identity(channel_name: str) -> None:
+    """Forget per-channel identity on disconnect.
+
+    Mirrors ``unregister_connection`` so the per-channel map doesn't grow
+    monotonically over the hub's lifetime.
+    """
+    if not channel_name:
+        return
+    with _lock:
+        _connection_identity.pop(channel_name, None)
+
+
+def get_connection_identity(channel_name: str) -> dict | None:
+    """Return the per-channel identity dict, or ``None`` if not tracked."""
+    with _lock:
+        if channel_name in _connection_identity:
+            return dict(_connection_identity[channel_name])
+        return None
+
+
+def list_sibling_channels(agent_name: str, exclude: str = "") -> list[dict]:
+    """Return identity dicts for every other live channel claiming ``agent_name``.
+
+    Used by the register handler to find candidates to compare the new
+    challenger against. ``exclude`` is the new connection's own channel
+    name so we don't compare it with itself.
+    """
+    if not agent_name:
+        return []
+    with _lock:
+        return [
+            {"channel_name": ch, **ident}
+            for ch, ident in _connection_identity.items()
+            if ident.get("agent") == agent_name and ch != exclude
+        ]
+
+
+def decide_singleton_winner(
+    incumbent_instance_id: str | None,
+    incumbent_start_ts_unix: float | None,
+    challenger_instance_id: str | None,
+    challenger_start_ts_unix: float | None,
+) -> str:
+    """Pick the winner of a two-process singleton race.
+
+    Returns ``"incumbent"`` when the existing connection should keep the
+    claim and the challenger should be closed; ``"challenger"`` when the
+    new connection wins and the incumbent should be evicted.
+
+    Rule precedence (matches the module-level docstring):
+
+      1. If either side is missing ``instance_id`` -> incumbent wins
+         (legacy permissive mode). The caller is expected to log a
+         WARNING in that branch so the situation is still observable.
+      2. Same ``instance_id`` -> incumbent (treat as harmless re-register,
+         not a real conflict — the caller decides not to close anyone).
+      3. Both have ``start_ts_unix`` and they differ -> older
+         ``start_ts_unix`` wins.
+      4. Tie or one side missing ``start_ts_unix`` -> incumbent wins
+         (don't disrupt the running process).
+    """
+    # Rule 1 — legacy permissive mode. Either side can't enforce.
+    if not incumbent_instance_id or not challenger_instance_id:
+        return "incumbent"
+    # Rule 2 — same process re-registering, not a conflict.
+    if incumbent_instance_id == challenger_instance_id:
+        return "incumbent"
+    # Rule 3 — strict tiebreaker on start_ts_unix.
+    if (
+        incumbent_start_ts_unix is not None
+        and challenger_start_ts_unix is not None
+        and incumbent_start_ts_unix != challenger_start_ts_unix
+    ):
+        return (
+            "incumbent"
+            if incumbent_start_ts_unix < challenger_start_ts_unix
+            else "challenger"
+        )
+    # Rule 4 — tie or missing tiebreaker; protect the running process.
+    return "incumbent"
+
+
+def record_singleton_conflict(
+    name: str,
+    winner_instance_id: str,
+    loser_instance_id: str,
+    winner_start_ts_unix: float | None = None,
+    loser_start_ts_unix: float | None = None,
+    outcome: str = "incumbent",
+) -> dict:
+    """Append a singleton-conflict event to the bounded ring buffer.
+
+    The dashboard reads back the most recent event per agent via
+    ``get_recent_singleton_event(name)`` and surfaces a banner /
+    detail-pane warning when the event is within the last hour.
+
+    ``outcome`` is the verbatim return value of ``decide_singleton_winner``
+    so the dashboard / log reader can tell which side actually got
+    closed without re-running the rule.
+    """
+    event = {
+        "name": name,
+        "ts": time.time(),
+        "winner_instance_id": winner_instance_id or "",
+        "loser_instance_id": loser_instance_id or "",
+        "winner_start_ts_unix": (
+            float(winner_start_ts_unix)
+            if winner_start_ts_unix is not None
+            else None
+        ),
+        "loser_start_ts_unix": (
+            float(loser_start_ts_unix)
+            if loser_start_ts_unix is not None
+            else None
+        ),
+        "outcome": outcome,
+    }
+    with _lock:
+        _singleton_events.append(event)
+    log.warning(
+        "Singleton conflict for agent %s — %s wins (winner=%s, loser=%s)",
+        name,
+        outcome,
+        winner_instance_id or "?",
+        loser_instance_id or "?",
+    )
+    return event
+
+
+def get_recent_singleton_event(
+    name: str, within_seconds: int = SINGLETON_EVENT_WINDOW_S
+) -> dict | None:
+    """Return the most recent conflict event for ``name`` within the window.
+
+    The dashboard banner / per-agent detail pane fades out once the
+    most recent event is older than ``within_seconds``. Default window
+    matches HANDOFF.md (last hour).
+    """
+    cutoff = time.time() - max(0, int(within_seconds))
+    with _lock:
+        # Iterate newest-first so we can return on the first matching
+        # hit. Events are time-ordered globally, so the first matching
+        # entry IS the most recent for ``name``; we only return it when
+        # it's still inside the window.
+        for event in reversed(_singleton_events):
+            if event.get("name") != name:
+                continue
+            if event.get("ts", 0) < cutoff:
+                return None
+            return dict(event)
+    return None

--- a/hub/registry/_store.py
+++ b/hub/registry/_store.py
@@ -12,12 +12,31 @@ directly. The names are part of the registry's public surface.
 import logging
 import threading
 import time
+from collections import deque
 
 log = logging.getLogger("orochi.registry")
 
 _lock = threading.Lock()
 _agents: dict[str, dict] = {}
 _connections: dict[str, set[str]] = {}
+# scitex-orochi#255 — per-channel connection identity for singleton
+# enforcement. Maps channel_name -> {"agent": str, "instance_id": str,
+# "start_ts_unix": float | None}. Populated by ``set_connection_identity``
+# at register-frame time so the hub can decide singleton conflicts even
+# after the second WS connection has already accepted (the register frame
+# is what carries the per-process identity).
+_connection_identity: dict[str, dict] = {}
+# scitex-orochi#255 — bounded ring buffer of singleton-conflict events.
+# Each entry: {"name": agent_name, "ts": float, "winner_instance_id":
+# str, "loser_instance_id": str, "winner_start_ts_unix": float | None,
+# "loser_start_ts_unix": float | None, "outcome": "incumbent" | "challenger"}.
+# Newest events appended on the right; we cap the buffer so a runaway
+# crash loop can't OOM the hub. The detail API filters by ``ts`` >=
+# now-3600 so an event ages out of the dashboard banner one hour after
+# it occurred even if it's still in the buffer.
+SINGLETON_EVENTS_MAX = 256
+SINGLETON_EVENT_WINDOW_S = 3600  # 1 hour
+_singleton_events: deque[dict] = deque(maxlen=SINGLETON_EVENTS_MAX)
 
 # Agents with no heartbeat for this many seconds are auto-marked offline
 HEARTBEAT_TIMEOUT_S = 60

--- a/hub/static/hub/components/components-agent-detail.css
+++ b/hub/static/hub/components/components-agent-detail.css
@@ -123,6 +123,21 @@
   background: #2a2a2a;
   border-color: #4ecdc4;
 }
+/* scitex-orochi#255 — duplicate-identity warning banner. Surfaces in
+ * the per-agent detail header when the hub recently closed a sibling
+ * connection because both processes claimed the same agent name.
+ * Auto-fades when the source event ages out of the hub's window
+ * (currently 1 hour); no client-side dismiss needed. */
+.agent-detail-dup-warn {
+  margin-top: 6px;
+  padding: 4px 8px;
+  background: #3a1f0d;
+  border: 1px solid #ff8c42;
+  border-radius: 4px;
+  color: #ffb98a;
+  font-size: 12px;
+  font-weight: 500;
+}
 .agent-detail-meta {
   font-size: 12px;
   color: #888;

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -26,6 +26,7 @@ from hub.tests.registry.test_canonical_metadata import *  # noqa: F401,F403
 from hub.tests.registry.test_echo_indicator import *  # noqa: F401,F403
 from hub.tests.registry.test_heartbeat import *  # noqa: F401,F403
 from hub.tests.registry.test_reexports import *  # noqa: F401,F403
+from hub.tests.registry.test_singleton_enforcement import *  # noqa: F401,F403
 from hub.tests.test_auth import *  # noqa: F401,F403
 from hub.tests.test_oauth_helper import *  # noqa: F401,F403
 from hub.tests.views.api.test_agent_detail import *  # noqa: F401,F403

--- a/hub/tests/registry/test_singleton_enforcement.py
+++ b/hub/tests/registry/test_singleton_enforcement.py
@@ -1,0 +1,492 @@
+"""Tests for #255 — singleton cardinality enforcement at the hub.
+
+Background: #257 added ``instance_id`` (UUID per process) and
+``start_ts_unix`` (epoch float) to the heartbeat metadata so the hub
+could distinguish two processes claiming the same ``SCITEX_OROCHI_AGENT``
+name. #255 then turns that data into an enforcement: when two WS
+connections claim the same agent, the hub picks ONE winner (older
+``start_ts_unix`` wins) and disconnects the OTHER with WebSocket close
+code 4409 / reason ``duplicate_identity``.
+
+These tests pin the decision rule, the conflict-event ring buffer, the
+heartbeat-survival contract for the winner, and the detail-API surface
+the dashboard reads to render the warning banner.
+
+Backwards compatibility: legacy clients that don't report
+``instance_id`` (older agent_meta.py installs) MUST keep working — the
+hub falls back to the pre-#255 permissive multi-connection behaviour
+with a logged WARNING (no enforcement, no eviction).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+from django.test import Client, TestCase
+
+from hub.models import Workspace, WorkspaceToken
+from hub.registry import (
+    SINGLETON_EVENT_WINDOW_S,
+    _agents,
+    _connection_identity,
+    _connections,
+    _singleton_events,
+    decide_singleton_winner,
+    get_recent_singleton_event,
+    list_sibling_channels,
+    record_singleton_conflict,
+    register_agent,
+    register_connection,
+    set_connection_identity,
+    update_heartbeat,
+)
+
+
+def _reset_registry() -> None:
+    _agents.clear()
+    _connections.clear()
+    _connection_identity.clear()
+    _singleton_events.clear()
+
+
+class DecideSingletonWinnerTests(TestCase):
+    """Pure-function tests for the decision rule — no Django, no async."""
+
+    def test_older_start_ts_wins(self):
+        """Case (a) from the spec: two registers with different start_ts
+        — the OLDER ``start_ts_unix`` wins."""
+        # Incumbent older → incumbent keeps the claim.
+        outcome = decide_singleton_winner(
+            incumbent_instance_id="aaa",
+            incumbent_start_ts_unix=1000.0,
+            challenger_instance_id="bbb",
+            challenger_start_ts_unix=2000.0,
+        )
+        self.assertEqual(outcome, "incumbent")
+
+    def test_challenger_wins_when_older(self):
+        """Symmetric case: when the challenger is older, the incumbent
+        is evicted (a faster-restarting sibling shouldn't be able to
+        steal the claim from the original process by reconnecting)."""
+        outcome = decide_singleton_winner(
+            incumbent_instance_id="aaa",
+            incumbent_start_ts_unix=2000.0,
+            challenger_instance_id="bbb",
+            challenger_start_ts_unix=1000.0,
+        )
+        self.assertEqual(outcome, "challenger")
+
+    def test_tie_keeps_incumbent(self):
+        """Case (b): equal ``start_ts_unix`` — incumbent wins.
+
+        Don't disrupt the running process when the tiebreaker is
+        ambiguous; both halves of the race are equally fresh.
+        """
+        outcome = decide_singleton_winner(
+            incumbent_instance_id="aaa",
+            incumbent_start_ts_unix=1000.0,
+            challenger_instance_id="bbb",
+            challenger_start_ts_unix=1000.0,
+        )
+        self.assertEqual(outcome, "incumbent")
+
+    def test_legacy_missing_instance_id_keeps_incumbent(self):
+        """Case (c): legacy clients without ``instance_id`` — no
+        enforcement (incumbent wins, caller must allow both)."""
+        # Challenger is legacy.
+        self.assertEqual(
+            decide_singleton_winner("aaa", 1000.0, "", 999.0),
+            "incumbent",
+        )
+        # Incumbent is legacy.
+        self.assertEqual(
+            decide_singleton_winner("", 1000.0, "bbb", 999.0),
+            "incumbent",
+        )
+        # Both legacy.
+        self.assertEqual(
+            decide_singleton_winner("", None, "", None),
+            "incumbent",
+        )
+
+    def test_same_instance_id_is_not_a_conflict(self):
+        """Same ``instance_id`` from both sides means the same process
+        re-registered after a transient WS reconnect — not a singleton
+        race. Decision: incumbent (caller treats it as a no-op, no
+        eviction)."""
+        outcome = decide_singleton_winner(
+            incumbent_instance_id="same-uuid",
+            incumbent_start_ts_unix=1000.0,
+            challenger_instance_id="same-uuid",
+            challenger_start_ts_unix=1500.0,
+        )
+        self.assertEqual(outcome, "incumbent")
+
+    def test_missing_start_ts_keeps_incumbent(self):
+        """If one side has ``instance_id`` but not ``start_ts_unix`` we
+        can't strictly tiebreak — incumbent wins to protect the running
+        process."""
+        outcome = decide_singleton_winner(
+            incumbent_instance_id="aaa",
+            incumbent_start_ts_unix=None,
+            challenger_instance_id="bbb",
+            challenger_start_ts_unix=2000.0,
+        )
+        self.assertEqual(outcome, "incumbent")
+        outcome = decide_singleton_winner(
+            incumbent_instance_id="aaa",
+            incumbent_start_ts_unix=1000.0,
+            challenger_instance_id="bbb",
+            challenger_start_ts_unix=None,
+        )
+        self.assertEqual(outcome, "incumbent")
+
+
+class ConnectionIdentityTrackingTests(TestCase):
+    """Per-channel identity map (used by the register handler to find
+    siblings)."""
+
+    def setUp(self):
+        _reset_registry()
+
+    def test_set_and_list_sibling_channels(self):
+        set_connection_identity("ch-1", "head-mba", "uuid-1", 1000.0)
+        set_connection_identity("ch-2", "head-mba", "uuid-2", 1500.0)
+        # An unrelated agent on a third channel — must NOT show up
+        # when we ask for head-mba siblings.
+        set_connection_identity("ch-3", "head-spartan", "uuid-3", 1000.0)
+        sibs = list_sibling_channels("head-mba", exclude="ch-1")
+        self.assertEqual(len(sibs), 1)
+        self.assertEqual(sibs[0]["channel_name"], "ch-2")
+        self.assertEqual(sibs[0]["instance_id"], "uuid-2")
+        self.assertEqual(sibs[0]["start_ts_unix"], 1500.0)
+
+    def test_clear_drops_entry(self):
+        from hub.registry import clear_connection_identity
+
+        set_connection_identity("ch-1", "head-mba", "uuid-1", 1000.0)
+        clear_connection_identity("ch-1")
+        self.assertEqual(list_sibling_channels("head-mba"), [])
+
+    def test_set_with_empty_args_is_noop(self):
+        set_connection_identity("", "head-mba", "uuid-1", 1000.0)
+        set_connection_identity("ch-1", "", "uuid-1", 1000.0)
+        self.assertEqual(list_sibling_channels("head-mba"), [])
+
+
+class SingletonConflictRingBufferTests(TestCase):
+    """Bounded conflict-event buffer + per-agent recent lookup."""
+
+    def setUp(self):
+        _reset_registry()
+
+    def test_record_and_get_recent_event(self):
+        record_singleton_conflict(
+            name="head-mba",
+            winner_instance_id="aaa",
+            loser_instance_id="bbb",
+            winner_start_ts_unix=1000.0,
+            loser_start_ts_unix=2000.0,
+            outcome="incumbent",
+        )
+        ev = get_recent_singleton_event("head-mba")
+        self.assertIsNotNone(ev)
+        self.assertEqual(ev["winner_instance_id"], "aaa")
+        self.assertEqual(ev["loser_instance_id"], "bbb")
+        self.assertEqual(ev["outcome"], "incumbent")
+        # Newer events for the same agent supersede older ones.
+        record_singleton_conflict(
+            name="head-mba",
+            winner_instance_id="ccc",
+            loser_instance_id="ddd",
+            outcome="challenger",
+        )
+        ev2 = get_recent_singleton_event("head-mba")
+        self.assertEqual(ev2["winner_instance_id"], "ccc")
+        self.assertEqual(ev2["outcome"], "challenger")
+
+    def test_recent_event_filtered_by_window(self):
+        """Events older than ``within_seconds`` MUST NOT be returned —
+        the dashboard banner depends on this auto-fade."""
+        record_singleton_conflict(
+            name="head-mba",
+            winner_instance_id="aaa",
+            loser_instance_id="bbb",
+        )
+        # Backdate the event past the default window.
+        _singleton_events[-1]["ts"] = time.time() - SINGLETON_EVENT_WINDOW_S - 1
+        self.assertIsNone(get_recent_singleton_event("head-mba"))
+
+    def test_recent_event_for_other_agent_is_none(self):
+        record_singleton_conflict(
+            name="head-mba",
+            winner_instance_id="aaa",
+            loser_instance_id="bbb",
+        )
+        self.assertIsNone(get_recent_singleton_event("head-spartan"))
+
+
+class HeartbeatSurvivalForWinnerTests(TestCase):
+    """Case (d): after a singleton race, the winner's heartbeat sequence
+    must continue to update — the eviction must not corrupt the registry
+    entry the winner is still using."""
+
+    def setUp(self):
+        _reset_registry()
+
+    def test_winner_heartbeat_still_updates(self):
+        # Incumbent registers as the winner.
+        register_agent(
+            "head-mba",
+            workspace_id=1,
+            info={
+                "instance_id": "winner-uuid",
+                "start_ts_unix": 1000.0,
+                "machine": "mba",
+            },
+        )
+        register_connection("head-mba", "ch-incumbent")
+        set_connection_identity("ch-incumbent", "head-mba", "winner-uuid", 1000.0)
+        # Conflict happens; record it (simulates _enforce_singleton).
+        record_singleton_conflict(
+            name="head-mba",
+            winner_instance_id="winner-uuid",
+            loser_instance_id="loser-uuid",
+            winner_start_ts_unix=1000.0,
+            loser_start_ts_unix=2000.0,
+            outcome="incumbent",
+        )
+        # Winner sends a fresh heartbeat — the registry entry MUST
+        # still be live (not blanked, not flipped to offline).
+        before_ts = _agents["head-mba"]["last_heartbeat"]
+        time.sleep(0.01)
+        update_heartbeat("head-mba", {"cpu_count": 8})
+        after_ts = _agents["head-mba"]["last_heartbeat"]
+        self.assertGreater(after_ts, before_ts)
+        self.assertEqual(_agents["head-mba"]["status"], "online")
+        self.assertEqual(_agents["head-mba"]["instance_id"], "winner-uuid")
+
+
+class AgentDetailApiSingletonEventTest(TestCase):
+    """Case (e): the conflict event surfaces in the detail API.
+
+    Mirrors the ``AgentDetailApiTest`` setup pattern: register an agent
+    against a real Workspace + WorkspaceToken, then GET the detail
+    endpoint and assert the new ``last_duplicate_identity_event`` key is
+    populated when an event has happened, and ``None`` otherwise.
+    """
+
+    def setUp(self):
+        _reset_registry()
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="singleton-ws")
+        self.token = WorkspaceToken.objects.create(
+            workspace=self.ws, label="singleton-test"
+        )
+
+    def _register_alpha(self):
+        register_agent(
+            name="alpha",
+            workspace_id=self.ws.id,
+            info={
+                "agent_id": "alpha",
+                "machine": "MBA",
+                "instance_id": "winner-uuid",
+                "start_ts_unix": 1000.0,
+            },
+        )
+
+    def _detail(self, name="alpha"):
+        return self.client.get(
+            f"/api/agents/{name}/detail/",
+            data={"token": self.token.token},
+        )
+
+    def test_no_event_yields_null_field(self):
+        self._register_alpha()
+        resp = self._detail()
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("last_duplicate_identity_event", data)
+        self.assertIsNone(data["last_duplicate_identity_event"])
+
+    def test_recent_event_surfaces_with_canonical_shape(self):
+        self._register_alpha()
+        record_singleton_conflict(
+            name="alpha",
+            winner_instance_id="winner-uuid",
+            loser_instance_id="loser-uuid",
+            winner_start_ts_unix=1000.0,
+            loser_start_ts_unix=2000.0,
+            outcome="incumbent",
+        )
+        resp = self._detail()
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        ev = data["last_duplicate_identity_event"]
+        self.assertIsNotNone(ev)
+        self.assertEqual(ev["winner_instance_id"], "winner-uuid")
+        self.assertEqual(ev["loser_instance_id"], "loser-uuid")
+        self.assertEqual(ev["winner_start_ts_unix"], 1000.0)
+        self.assertEqual(ev["loser_start_ts_unix"], 2000.0)
+        self.assertEqual(ev["outcome"], "incumbent")
+        self.assertIsNotNone(ev["ts"])
+        self.assertIsNotNone(ev["ts_iso"])
+
+    def test_aged_out_event_falls_back_to_null(self):
+        self._register_alpha()
+        record_singleton_conflict(
+            name="alpha",
+            winner_instance_id="winner-uuid",
+            loser_instance_id="loser-uuid",
+        )
+        # Backdate beyond the window — the API MUST drop it.
+        _singleton_events[-1]["ts"] = time.time() - SINGLETON_EVENT_WINDOW_S - 5
+        resp = self._detail()
+        self.assertIsNone(resp.json()["last_duplicate_identity_event"])
+
+
+def _make_consumer(agent_name: str, channel_name: str):
+    """Return a stub consumer with the attributes ``_enforce_singleton``
+    accesses. Heavy use of ``MagicMock`` keeps the test off the Channels
+    transport so the assertions stay focused on the hub-side decision
+    + close path."""
+    consumer = MagicMock()
+    consumer.agent_name = agent_name
+    consumer.channel_name = channel_name
+    consumer.send_json = AsyncMock()
+    consumer.close = AsyncMock()
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.send = AsyncMock()
+    return consumer
+
+
+class EnforceSingletonHandlerTests(TestCase):
+    """End-to-end exercise of ``_enforce_singleton`` from the
+    register-frame path.
+
+    Verifies:
+
+      * older incumbent → challenger is closed; no agent_meta written;
+      * older challenger → sibling is evicted; conflict recorded;
+      * legacy incumbent (no instance_id) → no eviction (permissive
+        fallback), challenger still proceeds.
+    """
+
+    def setUp(self):
+        _reset_registry()
+
+    def test_incumbent_wins_closes_challenger(self):
+        from hub.consumers._agent_handlers import (
+            DUPLICATE_IDENTITY_CLOSE_CODE,
+            _enforce_singleton,
+        )
+
+        # Incumbent already registered with older start_ts.
+        set_connection_identity(
+            "ch-incumbent", "head-mba", "winner-uuid", 1000.0
+        )
+        register_connection("head-mba", "ch-incumbent")
+
+        # Challenger arrives (newer start_ts → loses).
+        challenger = _make_consumer("head-mba", "ch-challenger")
+        closed = asyncio.run(
+            _enforce_singleton(
+                challenger,
+                challenger_instance_id="loser-uuid",
+                challenger_start_ts_unix=2000.0,
+            )
+        )
+        self.assertTrue(closed)
+        challenger.close.assert_awaited_once_with(
+            code=DUPLICATE_IDENTITY_CLOSE_CODE
+        )
+        # Conflict event recorded with the right sides.
+        ev = get_recent_singleton_event("head-mba")
+        self.assertIsNotNone(ev)
+        self.assertEqual(ev["winner_instance_id"], "winner-uuid")
+        self.assertEqual(ev["loser_instance_id"], "loser-uuid")
+        self.assertEqual(ev["outcome"], "incumbent")
+        # Sibling was NOT evicted (incumbent stays).
+        challenger.channel_layer.send.assert_not_awaited()
+
+    def test_challenger_wins_evicts_sibling(self):
+        from hub.consumers._agent_handlers import _enforce_singleton
+
+        # Incumbent has NEWER start_ts → it loses.
+        set_connection_identity(
+            "ch-incumbent", "head-mba", "loser-uuid", 2000.0
+        )
+        register_connection("head-mba", "ch-incumbent")
+
+        challenger = _make_consumer("head-mba", "ch-challenger")
+        closed = asyncio.run(
+            _enforce_singleton(
+                challenger,
+                challenger_instance_id="winner-uuid",
+                challenger_start_ts_unix=1000.0,
+            )
+        )
+        self.assertFalse(closed)
+        challenger.close.assert_not_awaited()
+        # Sibling channel was sent the eviction message.
+        challenger.channel_layer.send.assert_awaited_once()
+        args = challenger.channel_layer.send.await_args
+        self.assertEqual(args.args[0], "ch-incumbent")
+        self.assertEqual(args.args[1]["type"], "singleton.evict")
+        # Conflict event recorded with challenger as the winner.
+        ev = get_recent_singleton_event("head-mba")
+        self.assertEqual(ev["winner_instance_id"], "winner-uuid")
+        self.assertEqual(ev["loser_instance_id"], "loser-uuid")
+        self.assertEqual(ev["outcome"], "challenger")
+
+    def test_legacy_incumbent_no_eviction(self):
+        """Legacy permissive mode: incumbent has no ``instance_id`` so
+        the hub can't strictly enforce. The challenger MUST be allowed
+        through (returns False) and NO eviction message is sent."""
+        from hub.consumers._agent_handlers import _enforce_singleton
+
+        # Incumbent is legacy (no instance_id reported).
+        set_connection_identity("ch-incumbent", "head-mba", "", None)
+        register_connection("head-mba", "ch-incumbent")
+
+        challenger = _make_consumer("head-mba", "ch-challenger")
+        closed = asyncio.run(
+            _enforce_singleton(
+                challenger,
+                challenger_instance_id="new-uuid",
+                challenger_start_ts_unix=1000.0,
+            )
+        )
+        self.assertFalse(closed)
+        challenger.close.assert_not_awaited()
+        challenger.channel_layer.send.assert_not_awaited()
+        # No conflict event recorded — legacy mode is observed via the
+        # WARNING log only.
+        self.assertIsNone(get_recent_singleton_event("head-mba"))
+
+    def test_same_instance_id_is_not_a_conflict(self):
+        """Same UUID from both sides: a transient reconnect of the same
+        process. The new connection must register normally and no event
+        must be recorded."""
+        from hub.consumers._agent_handlers import _enforce_singleton
+
+        set_connection_identity(
+            "ch-incumbent", "head-mba", "same-uuid", 1000.0
+        )
+        register_connection("head-mba", "ch-incumbent")
+
+        challenger = _make_consumer("head-mba", "ch-challenger")
+        closed = asyncio.run(
+            _enforce_singleton(
+                challenger,
+                challenger_instance_id="same-uuid",
+                challenger_start_ts_unix=1500.0,
+            )
+        )
+        self.assertFalse(closed)
+        challenger.close.assert_not_awaited()
+        challenger.channel_layer.send.assert_not_awaited()
+        self.assertIsNone(get_recent_singleton_event("head-mba"))

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
 
-from hub.registry import get_agents
+from hub.registry import get_agents, get_recent_singleton_event
 
 # Canonical list of credential-ish strings to redact from terminal
 # captures before serving them to the dashboard. These are matched as
@@ -323,4 +323,22 @@ def api_agent_detail(request, name: str):
         "action_counts": agent.get("action_counts") or {},
         "p95_elapsed_s_by_action": agent.get("p95_elapsed_s_by_action") or {},
     }
+    # ── #255 singleton conflict surface ────────────────────────────────
+    # Most-recent duplicate-identity event for THIS agent within the
+    # last hour. ``None`` when no conflict has happened (or the most
+    # recent one has aged out of the window). The dashboard banner /
+    # detail-pane warning is driven off the presence of this key.
+    event = get_recent_singleton_event(name)
+    if event is not None:
+        payload["last_duplicate_identity_event"] = {
+            "ts": event.get("ts"),
+            "ts_iso": _iso(event.get("ts")),
+            "winner_instance_id": event.get("winner_instance_id", ""),
+            "loser_instance_id": event.get("loser_instance_id", ""),
+            "winner_start_ts_unix": event.get("winner_start_ts_unix"),
+            "loser_start_ts_unix": event.get("loser_start_ts_unix"),
+            "outcome": event.get("outcome", "incumbent"),
+        }
+    else:
+        payload["last_duplicate_identity_event"] = None
     return JsonResponse(payload)


### PR DESCRIPTION
## Summary
- Hub now picks ONE winner when two WS connections claim the same agent name (older `start_ts_unix` wins) and disconnects the loser with WebSocket close code 4409 / reason `duplicate_identity`. Builds on the per-process metadata (`instance_id`, `start_ts_unix`) #257 added.
- Bounded ring buffer (cap 256, 1h window) of conflict events; most-recent event surfaces in `/api/agents/<name>/detail/` as `last_duplicate_identity_event`. Agents-tab detail pane renders a warning banner that auto-fades when the source event ages out.
- Backwards compatible: legacy clients without `instance_id` keep working — the hub falls back to permissive multi-connection behavior with a logged WARNING.

## Decision rule
1. Both sides need `instance_id` to enforce; legacy = permissive (logged warning).
2. Same `instance_id` = transient reconnect, not a conflict.
3. Different `instance_id` + both `start_ts_unix`: OLDER wins.
4. Tie / missing tiebreaker: incumbent wins (protect the running process).

## Test plan
- [x] 20 new tests in `hub/tests/registry/test_singleton_enforcement.py` — all green
  - Decision rule (older wins, tie, legacy, same-uuid)
  - Per-channel identity map (`set` / `list_sibling_channels` / `clear`)
  - Conflict ring buffer (`record` / `get_recent` / window filter)
  - Winner heartbeat survival after a singleton race
  - End-to-end `_enforce_singleton` with stub consumers (incumbent-wins close, challenger-wins eviction, legacy-skip, same-uuid no-op)
  - Detail API surface (`last_duplicate_identity_event` shape + age-out)
- [x] Existing 35 registry tests still pass (`python manage.py test hub.tests.registry --verbosity=2`)
- [x] TS bundle rebuilt (`npm run build` in `hub/frontend`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)