### PR TITLE
feat(ops): Chrome code_sign_clone watchdog — launchd agent (#286 item 2)

### DIFF
--- a/deployment/host-setup/launchd/README.md
+++ b/deployment/host-setup/launchd/README.md
@@ -1,0 +1,38 @@
+# LaunchAgents
+
+macOS LaunchAgent templates installed per-user to protect host disk /
+run client-side maintenance without interfering with the container.
+
+## `com.scitex.chrome-codesign-watchdog.plist`
+
+scitex-orochi#286 item 2. Periodically reaps the Chrome
+`code_sign_clone` cache leak that contributed to the 2026-04-21
+full-disk outage.
+
+Install:
+
+```bash
+./scripts/client/install-chrome-codesign-watchdog.sh
+```
+
+Uninstall:
+
+```bash
+./scripts/client/install-chrome-codesign-watchdog.sh --uninstall
+```
+
+Status / logs:
+
+```bash
+launchctl list | grep com.scitex.chrome-codesign-watchdog
+tail -n 50 ~/Library/Logs/scitex/chrome-codesign-watchdog.log
+```
+
+Thresholds (tune per host by editing the `EnvironmentVariables` block
+in the installed plist and re-running the install helper):
+
+- `ADVISE_GIB` (default 2) — log an advisory at this size
+- `REAP_GIB` (default 5) — `rm -rf` the cache at this size
+
+See `skills/infra-hub-docker-disk-full.md` for why this cache is
+reaper-safe.

--- a/deployment/host-setup/launchd/com.scitex.chrome-codesign-watchdog.plist
+++ b/deployment/host-setup/launchd/com.scitex.chrome-codesign-watchdog.plist
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent: Chrome code_sign_clone watchdog (scitex-orochi#286 item 2).
+
+  Runs scripts/client/chrome-codesign-clone-watchdog.sh hourly on this
+  user's login session. Default thresholds: advise at >=2 GiB, reap at
+  >=5 GiB. See the script's header for threshold env-var overrides.
+
+  Install:
+    cp deployment/host-setup/launchd/com.scitex.chrome-codesign-watchdog.plist \
+       ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.scitex.chrome-codesign-watchdog.plist
+
+  Logs: ~/Library/Logs/scitex/chrome-codesign-watchdog.log (rotated by
+  macOS launchd; rotate manually if the file grows — `tail -n 2000` is
+  usually plenty of history).
+
+  Replace __HOME__ and __REPO__ with your actual paths before `launchctl
+  load`. The companion install helper
+  scripts/client/install-chrome-codesign-watchdog.sh does this rewrite
+  automatically.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.scitex.chrome-codesign-watchdog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>__REPO__/scripts/client/chrome-codesign-clone-watchdog.sh</string>
+    </array>
+
+    <!-- Every hour on login sessions. macOS schedules a single run at
+         load time, then on the interval thereafter. -->
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Don't respawn in a tight loop if the script exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/scitex/chrome-codesign-watchdog.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/scitex/chrome-codesign-watchdog.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <!-- Override here to tune thresholds on a specific host; leave
+           commented-out to inherit the script's defaults
+           (advise 2 GiB / reap 5 GiB). -->
+      <!--
+      <key>ADVISE_GIB</key>
+      <string>2</string>
+      <key>REAP_GIB</key>
+      <string>5</string>
+      -->
+    </dict>
+  </dict>
+</plist>

--- a/scripts/client/chrome-codesign-clone-watchdog.sh
+++ b/scripts/client/chrome-codesign-clone-watchdog.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# chrome-codesign-clone-watchdog.sh
+#
+# scitex-orochi#286 item 2.
+#
+# Reap the `/private/var/folders/*/*/X/com.google.Chrome.code_sign_clone`
+# cache when it grows large. This is a known Chrome-on-macOS
+# `codesign`-verification cache leak; the clone is harmless and Chrome
+# does not depend on its presence. On the 2026-04-21 mba outage a single
+# instance of this directory had grown to 13 GiB and contributed
+# directly to the host hitting 100% full (see
+# `skills/infra-hub-docker-disk-full.md`, 2026-04-21 incident
+# playbook).
+#
+# Usage:
+#   chrome-codesign-clone-watchdog.sh             # default thresholds
+#   chrome-codesign-clone-watchdog.sh --dry-run   # report only, never delete
+#   ADVISE_GIB=1 REAP_GIB=8 chrome-codesign-clone-watchdog.sh
+#
+# Thresholds (gibibytes):
+#   ADVISE_GIB (default 2) — log an advisory when total size ≥ this.
+#   REAP_GIB   (default 5) — delete the directory when total size ≥ this.
+#
+# Exit codes:
+#   0 — ran to completion (nothing found, or advisory, or reap).
+#   1 — failed to probe or delete (see stderr).
+#
+# The watchdog is read-mostly: it stats via `du -sk`, never writes
+# anything except the `rm -rf` on the exact codesign-clone path. It
+# does not touch any other cache, any user data, or any Chrome
+# profile state.
+
+set -euo pipefail
+
+ADVISE_GIB="${ADVISE_GIB:-2}"
+REAP_GIB="${REAP_GIB:-5}"
+DRY_RUN=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "chrome-codesign-clone-watchdog: unknown arg: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+log() {
+    printf '[%s] chrome-codesign-clone-watchdog: %s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+# Locate every Chrome code_sign_clone directory on this host. macOS
+# per-user temp paths live under /private/var/folders/<hash>/<hash>/X/.
+# Glob nulls if no matches; guard with nullglob.
+shopt -s nullglob
+CANDIDATES=( /private/var/folders/*/*/X/com.google.Chrome.code_sign_clone )
+shopt -u nullglob
+
+if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
+    log "no Chrome code_sign_clone paths found — nothing to do"
+    exit 0
+fi
+
+advise_kib=$((ADVISE_GIB * 1024 * 1024))
+reap_kib=$((REAP_GIB * 1024 * 1024))
+
+for path in "${CANDIDATES[@]}"; do
+    if [[ ! -d "$path" ]]; then
+        continue
+    fi
+    # -s total; -k kibibytes for predictable arithmetic. Drop stderr so
+    # sub-tree access errors don't abort the check.
+    kib="$(du -sk "$path" 2>/dev/null | awk '{print $1}')"
+    if [[ -z "$kib" ]]; then
+        log "ERROR: failed to size $path"
+        exit 1
+    fi
+    gib=$(( kib / 1024 / 1024 ))
+
+    if (( kib >= reap_kib )); then
+        if (( DRY_RUN )); then
+            log "WOULD REAP $path (${gib} GiB ≥ ${REAP_GIB} GiB) — dry run"
+        else
+            log "REAPING $path (${gib} GiB ≥ ${REAP_GIB} GiB)"
+            if rm -rf -- "$path"; then
+                log "reaped $path"
+            else
+                log "ERROR: rm -rf failed for $path"
+                exit 1
+            fi
+        fi
+    elif (( kib >= advise_kib )); then
+        log "ADVISORY $path is ${gib} GiB (≥ ${ADVISE_GIB} GiB, < ${REAP_GIB} GiB reap threshold)"
+    else
+        log "OK $path is ${gib} GiB (< ${ADVISE_GIB} GiB)"
+    fi
+done

--- a/scripts/client/install-chrome-codesign-watchdog.sh
+++ b/scripts/client/install-chrome-codesign-watchdog.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# install-chrome-codesign-watchdog.sh
+#
+# scitex-orochi#286 item 2 — install the Chrome code_sign_clone
+# watchdog as a per-user LaunchAgent on macOS.
+#
+# Rewrites __HOME__ / __REPO__ in the template plist, copies it to
+# ~/Library/LaunchAgents/, and loads it. Idempotent: unload + reload
+# if an existing copy is present.
+#
+# Usage:
+#   ./scripts/client/install-chrome-codesign-watchdog.sh
+#   ./scripts/client/install-chrome-codesign-watchdog.sh --uninstall
+#
+# Only runs on macOS.
+
+set -euo pipefail
+
+LABEL="com.scitex.chrome-codesign-watchdog"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
+TARGET="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="${HOME}/Library/Logs/scitex"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "install-chrome-codesign-watchdog: macOS only (uname=$(uname -s))" >&2
+    exit 2
+fi
+
+uninstall() {
+    if [[ -f "$TARGET" ]]; then
+        launchctl unload "$TARGET" 2>/dev/null || true
+        rm -f "$TARGET"
+        echo "uninstalled: $TARGET"
+    else
+        echo "nothing to uninstall (no $TARGET)"
+    fi
+}
+
+case "${1:-}" in
+    --uninstall) uninstall; exit 0 ;;
+    "") ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+esac
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "template missing: $TEMPLATE" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$TARGET")" "$LOG_DIR"
+
+# Rewrite the template. Use sed with a delimiter unlikely to appear in
+# a path (|) and escape any | in $HOME / $REPO_ROOT just in case.
+esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+sed -e "s|__HOME__|${esc_home}|g" -e "s|__REPO__|${esc_repo}|g" \
+    "$TEMPLATE" > "$TARGET"
+
+# Idempotent reload.
+launchctl unload "$TARGET" 2>/dev/null || true
+launchctl load "$TARGET"
+
+echo "installed: $TARGET"
+echo "log:       ${LOG_DIR}/chrome-codesign-watchdog.log"
+echo "status:    launchctl list | grep ${LABEL}"


