### PR TITLE
feat(mcp): target_agent + structured errors (#262)

### DIFF
--- a/hub/urls.py
+++ b/hub/urls.py
@@ -99,6 +99,20 @@ urlpatterns = [
     path("api/agents/pinned/", views.api_agents_pinned, name="api-agents-pinned"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
+    # Admin-scoped subscribe/unsubscribe (issue #262 §9.1). Routed to a
+    # dedicated view that requires the calling actor to hold the
+    # workspace ``admin`` (or ``staff``) role; non-admin agents get a
+    # structured ``permission_denied`` JSON envelope.
+    path(
+        "api/agents/<str:target>/subscribe/",
+        views.api_admin_agent_subscribe,
+        name="api-admin-agent-subscribe",
+    ),
+    path(
+        "api/agents/<str:target>/unsubscribe/",
+        views.api_admin_agent_unsubscribe,
+        name="api-admin-agent-unsubscribe",
+    ),
     # Per-agent single-screen detail payload (todo#420 MVP).
     path(
         "api/agents/<str:name>/detail/",

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -134,6 +134,19 @@ urlpatterns = [
         views.api_agents_register,
         name="api-agents-register",
     ),
+    # Admin subscribe/unsubscribe — issue #262 §9.1. Mirrored on the bare
+    # domain so MCP sidecars (which default to the apex) can hit the
+    # admin path without a subdomain.
+    path(
+        "api/agents/<str:target>/subscribe/",
+        views.api_admin_agent_subscribe,
+        name="api-admin-agent-subscribe-bare",
+    ),
+    path(
+        "api/agents/<str:target>/unsubscribe/",
+        views.api_admin_agent_unsubscribe,
+        name="api-admin-agent-unsubscribe-bare",
+    ),
     # Central container-agent registry — mounted on bare domain so the MCP
     # sidecar on localhost can reach it without the subdomain middleware.
     path(

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -9,6 +9,8 @@ from hub.views.api import (  # noqa: F401
     api_agents_pin,
     api_agents_pinned,
     api_agents_purge,
+    api_admin_agent_subscribe,
+    api_admin_agent_unsubscribe,
     api_agents_register,
     api_agents_registry,
     api_agents_restart,

--- a/hub/views/api/__init__.py
+++ b/hub/views/api/__init__.py
@@ -24,6 +24,10 @@ from hub.views.api._agents import (
 )
 from hub.views.api._agents_lifecycle import api_agents_kill, api_agents_restart
 from hub.views.api._agents_register import api_agents_register
+from hub.views.api._agents_subscribe import (
+    api_admin_agent_subscribe,
+    api_admin_agent_unsubscribe,
+)
 from hub.views.api._channels import (
     api_channel_members,
     api_channel_prefs,
@@ -58,6 +62,8 @@ __all__ = [
     "api_agents_pin",
     "api_agents_pinned",
     "api_agents_purge",
+    "api_admin_agent_subscribe",
+    "api_admin_agent_unsubscribe",
     "api_agents_register",
     "api_agents_registry",
     "api_agents_restart",

--- a/hub/views/api/_agents_subscribe.py
+++ b/hub/views/api/_agents_subscribe.py
@@ -1,0 +1,175 @@
+"""Admin-scoped agent channel subscription endpoints (issue #262 §9.1).
+
+These views let a fleet-coordinator (workspace ``admin`` or ``staff``
+role) toggle another agent's persistent ``ChannelMembership`` rows
+without that agent having to be online. The MCP ``subscribe`` /
+``unsubscribe`` tools route here when called with the optional
+``target_agent`` argument; the existing self-targeting WS path stays
+untouched.
+
+The view body is intentionally small — most of the work is delegated to
+:func:`hub.consumers._helpers._persist_agent_subscription` so the WS
+path and the admin REST path share a single ``ChannelMembership``
+mutation surface (no risk of the two diverging).
+"""
+
+import re
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from hub.consumers._helpers import _persist_agent_subscription
+from hub.models import normalize_channel_name
+from hub.views._helpers import resolve_workspace_and_actor
+from hub.views.api._common import (
+    JsonResponse,
+    csrf_exempt,
+    json,
+    log,
+    require_http_methods,
+)
+
+_ADMIN_ROLES = {"admin", "staff"}
+
+
+def _admin_subscribe(request, target, *, slug=None, subscribe: bool):
+    """Shared body for the admin subscribe + unsubscribe endpoints."""
+    workspace, actor, err = resolve_workspace_and_actor(request, slug=slug)
+    if err is not None:
+        return err
+
+    actor_role = (getattr(actor, "role", "") or "").lower()
+    if actor_role not in _ADMIN_ROLES:
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "reason": "agent-scope tokens cannot manage other agents",
+                    "hint": "Run as admin or use the dashboard",
+                }
+            },
+            status=403,
+        )
+
+    target_name = (target or "").strip()
+    if not target_name or not re.match(r"^[a-zA-Z0-9_.\-]+$", target_name):
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "invalid_input",
+                    "reason": "target agent name missing or malformed",
+                    "hint": "pass a non-empty name matching [a-zA-Z0-9_.-]+",
+                }
+            },
+            status=400,
+        )
+
+    body = {}
+    if request.body:
+        try:
+            body = json.loads(request.body)
+        except (json.JSONDecodeError, ValueError):
+            return JsonResponse(
+                {
+                    "error": {
+                        "code": "invalid_input",
+                        "reason": "request body is not valid JSON",
+                        "hint": "POST a JSON object with {\"channel\": \"#name\"}",
+                    }
+                },
+                status=400,
+            )
+
+    raw_channel = (body.get("channel") or "").strip()
+    if not raw_channel:
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "invalid_input",
+                    "reason": "channel is required",
+                    "hint": "include a non-empty channel name in the request body",
+                }
+            },
+            status=400,
+        )
+
+    ch_name = normalize_channel_name(raw_channel)
+
+    # ``_persist_agent_subscription`` is an async helper; wrap it so the
+    # synchronous view can call it without spinning a loop. It returns
+    # ``False`` only when the workspace cannot be resolved — every other
+    # failure raises.
+    ok = async_to_sync(_persist_agent_subscription)(
+        workspace.id, target_name, ch_name, subscribe
+    )
+    if not ok:
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "internal_error",
+                    "reason": "could not persist subscription",
+                    "hint": "check the hub log for the underlying error",
+                }
+            },
+            status=500,
+        )
+
+    # If the target is currently connected, nudge its consumer so the
+    # in-memory channel-layer group membership picks up the change without
+    # waiting for a reconnect. The consumer listens on its per-agent group
+    # for ``agent.subscribe.refresh`` and rehydrates from the DB.
+    try:
+        layer = get_channel_layer()
+        if layer is not None:
+            async_to_sync(layer.group_send)(
+                f"agent_{workspace.id}_{target_name}",
+                {
+                    "type": "agent.subscribe.refresh",
+                    "channel": ch_name,
+                    "subscribe": bool(subscribe),
+                },
+            )
+    except Exception as exc:  # pragma: no cover — best-effort nudge
+        log.debug(
+            "admin subscribe nudge failed for %s/%s: %s",
+            target_name,
+            ch_name,
+            exc,
+        )
+
+    log.info(
+        "admin %s: %s %s on %s by %s",
+        "subscribe" if subscribe else "unsubscribe",
+        target_name,
+        ch_name,
+        workspace.name,
+        getattr(actor.user, "username", "?"),
+    )
+
+    return JsonResponse(
+        {
+            "status": "ok",
+            "target_agent": target_name,
+            "channel": ch_name,
+            "action": "subscribe" if subscribe else "unsubscribe",
+        }
+    )
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def api_admin_agent_subscribe(request, target, slug=None):
+    """``POST /api/agents/<target>/subscribe/`` — admin subscribe a peer.
+
+    Body: ``{"channel": "#name"}``. Auth: workspace token + ``?agent=``
+    or Django session — but the actor must hold the ``admin`` (or
+    ``staff``) role on the resolved workspace.
+    """
+    return _admin_subscribe(request, target, slug=slug, subscribe=True)
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def api_admin_agent_unsubscribe(request, target, slug=None):
+    """``POST /api/agents/<target>/unsubscribe/`` — admin unsubscribe a peer."""
+    return _admin_subscribe(request, target, slug=slug, subscribe=False)

