### PR TITLE
fix(ui/sidebar): single-select + icon-state semantics + remove brightness dim (follow-up to #285)

### DIFF
--- a/hub/consumers/_helpers.py
+++ b/hub/consumers/_helpers.py
@@ -26,6 +26,11 @@ from hub.models import (
     WorkspaceToken,
 )
 
+# ``#agent`` was abolished 2026-04-21 (lead directive, PR #293 follow-up).
+# Keep a module-level constant so both the hub/views path and the
+# WebSocket-consumer path share a single source of truth for the blocklist.
+ABOLISHED_AGENT_CHANNELS = frozenset({"#agent"})
+
 
 @database_sync_to_async
 def _load_agent_channel_subs(workspace_id, agent_name):
@@ -49,7 +54,14 @@ def _load_agent_channel_subs(workspace_id, agent_name):
         user=user,
         channel__workspace_id=workspace_id,
     ).select_related("channel")
-    return [m.channel.name for m in memberships]
+    # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293 follow-up).
+    # Filter out any stale DB rows so a leftover membership can't resurrect
+    # the subscription on the next register() / agent-consumer connect.
+    return [
+        m.channel.name
+        for m in memberships
+        if m.channel.name not in ABOLISHED_AGENT_CHANNELS
+    ]
 
 
 @database_sync_to_async
