### PR TITLE
fix(hub/consumers): membership filter on thread_reply / reaction_update / message_edit / message_delete (#277)

### DIFF
--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -397,6 +397,24 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
 
     # --- channel-layer events forwarded to the agent WebSocket -----------
 
+    async def _is_channel_visible(self, ch_name: str) -> bool:
+        """Issue #277 — read-side ACL: apply the chat.message filter shape.
+
+        Mirrors ``chat_message`` (DM participant check for dm:* channels,
+        subscription-membership check for group channels) so thread /
+        reaction / edit / delete fan-out cannot leak cross-channel.
+        The write-side companion is #276 / PR #279.
+        """
+        is_dm = ch_name.startswith("dm:")
+        if is_dm:
+            return await _is_dm_participant_by_member(
+                channel_name=ch_name,
+                workspace_id=self.workspace_id,
+                member_id=getattr(self, "workspace_member_id", None),
+            )
+        agent_channels = getattr(self, "agent_meta", {}).get("channels", [])
+        return ch_name in agent_channels
+
     async def reaction_update(self, event):
         """Forward reaction add/remove events to agent WebSocket.
 
@@ -405,6 +423,9 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         thumbs-up to mean "received, no further action needed") without
         having to write a full reply.
         """
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "reaction_update",
@@ -416,24 +437,30 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         )
 
     async def message_edit(self, event):
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "message_edit",
                 "message_id": event["message_id"],
                 "sender": event["sender"],
-                "channel": event.get("channel", ""),
+                "channel": ch_name,
                 "text": event["text"],
                 "edited_at": event.get("edited_at"),
             }
         )
 
     async def message_delete(self, event):
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "message_delete",
                 "message_id": event["message_id"],
                 "sender": event["sender"],
-                "channel": event.get("channel", ""),
+                "channel": ch_name,
             }
         )
 
@@ -443,6 +470,9 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         The MCP sidecar rewrites thread_reply into a message with parent
         context, so agents can recognise and respond to threaded replies.
         """
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "thread_reply",
@@ -450,7 +480,7 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
                 "reply_id": event["reply_id"],
                 "sender": event["sender"],
                 "sender_type": event.get("sender_type", "human"),
-                "channel": event.get("channel", ""),
+                "channel": ch_name,
                 "text": event.get("text", ""),
                 "ts": event.get("ts"),
                 "metadata": event.get("metadata", {}),

--- a/hub/views/api/_reactions.py
+++ b/hub/views/api/_reactions.py
@@ -80,7 +80,9 @@ def api_reactions(request):
     if not message_id or not emoji:
         return JsonResponse({"error": "message_id and emoji required"}, status=400)
     try:
-        msg = Message.objects.get(id=message_id, workspace=workspace)
+        msg = Message.objects.select_related("channel").get(
+            id=message_id, workspace=workspace
+        )
     except Message.DoesNotExist:
         return JsonResponse({"error": "message not found"}, status=404)
 
@@ -106,7 +108,9 @@ def api_reactions(request):
         ).delete()
         action = "removed" if deleted else "not_found"
 
-    # Broadcast reaction update to workspace group
+    # Broadcast reaction update to workspace group. ``channel`` is
+    # required so the AgentConsumer read-side filter (#277) can drop
+    # events for channels the receiver is not a member of.
     layer = get_channel_layer()
     group = f"workspace_{workspace.id}"
     async_to_sync(layer.group_send)(
@@ -114,6 +118,7 @@ def api_reactions(request):
         {
             "type": "reaction.update",
             "message_id": msg.id,
+            "channel": msg.channel.name,
             "emoji": emoji,
             "reactor": reactor,
             "action": action,


### PR DESCRIPTION
## Summary

Closes the read-side channel-ACL leak in #277. Companion to #279 (#276 write-side) — together they complete the 3-path model from #251.

Four AgentConsumer handlers (`thread_reply`, `reaction_update`, `message_edit`, `message_delete`) broadcast every `workspace_<id>` event to every connected agent regardless of channel subscription. This PR gates all four on a `_is_channel_visible` helper that mirrors the existing `chat_message` filter shape:

- `dm:*` channels: `_is_dm_participant_by_member` (same helper chat.message uses)
- group channels: `self.agent_meta["channels"]` membership set

The `reaction.update` publisher in `hub/views/api/_reactions.py` did not include the channel name in its `group_send` payload; added `channel=msg.channel.name` (with `select_related`) so the consumer-side filter has what it needs. `message.edit` and `message.delete` already carried the channel.

## Caveats

- `agent_meta["channels"]` is still self-reported. Hardening it to a DB-authoritative membership lookup is flagged as follow-up and out of scope here — the leak is primarily from agents that never claimed a channel in their register frame, not from agents lying about their membership. That broader hardening is its own issue.
- Handlers that receive events with no `channel` field (legacy/unknown producers) fall through to the existing behaviour rather than dropping silently — matches the chat.message precedent.

## Test plan

- [x] `docker exec orochi-server-stable python manage.py test hub.tests.consumers -v 1` — 28 passed, 0 failed
- [x] `python manage.py check` — no issues
- [ ] Manual: open two agents, subscribe only one to `#foo`, thread-reply / react / edit / delete in `#foo`, verify only the subscribed agent's WS receives the fan-out event
- [ ] Dashboard observers still receive the workspace-group fan-out (they use a different consumer)

Refs: #251 (3-path ACL model), #276 / #279 (write-side), #277 (this, read-side).

Generated with [Claude Code](https://claude.com/claude-code).
