### PR TITLE
fix(hub/frontend): channel switch rebinds feed without reload (#278)

### DIFF
--- a/hub/frontend/src/app/state.ts
+++ b/hub/frontend/src/app/state.ts
@@ -57,6 +57,14 @@ try {
 export function setCurrentChannel(ch) {
   currentChannel = ch;
   if (ch) lastActiveChannel = ch;
+  /* #278: other modules read `(globalThis as any).currentChannel` — the
+   * module-local `var currentChannel` is a private binding that the rest
+   * of the app can't see. Without this write, a sidebar channel switch
+   * updates the local var but leaves the global pinned at its page-load
+   * value, causing the feed to stay stale, the WS filter to pass the wrong
+   * channel, and sendMessage() to post to the original channel instead of
+   * the one the sidebar highlights. Mirror every update to the global. */
+  (globalThis as any).currentChannel = ch;
   try {
     localStorage.setItem("orochi_active_channel", ch == null ? "__all__" : ch);
   } catch (_) {}


### PR DESCRIPTION
## Summary

Fixes #278. One-line root cause: `setCurrentChannel()` in `hub/frontend/src/app/state.ts` mutated the module-local `var currentChannel` but never mirrored the new value to `(globalThis as any).currentChannel`, which is what every other module in the bundle reads. After page load the global stayed frozen at its initial value.

That single stale binding is what caused all three reported symptoms:

1. Feed stays on the old channel after a sidebar switch — `loadHistory()` consults the global to decide which channel's history to fetch and `applyFeedFilter()` uses it to decide which messages to hide.
2. WebSocket live-append was dropping events for the newly-selected channel because `push.ts` compared the message's channel against the stale global.
3. head-mba's observation that sidebar highlight and actual POST target disagreed — `sendMessage()` in `chat-composer.ts` reads the global for the outgoing payload, so posts went to the originally-loaded channel (or `#general` fallback) regardless of the sidebar click.

## Fix

Minimal: add one line inside `setCurrentChannel()` to mirror every update to `(globalThis as any).currentChannel`. No refactor of the cross-module global pattern (that's a follow-up).

- Files touched: `hub/frontend/src/app/state.ts`
- Diff: +8 / -0 (1 line of real code + a comment explaining the invariant)

## Follow-ups spotted but NOT fixed (out of scope)

- The pattern of writing module-local `var` plus a one-shot `(globalThis as any).X = X` snapshot at end-of-module is fragile and invited this exact class of bug. Worth replacing with an exported getter/setter pair or migrating `currentChannel` into a proper state module. Filing as a separate follow-up, not gating #278.
- `hub/frontend/src/chat/chat-actions.ts` lines 466–473 *directly* assigns to `(globalThis as any).currentChannel` without going through `setCurrentChannel()`, which means localStorage persistence, placeholder update, composer-target update and channel-topic-banner update are skipped on that code path. Pre-existing; out of scope for this PR.

## Test plan

- [x] `make frontend-build` succeeds (vite build clean, 107 modules).
- [x] `make frontend-typecheck` succeeds (`tsc --noEmit` clean).
- [ ] Manual verification after deploy: click `#agent` → `#proj-foo` → `#general` in sidebar, confirm feed rebinds without reload and outgoing post lands in the highlighted channel.
- [ ] Manual verification: WS-delivered message on newly-selected channel appears in the live feed without reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