### PR DESCRIPTION
Addresses #286 item 2 (head-mba lane — healer-mba owns items 1+3).

## What
A macOS LaunchAgent that periodically reaps `/private/var/folders/*/*/X/com.google.Chrome.code_sign_clone` — the Chrome `codesign`-verification cache clone that contributed ~13 GiB to the 2026-04-21 full-disk outage on mba.

## How it's safe
- Only ever `rm -rf`'s the exact `com.google.Chrome.code_sign_clone` directory. Nothing else.
- Chrome regenerates the clone on demand; deleting it does not touch Chrome profile data, preferences, history, or any other cache.
- Defaults: **advise at ≥ 2 GiB**, **reap at ≥ 5 GiB**. Overridable per host via `ADVISE_GIB` / `REAP_GIB` env vars on the plist.
- `--dry-run` flag on the script for manual inspection.
- Glob-based discovery with `nullglob`, so "no candidates" is a quiet success exit (0).
- Non-zero exit reserved for actual `du` or `rm` failures.

## Files
- **`scripts/client/chrome-codesign-clone-watchdog.sh`** — the watchdog itself. `set -euo pipefail`, timestamped logging, idempotent.
- **`deployment/host-setup/launchd/com.scitex.chrome-codesign-watchdog.plist`** — LaunchAgent template. `StartInterval 3600` (hourly), `RunAtLoad`, `ThrottleInterval 60`. Logs to `~/Library/Logs/scitex/chrome-codesign-watchdog.log`. Uses `__HOME__` / `__REPO__` placeholders.
- **`scripts/client/install-chrome-codesign-watchdog.sh`** — idempotent installer (rewrites placeholders, `launchctl unload + load`). `--uninstall` supported. Darwin-guarded.
- **`deployment/host-setup/launchd/README.md`** — install / uninstall / status commands + threshold tuning note.

## Verification
- `bash -n` passes for both shell scripts.
- Live `--dry-run` on mba prints `no Chrome code_sign_clone paths found — nothing to do` (the leaked dir was already removed during today's outage recovery).
- Install helper is safe on non-Darwin (exits with a clear message).

## Role split on #286
- head-mba (this PR): item 2 — Chrome `code_sign_clone` watchdog.
- healer-mba (separate PR): item 1 (disk-reaper dry-run script) + item 3 (preemptive advisory thresholds).

## Not included (out of scope)
- Fleet-wide rollout of the LaunchAgent — operators install per-host with `./scripts/client/install-chrome-codesign-watchdog.sh`.
- Generalised reaper for other caches (`.gradle`, `.android`, `Xcode Archives`, `Downloads`) — those are healer-mba's item 1, with user-data caveats tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
