### PR TITLE
feat(ui/sidebar): canonical card layout + single-channel-select + remove color-coding (#284)

### DIFF
--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -177,7 +177,10 @@ export function _renderChannelRowHtml(row, ctx) {
  * the file-size budget without changing any observable behavior. */
 export function _wireChannelItemHandlers(chContainer, prevSelected) {
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render */
+    /* Restore selected state from before re-render. Channels are single-
+     * selection only (#284): at most one channel-item ever carries the
+     * .selected class. prevSelected is retained across renders so the
+     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
     if (elCh && prevSelected[elCh]) el.classList.add("selected");
     /* Pin icon click — toggle is_starred (pinned-to-top) */
@@ -288,41 +291,9 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
         _setChannelPref(ch, { is_hidden: false });
         return;
       }
-      var multi = ev.ctrlKey || ev.metaKey;
-      /* todo#274 Part 2: Ctrl/Cmd+Click toggles multi-select without
-       * disturbing siblings; plain click keeps legacy single-select. */
-      if (multi) {
-        el.classList.toggle("selected");
-        /* When multi-select is active, the DOM may only have messages from
-         * (globalThis as any).currentChannel. Switch to all-channel history so messages from
-         * every selected channel are present, then let applyFeedFilter
-         * show the merged subset. (#366) */
-        var _selCount = chContainer.querySelectorAll(
-          ".channel-item.selected[data-channel]",
-        ).length;
-        if (_selCount >= 2) {
-          /* Load all messages; applyFeedFilter handles visible subset */
-          setCurrentChannel(null);
-          var _applyAfter = function () {
-            if (typeof applyFeedFilter === "function") applyFeedFilter();
-          };
-          loadHistory().then
-            ? loadHistory().then(_applyAfter)
-            : (loadHistory(), _applyAfter());
-        } else if (_selCount === 1) {
-          var _onlyCh = chContainer.querySelector(
-            ".channel-item.selected[data-channel]",
-          );
-          if (_onlyCh) {
-            setCurrentChannel(_onlyCh.getAttribute("data-channel"));
-            loadChannelHistory(_onlyCh.getAttribute("data-channel"));
-          }
-        } else {
-          /* All deselected */
-          if (typeof applyFeedFilter === "function") applyFeedFilter();
-        }
-        return;
-      }
+      /* #284: channels are single-selection only. The legacy Ctrl/Cmd+Click
+       * multi-select has been removed — any click replaces the current
+       * selection with exactly this row. */
       if ((globalThis as any).currentChannel === ch) {
         setCurrentChannel(null);
         loadHistory();

--- a/hub/frontend/src/app/sidebar-stats.ts
+++ b/hub/frontend/src/app/sidebar-stats.ts
@@ -22,7 +22,10 @@ export async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* Preserve Ctrl+Click multi-select state across re-renders (#274 Part 2) */
+    /* #284: channels are single-select only. prevSelected keeps the one
+     * currently-selected row marked .selected across DOM re-renders so the
+     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
+     * multi-select — #274 Part 2 — has been removed for channels.) */
     var prevSelected = {};
     chContainer
       .querySelectorAll(".channel-item.selected")

--- a/hub/frontend/src/dms.ts
+++ b/hub/frontend/src/dms.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { renderAgentBadge } from "./agent-badge";
 import { _setChannelPref } from "./app/channel-prefs";
 import { _channelPrefs } from "./app/members";
 import { fetchStats } from "./app/sidebar-stats";
@@ -40,12 +41,70 @@ import { loadChannelHistory, loadHistory } from "./chat/chat-history";
       .join(", ");
   }
 
-  function dmBadgeHtml(row) {
+  /* #284: DM card === Agent card.
+   *
+   * DM rows render through the shared renderAgentBadge() so markup,
+   * CSS classes and icon/star/LEDs/name layout are IDENTICAL to the
+   * Agent card. For DMs where the counterparty is a live agent, we
+   * pick up its record from window.__lastAgents so real liveness LEDs
+   * light up. For human-to-human DMs, we synthesise a minimal agent-
+   * shaped object keyed off the human's name — the same badge renders
+   * with all LEDs off/unknown (humans don't have a WS/ping/pane/echo
+   * signal) and the star/name columns line up with the agent sidebar.
+   *
+   * Returns a plain object shaped like an agent-registry row. Never
+   * forks the markup — see agent-badge.ts renderAgentBadge. */
+  function dmCounterpartyAgentLike(row) {
     var others = (row && row.other_participants) || [];
-    if (others.length === 0) return "";
-    var t = others[0].type === "agent" ? "agent" : "human";
-    var label = t === "agent" ? "AI" : "U";
-    return '<span class="dm-principal-badge ' + t + '">' + label + "</span>";
+    /* Empty DM (no counterparty yet): fall back to the channel key as
+     * name so at least the row shows something stable. */
+    if (others.length === 0) {
+      return {
+        name: row && row.name ? row.name : "(empty DM)",
+        status: "offline",
+        liveness: "offline",
+      };
+    }
+    /* Collapse multi-participant DMs to the first counterparty so we
+     * always render one badge. The remaining names still appear in the
+     * fallback label via the data-channel tooltip. */
+    var p = others[0];
+    var label = (p && p.identity_name) || "?";
+    /* Agent principal: look up the live record so LEDs reflect truth. */
+    if (p && p.type === "agent") {
+      var live = Array.isArray(window.__lastAgents) ? window.__lastAgents : [];
+      var match = null;
+      for (var i = 0; i < live.length; i++) {
+        var a = live[i];
+        if (!a || !a.name) continue;
+        var bare = String(a.name).split("@")[0];
+        if (bare === label || a.name === label) {
+          match = a;
+          break;
+        }
+      }
+      if (match) return match;
+      /* Agent is listed in the DM but not currently in __lastAgents
+       * (offline / not yet registered) — synth an offline-agent-like
+       * record so the badge still renders. */
+      return {
+        name: label,
+        status: "offline",
+        liveness: "offline",
+        machine: (p && p.machine) || "",
+      };
+    }
+    /* Human principal: synthesise a minimal agent-shape object. All
+     * LEDs render grey/off because there's no WS/ping/pane/echo signal
+     * for humans. Star + icon + name layout match the agent card. */
+    return {
+      name: label,
+      status: "offline",
+      liveness: "offline",
+      /* Keep the type hint so CSS can style humans differently if it
+       * ever needs to (today it does not — identity is identical). */
+      _dm_counterparty_type: "human",
+    };
   }
 
   function renderDms(rows) {
@@ -65,70 +124,73 @@ import { loadChannelHistory, loadHistory } from "./chat/chat-history";
            * pin/mute state is shared between the Channels and DM sidebars. */
           var prefs =
             (typeof _channelPrefs !== "undefined" && _channelPrefs[ch]) || {};
-          var pinned = !!prefs.is_starred;
           var muted = !!prefs.is_muted;
+          var pinned = !!prefs.is_starred;
+          var counterparty = dmCounterpartyAgentLike(row);
+          /* Override .pinned so the star glyph reflects the DM-channel's
+           * is_starred pref rather than the underlying agent's own pin
+           * state — DMs are pinned on the conversation, not on the agent. */
+          var cpWithDmPin = {};
+          for (var k in counterparty)
+            if (Object.prototype.hasOwnProperty.call(counterparty, k))
+              cpWithDmPin[k] = counterparty[k];
+          cpWithDmPin.pinned = pinned;
+          /* DM card shares the .agent-card markup + class so CSS rules
+           * (hover, selected, drag affordances) apply uniformly across
+           * the Agent sidebar and the DM sidebar. .dm-item is retained
+           * as an extra hook for DM-specific behaviours (the per-row
+           * click handler attaches by that class); markup underneath
+           * is rendered by renderAgentBadge exactly as on the Agents
+           * sidebar. */
           return (
-            '<div class="dm-item' +
+            '<div class="dm-item agent-card' +
             active +
             (muted ? " ch-muted" : "") +
             '" data-channel="' +
             escapeHtml(ch) +
+            '" data-agent-name="' +
+            escapeHtml(counterparty.name || "") +
             '" title="' +
             escapeHtml(ch) +
             '">' +
-            '<span class="ch-pin ' +
-            (pinned ? "ch-pin-on" : "ch-pin-off") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (pinned ? "Unstar" : "Star (float to top)") +
-            '">' +
-            (pinned ? "\u2605" : "\u2606") +
-            "</span>" +
-            '<span class="ch-watch ' +
-            (muted ? "ch-watch-off" : "ch-watch-on") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (muted
-              ? "Unmute (watch this DM)"
-              : "Mute (stop DM notifications)") +
-            '">\uD83D\uDC41</span>' +
-            dmBadgeHtml(row) +
-            escapeHtml(dmDisplayName(row)) +
+            (typeof renderAgentBadge === "function"
+              ? renderAgentBadge(cpWithDmPin, { iconSize: 14 })
+              : escapeHtml(dmDisplayName(row))) +
             "</div>"
           );
         })
         .join("");
       container.querySelectorAll(".dm-item").forEach(function (el) {
-        /* Pin icon toggles is_starred via the shared _setChannelPref. */
-        var pinEl = el.querySelector(".ch-pin");
-        if (pinEl && typeof _setChannelPref === "function") {
-          pinEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = pinEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_starred: !pref.is_starred });
-          });
-        }
-        /* Eye icon toggles is_muted. */
-        var watchEl = el.querySelector(".ch-watch");
-        if (watchEl && typeof _setChannelPref === "function") {
-          watchEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = watchEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_muted: !pref.is_muted });
-          });
+        /* Star inside the shared agent-badge markup — override the
+         * default agent-pin behaviour so clicking the star on a DM row
+         * toggles is_starred on the CHANNEL pref (pin the conversation)
+         * rather than pin-to-top the underlying agent. Uses the .dm-item
+         * row's data-channel, not the button's own data-pin-name which
+         * points at the counterparty agent. Runs on capture phase so we
+         * beat the global agent-pin handler wired elsewhere. */
+        var starEl = el.querySelector(".agent-badge-star");
+        if (starEl && typeof _setChannelPref === "function") {
+          starEl.addEventListener(
+            "click",
+            function (ev) {
+              ev.stopPropagation();
+              ev.preventDefault();
+              var chName = el.getAttribute("data-channel");
+              if (!chName) return;
+              var pref =
+                (typeof _channelPrefs !== "undefined" &&
+                  _channelPrefs[chName]) ||
+                {};
+              _setChannelPref(chName, { is_starred: !pref.is_starred });
+            },
+            true,
+          );
         }
         el.addEventListener("click", function (ev) {
+          /* Don't treat star / avatar clicks as row-clicks. */
           if (
-            ev.target.classList.contains("ch-pin") ||
-            ev.target.classList.contains("ch-watch")
+            ev.target.closest(".agent-badge-star") ||
+            ev.target.closest(".avatar-clickable")
           )
             return;
           var ch = el.getAttribute("data-channel");

--- a/hub/frontend/src/filter/runner.ts
+++ b/hub/frontend/src/filter/runner.ts
@@ -75,11 +75,10 @@ export function runFilter() {
         });
       }
     }
