### PR TITLE
fix(hub/acl): enforce ChannelMembership on REST + WS write paths (#276)

### DIFF
--- a/hub/channel_acl.py
+++ b/hub/channel_acl.py
@@ -198,6 +198,62 @@ def _check_dm_write_allowed(
     return False
 
 
+def check_membership_allowed(
+    sender: str, channel: str, workspace_id: int | None = None
+) -> bool:
+    """Return True if ``sender`` is allowed to write to ``channel`` per
+    :class:`hub.models.ChannelMembership`.
+
+    Semantics (issue #276 — closing the REST/WS write-path ACL gap):
+
+    * DMs are handled by :func:`_check_dm_write_allowed`; this helper
+      returns ``True`` for ``dm:`` channels (deferring to the caller's
+      existing DM gate).
+    * If the caller did not supply ``workspace_id`` we cannot scope the
+      lookup and fall back to ``True`` (preserves non-WS test fixtures).
+    * If an explicit :class:`ChannelMembership` row exists with
+      ``permission = "read-only"`` the write is **denied**.
+    * If the sender is a synthetic agent user (``agent-*`` — see
+      ``hub/views/auth.py``) and *no* membership row exists for the
+      target non-DM channel, the write is **denied**. Agents must be
+      explicitly added (ywatanabe policy msg#11866 — "by default no
+      agent subscribes anywhere"). Human users keep the permissive
+      default so humans continue to post through the UI without a
+      pre-seeded row.
+    """
+    if channel.startswith("dm:") or workspace_id is None:
+        return True
+
+    try:
+        from hub.models import Channel as _Channel
+        from hub.models import ChannelMembership as _Membership
+    except Exception:
+        return True
+
+    ch = (
+        _Channel.objects.filter(workspace_id=workspace_id, name=channel)
+        .only("id", "kind")
+        .first()
+    )
+    if ch is None or ch.kind == _Channel.KIND_DM:
+        # Channel does not exist yet, or is a DM row without dm: prefix —
+        # let the caller's other gates decide.
+        return True
+
+    row = (
+        _Membership.objects.filter(channel_id=ch.id, user__username=sender)
+        .only("permission")
+        .first()
+    )
+    if row is not None:
+        return row.permission != _Membership.PERM_READ_ONLY
+
+    # No explicit row. Agents must be explicitly added; humans default-allow.
+    if sender.startswith("agent-"):
+        return False
+    return True
+
+
 def reload() -> int:
     """Force reload of ACL from disk. Returns number of channel rules loaded."""
     global _last_load

--- a/hub/consumers/_agent_message.py
+++ b/hub/consumers/_agent_message.py
@@ -9,7 +9,7 @@ without becoming a method.
 
 from __future__ import annotations
 
-from hub.channel_acl import check_write_allowed
+from hub.channel_acl import check_membership_allowed, check_write_allowed
 from hub.models import Workspace
 
 from ._groups import _sanitize_group, log
@@ -73,6 +73,29 @@ async def handle_agent_message(consumer, content):
                 "type": "error",
                 "code": "acl_denied",
                 "message": f"You are not allowed to write to {ch_name}",
+            }
+        )
+        return
+
+    # Issue #276 — close the WS write-path ACL gap. AgentConsumer
+    # authenticates as the synthetic ``agent-<name>`` user; the
+    # membership gate requires an explicit ChannelMembership row for
+    # non-DM channels so agents cannot write to channels they were
+    # never subscribed to.
+    _member_allowed = await _sta(check_membership_allowed)(
+        f"agent-{consumer.agent_name}", ch_name, consumer.workspace_id
+    )
+    if not _member_allowed:
+        log.warning(
+            "[ACL] blocked non-member write from %s to %s",
+            consumer.agent_name,
+            ch_name,
+        )
+        await consumer.send_json(
+            {
+                "type": "error",
+                "code": "not_a_member",
+                "message": f"You are not a member of {ch_name}",
             }
         )
         return

--- a/hub/tests/consumers/test_dm.py
+++ b/hub/tests/consumers/test_dm.py
@@ -427,6 +427,15 @@ class DMConsumerRoutingTest(TestCase):
         from asgiref.sync import async_to_sync
 
         from hub.consumers import AgentConsumer
+        from hub.models import ChannelMembership
+
+        # Issue #276 — agent senders require an explicit membership row
+        # on non-DM channels. This test uses bare ``alice`` as the agent
+        # name; the WS handler authenticates as ``agent-alice``, so seed
+        # the membership for that synthetic user.
+        agent_user, _ = User.objects.get_or_create(username="agent-alice")
+        general, _ = Channel.objects.get_or_create(workspace=self.ws, name="#general")
+        ChannelMembership.objects.get_or_create(user=agent_user, channel=general)
 
         consumer = AgentConsumer.__new__(AgentConsumer)
         consumer.workspace_id = self.ws.id

