### PR TITLE
chore(docs): scrub abolished #agent channel references -> DM / #heads routing

### DIFF
--- a/src/scitex_orochi/_skills/scitex-orochi/agent-permission-prompt-patterns.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-permission-prompt-patterns.md
@@ -78,7 +78,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 5 min
     after a "2" send, something is wrong with the allowlist
-    persistence — escalate to #agent for human call.
+    persistence — DM the dispatcher (or post to #heads) for human call.
 ```
 
 ### 2. Claude Code "Esc to cancel · Tab to amend" modal
@@ -166,7 +166,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 10 min,
     the agent is not consuming its own pasted input (deeper
-    issue) — escalate to #agent with the pane capture.
+    issue) — DM the dispatcher (or post to #heads) with the pane capture.
 ```
 
 ### 5. Claude Code "Press Enter to continue" pagination

--- a/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
@@ -222,7 +222,7 @@ Tracked 2026-04-13. Agents responsible for each lane must update this list when 
 
 ## Per-lane issue templates
 
-Copy-paste these into #agent / issue tracker when assigning adoption work to a host owner.
+Copy-paste these into the issue tracker (or DM the host owner) when assigning adoption work to a host owner. (`#agent` was abolished 2026-04-21; cross-head coordination now lives in `#heads`.)
 
 ### Primary workstation lane (owner: head-<host>)
 > **Task**: Align `worker-healer-<host>` `/loop` with `convention-connectivity-probe.md` canonical pattern.
@@ -234,7 +234,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > 4. Routine all-green: written to `~/.scitex/healer/last-scan.json`, **not** posted.
 > 5. Consume `~/.scitex/orochi/fleet-watch/` if head-<host> snapshot is available; fall back to own probe otherwise.
 >
-> **Done signal**: one-line post to #agent: `worker-healer-<host> adoption complete, job <id>`, then mark this row ✅ in `convention-connectivity-probe.md`.
+> **Done signal**: DM the dispatcher (or one-line post to `#heads` for cross-head visibility): `worker-healer-<host> adoption complete, job <id>`, then mark this row ✅ in `convention-connectivity-probe.md`.
 
 ### NAS/storage lane (owner: head-<host>)
 > **Task**: Align `worker-healer-<host>` `/loop` with canonical pattern and switch it to **pure consumer** of its own `fleet_watch.sh` output (no duplicate probes).
@@ -253,7 +253,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > **Acceptance**:
 > 1. Document whether a long-lived probe loop can run on login1 (policy: controller-only is OK, see `project_spartan_login_node` memory).
 > 2. List which metrics are obtainable on login1 vs require a compute allocation.
-> 3. Post a short design note to #agent; update this skill's per-host row with link.
+> 3. Post a short design note to `#heads` (or DM lead); update this skill's per-host row with link.
 >
 > **Done signal**: feasibility note posted; skill row updated to 📝 feasibility-complete.
 

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-deployment.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-deployment.md
@@ -226,8 +226,9 @@ the sweep sees the sustained-wedged state and acts).
 2. **"daemon injects keystrokes"** — never. Judgment is worker-side.
 3. **"worker polls instead of reading breadcrumbs"** — defeats the
    quota relief. Worker idles between breadcrumb events.
-4. **"continuous threshold chatter to `#agent`"** — daemons are
-   silent-otherwise.
+4. **"continuous threshold chatter to `#heads`"** — daemons are
+   silent-otherwise. (`#agent` was abolished 2026-04-21; cross-head
+   chatter now lives in `#heads`, lead-moderated.)
 5. **"one healer on NAS covers everything"** — violates host
    diversity and the redundancy-mesh requirement.
 6. **"reshape NDJSON schema when adding a signal"** — append only.

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-recovery.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-recovery.md
@@ -86,9 +86,10 @@ to `#escalation`).
   not a mutation of state. If the session misread and "2" is the
   wrong choice, the agent sees the follow-up screen and decides
   its own next action.
-- **Escalation**: post to `#agent` if the same session hits the
-  same prompt pattern 3 times within 5 min (pattern needs to be
-  added to the allowlist or the permission scope needs widening).
+- **Escalation**: DM the dispatcher (or post to `#heads` for cross-head
+  visibility) if the same session hits the same prompt pattern 3 times
+  within 5 min (pattern needs to be added to the allowlist or the
+  permission scope needs widening). (`#agent` was abolished 2026-04-21.)
 - **Rate limit**: max 1 recovery attempt per session per 30 s.
 
 ### 7.2 Extra-usage wedge recovery