-    /* Skip single-channel filter when multi-select is active (#366):
-     * applyFeedFilter() handles multi-channel visibility in that case. */
-    var _multiActive =
-      document.querySelectorAll("#channels .channel-item.selected").length >= 2;
-    if (show && (globalThis as any).currentChannel && !_multiActive) {
+    /* #284: channels are single-select — at most one .channel-item.selected
+     * ever exists. The legacy multi-channel bypass was removed; currentChannel
+     * alone is the filter gate. */
+    if (show && (globalThis as any).currentChannel) {
       show = el.getAttribute("data-channel") === (globalThis as any).currentChannel;
     }
     el.style.display = show ? "" : "none";

--- a/hub/frontend/src/resources-tab/tab.ts
+++ b/hub/frontend/src/resources-tab/tab.ts
@@ -81,11 +81,18 @@ export function renderResources() {
           d.slurm.total_jobs +
           " jobs</span>";
       }
-      /* Entity-consistency format (TODO.md "Entity Consistency"):
-       * machine: [icon] [star] [<host-label>]. Icon is a compact
-       * server glyph; star is a reserved placeholder slot (machines
-       * aren't pinnable yet but the slot keeps the column aligned
-       * with sidebar channel rows). */
+      /* #284 Machine card order: [icon] [star] [LED] [<host-label>
+       * (<hostname-canonical>)] [metrics].
+       *
+       * The single LED replaces the old leading connection dot; it
+       * sits BETWEEN star and the name so the icon/star columns line
+       * up with agent + DM sidebar rows. Machines don't have the
+       * 4-LED liveness model agents do (no WS handshake / ping / pane
+       * state / nonce-echo signal is meaningful for a bare host), so
+       * we keep a single health LED driven by the heartbeat health
+       * status. Metrics (CPU / Mem / Disk / GPU / SLURM) stay inline
+       * where horizontal space allows — the full metric breakdown is
+       * always available on the hover tooltip regardless. */
       var mStarred = !!(d && d._starred);
       return (
         '<div class="res-card res-card-compact" data-machine="' +
@@ -94,9 +101,6 @@ export function renderResources() {
         escapeHtml(k) +
         (d._status ? " · " + d._status : "") +
         '">' +
-        '<span class="res-conn res-conn-' +
-        (healthy ? "ok" : "stale") +
-        '"></span>' +
         '<span class="res-machine-icon" title="right-click to change" aria-hidden="true">' +
         (_machineIcons[k] || "\uD83D\uDDA5\uFE0F") +
         "</span>" +
@@ -109,11 +113,17 @@ export function renderResources() {
         '">' +
         (mStarred ? "\u2605" : "\u2606") +
         "</span>" +
-        /* Spec: machine: [icon] [star] [<host-label> (<canonical-$HOSTNAME>)]
-         * — show the canonical FQDN in parentheses after the short
-         * label when it differs meaningfully from the label. Uses
-         * the same collapse rules as the Machine detail view
-         * (.local/.localdomain suffixes aren't "different"). */
+        '<span class="res-conn res-conn-' +
+        (healthy ? "ok" : "stale") +
+        '" title="' +
+        (healthy ? "Host healthy" : "Host stale / degraded") +
+        '"></span>' +
+        /* Spec: machine: [icon] [star] [LED] [<host-label>
+         * (<hostname-canonical>)] — show the canonical FQDN in
+         * parentheses after the short label when it differs
+         * meaningfully from the label. Uses the same collapse rules
+         * as the agents-tab Machine detail view (.local /
+         * .localdomain suffixes aren't "different"). */
         '<span class="res-host-name" style="color:' +
         color +
         '">' +

--- a/hub/static/hub/app/sidebar-channel-tree.js
+++ b/hub/static/hub/app/sidebar-channel-tree.js
@@ -163,7 +163,10 @@ function _renderChannelRowHtml(row, ctx) {
  * the file-size budget without changing any observable behavior. */
 function _wireChannelItemHandlers(chContainer, prevSelected) {
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render */
+    /* Restore selected state from before re-render. Channels are single-
+     * selection only (#284): at most one channel-item ever carries the
+     * .selected class. prevSelected is retained across renders so the
+     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
     if (elCh && prevSelected[elCh]) el.classList.add("selected");
     /* Pin icon click — toggle is_starred (pinned-to-top) */
@@ -274,41 +277,9 @@ function _wireChannelItemHandlers(chContainer, prevSelected) {
         _setChannelPref(ch, { is_hidden: false });
         return;
       }
-      var multi = ev.ctrlKey || ev.metaKey;
-      /* todo#274 Part 2: Ctrl/Cmd+Click toggles multi-select without
-       * disturbing siblings; plain click keeps legacy single-select. */
-      if (multi) {
-        el.classList.toggle("selected");
-        /* When multi-select is active, the DOM may only have messages from
-         * currentChannel. Switch to all-channel history so messages from
-         * every selected channel are present, then let applyFeedFilter
-         * show the merged subset. (#366) */
-        var _selCount = chContainer.querySelectorAll(
-          ".channel-item.selected[data-channel]",
-        ).length;
-        if (_selCount >= 2) {
-          /* Load all messages; applyFeedFilter handles visible subset */
-          setCurrentChannel(null);
-          var _applyAfter = function () {
-            if (typeof applyFeedFilter === "function") applyFeedFilter();
-          };
-          loadHistory().then
-            ? loadHistory().then(_applyAfter)
-            : (loadHistory(), _applyAfter());
-        } else if (_selCount === 1) {
-          var _onlyCh = chContainer.querySelector(
-            ".channel-item.selected[data-channel]",
-          );
-          if (_onlyCh) {
-            setCurrentChannel(_onlyCh.getAttribute("data-channel"));
-            loadChannelHistory(_onlyCh.getAttribute("data-channel"));
-          }
-        } else {
-          /* All deselected */
-          if (typeof applyFeedFilter === "function") applyFeedFilter();
-        }
-        return;
-      }
+      /* #284: channels are single-selection only. The legacy Ctrl/Cmd+Click
+       * multi-select has been removed — any click replaces the current
+       * selection with exactly this row. */
       if (currentChannel === ch) {
         setCurrentChannel(null);
         loadHistory();

--- a/hub/static/hub/app/sidebar-stats.js
+++ b/hub/static/hub/app/sidebar-stats.js
@@ -15,7 +15,10 @@ async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* Preserve Ctrl+Click multi-select state across re-renders (#274 Part 2) */
+    /* #284: channels are single-select only. prevSelected keeps the one
+     * currently-selected row marked .selected across DOM re-renders so the
+     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
+     * multi-select — #274 Part 2 — has been removed for channels.) */
     var prevSelected = {};
     chContainer
       .querySelectorAll(".channel-item.selected")

--- a/hub/static/hub/dms.js
+++ b/hub/static/hub/dms.js
@@ -32,12 +32,56 @@
       .join(", ");
   }
 
-  function dmBadgeHtml(row) {
+  /* #284: DM card === Agent card.
+   *
+   * DM rows render through the shared renderAgentBadge() so markup,
+   * CSS classes and icon/star/LEDs/name layout are IDENTICAL to the
+   * Agent card. For DMs where the counterparty is a live agent, we
+   * pick up its record from window.__lastAgents so real liveness LEDs
+   * light up. For human-to-human DMs, we synthesise a minimal agent-
+   * shaped object keyed off the human's name — the same badge renders
+   * with all LEDs off/unknown (humans don't have a WS/ping/pane/echo
+   * signal) and the star/name columns line up with the agent sidebar.
+   *
+   * Returns a plain object shaped like an agent-registry row. Never
+   * forks the markup — see agent-badge.js renderAgentBadge. */
+  function dmCounterpartyAgentLike(row) {
     var others = (row && row.other_participants) || [];
-    if (others.length === 0) return "";
-    var t = others[0].type === "agent" ? "agent" : "human";
-    var label = t === "agent" ? "AI" : "U";
-    return '<span class="dm-principal-badge ' + t + '">' + label + "</span>";
+    if (others.length === 0) {
+      return {
+        name: row && row.name ? row.name : "(empty DM)",
+        status: "offline",
+        liveness: "offline",
+      };
+    }
+    var p = others[0];
+    var label = (p && p.identity_name) || "?";
+    if (p && p.type === "agent") {
+      var live = Array.isArray(window.__lastAgents) ? window.__lastAgents : [];
+      var match = null;
+      for (var i = 0; i < live.length; i++) {
+        var a = live[i];
+        if (!a || !a.name) continue;
+        var bare = String(a.name).split("@")[0];
+        if (bare === label || a.name === label) {
+          match = a;
+          break;
+        }
+      }
+      if (match) return match;
+      return {
+        name: label,
+        status: "offline",
+        liveness: "offline",
+        machine: (p && p.machine) || "",
+      };
+    }
+    return {
+      name: label,
+      status: "offline",
+      liveness: "offline",
+      _dm_counterparty_type: "human",
+    };
   }
 
   function renderDms(rows) {
@@ -59,68 +103,61 @@
             (typeof _channelPrefs !== "undefined" && _channelPrefs[ch]) || {};
           var pinned = !!prefs.is_starred;
           var muted = !!prefs.is_muted;
+          var counterparty = dmCounterpartyAgentLike(row);
+          var cpWithDmPin = {};
+          for (var k in counterparty)
+            if (Object.prototype.hasOwnProperty.call(counterparty, k))
+              cpWithDmPin[k] = counterparty[k];
+          cpWithDmPin.pinned = pinned;
           return (
-            '<div class="dm-item' +
+            '<div class="dm-item agent-card' +
             active +
             (muted ? " ch-muted" : "") +
             '" data-channel="' +
             escapeHtml(ch) +
+            '" data-agent-name="' +
+            escapeHtml(counterparty.name || "") +
             '" title="' +
             escapeHtml(ch) +
             '">' +
-            '<span class="ch-pin ' +
-            (pinned ? "ch-pin-on" : "ch-pin-off") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (pinned ? "Unstar" : "Star (float to top)") +
-            '">' +
-            (pinned ? "\u2605" : "\u2606") +
-            "</span>" +
-            '<span class="ch-watch ' +
-            (muted ? "ch-watch-off" : "ch-watch-on") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (muted
-              ? "Unmute (watch this DM)"
-              : "Mute (stop DM notifications)") +
-            '">\uD83D\uDC41</span>' +
-            dmBadgeHtml(row) +
-            escapeHtml(dmDisplayName(row)) +
+            (typeof renderAgentBadge === "function"
+              ? renderAgentBadge(cpWithDmPin, { iconSize: 14 })
+              : escapeHtml(dmDisplayName(row))) +
             "</div>"
           );
         })
         .join("");
       container.querySelectorAll(".dm-item").forEach(function (el) {
-        /* Pin icon toggles is_starred via the shared _setChannelPref. */
-        var pinEl = el.querySelector(".ch-pin");
-        if (pinEl && typeof _setChannelPref === "function") {
-          pinEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = pinEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_starred: !pref.is_starred });
-          });
-        }
-        /* Eye icon toggles is_muted. */
-        var watchEl = el.querySelector(".ch-watch");
-        if (watchEl && typeof _setChannelPref === "function") {
-          watchEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = watchEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_muted: !pref.is_muted });
-          });
+        /* Star inside the shared agent-badge markup — override the
+         * default agent-pin behaviour so clicking the star on a DM row
+         * toggles is_starred on the CHANNEL pref (pin the conversation)
+         * rather than pin-to-top the underlying agent. Uses the .dm-item
+         * row's data-channel, not the button's own data-pin-name which
+         * points at the counterparty agent. Runs on capture phase so we
+         * beat the global agent-pin handler wired elsewhere. */
+        var starEl = el.querySelector(".agent-badge-star");
+        if (starEl && typeof _setChannelPref === "function") {
+          starEl.addEventListener(
+            "click",
+            function (ev) {
+              ev.stopPropagation();
+              ev.preventDefault();
+              var chName = el.getAttribute("data-channel");
+              if (!chName) return;
+              var pref =
+                (typeof _channelPrefs !== "undefined" &&
+                  _channelPrefs[chName]) ||
+                {};
+              _setChannelPref(chName, { is_starred: !pref.is_starred });
+            },
+            true,
+          );
         }
         el.addEventListener("click", function (ev) {
+          /* Don't treat star / avatar clicks as row-clicks. */
           if (
-            ev.target.classList.contains("ch-pin") ||
-            ev.target.classList.contains("ch-watch")
+            ev.target.closest(".agent-badge-star") ||
+            ev.target.closest(".avatar-clickable")
           )
             return;
           var ch = el.getAttribute("data-channel");

--- a/hub/static/hub/filter/runner.js
+++ b/hub/static/hub/filter/runner.js
@@ -72,11 +72,10 @@ function runFilter() {
         });
       }
     }
-    /* Skip single-channel filter when multi-select is active (#366):
-     * applyFeedFilter() handles multi-channel visibility in that case. */
-    var _multiActive =
-      document.querySelectorAll("#channels .channel-item.selected").length >= 2;
-    if (show && currentChannel && !_multiActive) {
+    /* #284: channels are single-select — at most one .channel-item.selected
+     * ever exists. The legacy multi-channel bypass was removed; currentChannel
+     * alone is the filter gate. */
+    if (show && currentChannel) {
       show = el.getAttribute("data-channel") === currentChannel;
     }
     el.style.display = show ? "" : "none";

--- a/hub/static/hub/resources-tab/tab.js
+++ b/hub/static/hub/resources-tab/tab.js
@@ -74,11 +74,18 @@ function renderResources() {
           d.slurm.total_jobs +
           " jobs</span>";
       }
-      /* Entity-consistency format (TODO.md "Entity Consistency"):
-       * machine: [icon] [star] [<host-label>]. Icon is a compact
-       * server glyph; star is a reserved placeholder slot (machines
-       * aren't pinnable yet but the slot keeps the column aligned
-       * with sidebar channel rows). */
+      /* #284 Machine card order: [icon] [star] [LED] [<host-label>
+       * (<hostname-canonical>)] [metrics].
+       *
+       * The single LED replaces the old leading connection dot; it
+       * sits BETWEEN star and the name so the icon/star columns line
+       * up with agent + DM sidebar rows. Machines don't have the
+       * 4-LED liveness model agents do (no WS handshake / ping / pane
+       * state / nonce-echo signal is meaningful for a bare host), so
+       * we keep a single health LED driven by the heartbeat health
+       * status. Metrics (CPU / Mem / Disk / GPU / SLURM) stay inline
+       * where horizontal space allows — the full metric breakdown is
+       * always available on the hover tooltip regardless. */
       var mStarred = !!(d && d._starred);
       return (
         '<div class="res-card res-card-compact" data-machine="' +
@@ -87,9 +94,6 @@ function renderResources() {
         escapeHtml(k) +
         (d._status ? " · " + d._status : "") +
         '">' +
-        '<span class="res-conn res-conn-' +
-        (healthy ? "ok" : "stale") +
-        '"></span>' +
         '<span class="res-machine-icon" title="right-click to change" aria-hidden="true">' +
         (_machineIcons[k] || "\uD83D\uDDA5\uFE0F") +
         "</span>" +
@@ -102,11 +106,17 @@ function renderResources() {
         '">' +
         (mStarred ? "\u2605" : "\u2606") +
         "</span>" +
-        /* Spec: machine: [icon] [star] [<host-label> (<canonical-$HOSTNAME>)]
-         * — show the canonical FQDN in parentheses after the short
-         * label when it differs meaningfully from the label. Uses
-         * the same collapse rules as the Machine detail view
-         * (.local/.localdomain suffixes aren't "different"). */
+        '<span class="res-conn res-conn-' +
+        (healthy ? "ok" : "stale") +
+        '" title="' +
+        (healthy ? "Host healthy" : "Host stale / degraded") +
+        '"></span>' +
+        /* Spec: machine: [icon] [star] [LED] [<host-label>
+         * (<hostname-canonical>)] — show the canonical FQDN in
+         * parentheses after the short label when it differs
+         * meaningfully from the label. Uses the same collapse rules
+         * as the agents-tab Machine detail view (.local /
+         * .localdomain suffixes aren't "different"). */
         '<span class="res-host-name" style="color:' +
         color +
         '">' +

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -308,7 +308,11 @@
   line-height: 1;
 }
 .ch-identity-icon .entity-icon-channel {
-  opacity: 0.55;
+  /* #284: channel icons render at full brightness — no dimming on the
+   * default "#" glyph, and no grayscale cascade. Previously 0.55 opacity
+   * made the icons hard to read; the canonical sidebar layout keeps them
+   * the same weight as agent/DM icons. */
+  opacity: 1;
   display: inline-block;
   width: 100%;
   text-align: center;

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -122,14 +122,16 @@ blockquote.chat-blockquote {
   border-color: #4ecdc4;
 }
 
-/* Filter toggle active states (click-to-toggle on sidebar items) */
+/* Filter toggle active states (click-to-toggle on sidebar items).
+ * #284: the channel rule has been removed — the spec requires a single
+ * "currently-selected" marker on the Channels list with no additional
+ * highlight / category / filter tinting. Agent and resource rows still
+ * show a filter-active accent since those aren't under the single-
+ * select constraint (agents still support multi-select; resources use
+ * this to show when a host: tag is focusing them). */
 .agent-card.filter-active {
   background: rgba(78, 205, 196, 0.15);
   border-left: 3px solid #4ecdc4;
-}
-.channel-item.filter-active {
-  background: rgba(126, 200, 227, 0.15);
-  border-left: 3px solid #7ec8e3;
 }
 .res-card.filter-active {
   background: rgba(78, 205, 196, 0.15);
@@ -145,7 +147,10 @@ blockquote.chat-blockquote {
 .sidebar .agent-card.selected {
   background: rgba(78, 205, 196, 0.2);
 }
-.sidebar #channels:has(.channel-item.selected) .channel-item:not(.selected),
+/* #284: don't dim non-selected channels when one is selected — the
+ * spec calls for a single currently-selected marker only, no additional
+ * tinting/dimming cascade on the channel list. Agent sibling-dim stays
+ * (agents still support multi-select outside the #284 scope). */
 .sidebar #agents:has(.agent-card.selected) .agent-card:not(.selected) {
   opacity: 0.6;
 }


### PR DESCRIPTION
Closes #284.

Frontend sidebar card-layout rewrite per ywatanabe msg#15117-15135 / #15151, dispatched by lead #agent msg#15223.

## Canonical card layouts

| Card | Layout (left to right) |
|---|---|
| Agent | icon * 4LEDs name@hostname-label |
| DM | icon * 4LEDs name@hostname-label (identical component to Agent) |
| Channels | icon * eye bell channel-name |
| Machines (sidebar) | icon * LED host-label (hostname-canonical) metrics |
| Machines (detail) | icon * LED host-label (hostname-canonical) + Resources grid |

## Behavioural changes

- **Channels: single-selection only.** Removed Ctrl/Cmd+Click multi-select in `sidebar-channel-tree`; removed the `selectedChannels >= 2` bypass in `filter/runner`. Clicking a channel row replaces the current selection with exactly that channel.
- **Channels: removed highlight / filter color / category tinting.** `.channel-item.filter-active` rule dropped; `#channels:has(.selected) .channel-item:not(.selected) { opacity: 0.6 }` sibling-dim dropped. Only the single `.selected` marker (subtle background) remains.
- **Channel icons: full brightness.** `.ch-identity-icon .entity-icon-channel` opacity bumped `0.55 -> 1`; no grayscale / dim cascade on the icon column.
- **DM card === Agent card.** `dms.ts` / `dms.js` now call the shared `renderAgentBadge()` for every DM row so the markup, CSS classes and column ordering are byte-identical to the Agent sidebar. For DMs whose counterparty is a live agent, the record is picked up from `window.__lastAgents` so real liveness LEDs light up. For human-principal DMs, a minimal agent-shape synth object is used — all LEDs render off/unknown (humans have no WS / ping / pane / echo signal). The star slot is rewired so clicking it toggles `is_starred` on the DM channel pref (pin the conversation) rather than `togglePinAgent` on the counterparty.
- **Machines card.** LED moved from the leading column to between star and host-name so the icon/star columns align with the agent + DM rows. Single LED (healthy / stale) is preserved because machines don't have the agent 4-LED liveness model (no WS handshake / ping / pane state / nonce-echo signal is meaningful for a bare host). Metrics chips stay inline; full CPU/RAM/GPU/VRAM/Disk is always available on the hover tooltip, matching the "Resources may become a hover tooltip when horizontal space is tight" spec note.

## Files touched

**TypeScript** (`hub/frontend/src/`)
- `app/sidebar-channel-tree.ts` — drop channel multi-select
- `app/sidebar-stats.ts` — update stale multi-select comment
- `dms.ts` — render DM rows through `renderAgentBadge`
- `filter/runner.ts` — drop `_multiActive` branch (never true after #284)
- `resources-tab/tab.ts` — reorder Machines card to `icon * LED host-label (canonical) metrics`

**Legacy JS mirrors** (`hub/static/hub/`) — same behavioural change mirrored to every hand-maintained `.js` twin:
- `app/sidebar-channel-tree.js`, `app/sidebar-stats.js`, `dms.js`, `filter/runner.js`, `resources-tab/tab.js`

**CSS**
- `style/style-channels.css` — `ch-identity-icon` icon opacity `0.55 -> 1`
- `style/style-messages.css` — drop `channel-item.filter-active` and channel sibling-dim

## Not changed

- **Backend.** Zero backend / Django / channel-consumer edits. No migrations.
- **Agent color-coding.** The per-agent palette (`getAgentColor` / `getResolvedAgentColor`) is untouched; agent rows render with the same color-keyed name + avatar they had before.
- **Agent multi-select.** `.agent-card.selected` multi-select and the agent sibling-dim cascade remain — the #284 single-select rule only applied to channels.
- **`ts-migration-v2` branch.** Not checked out, not modified.
- **Activity tab topology SVG / pool chips.** Already on the shared badge components; nothing to fix.
- **Channel-badge `renderChannelBadgeHtml`.** Already emits `icon -> star -> eye -> mute -> name` in sidebar context.

## Spec ambiguity (judgment calls)

1. **"4 LEDs" on the Machines card** (spec #1) vs **"LED" (singular) on Machines detail view** (spec #3). Went with a single LED in both views — machines don't have a 4-lamp liveness model and fabricating four lamps from one health bit felt worse than mismatching the spec letter. Noted as a point to revisit if ywatanabe wants four lamps.
2. **Channel "single currently-selected marker"**: kept the existing `.selected` subtle-background highlight as the marker (no new left-border accent); dropped all sibling-dim / filter-active tinting.

## Test plan

- [ ] `npm run typecheck` passes (verified locally - clean)
- [ ] `npm run build` passes (verified locally - 107 modules, ~699 KB)
- [ ] Manual: open Channels sidebar, Ctrl/Cmd+click a row - verify only that row is selected (no accumulation)
- [ ] Manual: click a non-selected channel - verify the selection replaces cleanly
- [ ] Manual: open DM sidebar - verify DM rows render with exactly the same icon * LEDs name layout as the Agent sidebar
- [ ] Manual: star a DM - verify pin persists on the channel (not on the agent) and row floats to top
- [ ] Manual: open Machines sidebar - verify `icon * LED host (fqdn) metrics` ordering
- [ ] Manual: channel icons render at full brightness
- [ ] Manual: Agent color-coding palette unchanged

## Constraints from lead (dispatch)

- No draft PR - ready, CI-green only.
- 1-line completion ack in `#agent` (head-mba will post after merge).