--- a/ts/src/tools/_shared.ts
+++ b/ts/src/tools/_shared.ts
@@ -62,3 +62,48 @@ export function resolveWorkspaceSlug(arg?: string): string | null {
 // MCP server (this bun process) start time for sidecar_status / uptime.
 // Captured at module load.
 export const MCP_SERVER_STARTED_AT = new Date().toISOString();
+
+// ── Structured error envelope (issue #262 §9.2) ──────────────────────────
+//
+// Every MCP tool returns either a content text payload OR a structured
+// error envelope ``{ "error": { code, reason, hint } }`` packed as the
+// ``text`` of a single content block. Centralizing the codes + helper
+// here means callers (LLM-side or programmatic) can machine-parse the
+// failure mode without scraping ``Error: HTTP 404 — <html>`` strings.
+
+/** Closed enum of error codes a tool may surface. */
+export const MCP_ERROR_CODES = {
+  /** Tool requires the target agent to have a live MCP sidecar, but it does not. */
+  AGENT_OFFLINE: "agent_offline",
+  /** Caller is not a member of the workspace the action targets. */
+  NOT_WORKSPACE_MEMBER: "not_workspace_member",
+  /** Caller authenticated, but lacks the admin/staff role required. */
+  PERMISSION_DENIED: "permission_denied",
+  /** Caller-supplied argument is missing or malformed. */
+  INVALID_INPUT: "invalid_input",
+  /** Resource (channel, agent, message, ...) does not exist. */
+  NOT_FOUND: "not_found",
+  /** Anything else — wraps unexpected exceptions or upstream failures. */
+  INTERNAL_ERROR: "internal_error",
+} as const;
+
+export type McpErrorCode = (typeof MCP_ERROR_CODES)[keyof typeof MCP_ERROR_CODES];
+
+export interface McpErrorPayload {
+  error: { code: McpErrorCode; reason: string; hint: string };
+}
+
+/**
+ * Build a structured error response for an MCP tool. Pack the JSON as the
+ * ``text`` of a single content block so existing MCP clients render it
+ * verbatim while machine consumers can ``JSON.parse(result.content[0].text)``
+ * and key off ``result.error.code``.
+ */
+export function mcpError(
+  code: McpErrorCode,
+  reason: string,
+  hint: string,
+): { content: Array<{ type: string; text: string }> } {
+  const payload: McpErrorPayload = { error: { code, reason, hint } };
+  return { content: [{ type: "text", text: JSON.stringify(payload) }] };
+}

--- a/ts/src/tools/agent_status.ts
+++ b/ts/src/tools/agent_status.ts
@@ -5,8 +5,10 @@ import { readFileSync, unlinkSync } from "fs";
 import { execSync } from "child_process";
 import {
   ConnLike,
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   buildWsUrl,
@@ -31,14 +33,11 @@ export async function handleHealth(args: {
     if (args.updates) body.updates = args.updates;
     else {
       if (!args.agent || !args.status) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "Error: agent and status required (or pass updates[])",
-            },
-          ],
-        };
+        return mcpError(
+          MCP_ERROR_CODES.INVALID_INPUT,
+          "agent and status required (or pass updates[])",
+          "include both fields, or send a list under 'updates'",
+        );
       }
       body.agent = args.agent;
       body.status = args.status;
@@ -53,23 +52,28 @@ export async function handleHealth(args: {
     });
     if (!resp.ok) {
       const t = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${t.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `health HTTP ${resp.status}`,
+        t.slice(0, 200) || "no response body",
+      );
     }
     const out = (await resp.json()) as { applied?: number };
     return {
       content: [{ type: "text", text: `health applied: ${out.applied ?? 0}` }],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `health failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -78,7 +82,11 @@ export async function handleTask(
   args: { task: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   if (!conn.isConnected) {
-    return { content: [{ type: "text", text: "Error: not connected" }] };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect",
+    );
   }
   const task = (args.task || "").slice(0, 200);
   conn.send(
@@ -96,7 +104,11 @@ export async function handleSubagents(
   args: { subagents: Array<{ name?: string; task?: string; status?: string }> },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   if (!conn.isConnected) {
-    return { content: [{ type: "text", text: "Error: not connected" }] };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect",
+    );
   }
   const list = Array.isArray(args.subagents) ? args.subagents : [];
   conn.send(
@@ -143,14 +155,11 @@ export async function handleContext(args: {
     }
 
     if (contextPercent === null) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Could not parse context percentage from screen "${screenName}". Last 3 lines:\n${lines.slice(-3).join("\n")}`,
-          },
-        ],
-      };
+      return mcpError(
+        MCP_ERROR_CODES.NOT_FOUND,
+        `could not parse context percentage from screen "${screenName}"`,
+        `last lines: ${lines.slice(-3).join(" | ").slice(0, 200)}`,
+      );
     }
 
     return {
@@ -165,14 +174,11 @@ export async function handleContext(args: {
       ],
     };
   } catch (err) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error reading screen "${screenName}": ${(err as Error).message}`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `failed to read screen "${screenName}": ${(err as Error).message}`,
+      "ensure the screen/tmux session for this agent is alive on its host",
+    );
   }
 }
 

--- a/ts/src/tools/channels.ts
+++ b/ts/src/tools/channels.ts
@@ -5,31 +5,113 @@
  * READ / CREATE only — actual message sending stays on the WS `reply` path
  * (spec v3.1 §4.1: REST sender-identity for token-auth agents is unreliable;
  * `reply` is the sole agent write path).
+ *
+ * subscribe / unsubscribe accept an optional ``target_agent`` argument
+ * (issue #262 §9.1). When present, the call routes through the admin
+ * REST endpoint instead of the agent's own WS session — only useful for
+ * fleet-coordinator agents whose workspace token resolves to the
+ * ``admin`` (or ``staff``) role. See ``hub/views/api/_agents_subscribe.py``.
  */
 import {
   ConnLike,
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   normalizeGroupChannel,
   resolveWorkspaceSlug,
 } from "./_shared.js";
 
+/**
+ * Hand off subscribe/unsubscribe to the admin REST endpoint when the
+ * caller passed a ``target_agent``. The hub view enforces the admin/
+ * staff role; any non-admin caller gets a structured permission_denied
+ * envelope back, which we surface verbatim.
+ */
+async function callAdminSubscribe(
+  targetAgent: string,
+  channel: string,
+  subscribe: boolean,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const action = subscribe ? "subscribe" : "unsubscribe";
+  const encoded = encodeURIComponent(targetAgent);
+  // Pass ``?agent=<self>`` so resolve_workspace_and_actor knows who's
+  // making the call; the workspace token is appended by tokenParam.
+  const url =
+    `${httpBase}/api/agents/${encoded}/${action}/${tokenParam("?")}` +
+    (tokenParam("?") ? "&" : "?") +
+    "agent=" +
+    encodeURIComponent(OROCHI_AGENT);
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: buildFetchHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ channel }),
+    });
+    const bodyText = await resp.text();
+    let parsed: any = null;
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      parsed = null;
+    }
+    if (!resp.ok) {
+      // Hub returns a structured error envelope already — pass it
+      // through verbatim so the caller sees the same {code, reason, hint}
+      // shape regardless of which leg failed.
+      if (parsed && parsed.error && typeof parsed.error.code === "string") {
+        return {
+          content: [{ type: "text", text: JSON.stringify(parsed) }],
+        };
+      }
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : resp.status === 400
+              ? MCP_ERROR_CODES.INVALID_INPUT
+              : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `admin ${action} HTTP ${resp.status}`,
+        bodyText.slice(0, 200) || "no response body",
+      );
+    }
+    return { content: [{ type: "text", text: bodyText }] };
+  } catch (err) {
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `admin ${action} request failed: ${(err as Error).message}`,
+      "check hub reachability and SCITEX_OROCHI_URL",
+    );
+  }
+}
+
 export async function handleSubscribe(
   conn: ConnLike,
-  args: { channel: string },
+  args: { channel: string; target_agent?: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const channel = normalizeGroupChannel(args.channel);
   if (!channel) {
-    return { content: [{ type: "text", text: "Error: channel required" }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "channel required",
+      "pass channel='#name'",
+    );
+  }
+  const target = (args.target_agent || "").trim();
+  if (target) {
+    return callAdminSubscribe(target, channel, true);
   }
   if (!conn.isConnected) {
-    return {
-      content: [
-        { type: "text", text: `Error: not connected (state=${conn.state})` },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect or check SCITEX_OROCHI_URL",
+    );
   }
   conn.send(
     JSON.stringify({
@@ -43,18 +125,26 @@ export async function handleSubscribe(
 
 export async function handleUnsubscribe(
   conn: ConnLike,
-  args: { channel: string },
+  args: { channel: string; target_agent?: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const channel = normalizeGroupChannel(args.channel);
   if (!channel) {
-    return { content: [{ type: "text", text: "Error: channel required" }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "channel required",
+      "pass channel='#name'",
+    );
+  }
+  const target = (args.target_agent || "").trim();
+  if (target) {
+    return callAdminSubscribe(target, channel, false);
   }
   if (!conn.isConnected) {
-    return {
-      content: [
-        { type: "text", text: `Error: not connected (state=${conn.state})` },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect or check SCITEX_OROCHI_URL",
+    );
   }
   conn.send(
     JSON.stringify({
@@ -71,7 +161,11 @@ export async function handleChannelInfo(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const channel = normalizeGroupChannel(args.channel);
   if (!channel) {
-    return { content: [{ type: "text", text: "Error: channel required" }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "channel required",
+      "pass channel='#name'",
+    );
   }
   try {
     const url =
@@ -83,28 +177,28 @@ export async function handleChannelInfo(args: {
       headers: buildFetchHeaders({ Accept: "application/json" }),
     });
     if (!res.ok) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${res.status} fetching channel info`,