@@ -60,6 +72,12 @@ def _persist_agent_subscription(workspace_id, agent_name, ch_name, subscribe):
     be resolved. Creates the channel if missing (group kind).
     """
     from django.contrib.auth.models import User
+
+    # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293 follow-up).
+    # Hard-block the channel on the server so no agent can re-create the
+    # row via a subscribe WebSocket op, regardless of what the client sends.
+    if ch_name in ABOLISHED_AGENT_CHANNELS:
+        return False
 
     try:
         workspace = Workspace.objects.get(id=workspace_id)

--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -176,13 +176,27 @@ export function _renderChannelRowHtml(row, ctx) {
  * chContainer. Pulled out of fetchStats so the main entry point stays under
  * the file-size budget without changing any observable behavior. */
 export function _wireChannelItemHandlers(chContainer, prevSelected) {
+  /* #293: enforce single-select hard invariant on restore. Even if
+   * prevSelected contained multiple entries (from a stale DOM where
+   * two rows both carried .selected — the regression this PR fixes),
+   * we restore .selected to AT MOST ONE row, preferring the current
+   * channel. Anything else is dropped on the floor. */
+  var restoredOne = false;
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render. Channels are single-
-     * selection only (#284): at most one channel-item ever carries the
-     * .selected class. prevSelected is retained across renders so the
-     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
-    if (elCh && prevSelected[elCh]) el.classList.add("selected");
+    if (
+      !restoredOne &&
+      elCh &&
+      prevSelected[elCh] &&
+      (globalThis as any).currentChannel === elCh
+    ) {
+      el.classList.add("selected");
+      restoredOne = true;
+    } else {
+      /* Defensive: make sure NO row carries .selected unless we just
+       * added it above. Belt-and-braces against any stale DOM state. */
+      el.classList.remove("selected");
+    }
     /* Pin icon click — toggle is_starred (pinned-to-top) */
     var pinEl = el.querySelector(".ch-pin");
     if (pinEl) {
@@ -308,12 +322,18 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
       /* Clear unread for this channel (#322) */
       channelUnread[ch] = 0;
       updateChannelUnreadBadges();
-      /* todo#274 Part 1: pure visual highlight, toggle on second click. */
-      var items = chContainer.querySelectorAll(".channel-item");
+      /* todo#274 Part 1 + #293: single-select is the HARD invariant —
+       * clear .selected across the ENTIRE sidebar (channel rows AND
+       * DM agent-cards), not just this chContainer. Previously only
+       * chContainer was cleared, which left a stale .selected on a
+       * DM row when the user switched from a DM to a channel and
+       * manifested as "two rows selected at once" (#293). */
       var wasSelected = el.classList.contains("selected");
-      items.forEach(function (it) {
-        it.classList.remove("selected");
-      });
+      document
+        .querySelectorAll(".sidebar .channel-item.selected, .sidebar .dm-item.selected")
+        .forEach(function (it) {
+          it.classList.remove("selected");
+        });
       if (!wasSelected && (globalThis as any).currentChannel === ch) {
         el.classList.add("selected");
       }

--- a/hub/frontend/src/app/sidebar-stats.ts
+++ b/hub/frontend/src/app/sidebar-stats.ts
@@ -22,17 +22,24 @@ export async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* #284: channels are single-select only. prevSelected keeps the one
-     * currently-selected row marked .selected across DOM re-renders so the
-     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
-     * multi-select — #274 Part 2 — has been removed for channels.) */
+    /* #284/#293: channels are single-select only. prevSelected keeps
+     * the ONE currently-selected row marked .selected across DOM re-
+     * renders so the selection indicator doesn't flicker mid-refresh.
+     *
+     * Hard invariant: at most one key ever lands in prevSelected. The
+     * source of truth is (globalThis as any).currentChannel — even if
+     * the DOM somehow accumulated .selected on multiple rows (the
+     * regression this PR fixes), we only ever carry the current-channel
+     * pointer forward. _wireChannelItemHandlers enforces the same rule
+     * on restore. */
     var prevSelected = {};
-    chContainer
-      .querySelectorAll(".channel-item.selected")
-      .forEach(function (el) {
-        var ch = el.getAttribute("data-channel");
-        if (ch) prevSelected[ch] = true;
-      });
+    var _curCh = (globalThis as any).currentChannel;
+    if (_curCh) {
+      var _hasSelected = !!chContainer.querySelector(
+        '.channel-item.selected[data-channel="' + String(_curCh).replace(/"/g, '\\"') + '"]',
+      );
+      if (_hasSelected) prevSelected[_curCh] = true;
+    }
     /* todo#325: hide dm:* channels from the public Channels list
      * (they still render in the DM tab via its own path).
      * todo#326: normalize "general" -> "#general" and dedupe by

--- a/hub/static/hub/app/sidebar-channel-tree.js
+++ b/hub/static/hub/app/sidebar-channel-tree.js
@@ -162,13 +162,27 @@ function _renderChannelRowHtml(row, ctx) {
  * chContainer. Pulled out of fetchStats so the main entry point stays under
  * the file-size budget without changing any observable behavior. */
 function _wireChannelItemHandlers(chContainer, prevSelected) {
+  /* #293: enforce single-select hard invariant on restore. Even if
+   * prevSelected contained multiple entries (from a stale DOM where
+   * two rows both carried .selected — the regression this PR fixes),
+   * we restore .selected to AT MOST ONE row, preferring the current
+   * channel. Anything else is dropped on the floor. */
+  var restoredOne = false;
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render. Channels are single-
-     * selection only (#284): at most one channel-item ever carries the
-     * .selected class. prevSelected is retained across renders so the
-     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
-    if (elCh && prevSelected[elCh]) el.classList.add("selected");
+    if (
+      !restoredOne &&
+      elCh &&
+      prevSelected[elCh] &&
+      currentChannel === elCh
+    ) {
+      el.classList.add("selected");
+      restoredOne = true;
+    } else {
+      /* Defensive: make sure NO row carries .selected unless we just
+       * added it above. Belt-and-braces against any stale DOM state. */
+      el.classList.remove("selected");
+    }
     /* Pin icon click — toggle is_starred (pinned-to-top) */
     var pinEl = el.querySelector(".ch-pin");
     if (pinEl) {
@@ -294,12 +308,18 @@ function _wireChannelItemHandlers(chContainer, prevSelected) {
       /* Clear unread for this channel (#322) */
       channelUnread[ch] = 0;
       updateChannelUnreadBadges();
-      /* todo#274 Part 1: pure visual highlight, toggle on second click. */
-      var items = chContainer.querySelectorAll(".channel-item");
+      /* todo#274 Part 1 + #293: single-select is the HARD invariant —
+       * clear .selected across the ENTIRE sidebar (channel rows AND
+       * DM agent-cards), not just this chContainer. Previously only
+       * chContainer was cleared, which left a stale .selected on a
+       * DM row when the user switched from a DM to a channel and
+       * manifested as "two rows selected at once" (#293). */
       var wasSelected = el.classList.contains("selected");
-      items.forEach(function (it) {
-        it.classList.remove("selected");
-      });
+      document
+        .querySelectorAll(".sidebar .channel-item.selected, .sidebar .dm-item.selected")
+        .forEach(function (it) {
+          it.classList.remove("selected");
+        });
       if (!wasSelected && currentChannel === ch) {
         el.classList.add("selected");
       }

--- a/hub/static/hub/app/sidebar-stats.js
+++ b/hub/static/hub/app/sidebar-stats.js
@@ -15,17 +15,23 @@ async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* #284: channels are single-select only. prevSelected keeps the one
-     * currently-selected row marked .selected across DOM re-renders so the
-     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
-     * multi-select — #274 Part 2 — has been removed for channels.) */
+    /* #284/#293: channels are single-select only. prevSelected keeps
+     * the ONE currently-selected row marked .selected across DOM re-
+     * renders so the selection indicator doesn't flicker mid-refresh.
+     *
+     * Hard invariant: at most one key ever lands in prevSelected. The
+     * source of truth is `currentChannel` — even if the DOM somehow
+     * accumulated .selected on multiple rows (the regression this PR
+     * fixes), we only ever carry the current-channel pointer forward.
+     * _wireChannelItemHandlers enforces the same rule on restore. */
     var prevSelected = {};
-    chContainer
-      .querySelectorAll(".channel-item.selected")
-      .forEach(function (el) {
-        var ch = el.getAttribute("data-channel");
-        if (ch) prevSelected[ch] = true;
-      });
+    var _curCh = currentChannel;
+    if (_curCh) {
+      var _hasSelected = !!chContainer.querySelector(
+        '.channel-item.selected[data-channel="' + String(_curCh).replace(/"/g, '\\"') + '"]',
+      );
+      if (_hasSelected) prevSelected[_curCh] = true;
+    }
     /* todo#325: hide dm:* channels from the public Channels list
      * (they still render in the DM tab via its own path).
      * todo#326: normalize "general" -> "#general" and dedupe by

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -271,15 +271,32 @@
 /* .ch-mute sizing consolidated into the .ch-star/.ch-pin/.ch-watch/
  * .ch-eye rule above (ywatanabe 2026-04-21: "bell is too large
  * compared to other icons"). */
-.ch-mute-on {
-  opacity: 0.9;
+/* #293: bell glyphs (🔔 / 🔕) render as color emoji on every major
+ * platform, which made the "not-muted" bell look like a big prominent
+ * yellow icon on every single row — drowning out the other icons and
+ * misrepresenting muted state. Force monochrome via grayscale filter
+ * so the bell sits at the same visual weight as ★ / 👁 / the row
+ * text. ywatanabe msg#15299 / #15317. The muted-state glyph already
+ * encodes the slash (U+1F515 "bell with slash"); no extra overlay
+ * needed. */
+.ch-mute {
+  filter: grayscale(1);
+  opacity: 0.7;
   color: #94a3b8;
 }
-.ch-mute-off {
-  opacity: 1;
-}
-.channel-item:hover .ch-mute-off {
+.ch-mute-on {
+  /* Muted — bell-with-slash glyph, slightly dimmer than the default
+   * state so the "notifications are off" read is not louder than
+   * "notifications are on". */
   opacity: 0.55;
+}
+.ch-mute-off {
+  /* Not muted — neutral bell, monochrome, same weight as the other
+   * row icons. No yellow emphasis. */
+  opacity: 0.7;
+}
+.channel-item:hover .ch-mute {
+  opacity: 1;
 }
 .ch-pin,
 .ch-eye {
@@ -345,17 +362,17 @@
    dim; keep the icon-level signal. */
 
 /* Hidden channel rows — rendered inline at the bottom of the Channels
- * section, dimmed so the list stays scannable. Clicking a dimmed row
- * un-hides it (promotes back to the normal list on next render).
- * No bulk toggle button — the dimmed rows ARE the affordance.
+ * section. #293 / ywatanabe msg#15299: DO NOT dim the row — every
+ * channel row (including #proj/* and other hidden ones) must render
+ * at opacity 1. Hidden state is communicated ONLY via the eye-with-
+ * red-slash glyph (.ch-eye-off ::after). Previously the row-level
+ * opacity: 0.4 made the #proj-* rows look permanently dim, which
+ * cascaded to every child glyph and muddied the read. The class is
+ * kept in the DOM for ordering/click behaviour (click a hidden row
+ * to un-hide) but it MUST NOT affect brightness.
  * See todo#418. */
 .channel-item.ch-hidden {
-  opacity: 0.4;
-  color: #6a7785;
   cursor: pointer;
-}
-.channel-item.ch-hidden:hover {
-  opacity: 0.7;
 }
 /* Subtle separator above the first hidden row so users understand
  * they're entering the "hidden" zone. */

--- a/hub/static/hub/style/style-composer.css
+++ b/hub/static/hub/style/style-composer.css
@@ -421,11 +421,14 @@
 .agent-card {
   position: relative;
 }
-.agent-card > .pin-btn {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-}
+/* ywatanabe 2026-04-20 + PR #293 follow-up: the star (.pin-btn) must
+ * sit in canonical badge order icon → ★ → LEDs → name as emitted by
+ * renderAgentBadge(). A historical absolute-positioning rule pushed
+ * the star to the far right of every .agent-card (sidebar agent rows,
+ * DM rows, Activity list-view rows), breaking that order. Keeping the
+ * star in flex flow lets agent-badge.ts own layout as the single
+ * source of truth. If a legacy card EVER needs a floated star again,
+ * scope it with a specific child class — not .agent-card > .pin-btn. */
 /* Pinned but offline agent styling */
 .agent-card.pinned-offline {
   opacity: 0.55;

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -138,13 +138,18 @@ blockquote.chat-blockquote {
   border-left: 3px solid #4ecdc4;
 }
 
-/* todo#274 Part 1: pure visual selection in sidebar — clicking a
- * channel or agent highlights just that item and dims siblings.
- * Replaces the previous badge-filter UX. */
+/* todo#274 Part 1 / #293: selection marker is a BACKGROUND COLOUR ONLY.
+ * Do not boost opacity, do not brighten icons, do not bold the name —
+ * the selected row must read the same as the rest except for its
+ * subtle tint. This is ywatanabe msg#15299 / #15317: "all other rows
+ * keep their normal icons; the selected row is distinguished only by
+ * a subtle solid background". Applies to .sidebar .channel-item and
+ * .sidebar .agent-card (DMs render as .agent-card so they inherit). */
 .sidebar .channel-item.selected {
   background: rgba(126, 200, 227, 0.2);
 }
-.sidebar .agent-card.selected {
+.sidebar .agent-card.selected,
+.sidebar .dm-item.selected {
   background: rgba(78, 205, 196, 0.2);
 }
 /* #284: don't dim non-selected channels when one is selected — the

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -12,13 +12,13 @@
     <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=136">
     <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-messages.css' %}?v=134">
+          href="{% static 'hub/style/style-messages.css' %}?v=135">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-composer.css' %}?v=134">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-agents.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-channels.css' %}?v=137">
+          href="{% static 'hub/style/style-channels.css' %}?v=138">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"

--- a/hub/tests/consumers/test_agent_subscription.py
+++ b/hub/tests/consumers/test_agent_subscription.py
@@ -102,3 +102,48 @@ class AgentChannelSubscriptionPersistenceTest(TestCase):
         subs_other = async_to_sync(_load_agent_channel_subs)(ws2.id, "worker-d")
         self.assertEqual(subs_self, ["#self"])
         self.assertEqual(subs_other, ["#other"])
+
+    def test_persist_subscribe_rejects_abolished_agent_channel(self):
+        """``#agent`` was abolished 2026-04-21 — no agent may (re)subscribe.
+
+        The helper must short-circuit with ``False`` and NOT create any
+        ``ChannelMembership`` / ``Channel`` rows, so a stray WebSocket
+        subscribe op can't resurrect the channel.
+        """
+        from asgiref.sync import async_to_sync
+        from django.contrib.auth.models import User
+
+        from hub.consumers import _persist_agent_subscription
+
+        ok = async_to_sync(_persist_agent_subscription)(
+            self.ws.id, "worker-e", "#agent", True
+        )
+        self.assertFalse(ok)
+        # No Channel row created for #agent in this workspace:
+        self.assertFalse(
+            self.Channel.objects.filter(workspace=self.ws, name="#agent").exists()
+        )
+        # No synthetic agent user created as a side-effect either:
+        self.assertFalse(User.objects.filter(username="agent-worker-e").exists())
+
+    def test_load_filters_abolished_agent_channel(self):
+        """Stale ``#agent`` ``ChannelMembership`` rows from before the
+        2026-04-21 abolition must NOT surface in ``_load_agent_channel_subs``
+        — otherwise the WS consumer would re-join the group on connect.
+        """
+        from asgiref.sync import async_to_sync
+        from django.contrib.auth.models import User
+
+        from hub.consumers import _load_agent_channel_subs
+
+        # Simulate a pre-abolition DB row: create the channel + membership
+        # directly, bypassing _persist_agent_subscription's guard.
+        user = User.objects.create_user(username="agent-worker-f")
+        stale_ch = self.Channel.objects.create(workspace=self.ws, name="#agent")
+        alive_ch = self.Channel.objects.create(workspace=self.ws, name="#heads")
+        self.ChannelMembership.objects.create(user=user, channel=stale_ch)
+        self.ChannelMembership.objects.create(user=user, channel=alive_ch)
+
+        subs = async_to_sync(_load_agent_channel_subs)(self.ws.id, "worker-f")
+        self.assertNotIn("#agent", subs)
+        self.assertIn("#heads", subs)

--- a/hub/tests/views/api/test_channel_members.py
+++ b/hub/tests/views/api/test_channel_members.py
@@ -160,3 +160,27 @@ class ChannelMembersAdminApiTest(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["deleted"], 0)
+
+    def test_post_subscribe_abolished_agent_channel_returns_403(self):
+        """``#agent`` was abolished 2026-04-21 (lead directive, PR #293
+        follow-up). POST/PATCH must return 403 so the client gets a real
+        signal — a silent 200 would let the bad client think it's
+        subscribed and retry endlessly.
+        """
+        self.client.force_login(self.admin)
+        resp = self.client.post(
+            "/api/channel-members/",
+            data=json.dumps(
+                {"channel": "#agent", "username": "agent-worker-x"}
+            ),
+            content_type="application/json",
+            HTTP_HOST=self.host,
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.json().get("error"), "channel abolished")
+        self.assertFalse(
+            self.Channel.objects.filter(workspace=self.ws, name="#agent").exists()
+        )
+        self.assertFalse(
+            self.ChannelMembership.objects.filter(user=self.agent_user).exists()
+        )

--- a/hub/views/api/_channels.py
+++ b/hub/views/api/_channels.py
@@ -290,6 +290,15 @@ def api_channel_members(request, slug=None):
         if perm not in ("read-write", "read-only"):
             return JsonResponse({"error": "invalid permission"}, status=400)
 
+        # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293
+        # follow-up). Block any subscribe/update attempt at the REST layer
+        # so the client gets a real signal instead of a silent 200.
+        # DELETE is still allowed above so stale memberships can be cleaned.
+        from hub.consumers._helpers import ABOLISHED_AGENT_CHANNELS
+
+        if ch_name in ABOLISHED_AGENT_CHANNELS and request.method in ("POST", "PATCH"):
+            return JsonResponse({"error": "channel abolished"}, status=403)
+
         if request.method == "POST":
             # Idempotent subscribe: create the channel if missing.
             ch, _ = Channel.objects.get_or_create(


### PR DESCRIPTION
## Defects fixed (all 5 + 2 follow-ups)

Follow-up to PR #285 / PR #291 — sidebar UX regressions reported by ywatanabe in msg#15299 / msg#15317; dispatched by lead in `#heads` msg#15321, extended by lead in `#heads` msg#15324.

Screenshot: https://scitex-orochi.com/media/2026-04/610d55b6-181e-46ae-bde0-c8fb98be2904/image.png

### 1. Multi-highlight regression on channel sidebar
`#ywatanabe` and `#heads` both rendered with the `.selected` background simultaneously. Root cause: `sidebar-stats.fetchStats()` captured every `.channel-item.selected` into `prevSelected`, so any stale DOM leftover survived every re-render. Fix:
- Narrow `prevSelected` to `{currentChannel}` only.
- `_wireChannelItemHandlers` restores `.selected` to AT MOST ONE row (the `currentChannel`) and strips it from every other row defensively.
- The click handler now clears `.selected` across the entire sidebar (`.sidebar .channel-item.selected, .sidebar .dm-item.selected`), not just `chContainer`, so a cross-section switch (DM → channel) can't leave a stale marker behind.

### 2. Bell icon state inverted / over-prominent
Every row showed a big yellow prominent bell regardless of muted state, because the `🔔 / 🔕` glyphs render as colour emoji. Fix (CSS only):
- `filter: grayscale(1)` on `.ch-mute` makes the bell monochrome.
- Both states normalise to ~0.7 opacity so the bell sits at the same visual weight as `★` and `👁`.
- Muted state is slightly quieter (~0.55 opacity) so "notifications are off" doesn't read louder than "on". No yellow emphasis in either state. The slash is already encoded in the `🔕` (U+1F515) glyph.

### 3. `.ch-hidden` opacity dim on `#proj-*` and siblings
`.channel-item.ch-hidden { opacity: 0.4 }` made hidden rows render at ~40% brightness, cascading to every child. Fix: drop `opacity` and the `:hover` override from `.ch-hidden`. The class stays in the DOM for ordering + click-to-unhide behaviour, but no longer affects brightness. Hidden state is communicated only by the red-strike eye glyph (`.ch-eye-off::after`).

### 4. Selected state uses background colour only
Confirmed `.sidebar .channel-item.selected` and `.sidebar .agent-card.selected` already use background colour only (no opacity / brightness boost). Extended the agent-card rule to also cover `.sidebar .dm-item.selected` so DM selection renders the same tint. Comment updated to make the invariant explicit.

### 5. Star at position 2 across all card types (channels)
Verified canonical order on every card type:
- Channel: `drag → icon → star → eye → mute → name` (channel-badge.ts `renderChannelBadgeHtml`)
- Agent: DOM order is correct in `renderAgentBadge`, but CSS was overriding — see follow-up **5A** below.
- DM: same as Agent (dms.ts delegates to `renderAgentBadge`).
- Machine: not rendered as a TS sidebar component in this repo (skipped — no-op).

### 5A. Agent-list star-at-far-right (lead `#heads` msg#15324 item 1)
Previous pass checked the DOM order in `agent-badge.ts` and found it correct — but missed the CSS rule that was overriding flex flow. Screenshot still showed sidebar Agents list rendering `icon → 4LEDs → name → ★` with the star glued to the far right of every agent row. Root cause:

```css
/* style-composer.css (old) */
.agent-card > .pin-btn {
  position: absolute;
  top: 4px;
  right: 4px;
}
```

That rule absolutely-positioned EVERY direct-child `.pin-btn` of every `.agent-card` to the right edge, regardless of its position in the flex flow. Because the sidebar agent row, DM row, and Activity list-view row all emit the star as a direct child of `.agent-card` via `renderAgentBadge`, every one of them got its star shoved right.

**Fix**: delete the absolute-positioning rule. `agent-badge.ts` stays the single source of truth for layout; the star sits in flex flow at position 2 (`icon → ★ → LEDs → name`) across sidebar agents, DMs, and Activity list rows. Replaced the rule with a note explaining why future contributors should scope any re-introduction by a specific child class.

### 5B. Backend `#agent` subscribe blacklist (lead `#heads` msg#15324 item 2)
`#agent` was abolished 2026-04-21. Added a server-side guard so no agent can re-create a `ChannelMembership` row for `#agent`, regardless of what a stale client sends:

- `hub/consumers/_helpers.py`: module-level `ABOLISHED_AGENT_CHANNELS = frozenset({"#agent"})`. `_persist_agent_subscription` short-circuits with `False` at the top; the WS-consumer path (`_agent_handlers.py`) already routes through it, so the guard covers the subscribe-over-WebSocket case automatically.
- `hub/consumers/_helpers.py`: `_load_agent_channel_subs` filters out any stale `#agent` row so a leftover DB membership from before the abolition can't resurrect the subscription on the next `register()`.
- `hub/views/api/_channels.py`: REST endpoint `api_channel_members` returns `403 {"error": "channel abolished"}` on POST/PATCH when `ch_name` matches the blacklist. DELETE still works so stale rows can be cleaned explicitly.

Tests (under `hub/tests/`):
- `test_agent_subscription.py`:
  - `test_persist_subscribe_rejects_abolished_agent_channel` — POST-equivalent WS path returns `False`, no `Channel` or `User` rows created.
  - `test_load_filters_abolished_agent_channel` — pre-existing stale `#agent` membership does NOT surface in `_load_agent_channel_subs`; `#heads` does.
- `test_channel_members.py`:
  - `test_post_subscribe_abolished_agent_channel_returns_403` — `POST /api/channel-members/ {"channel":"#agent",...}` → 403 `{"error":"channel abolished"}`; no DB rows created.

## Files touched

TS sources:
- `hub/frontend/src/app/sidebar-channel-tree.ts`
- `hub/frontend/src/app/sidebar-stats.ts`

JS hand-mirrors (PR #285 convention):
- `hub/static/hub/app/sidebar-channel-tree.js`
- `hub/static/hub/app/sidebar-stats.js`

CSS:
- `hub/static/hub/style/style-channels.css`  (bell monochrome + `.ch-hidden` opacity removal)
- `hub/static/hub/style/style-messages.css`  (DM selection tint + comment)
- `hub/static/hub/style/style-composer.css`  (remove `.agent-card > .pin-btn` absolute-position — 5A)

Template:
- `hub/templates/hub/dashboard.html`  (cache-bust `style-channels.css` v=137 → v=138, `style-messages.css` v=134 → v=135)

Python (5B):
- `hub/consumers/_helpers.py`
- `hub/views/api/_channels.py`

Python tests (5B):
- `hub/tests/consumers/test_agent_subscription.py`
- `hub/tests/views/api/test_channel_members.py`

## Test plan

- [ ] Click a channel — only that row highlights; previous selection clears.
- [ ] Click a DM, then a channel — only the channel shows `.selected`.
- [ ] Observe bell icons across Channels list — all monochrome, no yellow.
- [ ] Mute a channel — bell switches to slashed glyph, slightly dimmer.
- [ ] Hide a channel — row drops below divider, icons + name stay at opacity 1; eye glyph shows red strike.
- [ ] `#proj-scitex-orochi` and other `#proj/*` rows render at full brightness.
- [ ] Agent card, DM card, Channel card all have star glyph in position 2 (5A).
- [ ] Sidebar Agents list row renders `icon → ★ → LEDs → name` with NO star floating to the far right (5A).
- [ ] Dashboard CSS cache-bust picks up `v=138` / `v=135` after refresh.
- [ ] Subscribe an agent to `#agent` via the admin UI / REST → 403 `{"error":"channel abolished"}` (5B).
- [ ] Agent WS subscribe op for `#agent` is silently dropped server-side; no `ChannelMembership` row created (5B).
- [ ] Stale pre-abolition `#agent` membership in DB does NOT surface in `_load_agent_channel_subs` on register (5B).

## CI

`typecheck` + `build` pass locally in `hub/frontend/`. venv is broken on mba so Python tests must run in CI.

refs #285 #291 ywatanabe msg#15299 #15317 lead `#heads` msg#15321 msg#15324

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
