### PR TITLE
fix(ui/sidebar): brighter selected-row accent + remove name-based bold regression

### DIFF
--- a/hub/static/hub/style/style-agents.css
+++ b/hub/static/hub/style/style-agents.css
@@ -322,9 +322,13 @@
 .dm-item:hover {
   background: #1a1a1a;
 }
+/* #293/#294: see .channel-item.active in style-base.css for the full
+ * rationale. The .selected rule in style-messages.css is the single
+ * source of truth for the "this is the current row" marker. Keep
+ * the background from cascading .active paths but do NOT bold the
+ * name; every DM row renders with identical weight. */
 .dm-item.active {
   background: #1a1a1a;
-  font-weight: bold;
   color: #f8f7f5;
 }
 .dm-item .dm-principal-badge {

--- a/hub/static/hub/style/style-base.css
+++ b/hub/static/hub/style/style-base.css
@@ -439,9 +439,13 @@ body {
 .channel-item:hover {
   background: #1a1a1a;
 }
+/* #293/#294: the current channel's visual marker is the .selected
+ * rule in style-messages.css (accent-coloured background). .active
+ * is a legacy class that some code paths still add — keep the
+ * background hover-equivalent but DO NOT bold the name. The selected
+ * row must read with the SAME font-weight as every other row. */
 .channel-item.active {
   background: #1a1a1a;
-  font-weight: bold;
 }
 #no-agents {
   color: #555;

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -138,19 +138,45 @@ blockquote.chat-blockquote {
   border-left: 3px solid #4ecdc4;
 }
 
-/* todo#274 Part 1 / #293: selection marker is a BACKGROUND COLOUR ONLY.
- * Do not boost opacity, do not brighten icons, do not bold the name —
- * the selected row must read the same as the rest except for its
- * subtle tint. This is ywatanabe msg#15299 / #15317: "all other rows
- * keep their normal icons; the selected row is distinguished only by
- * a subtle solid background". Applies to .sidebar .channel-item and
- * .sidebar .agent-card (DMs render as .agent-card so they inherit). */
+/* todo#274 Part 1 / #293 / #294: selection marker is a BACKGROUND COLOUR
+ * ONLY. Do not boost opacity, do not brighten icons, do not bold the
+ * name — the selected row must read the same as the rest except for
+ * its background tint. This is ywatanabe msg#15299 / #15317: "all
+ * other rows keep their normal icons; the selected row is
+ * distinguished only by a solid background".
+ *
+ * #294 (msg#15352 / #heads #15353): bump the accent alpha so the
+ * selected row is UNAMBIGUOUSLY brighter than its siblings AND
+ * clearly distinct from the row-hover state (:hover uses #1a1a1a,
+ * a flat dark grey; the selected tint must read as an accent colour
+ * rather than "slightly darker"). Text/icon styling stays identical
+ * to unselected rows — only the background differs.
+ *
+ * Applies to .sidebar .channel-item and .sidebar .agent-card (DMs
+ * render as .agent-card so they inherit). */
 .sidebar .channel-item.selected {
-  background: rgba(126, 200, 227, 0.2);
+  background: rgba(126, 200, 227, 0.35);
 }
 .sidebar .agent-card.selected,
 .sidebar .dm-item.selected {
-  background: rgba(78, 205, 196, 0.2);
+  background: rgba(78, 205, 196, 0.35);
+}
+/* #294: normalise font-weight on every sidebar channel/DM row so no
+ * per-name rule (e.g. a stale .channel-item.active path, or a
+ * selector that happens to overlap a user/agent slug) can re-bold
+ * individual rows. The sidebar rows must render with identical
+ * weight — visual distinction comes from the .selected background
+ * above, nothing else. Belt-and-braces against regressions like the
+ * one reported in msg#15352 where #ywatanabe, #proj-neurovista,
+ * #proj-scitex-clew, #proj-scitex-orochi all rendered bold while
+ * #general, #heads, #releases did not. */
+.sidebar .channel-item,
+.sidebar .channel-item .ch-name,
+.sidebar .dm-item,
+.sidebar .dm-item .dm-name,
+.sidebar .agent-card,
+.sidebar .agent-card .agent-name {
+  font-weight: normal;
 }
 /* #284: don't dim non-selected channels when one is selected — the
  * spec calls for a single currently-selected marker only, no additional


### PR DESCRIPTION
## Summary

Follow-up to #293. Fixes two sidebar defects surfaced by ywatanabe
(msg#15352) and lead (#heads msg#15353).

### (A) Selected-row accent too dark

- **Before:** `rgba(126, 200, 227, 0.2)` / `rgba(78, 205, 196, 0.2)` —
  the selected tint read as "slightly darker" rather than "clearly
  selected", easy to confuse with an every-other-row highlight.
- **After:** alpha bumped to `0.35` so the accent is unambiguously
  brighter than siblings AND clearly distinct from the `:hover` state
  (which is flat `#1a1a1a` grey, not an accent colour).
- Text and icon styling stay identical to unselected rows — only the
  background differs. Preserves the #293 "no opacity / brightness
  change on text and icons" rule.

### (B) Per-name bold regression

Reported: `#ywatanabe`, `#proj-neurovista`, `#proj-scitex-clew`,
`#proj-scitex-orochi` rendered bold while `#general`, `#heads`,
`#releases` did not.

**Root cause:** two stale CSS rules in the sidebar still carried the
pre-#293 design's `font-weight: bold` for the "current row" marker:

- `.channel-item.active` in `hub/static/hub/style/style-base.css`
- `.dm-item.active` in `hub/static/hub/style/style-agents.css`

Per PR #293 the selection marker is a BACKGROUND COLOUR ONLY (no
bold name) but those two rules weren't updated. Once a row's name
slug happened to coincide with an agent/user name or any other
selector in the codebase, the `.active` bolding flared. Removed both
`font-weight: bold` declarations.

**Belt-and-braces:** also added an explicit
`.sidebar .channel-item / .dm-item / .agent-card { font-weight:
normal }` so any future overlapping selector can't re-bold rows.

## Files touched

- `hub/static/hub/style/style-messages.css` — selected-row accent
  alpha 0.2 → 0.35; new `font-weight: normal` guard rule
- `hub/static/hub/style/style-base.css` — drop
  `font-weight: bold` from `.channel-item.active`
- `hub/static/hub/style/style-agents.css` — drop
  `font-weight: bold` from `.dm-item.active`

No TS / JS changes — CSS only. `npm run typecheck` and `npm run
build` both pass.

## Test plan

- [ ] Reload hub; confirm the currently-selected channel row shows a
  clearly brighter accent tint (not just "slightly darker") against
  unselected siblings.
- [ ] Hover an unselected row and confirm its grey `:hover` tint is
  visually distinct from the selected row's accent tint.
- [ ] Confirm `#ywatanabe`, `#proj-neurovista`, `#proj-scitex-clew`,
  `#proj-scitex-orochi` render at the same font-weight as `#general`,
  `#heads`, `#releases` (no bolding).
- [ ] Click through several channels — only one row at a time shows
  the selected accent; weight remains identical across all rows.
- [ ] DM sidebar section: currently-open DM row shows the teal accent
  (not grey `.active`) and no bolding.

References: `#heads` msg#15353, `#ywatanabe` msg#15352, follow-up to
#293.

Generated with [Claude Code](https://claude.com/claude-code)