@@ -163,9 +164,9 @@ to `#escalation`).
   still responds.
 - **Rollback**: re-launch the agent's MCP subprocess if the kill
   took the wrong one.
-- **Escalation**: post to `#agent` if the kill did not reduce the
-  duplicate count, or if the agent becomes unresponsive after the
-  kill.
+- **Escalation**: DM the dispatcher (or post to `#heads`) if the kill
+  did not reduce the duplicate count, or if the agent becomes
+  unresponsive after the kill.
 - **Rate limit**: max 1 dedup per agent per 10 min.
 
 ### 7.6 Paste-buffer-unsent recovery
@@ -192,8 +193,8 @@ to `#escalation`).
   see the follow-up and correct.
 - **Escalation**: if the same session hits paste-buffer-unsent 3
   times in 10 min, something is systematically broken upstream
-  (agent not consuming its own composed message); escalate to
-  `#agent` with the pane capture.
+  (agent not consuming its own composed message); escalate via DM
+  to the dispatcher (or post to `#heads`) with the pane capture.
 - **Rate limit**: max 1 Enter per session per 60 s.
 - **Relationship to §7.1 permission prompt**: if the pane matches
   *both* the paste-buffer marker and a permission prompt pattern,

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
@@ -125,8 +125,8 @@ loop) to every form of debugging artifact:
   (macOS) or an iOS Simulator Safari, never by the operator.
 - **DevTools logs** (console, network, blur traces) are dumped by the
   verifier running a real headed session against the real hub, then
-  forwarded to the responsible agent via `#agent`. Never ask the operator
-  to open DevTools.
+  forwarded to the responsible agent via DM (or `#heads` if it affects
+  cross-head coordination). Never ask the operator to open DevTools.
 - **Tmux pane snapshots** are taken by the operator agents via
   `tmux capture-pane` or `screen hardcopy`, not by asking the operator
   what the terminal shows.
@@ -170,12 +170,17 @@ miss blur/focus/WS timing bugs that real sessions exhibit.
 | Channel | Purpose | Who writes |
 |---|---|---|
 | `#general` | the operator ↔ fleet dialogue; broadcast announcements | the operator + any agent (sparingly) |
-| `#agent` | agent-to-agent coordination, hand-offs, claim-and-release | agents only, freely |
+| DM | task dispatch, completion acks, worker-to-worker coordination | agents only, freely |
+| `#heads` | cross-head coordination, lead-moderated | heads + lead |
 | `#operator` | fleet → operator direct reports, digests, blocking asks | `worker-todo-manager` primary; any `head-*` as failover. No `worker-*` else. |
 | `#progress` | periodic status reports (done/doing/next) | any agent, on schedule |
 | `#escalation` | critical failures and alerts requiring immediate attention | `quality-checker`, `healer`, anyone on a genuine critical |
 | `#grant` | research funding pipeline coordination | `worker-todo-manager`, `worker-explorer-<host>`, the operator |
 | `#todo` | GitHub issue bot feed | bot only |
