### PR TITLE
fix(hub): live agent_meta[channels] refresh on ChannelMembership change (#282)

### DIFF
--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -395,6 +395,16 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
     async def system_message(self, event):
         pass
 
+    async def agent_subs_refresh(self, event):
+        """Re-sync ``agent_meta["channels"]`` from DB (#282).
+
+        Delegates to :func:`handle_agent_subs_refresh` in
+        ``_agent_refresh`` to keep this file under the 512-line cap.
+        """
+        from ._agent_refresh import handle_agent_subs_refresh
+
+        await handle_agent_subs_refresh(self, event)
+
     # --- channel-layer events forwarded to the agent WebSocket -----------
 
     async def _is_channel_visible(self, ch_name: str) -> bool:

--- a/hub/consumers/_agent_refresh.py
+++ b/hub/consumers/_agent_refresh.py
@@ -1,0 +1,74 @@
+"""``agent.subs_refresh`` channel-layer event handler for AgentConsumer.
+
+Fired from ``hub.signals`` post_save/post_delete on ``ChannelMembership``
+(issue #282) so out-of-band subscription changes propagate to live WS
+consumers without waiting for reconnect. Extracted from ``_agent.py``
+to stay under the 512-line cap.
+"""
+
+from __future__ import annotations
+
+from ._groups import _sanitize_group
+from ._helpers import _load_agent_channel_subs
+
+
+async def handle_agent_subs_refresh(consumer, event):
+    """Re-sync ``consumer.agent_meta["channels"]`` + group joins from DB.
+
+    Events whose ``workspace_id`` doesn't match this connection are
+    ignored — the signal broadcasts globally via
+    ``list_sibling_channels`` which is not workspace-scoped.
+    """
+    event_ws = event.get("workspace_id")
+    if event_ws is not None and event_ws != consumer.workspace_id:
+        return
+    if event.get("agent") and event["agent"] != consumer.agent_name:
+        return
+
+    persisted = await _load_agent_channel_subs(
+        consumer.workspace_id, consumer.agent_name
+    )
+    dm_names = list(getattr(consumer, "_dm_channel_names", []) or [])
+    desired = list(dict.fromkeys(list(dm_names) + list(persisted)))
+    current = list(
+        getattr(consumer, "agent_meta", {}).get("channels", []) or []
+    )
+
+    desired_set = set(desired)
+    current_set = set(current)
+    to_add = desired_set - current_set
+    # Never group_discard DM channels — those are auto-subscribed at
+    # connect based on DMParticipant and must not be affected by a
+    # refresh driven by a group-channel ChannelMembership change.
+    to_remove = {
+        ch for ch in (current_set - desired_set) if not ch.startswith("dm:")
+    }
+
+    for ch_name in to_add:
+        group = _sanitize_group(f"channel_{consumer.workspace_id}_{ch_name}")
+        await consumer.channel_layer.group_add(group, consumer.channel_name)
+    for ch_name in to_remove:
+        group = _sanitize_group(f"channel_{consumer.workspace_id}_{ch_name}")
+        await consumer.channel_layer.group_discard(
+            group, consumer.channel_name
+        )
+
+    if hasattr(consumer, "agent_meta"):
+        consumer.agent_meta["channels"] = desired
+    else:
+        consumer.agent_meta = {"channels": desired}
+
+    if to_add or to_remove:
+        from hub.registry import register_agent
+
+        register_agent(
+            consumer.agent_name, consumer.workspace_id, consumer.agent_meta
+        )
+        await consumer.channel_layer.group_send(
+            consumer.workspace_group,
+            {
+                "type": "agent.info",
+                "agent": consumer.agent_name,
+                "info": consumer.agent_meta,
+            },
+        )

--- a/hub/signals.py
+++ b/hub/signals.py
@@ -6,15 +6,28 @@ authoritative identity changes (``AgentProfile.name`` rename for agents,
 ``User.username`` rename for humans), any ``DMParticipant`` rows whose
 ``member`` points at the affected principal must have their
 ``identity_name`` updated in the same transaction.
+
+Issue #282 — ``ChannelMembership`` changes fan out to any live
+``AgentConsumer`` so the in-memory ``agent_meta["channels"]`` and the
+per-channel group-layer joins stay DB-authoritative under out-of-band
+edits (admin REST subscribe, drag-to-channel, Django admin UI).
 """
 
 from __future__ import annotations
 
+import logging
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.contrib.auth.models import User
-from django.db.models.signals import post_save
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from hub.models import AgentProfile, DMParticipant
+from hub.models import AgentProfile, ChannelMembership, DMParticipant
+from hub.registry import list_sibling_channels
+
+log = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=AgentProfile)
@@ -52,3 +65,89 @@ def _user_rename(sender, instance: User, created, **kwargs):
     DMParticipant.objects.filter(member__user_id=instance.id).exclude(
         identity_name=identity
     ).update(identity_name=identity)
+
+
+# ---------------------------------------------------------------------------
+# Issue #282 — ChannelMembership change → refresh live agent consumers.
+# ---------------------------------------------------------------------------
+
+_AGENT_USERNAME_PREFIX = "agent-"
+
+
+def _broadcast_agent_subs_refresh(
+    agent_name: str, workspace_id: int
+) -> None:
+    """Notify every live AgentConsumer for the affected agent to re-sync.
+
+    Only agent users (synthetic ``agent-<name>`` Django users) drive this
+    path; humans are irrelevant because they connect via
+    :class:`DashboardConsumer` which reads membership on each delivery.
+
+    Called from ``transaction.on_commit`` so the consumer's DB re-fetch
+    observes the committed state (avoids a read-before-commit race).
+    """
+    layer = get_channel_layer()
+    if layer is None:
+        return
+
+    channel_names = list_sibling_channels(agent_name)
+    if not channel_names:
+        return
+
+    payload = {
+        "type": "agent.subs_refresh",
+        "agent": agent_name,
+        "workspace_id": workspace_id,
+    }
+    for channel_name in channel_names:
+        try:
+            async_to_sync(layer.send)(channel_name, payload)
+        except Exception:  # noqa: BLE001 — best-effort; one bad socket
+            # shouldn't mask refreshes to the other sibling connections.
+            log.exception(
+                "agent.subs_refresh send failed (agent=%s channel=%s)",
+                agent_name,
+                channel_name,
+            )
+
+
+def _queue_membership_refresh(membership: ChannelMembership) -> None:
+    """Extract ``(agent_name, workspace_id)`` then schedule the refresh.
+
+    No-ops for non-agent users. Schedules the dispatch via
+    ``transaction.on_commit`` so tests that create ChannelMembership rows
+    without an explicit transaction still observe the side effect
+    (on_commit runs immediately in autocommit mode).
+    """
+    try:
+        user = membership.user
+    except User.DoesNotExist:
+        return
+    username = getattr(user, "username", "") or ""
+    if not username.startswith(_AGENT_USERNAME_PREFIX):
+        return
+    agent_name = username[len(_AGENT_USERNAME_PREFIX):]
+
+    try:
+        workspace_id = membership.channel.workspace_id
+    except Exception:  # noqa: BLE001
+        log.exception("ChannelMembership signal: missing channel/workspace")
+        return
+
+    transaction.on_commit(
+        lambda: _broadcast_agent_subs_refresh(agent_name, workspace_id)
+    )
+
+
+@receiver(post_save, sender=ChannelMembership)
+def _channel_membership_saved(
+    sender, instance: ChannelMembership, created, **kwargs
+):
+    _queue_membership_refresh(instance)
+
+
+@receiver(post_delete, sender=ChannelMembership)
+def _channel_membership_deleted(
+    sender, instance: ChannelMembership, **kwargs
+):
+    _queue_membership_refresh(instance)

--- a/hub/tests/consumers/test_agent_subs_refresh.py
+++ b/hub/tests/consumers/test_agent_subs_refresh.py
@@ -1,0 +1,254 @@
+"""Tests for #282 — ChannelMembership signal → live AgentConsumer re-sync.
+
+Covers both halves of the fix:
+
+1. ``hub/signals.py`` — the ``ChannelMembership`` post_save / post_delete
+   handlers dispatch an ``agent.subs_refresh`` frame to every live sibling
+   WS connection for the affected agent (and ONLY for agent users).
+2. ``hub/consumers/_agent.py`` — the ``agent_subs_refresh`` handler
+   re-reads the DB, diffs against in-memory ``agent_meta["channels"]``,
+   and performs the matching group_add / group_discard calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from hub.models import Channel, ChannelMembership, Workspace
+
+
+def _fake_consumer(agent_name, workspace_id, channels, dm_channels=()):
+    """Build a minimal consumer stub for the async handler under test."""
+    from hub.consumers._agent import AgentConsumer
+
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_name = agent_name
+    consumer.workspace_id = workspace_id
+    consumer.workspace_group = f"workspace_{workspace_id}"
+    consumer.channel_name = f"test-ch-{agent_name}"
+    consumer._dm_channel_names = list(dm_channels)
+    consumer.agent_meta = {"channels": list(channels)}
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    return consumer
+
+
+class ChannelMembershipSignalTest(TestCase):
+    """Signal-fan-out half — ``hub/signals.py``."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="signal-ws")
+        self.ch = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.agent_user = User.objects.create(username="agent-worker-z")
+        self.human_user = User.objects.create(username="alice")
+
+    def _patched_send(self):
+        """Patch the registry + channel layer used by the signal."""
+        layer = MagicMock()
+        layer.send = AsyncMock()
+        return (
+            patch(
+                "hub.signals.get_channel_layer", return_value=layer
+            ),
+            patch(
+                "hub.signals.list_sibling_channels",
+                return_value=["ws-conn-1"],
+            ),
+            layer,
+        )
+
+    def test_save_fires_agent_subs_refresh_for_agent_user(self):
+        p_layer, p_siblings, layer = self._patched_send()
+        with p_layer, p_siblings, self.captureOnCommitCallbacks(execute=True):
+            ChannelMembership.objects.create(
+                user=self.agent_user, channel=self.ch
+            )
+        layer.send.assert_awaited_once()
+        args, _kwargs = layer.send.call_args
+        self.assertEqual(args[0], "ws-conn-1")
+        payload = args[1]
+        self.assertEqual(payload["type"], "agent.subs_refresh")
+        self.assertEqual(payload["agent"], "worker-z")
+        self.assertEqual(payload["workspace_id"], self.ws.id)
+
+    def test_save_is_noop_for_human_user(self):
+        p_layer, p_siblings, layer = self._patched_send()
+        with p_layer, p_siblings, self.captureOnCommitCallbacks(execute=True):
+            ChannelMembership.objects.create(
+                user=self.human_user, channel=self.ch
+            )
+        layer.send.assert_not_awaited()
+
+    def test_delete_fires_agent_subs_refresh(self):
+        m = ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch
+        )
+        p_layer, p_siblings, layer = self._patched_send()
+        with p_layer, p_siblings, self.captureOnCommitCallbacks(execute=True):
+            m.delete()
+        layer.send.assert_awaited_once()
+        payload = layer.send.call_args[0][1]
+        self.assertEqual(payload["type"], "agent.subs_refresh")
+
+    def test_no_send_when_no_sibling_connections(self):
+        layer = MagicMock()
+        layer.send = AsyncMock()
+        with patch(
+            "hub.signals.get_channel_layer", return_value=layer
+        ), patch(
+            "hub.signals.list_sibling_channels", return_value=[]
+        ), self.captureOnCommitCallbacks(execute=True):
+            ChannelMembership.objects.create(
+                user=self.agent_user, channel=self.ch
+            )
+        layer.send.assert_not_awaited()
+
+
+class AgentSubsRefreshHandlerTest(TestCase):
+    """Consumer handler half — ``AgentConsumer.agent_subs_refresh``."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="handler-ws")
+        self.ch_alpha = Channel.objects.create(
+            workspace=self.ws, name="#alpha"
+        )
+        self.ch_beta = Channel.objects.create(
+            workspace=self.ws, name="#beta"
+        )
+        self.agent_user = User.objects.create(username="agent-worker-q")
+
+    def test_add_membership_joins_new_group_and_updates_meta(self):
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_alpha
+        )
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_beta
+        )
+
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id,
+            }
+        )
+
+        self.assertIn("#beta", consumer.agent_meta["channels"])
+        consumer.channel_layer.group_add.assert_awaited()
+        added_groups = [
+            call.args[0]
+            for call in consumer.channel_layer.group_add.await_args_list
+        ]
+        self.assertTrue(any("beta" in g for g in added_groups))
+
+    def test_remove_membership_discards_group_and_updates_meta(self):
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_alpha
+        )
+        consumer = _fake_consumer(
+            "worker-q",
+            self.ws.id,
+            channels=["#alpha", "#beta"],  # in-memory stale
+        )
+
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id,
+            }
+        )
+
+        self.assertNotIn("#beta", consumer.agent_meta["channels"])
+        discarded = [
+            call.args[0]
+            for call in consumer.channel_layer.group_discard.await_args_list
+        ]
+        self.assertTrue(any("beta" in g for g in discarded))
+
+    def test_refresh_preserves_dm_channels(self):
+        consumer = _fake_consumer(
+            "worker-q",
+            self.ws.id,
+            channels=["dm:worker-q|alice", "#alpha"],
+            dm_channels=["dm:worker-q|alice"],
+        )
+        # No ChannelMembership rows → DB says agent is subscribed to nothing
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id,
+            }
+        )
+        self.assertIn("dm:worker-q|alice", consumer.agent_meta["channels"])
+        # DM group must not be discarded by the refresh.
+        discarded = [
+            call.args[0]
+            for call in consumer.channel_layer.group_discard.await_args_list
+        ]
+        self.assertFalse(any("dm:" in g for g in discarded))
+
+    def test_refresh_skips_mismatched_workspace_event(self):
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_beta
+        )
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id + 9999,
+            }
+        )
+        # Event was for a different workspace — no DB lookup, no mutation.
+        self.assertEqual(consumer.agent_meta["channels"], ["#alpha"])
+        consumer.channel_layer.group_add.assert_not_awaited()
+        consumer.channel_layer.group_discard.assert_not_awaited()
+
+    def test_refresh_skips_other_agent_events(self):
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-other",
+                "workspace_id": self.ws.id,
+            }
+        )
+        self.assertEqual(consumer.agent_meta["channels"], ["#alpha"])
+        consumer.channel_layer.group_add.assert_not_awaited()
+        consumer.channel_layer.group_discard.assert_not_awaited()
+
+    def test_refresh_broadcasts_agent_info_on_change(self):
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_beta
+        )
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        with patch("hub.registry.register_agent") as reg:
+            async_to_sync(consumer.agent_subs_refresh)(
+                {
+                    "type": "agent.subs_refresh",
+                    "agent": "worker-q",
+                    "workspace_id": self.ws.id,
+                }
+            )
+            reg.assert_called_once()
+        consumer.channel_layer.group_send.assert_awaited()
+        sent_event = consumer.channel_layer.group_send.await_args.args[1]
+        self.assertEqual(sent_event["type"], "agent.info")
+        self.assertEqual(sent_event["agent"], "worker-q")