--- a/hub/views/api/_common.py
+++ b/hub/views/api/_common.py
@@ -23,7 +23,7 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods
 
-from hub.channel_acl import check_write_allowed
+from hub.channel_acl import check_membership_allowed, check_write_allowed
 from hub.models import (
     Channel,
     ChannelPreference,
@@ -57,6 +57,7 @@ __all__ = [
     "WorkspaceToken",
     "_server_start_time",
     "async_to_sync",
+    "check_membership_allowed",
     "check_write_allowed",
     "csrf_exempt",
     "datetime",

--- a/hub/views/api/_messages.py
+++ b/hub/views/api/_messages.py
@@ -10,6 +10,7 @@ from hub.views.api._common import (
     Message,
     MessageThread,
     async_to_sync,
+    check_membership_allowed,
     check_write_allowed,
     get_channel_layer,
     get_workspace,
@@ -99,6 +100,19 @@ def api_messages(request, slug=None):
     ):
         return JsonResponse(
             {"error": "not allowed to write to this channel"}, status=403
+        )
+    # Issue #276 — close the REST write-path ACL gap. The yaml ACL above
+    # is permissive-by-default when channels.yaml is absent; the
+    # ChannelMembership gate enforces the per-(user, channel) permission
+    # rows managed via /api/channel-members/ and blocks agents that were
+    # never explicitly subscribed to the target group channel.
+    if not check_membership_allowed(
+        sender=sender_identity,
+        channel=ch_name,
+        workspace_id=workspace.id,
+    ):
+        return JsonResponse(
+            {"error": "not a member of this channel"}, status=403
         )
 
     channel, _ = Channel.objects.get_or_create(


### PR DESCRIPTION
## Summary
- Closes the write-path ACL gap described in #276: the REST `POST /api/messages/` and the WS `message` frame only consult the yaml ACL (`check_write_allowed`), which is permissive-by-default when `~/.scitex/orochi/channels.yaml` is absent — so any authenticated agent could write to any channel.
- Adds `hub.channel_acl.check_membership_allowed` and wires it into both write paths (`hub/views/api/_messages.py`, `hub/consumers/_agent_message.py`).
- Enforces explicit `ChannelMembership` rows the admin API already creates via `/api/channel-members/`: `agent-*` synthetic senders without a row are denied on non-DM channels, and rows with `permission="read-only"` are honored. Human senders keep the permissive default (UI flow does not pre-seed rows).

## Rationale
- Evidence from head-mba on `develop@a6a9969`: `hub/channel_acl.py:151-158` falls through to `return True` when no yaml config is present, and `hub/consumers/_persistence.py::save_message_sync` has no membership gate.
- ywatanabe policy (msg#11866 — "デフォルトですべてのエージェントはどこも購読しない"): agents must subscribe/be-added explicitly. The sparse `ChannelMembership` table is the canonical record of who has been added; the read-side (`_agent.py:330-346` `chat_message`) already respects it. The write side now mirrors that pattern.
- DM confidentiality is unchanged — `check_write_allowed` keeps its DM participant gate via `_check_dm_write_allowed`, and the new helper short-circuits on `dm:` so the two gates compose cleanly.

## Response shapes (for clients)
- REST: `403 {"error": "not a member of this channel"}`
- WS: `{"type":"error","code":"not_a_member","message": "You are not a member of <channel>"}`

## DM behavior (deliberately out of scope)
- DMs remain governed by `_check_dm_write_allowed` (DMParticipant). `check_membership_allowed` returns `True` for `dm:` channels and falls through to the existing gate — no behavior change for DMs.

## Diff size
- `+105 / -2` across 5 files (helper + docstring dominates the count; logic is ~30 LOC, WS parity is 16 LOC, REST wire-up is 11 LOC, test seed is 9 LOC).

## Test plan
- [x] `python manage.py test hub.tests.views.api` — 103 tests pass
- [x] `python manage.py test hub.tests.consumers` — 28 tests pass
- [x] `test_post_message` (human user, no membership row) — still 201 (humans keep permissive default)
- [x] `test_group_broadcast_still_hits_workspace_group` — updated to seed `agent-alice`/`#general` membership (test harness used bare `alice` as `agent_name`)
- [ ] Follow-up in a separate PR: the persistence-ACK half of #276 (`reply` MCP → `message.ack` round-trip). This PR only closes the write-ACL hole; the UX-ACK fix is orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)