### PR TITLE
fix(heartbeat): propagate metrics + slurm in agent_meta --push (todo#369)

### DIFF
--- a/scripts/client/agent_meta_pkg/_push.py
+++ b/scripts/client/agent_meta_pkg/_push.py
@@ -99,6 +99,24 @@ def _build_payload(meta: dict, tok: str) -> dict:
         "agent_calls": meta.get("agent_calls") or [],
         "background_tasks": meta.get("background_tasks") or [],
         "subagents": meta.get("subagents") or [],
+        # scitex-orochi todo#369 — host-level machine metrics (CPU / mem
+        # / disk / load) + optional SLURM cluster snapshot. Without
+        # these two keys the hub's /api/resources rollup has no data
+        # to populate the Machines tab card for agents pushed via this
+        # legacy daemon path (symptom: mba / nas / spartan show zero /
+        # blink while ywata-note-win — which pushes via the sidecar
+        # heartbeat in ts/mcp_channel/heartbeat.ts that spreads the
+        # full collect() output — renders correctly).
+        #
+        # Hub-side contract: POST /api/agents/register/ reads
+        # body["metrics"] verbatim (see hub/views/api/_agents_register.py
+        # line `update_heartbeat(name, metrics=body.get("metrics") or
+        # {})`), and the merged per-agent snapshot is flattened into
+        # each machine's aggregate card by hub/views/api/_resources.py.
+        # `slurm` is a nested dict used by the Machines tab's SLURM
+        # card on HPC hosts and is expected to be None on non-HPC.
+        "metrics": meta.get("metrics") or {},
+        "slurm": meta.get("slurm"),
     }
 
 


### PR DESCRIPTION
## Summary
- Fixes todo#369 — Machines tab shows zero / blink for 3 of 4 hosts (mba / nas / spartan); only ywata-note-win renders resources correctly.
- Root cause: `agent_meta.py --push` (the legacy daemon running on mba/nas/spartan) dropped `metrics` and `slurm` from `_build_payload`'s whitelist before POSTing to `/api/agents/register/`. Without those keys the hub's `/api/resources` rollup has no data to populate the Machines tab card for those hosts.
- ywata-note-win works because its sidecar heartbeat (`ts/mcp_channel/heartbeat.ts`) spreads the full `collect()` output into the payload, preserving `metrics` all the way to the hub.

## What changed
`scripts/client/agent_meta_pkg/_push.py` — add two keys to `_build_payload`:

```python
"metrics": meta.get("metrics") or {},
"slurm": meta.get("slurm"),
```

No hub-side change needed — `hub/views/api/_agents_register.py` already reads `body.get("metrics")` and forwards it to `update_heartbeat(name, metrics=...)`, and `/api/resources` already aggregates from there.

## Scope / coordination
- Explicitly scoped to the **heartbeat payload whitelist gap**. Does not touch the TS frontend (v0.11.17's fetchResourcesThrottled handles the UI debounce side), does not add a new host-level probe daemon, does not change the registry schema.
- Not overlapping with todo#271 (mamba-healer auto-resurrect / agent liveness). #271 is about **agent** liveness + restart; #369 is about **host** resource display.
- The issue's "one probe per host per interval" remediation sketch is achieved in practice because `collect_machine_metrics()` already runs once per push cycle per agent — all agents on the same host report the same host-level numbers and the hub de-dupes under `machine`.

## Test plan
- [x] Smoke-test: `_build_payload` now emits `metrics` and `slurm` keys.
- [ ] Deploy fix to mba / nas / spartan (pull on each, restart the `agent_meta.py --push` systemd/launchd loop).
- [ ] Open Machines tab — all 4 hosts display CPU / mem / disk with non-zero values.
- [ ] Leave tab open 60s — no blink / no zero / no empty frames.
- [ ] Kill one agent on a multi-agent host (e.g. mba) — Machines card still shows resources because a sibling agent keeps reporting.