### PR TITLE
fix(hub/ui): remove row-level opacity dim on muted channels

### DIFF
--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -338,9 +338,11 @@
   opacity: 1 !important;
   filter: none !important;
 }
-.ch-muted {
-  opacity: 0.5;
-}
+/* ywatanabe msg#15282 / 2026-04-21: muted state is already communicated
+   by the .ch-mute-on bell icon; dimming the whole row on top cascades
+   down to every child (making icons look dim despite opacity:1 rules)
+   and was the root cause of the "まだ暗いまま" report. Drop the row-level
+   dim; keep the icon-level signal. */
 
 /* Hidden channel rows — rendered inline at the bottom of the Channels
  * section, dimmed so the list stays scannable. Clicking a dimmed row

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/style/style-agents.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-channels.css' %}?v=136">
+          href="{% static 'hub/style/style-channels.css' %}?v=137">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"


### PR DESCRIPTION
Follow-up to #290.

## Root cause (found via playwright after #290 didn't fully solve it)

ywatanabe msg#15282 reported icons still dim after #290 set them to `opacity: 1`. Re-inspection via playwright showed `.channel-item` row computed opacity = **0.5** because every visible row carried `.ch-muted`. Opacity cascades multiplicatively: row 0.5 × icon 1 = **effective 0.5**.

## Fix

- Drop `.ch-muted { opacity: 0.5 }` — muted state is already signaled by the bell glyph (`.ch-mute-on`, red strike + color).
- Bump `dashboard.html` cache-bust v=136 → v=137.

## Verified

- Pre-fix playwright: row_opacity=0.5, star=op:1, eye=op:1, mute=op:1 (icons cascaded to 0.5).
- Post-fix (locally): row opacity gone, children effectively at opacity 1.