### PR DESCRIPTION
Closes #282. Follow-up to #277 / #280.

## Problem
`consumer.agent_meta["channels"]` on a live `AgentConsumer` only tracked WS-originated subscribe / unsubscribe frames. Out-of-band `ChannelMembership` edits (REST admin subscribe, drag-to-channel, Django admin UI, direct ORM) never propagated to live consumers, so:

- admin-added subscriptions were silently ignored by the `chat_message` / `_is_channel_visible` filter until the agent reconnected;
- admin-removed subscriptions kept leaking messages to the agent for the remainder of the session.

## Fix
`hub/signals.py`
- `post_save` + `post_delete` receivers on `ChannelMembership` (agent users only).
- Refresh dispatched via `transaction.on_commit` so the consumer's DB re-fetch observes the committed state (avoids a read-before-commit race).
- Human user memberships are ignored — the dashboard path reads membership per-delivery.

`hub/consumers/_agent_refresh.py` (new)
- `handle_agent_subs_refresh(consumer, event)` re-reads `_load_agent_channel_subs(...)`, diffs against `agent_meta["channels"]` while preserving auto-subscribed `dm:` channels, and calls `group_add` / `group_discard` for the delta.
- Rewrites `agent_meta["channels"]` to the DB-authoritative set.
- When the set actually changed, re-registers with the in-process registry and broadcasts a fresh `agent.info` so dashboards stay in sync.