+
+> `#agent` was abolished 2026-04-21 (per ywatanabe msg#15307 / lead
+> msg#15310). Fleet coordination now splits: DM for 1:1 dispatch
+> and completion acks, `#heads` for cross-head broadcasts.
 
 ### `#operator` write ACL (hard rule)
 
@@ -187,8 +192,8 @@ is restricted to agents that have audit/responsibility authority:
   `head-<host>` — these may post directly only when
   `worker-todo-manager` is unreachable (quota, login, crash), and should
   clearly tag the message as a failover relay.
-- **Everyone else** routes through `#agent` with an `@worker-todo-manager`
-  tag and lets todo-manager decide whether to escalate to `#operator`.
+- **Everyone else** DMs `worker-todo-manager` and lets todo-manager
+  decide whether to escalate to `#operator`.
 
 This stays the rule until the YAML `ChannelPolicy` (scitex-orochi#93)
 lands and enforces it at the hub.
@@ -203,8 +208,8 @@ lands and enforces it at the hub.
 3. Out-of-domain chatter in `#general`: stay silent. The cost of "me
    too"-ing a topic you don't own is that the operator has to scroll past
    it.
-4. Agent-to-agent acks, handoffs, and "claiming X" declarations go in
-   `#agent`, never in `#general`.
+4. Agent-to-agent acks, handoffs, and "claiming X" declarations go via
+   DM (or `#heads` for cross-head coordination), never in `#general`.
 
 ### Post-type prefixes
 
@@ -368,9 +373,10 @@ Therefore every agent that is actively working must:
 
 - Keep `current_task` populated (updated by `agent_meta.py` /
   `scitex-agent-container status --json` heartbeats).
-- Post a 1-line `[INFO]` or `[PERIODIC]` update to `#agent` on each
-  meaningful state change (claim, progress milestone, completion). Silent
-  work looks dead on the dashboard.
+- Post a 1-line `[INFO]` or `[PERIODIC]` update to `#heads` (heads) or
+  DM the dispatcher (workers) on each meaningful state change (claim,
+  progress milestone, completion). Silent work looks dead on the
+  dashboard.
 - For long jobs, name the subagent so it shows up in `subagent_count`
   with a recognizable label.
 

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-role-taxonomy.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-role-taxonomy.md
@@ -226,7 +226,7 @@ directory separation — `head-mba`, `head-nas`, `head-spartan`,
 `head-ywata-note-win`, `mamba-skill-manager-mba` etc. — because
 `~/.scitex/orochi/workspaces/<id>/` needs a unique-per-agent path.
 
-The **display form** (in dashboards, #agent posts, #ywatanabe
+The **display form** (in dashboards, #heads posts, #ywatanabe
 relays) is `role[:function]@host`, rendered by the hub-side
 username filter. So `head-mba` renders as `head@mba`,
 `mamba-skill-manager-mba` renders as `worker:skill-sync@mba`,

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
@@ -221,9 +221,11 @@ drift/dedupe candidates, curate taxonomy.
 | Source              | Target latency | Escalate if                                       |
 |---------------------|----------------|---------------------------------------------------|
 | DM from any agent   | ≤ 60 s         | miss → #escalation after 5 min                    |
-| #agent @mention     | ≤ 60 s         | same                                              |
+| #heads @mention     | ≤ 60 s         | same (cross-head coordination)                    |
 | #the operator direct   | ≤ 30 s         | miss → TTS escalation                             |
 | #the operator fleet    | only if skills expertise is the blocker; otherwise silent (the operator thread is DM-ish, not fleet broadcast) |
+
+> `#agent` was abolished 2026-04-21; cross-head @mentions now go to `#heads`, and task dispatch/ack uses DM.
 
 ### Response format (terse, in order)
 
@@ -331,8 +333,8 @@ should copy this pattern.
   metrics-collector daemons.
 - `silent-success.md` — rule #6 discipline that governs the
   worker's posting behavior.
-- `fleet-communication-discipline.md` — #the operator vs #agent vs
-  #progress rules the worker follows.
+- `fleet-communication-discipline.md` — #the operator vs DM vs
+  #heads vs #progress rules the worker follows.
 - `agent-startup-protocol.md` — 5-step boot sequence the Track B
   worker runs before entering its idle-respond loop.
 - `fleet-close-evidence-gate.md` — the evidence standard the worker

--- a/src/scitex_orochi/_skills/scitex-orochi/paper-writing-discipline.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/paper-writing-discipline.md
@@ -343,11 +343,12 @@ belongs here for reference):
    (the env var was removed; channel subscriptions are hub-DB
    authoritative now). After first boot, subscribe the proj-agent
    to **`#proj-<topic>` only** via the hub UI or MCP `subscribe`
-   tool. The proj-agent is deliberately invisible to `#agent`,
+   tool. The proj-agent is deliberately invisible to `#heads`,
    `#progress`, `#escalation`, `#general`, and `#ywatanabe` —
    narrow-subscription policy. Cross-fleet coordination reaches
    it via DM from `lead` or via the one channel it owns; no
-   fleet-wide broadcast.
+   fleet-wide broadcast. (`#agent` was abolished 2026-04-21;
+   cross-head coordination moved to `#heads`.)
 4. **transfer dir** `~/.scitex/orochi/transfer/proj-<topic>/`
    (note: `proj-` prefix, matching the canonical channel
    and agent naming from ywatanabe msg#12286) with
@@ -397,7 +398,7 @@ Operational implications:
 - **Red-as-red permission model** (ywatanabe msg#12290): a
   future hub-side 4-level permission API (none / readonly /
   writable / subscribed) may add `readonly` grants to
-  `#agent` / `#heads` for proj-agents so they see coordinator
+  `#heads` for proj-agents so they see coordinator
   chatter without being able to post. That would partially
   close the rule-10 gap at the observation layer without
   changing the narrow write-surface. Out of scope for this

--- a/src/scitex_orochi/_skills/scitex-orochi/permission-prompt-patterns.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/permission-prompt-patterns.md
@@ -78,7 +78,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 5 min
     after a "2" send, something is wrong with the allowlist
-    persistence — escalate to #agent for human call.
+    persistence — DM the dispatcher (or post to #heads) for human call.
 ```
 
 ### 2. Claude Code "Esc to cancel · Tab to amend" modal
@@ -166,7 +166,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 10 min,
     the agent is not consuming its own pasted input (deeper
-    issue) — escalate to #agent with the pane capture.
+    issue) — DM the dispatcher (or post to #heads) with the pane capture.
 ```
 
 ### 5. Claude Code "Press Enter to continue" pagination

--- a/src/scitex_orochi/_skills/scitex-orochi/skill-manager-architecture.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/skill-manager-architecture.md
@@ -220,9 +220,11 @@ drift/dedupe candidates, curate taxonomy.
 | Source              | Target latency | Escalate if                                       |
 |---------------------|----------------|---------------------------------------------------|
 | DM from any agent   | ≤ 60 s         | miss → #escalation after 5 min                    |
-| #agent @mention     | ≤ 60 s         | same                                              |
+| #heads @mention     | ≤ 60 s         | same (cross-head coordination)                    |
 | #ywatanabe direct   | ≤ 30 s         | miss → TTS escalation                             |
 | #ywatanabe fleet    | only if skills expertise is the blocker; otherwise silent (ywatanabe thread is DM-ish, not fleet broadcast) |
+
+> `#agent` was abolished 2026-04-21; cross-head @mentions now go to `#heads`, and task dispatch/ack uses DM.
 
 ### Response format (terse, in order)
 
@@ -330,7 +332,7 @@ should copy this pattern.
   metrics-collector daemons.
 - `silent-success.md` — rule #6 discipline that governs the
   worker's posting behavior.
-- `fleet-communication-discipline.md` — #ywatanabe vs #agent vs
+- `fleet-communication-discipline.md` — #ywatanabe vs DM vs #heads vs
   #progress rules the worker follows.
 - `agent-startup-protocol.md` — 5-step boot sequence the Track B
   worker runs before entering its idle-respond loop.


### PR DESCRIPTION
## Summary

- `#agent` was abolished 2026-04-21 per ywatanabe msg#15307 / lead `#agent` msg#15310. Coordination moved to DM (task dispatch/completion) + new `#heads` channel (cross-head coord, lead-moderated).
- Updates forward-looking process instructions in `src/scitex_orochi/_skills/scitex-orochi/` to reflect the new routing.
- Preserves past-tense narrative / historical provenance citations (2026-04-13 source-wording cite, draft-status "Posted to #agent for fleet review" notes).

## Changes

- 10 skill docs edited under `src/scitex_orochi/_skills/scitex-orochi/`
- Channel tables in `fleet-operating-principles.md`, `skill-manager-architecture.md`, `fleet-skill-manager-architecture.md`: `#agent` row replaced with DM + `#heads` rows + abolition footnote.
- Escalation instructions in `fleet-health-daemon-design-recovery.md`, `permission-prompt-patterns.md`, `agent-permission-prompt-patterns.md`: "post to #agent" → "DM the dispatcher (or post to #heads)".
- Subscription copy in `paper-writing-discipline.md`: `#agent` removed from proj-agent exclusion lists (it no longer exists).
- Display-form taxonomy in `fleet-role-taxonomy.md`: `#agent posts` → `#heads posts`.
- Issue-template copy in `convention-connectivity-probe.md`: `#agent` coordination → DM / `#heads` + abolition footnote.

## Preserved (historical narrative)

- `fleet-health-daemon-design.md` / `fleet-health-daemon-design-overview.md` line 9: draft-status note describing past posting ritual.
- `product-scientific-figure-standards.md`: source-wording provenance cite ("pasted in #agent msg #8618") and change-log entry.

## Test plan

- [ ] `git grep -n '#agent\b' src/scitex_orochi/_skills/` returns only preserved historical narrative + newly-added abolition footnotes.
- [ ] Skills still parse as valid markdown (no broken tables / unbalanced backticks).
- [ ] No code/test files touched — docs-only pass.

Companion dotfiles commit touches the complementary `~/.dotfiles/src/.scitex/orochi/shared/skills/scitex-orochi-private/` tree and `agents/*/src_CLAUDE.md`.

Generated with Claude Code