-          },
-        ],
-      };
+      const code =
+        res.status === 401 || res.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : res.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `HTTP ${res.status} fetching channel info`,
+        "verify the channel name and that the workspace token is valid",
+      );
     }
     const data = await res.json();
     const match = Array.isArray(data)
       ? data.find((c: any) => c && c.name === channel)
       : null;
     if (!match) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `(no channel named ${channel} in this workspace)`,
-          },
-        ],
-      };
+      return mcpError(
+        MCP_ERROR_CODES.NOT_FOUND,
+        `no channel named ${channel} in this workspace`,
+        "use the dashboard or the channels list to confirm the name",
+      );
     }
     const desc = (match.description || "").trim();
     return {
@@ -118,9 +212,11 @@ export async function handleChannelInfo(args: {
       ],
     };
   } catch (e) {
-    return {
-      content: [{ type: "text", text: `Error fetching channel info: ${e}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `channel_info failed: ${(e as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -133,14 +229,11 @@ export async function handleDmList(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const slug = resolveWorkspaceSlug(args.workspace);
   if (!slug) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Error: workspace slug required. Pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE.",
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "workspace slug required",
+      "pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE",
+    );
   }
   try {
     const resp = await fetch(dmsUrl(slug), {
@@ -149,21 +242,26 @@ export async function handleDmList(args: {
     });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 300)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `dm_list HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     const out = await resp.json();
     return { content: [{ type: "text", text: JSON.stringify(out) }] };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `dm_list failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -174,25 +272,19 @@ export async function handleDmOpen(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const slug = resolveWorkspaceSlug(args.workspace);
   if (!slug) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Error: workspace slug required. Pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE.",
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "workspace slug required",
+      "pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE",
+    );
   }
   const recipient = (args.recipient || args.peer || "").trim();
   if (!recipient) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Error: recipient required (e.g. 'agent:mamba-healer-mba' or 'human:ywatanabe').",
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "recipient required",
+      "pass recipient='agent:<name>' or 'human:<username>'",
+    );
   }
   try {
     const resp = await fetch(dmsUrl(slug), {
@@ -202,21 +294,28 @@ export async function handleDmOpen(args: {
     });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 300)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : resp.status === 400
+              ? MCP_ERROR_CODES.INVALID_INPUT
+              : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `dm_open HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     const out = await resp.json();
     /* Caller chains `reply` with chat_id=out.name to actually send. */
     return { content: [{ type: "text", text: JSON.stringify(out) }] };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `dm_open failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }

--- a/ts/src/tools/media.ts
+++ b/ts/src/tools/media.ts
@@ -5,9 +5,11 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { basename, dirname } from "path";
 import { createHash } from "crypto";
 import {
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   OROCHI_TOKEN,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   MIME,
@@ -39,14 +41,17 @@ export async function handleDownloadMedia(args: {
       headers: buildFetchHeaders(),
     });
     if (!resp.ok) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} downloading ${fullUrl}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `HTTP ${resp.status} downloading ${fullUrl}`,
+        "verify the URL and that the workspace token is valid",
+      );
     }
 
     // Determine output path
@@ -72,9 +77,11 @@ export async function handleDownloadMedia(args: {
       ],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `download_media failed: ${(err as Error).message}`,
+      "check hub reachability and local disk space",
+    );
   }
 }
 
@@ -84,11 +91,11 @@ export async function handleUploadMedia(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     if (!existsSync(args.file_path)) {
-      return {
-        content: [
-          { type: "text", text: `Error: file not found: ${args.file_path}` },
-        ],
-      };
+      return mcpError(
+        MCP_ERROR_CODES.NOT_FOUND,
+        `file not found: ${args.file_path}`,
+        "pass an absolute path that exists on this host",
+      );
     }
 
     const fileData = readFileSync(args.file_path);
@@ -169,14 +176,17 @@ export async function handleUploadMedia(args: {
 
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `upload_media HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
 
     const result = (await resp.json()) as {
@@ -200,8 +210,10 @@ export async function handleUploadMedia(args: {
       ],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `upload_media failed: ${(err as Error).message}`,
+      "check hub reachability and local disk",
+    );
   }
 }

--- a/ts/src/tools/messaging.ts
+++ b/ts/src/tools/messaging.ts
@@ -5,9 +5,11 @@ import { readFileSync } from "fs";
 import { basename } from "path";
 import {
   ConnLike,
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   OROCHI_TOKEN,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   MIME,
@@ -18,14 +20,11 @@ export async function handleReply(
   args: { chat_id: string; text: string; reply_to?: string; files?: string[] },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   if (!conn.isConnected) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error: not connected to Orochi (state=${conn.state}, attempts=${(conn as any).reconnectAttempts})`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected to Orochi (state=${conn.state}, attempts=${(conn as any).reconnectAttempts})`,
+      "wait for the MCP sidecar to reconnect",
+    );
   }
 
   const attachments: Array<Record<string, unknown>> = [];
@@ -133,9 +132,11 @@ export async function handleReact(args: {
   const messageId = String(args.message_id);
   const emoji = args.emoji;
   if (!messageId || !emoji) {
-    return {
-      content: [{ type: "text", text: "Error: message_id and emoji required" }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "message_id and emoji required",
+      "pass both fields",
+    );
   }
   try {
     const url = `${httpBase}/api/reactions/${tokenParam("?")}`;
@@ -150,22 +151,27 @@ export async function handleReact(args: {
     });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `react HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     return {
       content: [{ type: "text", text: `reacted ${emoji} to ${messageId}` }],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `react failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -188,19 +194,26 @@ export async function handleExportChannel(args: {
     const resp = await fetch(url, { headers: buildFetchHeaders() });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `export_channel HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     const text = await resp.text();
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { content: [{ type: "text", text: `Error: ${msg}` }] };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `export_channel failed: ${msg}`,
+      "check hub reachability",
+    );
   }
 }

--- a/ts/src/tools/rsync.ts
+++ b/ts/src/tools/rsync.ts
@@ -12,7 +12,13 @@ import { readFileSync, mkdirSync, existsSync, createWriteStream } from "fs";
 import { basename, join as pathJoin } from "path";
 import { spawn } from "child_process";
 import { randomBytes } from "crypto";
-import { OROCHI_AGENT, httpBase, buildFetchHeaders } from "./_shared.js";
+import {
+  MCP_ERROR_CODES,
+  OROCHI_AGENT,
+  httpBase,
+  mcpError,
+  buildFetchHeaders,
+} from "./_shared.js";
 
 export interface RsyncJob {
   id: string;
@@ -62,23 +68,20 @@ export async function handleRsyncMedia(args: {
   // Validate allowed hosts (prevent shell injection via dst_host)
   const ALLOWED_HOSTS = new Set(["mba", "nas", "ywata-note-win", "spartan"]);
   if (!ALLOWED_HOSTS.has(dst_host)) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error: dst_host must be one of: ${[...ALLOWED_HOSTS].join(", ")}`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      `dst_host must be one of: ${[...ALLOWED_HOSTS].join(", ")}`,
+      "pass an allowed fleet host name",
+    );
   }
 
   // Validate src_path exists locally
   if (!existsSync(src_path)) {
-    return {
-      content: [
-        { type: "text", text: `Error: src_path not found: ${src_path}` },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.NOT_FOUND,
+      `src_path not found: ${src_path}`,
+      "pass an absolute path that exists on this host",
+    );
   }
 
   // Ensure log dir
@@ -182,9 +185,11 @@ export async function handleRsyncStatus(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const job = rsyncJobs.get(args.job_id);
   if (!job) {
-    return {
-      content: [{ type: "text", text: `Error: job not found: ${args.job_id}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.NOT_FOUND,
+      `job not found: ${args.job_id}`,
+      "pass a job_id returned by rsync_media in this MCP session",
+    );
   }
   const logPath = rsyncLogPath(job.id);
   const tail = tailLog(logPath, 10);

--- a/ts/src/tools/self_command.ts
+++ b/ts/src/tools/self_command.ts
@@ -10,7 +10,7 @@
  * (screen|tmux); default is "tmux" — set SCITEX_OROCHI_MULTIPLEXER=screen to opt in.
  */
 import { exec } from "child_process";
-import { OROCHI_AGENT } from "./_shared.js";
+import { MCP_ERROR_CODES, OROCHI_AGENT, mcpError } from "./_shared.js";
 
 // Allow only safe characters in the session name to prevent shell injection.
 function validateSessionName(name: string): string | null {
@@ -55,22 +55,19 @@ function scheduleSelfCommand(
 ): { content: Array<{ type: string; text: string }> } {
   const rawSession = OROCHI_AGENT;
   if (!rawSession) {
-    return {
-      content: [
-        { type: "text", text: "ERROR: SCITEX_OROCHI_AGENT env var not set" },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "SCITEX_OROCHI_AGENT env var not set",
+      "set SCITEX_OROCHI_AGENT in the MCP sidecar environment",
+    );
   }
   const session = validateSessionName(rawSession);
   if (!session) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `ERROR: SCITEX_OROCHI_AGENT contains unsafe characters: ${rawSession}`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      `SCITEX_OROCHI_AGENT contains unsafe characters: ${rawSession}`,
+      "agent name must match [A-Za-z0-9._-]+",
+    );
   }
 
   const mux = getMultiplexer();
@@ -78,9 +75,11 @@ function scheduleSelfCommand(
   try {
     cmd = buildSendKeysCommand(mux, session, text);
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `ERROR: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      (err as Error).message,
+      "remove single quotes from the command text",
+    );
   }
 
   const delay = Math.max(0, delayMs);
@@ -165,37 +164,31 @@ export async function handleSelfCommand(args: {
   const command = (args?.command || "").trim();
   const err = validateSelfCommand(command);
   if (err) {
-    return { content: [{ type: "text", text: `ERROR: ${err}` }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      err,
+      "use a slash command matching /^\\/[A-Za-z0-9_-]+( .*)?$/ or a free-text prompt without single quotes",
+    );
   }
 
   // Allowlist gate: reject modal-opening slash commands before scheduling.
   if (!isSafeForSelfCommand(command)) {
     const rejected = command.split(/\s+/, 1)[0];
-    return {
-      content: [
-        {
-          type: "text",
-          text:
-            `ERROR: slash command '${rejected}' is not in self_command allowlist. ` +
-            `Safe commands: ${SELF_COMMAND_ALLOWLIST.join(", ")}. ` +
-            `Modal-opening commands like /model, /agents, /permissions trap the agent and are blocked. ` +
-            `Free-text prompts (no leading slash) are always allowed.`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.PERMISSION_DENIED,
+      `slash command '${rejected}' is not in self_command allowlist`,
+      `safe commands: ${SELF_COMMAND_ALLOWLIST.join(", ")} (free-text prompts without a leading slash are always allowed)`,
+    );
   }
 
   // Extract the bare slash name (no args) for destructive-list lookup.
   const slashName = command.split(/\s+/, 1)[0];
   if (DESTRUCTIVE_COMMANDS.has(slashName) && !args?.confirm) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `ERROR: '${slashName}' is destructive; pass confirm=true to fire`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.PERMISSION_DENIED,
+      `'${slashName}' is destructive`,
+      "pass confirm=true to fire",
+    );
   }
 
   const delay = args?.delay_ms ?? 6000;


### PR DESCRIPTION
Closes #262. (A) target_agent admin path for subscribe/unsubscribe with permission gate. (B) Structured error envelope {code,reason,hint}. (C) HUB-ONLY/PEER-LIVE tags in tool descriptions. 80 tests pass.