`hub/consumers/_agent.py`
- Trivial `agent_subs_refresh` method that delegates to the new sibling so the consumer class stays under the 512-line cap.

## Tests
`hub/tests/consumers/test_agent_subs_refresh.py` (new, 7 cases):
- Signal fires `agent.subs_refresh` for agent users, with expected payload and workspace scoping.
- Signal is a no-op for human `User` memberships and when no live sibling WS exists.
- Signal fires on both `create` and `delete` of `ChannelMembership`.
- Handler adds new channels (group_add + in-memory update).
- Handler discards removed channels but preserves `dm:` auto-subs.
- Handler ignores events for a different workspace or agent.
- Handler broadcasts `agent.info` only when the set actually changed.

Tests use `TestCase.captureOnCommitCallbacks(execute=True)` to run the `on_commit` callbacks inside the test transaction. Synchronous sends are patched via `hub.signals.get_channel_layer` and `hub.signals.list_sibling_channels`.

## Scope / safety
- Backend Python only; no frontend, no migration. Safe to land alongside `ts-migration-v2`.
- The signal is a best-effort fan-out — a single failing socket is logged but does not mask refreshes to sibling sockets or other agents.

## Not included (deferred)
- **Self-subscribe ACL on `_persist_agent_subscription` and `api_admin_agent_subscribe`.** Currently any agent can create a `ChannelMembership` row for itself on any channel. That is a separate policy decision (which channels are private, who may add whom) and worth its own issue rather than bundling with this mechanical sync fix. Filing a follow-up once this lands.

## Local test note
mba `.venv` is a broken Linux symlink (the hub actually runs inside the Docker host), so the full Django suite must run under CI. All four edited/added files parse clean under `python3 -c 'ast.parse(...)'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
