### PR TITLE
fix(fleet-watch/install): REPO_ROOT was one level short, template not found (#296 follow-up)

### DIFF
--- a/scripts/client/install-fleet-host-liveness-probe.sh
+++ b/scripts/client/install-fleet-host-liveness-probe.sh
@@ -18,7 +18,7 @@ set -u
 set -o pipefail
 
 LABEL="com.scitex.fleet-host-liveness-probe"
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
 TARGET_LAUNCHD="${HOME}/Library/LaunchAgents/${LABEL}.plist"
 MAC_LOG_DIR="${HOME}/Library/Logs/scitex"


### PR DESCRIPTION
One-line fix to the install helper landed by #296 — the single-`..` dirname resolver landed in `scripts/` instead of the repo root, so every invocation failed with `template missing: .../scripts/deployment/...`. Mirror the two-level climb that `install-chrome-codesign-watchdog.sh` already uses.

Verified live on mba in `--dry-run-only` mode: LaunchAgent loaded (launchctl PID 82168), first run logged, probe classified `spartan` as `critical` (tmux dead) as expected.