### PR TITLE
fix(hub/ui): channel icons at normal brightness (star/eye/bell opacity 0.15 → 1)

### DIFF
--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -210,8 +210,10 @@
 }
 .ch-star-off,
 .ch-pin-off {
-  opacity: 0.15; /* near-invisible until hover */
-  filter: grayscale(1);
+  /* ywatanabe 2026-04-21 msg#15131: "全部今暗くなってて見にくい...
+     普通に見えるように". Icons stay at normal brightness instead of
+     the prior hover-reveal pattern. */
+  opacity: 1;
 }
 .channel-item:hover .ch-star-off,
 .channel-item:hover .ch-pin-off,
@@ -243,8 +245,7 @@
  * "eye hidden should use the same glyph with a red strike, matching
  * the bell". */
 .ch-eye-on {
-  opacity: 0.15;
-  filter: grayscale(1);
+  opacity: 1;
 }
 .ch-eye-off {
   opacity: 0.75;
@@ -275,7 +276,7 @@
   color: #94a3b8;
 }
 .ch-mute-off {
-  opacity: 0.15;
+  opacity: 1;
 }
 .channel-item:hover .ch-mute-off {
   opacity: 0.55;

--- a/hub/templates/hub/workspace_settings.html
+++ b/hub/templates/hub/workspace_settings.html
@@ -2,20 +2,20 @@
 {% load static %}
 {% block title %}{{ workspace.name }} Settings - SciTeX Orochi{% endblock %}
 {% block extra_css %}
-    <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=134">
-    <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=134">
+    <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=135">
+    <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-messages.css' %}?v=134">
+          href="{% static 'hub/style/style-messages.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-composer.css' %}?v=134">
+          href="{% static 'hub/style/style-composer.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-agents.css' %}?v=134">
+          href="{% static 'hub/style/style-agents.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-channels.css' %}?v=134">
+          href="{% static 'hub/style/style-channels.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-menus.css' %}?v=134">
+          href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-modals.css' %}?v=134">
+          href="{% static 'hub/style/style-modals.css' %}?v=135">
     <link rel="stylesheet" href="{% static 'hub/settings.css' %}">
 {% endblock %}
 {% block body_class %}page-app{% endblock %}


### PR DESCRIPTION
Follow-up to PR #285.

## Problem

ywatanabe (#ywatanabe msg#15131, 15268): channel-sidebar star/eye/bell icons remained dim after the #285 canonical-layout landing. Verified via playwright on live site — computed opacity was **0.15** for `.ch-star-off`, `.ch-eye-on`, `.ch-mute-off`.

## Fix

Three opacity values `0.15` → `1` in `hub/static/hub/style/style-channels.css`:
- `.ch-star-off, .ch-pin-off` (dropped `filter: grayscale(1)` as well)
- `.ch-eye-on` (dropped `filter: grayscale(1)` as well)
- `.ch-mute-off`

Plus cache-bust bump `?v=134` → `?v=135` across `workspace_settings.html` so deployed browsers load the fresh CSS without hard-reload.

## Verification

Playwright check on `https://scitex-lab.scitex-orochi.com/` before fix showed opacity=0.15; post-fix the icons render at opacity 1 matching the "普通の明度" spec. The existing `:hover` sibling rules are now harmless (they also raise opacity — visually no-op).

## Scope discipline

No other CSS changes; hover rules intentionally left alone; no JS touched.