### PR TITLE
feat(worker-progress): headless daemon for throttled progress digest (todo#272)

### DIFF
--- a/deployment/host-setup/launchd/README.md
+++ b/deployment/host-setup/launchd/README.md
@@ -86,3 +86,45 @@ in the installed plist and re-running the install helper):
 
 See `skills/infra-hub-docker-disk-full.md` for why this cache is
 reaper-safe.
+
+## `com.scitex.worker-progress.plist`
+
+scitex-orochi#272. Long-running Python daemon (`KeepAlive=true`, no
+`StartInterval`) that subscribes to `#progress`, `#heads`,
+`#ywatanabe` and emits a 60 s throttled digest line to `#ywatanabe`.
+See `scripts/server/worker-progress.py` and
+`scripts/server/worker_progress_pkg/` for the implementation.
+
+Install (live mode):
+
+```bash
+./scripts/client/install-worker-progress.sh
+```
+
+Install in dry-run smoke-test mode (no posts, just logged):
+
+```bash
+./scripts/client/install-worker-progress.sh --dry-run
+```
+
+Uninstall:
+
+```bash
+./scripts/client/install-worker-progress.sh --uninstall
+```
+
+Status / logs:
+
+```bash
+launchctl list | grep com.scitex.worker-progress
+tail -n 200 ~/Library/Logs/scitex/worker-progress.log
+```
+
+Requires `SCITEX_OROCHI_TOKEN` in the launchd environment. The
+simplest path is to set it in `~/.zshenv` (interactive shells pick it
+up immediately; new launchd jobs see it after the next login or a
+manual `launchctl setenv SCITEX_OROCHI_TOKEN <value>`).
+
+Linux hosts use the systemd user-unit counterpart at
+`../systemd/scitex-worker-progress.service` — see
+`../systemd/README.md` for install / uninstall commands.

--- a/deployment/host-setup/launchd/com.scitex.worker-progress.plist
+++ b/deployment/host-setup/launchd/com.scitex.worker-progress.plist
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent: worker-progress headless daemon (todo#272).
+
+  Long-running Python daemon that subscribes to #progress / #heads /
+  #ywatanabe and emits a 60 s throttled digest line to #ywatanabe. This
+  is NOT an sac-managed agent and NOT a Claude process — it's a plain
+  Python loop that lives alongside the other LaunchAgents in this
+  directory.
+
+  Install:
+    ./scripts/client/install-worker-progress.sh
+    ./scripts/client/install-worker-progress.sh --dry-run   # smoke-test
+    ./scripts/client/install-worker-progress.sh --uninstall
+
+  KeepAlive is true because this is a long-running daemon (distinct
+  from the interval-triggered LaunchAgents like
+  chrome-codesign-watchdog.plist and fleet-host-liveness-probe.plist
+  which only run periodically and exit). If the daemon exits for any
+  reason launchd will respawn it after ThrottleInterval seconds.
+
+  Logs: ~/Library/Logs/scitex/worker-progress.log (Python side also
+  writes structured logs there via FileHandler).
+
+  Replace __HOME__ / __REPO__ / __DRY_RUN__ with your actual paths and
+  mode before `launchctl load`. The companion install helper
+  scripts/client/install-worker-progress.sh does this rewrite
+  automatically.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.scitex.worker-progress</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/bin/env</string>
+      <string>python3</string>
+      <string>__REPO__/scripts/server/worker-progress.py</string>
+      <string>__DRY_RUN__</string>
+    </array>
+
+    <!-- Long-running daemon: respawn on exit. -->
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Don't respawn in a tight loop if the script exits non-zero. -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/scitex/worker-progress.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/scitex/worker-progress.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <!--
+        SCITEX_OROCHI_TOKEN must be set in the user's env / .env so the
+        daemon can authenticate. See scripts/client/install/bootstrap-
+        host.sh for the canonical .env path.
+      -->
+    </dict>
+  </dict>
+</plist>

--- a/deployment/host-setup/systemd/README.md
+++ b/deployment/host-setup/systemd/README.md
@@ -1,0 +1,46 @@
+# systemd user units
+
+Linux counterparts to the macOS LaunchAgent templates in
+`../launchd/`. Installed per-user via `systemctl --user` so the unit
+survives logout only if `loginctl enable-linger $USER` has been run
+(standard for fleet hosts).
+
+## `scitex-worker-progress.service`
+
+scitex-orochi#272. Long-running Python daemon that subscribes to
+`#progress`, `#heads`, `#ywatanabe` and emits a 60 s throttled digest
+line to `#ywatanabe`. See `scripts/server/worker-progress.py` and
+`scripts/server/worker_progress_pkg/` for the implementation.
+
+Install (live mode):
+
+```bash
+./scripts/client/install-worker-progress.sh
+```
+
+Install in dry-run smoke-test mode (no posts, just logged):
+
+```bash
+./scripts/client/install-worker-progress.sh --dry-run
+```
+
+Uninstall:
+
+```bash
+./scripts/client/install-worker-progress.sh --uninstall
+```
+
+Status / logs:
+
+```bash
+systemctl --user status scitex-worker-progress.service
+journalctl --user -u scitex-worker-progress.service -f
+tail -n 200 ~/.local/state/scitex/worker-progress.log
+```
+
+Requires `SCITEX_OROCHI_TOKEN` in `~/.scitex/orochi/env` (canonical
+path — same file written by
+`scripts/client/install/bootstrap-host.sh`). The unit uses
+`EnvironmentFile=-%h/.scitex/orochi/env` (leading `-` = "don't fail if
+missing"), so the daemon exits with a clear error if the token is
+absent, rather than crashing systemd's restart loop.

--- a/deployment/host-setup/systemd/scitex-worker-progress.service
+++ b/deployment/host-setup/systemd/scitex-worker-progress.service
@@ -1,0 +1,42 @@
+# systemd user unit: worker-progress headless daemon (todo#272).
+#
+# Long-running Python daemon that subscribes to #progress / #heads /
+# #ywatanabe and emits a 60 s throttled digest line to #ywatanabe. This
+# is NOT an sac-managed agent and NOT a Claude process — it's a plain
+# Python loop that lives alongside the other fleet LaunchAgents.
+#
+# Install (user-scope):
+#   ./scripts/client/install-worker-progress.sh
+#   ./scripts/client/install-worker-progress.sh --dry-run    # smoke-test
+#   ./scripts/client/install-worker-progress.sh --uninstall
+#
+# The install helper rewrites __REPO__ / __DRY_RUN__ before copying
+# this template into ~/.config/systemd/user/ and running
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now scitex-worker-progress.service
+#
+# Logs: journalctl --user -u scitex-worker-progress.service
+#       plus ~/.local/state/scitex/worker-progress.log (Python FileHandler)
+
+[Unit]
+Description=scitex worker-progress headless daemon (todo#272)
+Documentation=https://github.com/ywatanabe1989/scitex-orochi
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# SCITEX_OROCHI_TOKEN must be present in the user's env. The default
+# EnvironmentFile path matches scripts/client/install/bootstrap-host.sh.
+EnvironmentFile=-%h/.scitex/orochi/env
+ExecStart=/usr/bin/env python3 __REPO__/scripts/server/worker-progress.py __DRY_RUN__
+
+Restart=always
+RestartSec=30
+# Keep a dozen lines of history buffered so the daemon survives an
+# early log-rotation race on boot.
+StandardOutput=append:%h/.local/state/scitex/worker-progress.log
+StandardError=append:%h/.local/state/scitex/worker-progress.log
+
+[Install]
+WantedBy=default.target

--- a/hub/management/commands/seed_worker_progress.py
+++ b/hub/management/commands/seed_worker_progress.py
@@ -1,0 +1,137 @@
+"""Seed the synthetic ``agent-worker-progress`` user + ChannelMemberships.
+
+Implements the data-plane side of todo#272. Idempotent: running it
+multiple times is a no-op. Mirrors the ``agent-*`` synthetic-user
+pattern used by ``hub/consumers/_helpers.py::_persist_agent_subscription``
+and the hub auth layer.
+
+Usage:
+    python manage.py seed_worker_progress --workspace <workspace-name>
+
+Exits non-zero only if the workspace can't be found. The
+``#agent`` channel is explicitly skipped — it was abolished 2026-04-21
+(lead directive, PR #293 follow-up) and the server-side blocklist in
+``ABOLISHED_AGENT_CHANNELS`` would reject any attempt to add it.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from hub.consumers._helpers import ABOLISHED_AGENT_CHANNELS
+from hub.models import Channel, ChannelMembership, Workspace, WorkspaceMember
+
+User = get_user_model()
+
+# Keep in sync with ``scripts/server/worker_progress_pkg/__init__.py``
+# (AGENT_NAME, SUBSCRIBE_CHANNELS). Duplicated here so the mgmt
+# command doesn't have to import the server-side package.
+AGENT_NAME = "worker-progress"
+AGENT_USERNAME = f"agent-{AGENT_NAME}"
+DEFAULT_CHANNELS = ("#progress", "#heads", "#ywatanabe")
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed agent-worker-progress synthetic user + read-write memberships "
+        "for #progress, #heads, #ywatanabe (todo#272). Idempotent."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--workspace",
+            default="default",
+            help="Workspace slug to seed into (default: default)",
+        )
+        parser.add_argument(
+            "--channels",
+            nargs="*",
+            default=list(DEFAULT_CHANNELS),
+            help=(
+                "Channel names to grant read-write to. Defaults to "
+                "#progress, #heads, #ywatanabe. ``#agent`` is always "
+                "skipped (abolished 2026-04-21)."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        ws_name = options["workspace"]
+        try:
+            workspace = Workspace.objects.get(name=ws_name)
+        except Workspace.DoesNotExist as exc:
+            raise CommandError(f"Workspace '{ws_name}' does not exist") from exc
+
+        user, user_created = User.objects.get_or_create(
+            username=AGENT_USERNAME,
+            defaults={
+                "email": f"{AGENT_USERNAME}@agents.orochi.local",
+                "is_active": True,
+                "is_staff": False,
+            },
+        )
+        if user_created:
+            self.stdout.write(self.style.SUCCESS(f"created user: {AGENT_USERNAME}"))
+        else:
+            self.stdout.write(f"user exists: {AGENT_USERNAME}")
+
+        member, member_created = WorkspaceMember.objects.get_or_create(
+            workspace=workspace,
+            user=user,
+            defaults={"role": "member"},
+        )
+        if member_created:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"added {AGENT_USERNAME} to workspace '{ws_name}'"
+                )
+            )
+        else:
+            self.stdout.write(
+                f"{AGENT_USERNAME} already in workspace '{ws_name}'"
+            )
+
+        created, existed, skipped = 0, 0, 0
+        for raw in options["channels"]:
+            name = raw if raw.startswith(("#", "dm:")) else f"#{raw}"
+            if name in ABOLISHED_AGENT_CHANNELS:
+                self.stdout.write(
+                    self.style.WARNING(f"skipping abolished channel: {name}")
+                )
+                skipped += 1
+                continue
+            channel, _ = Channel.objects.get_or_create(
+                workspace=workspace,
+                name=name,
+                defaults={"kind": Channel.KIND_GROUP},
+            )
+            membership, was_created = ChannelMembership.objects.get_or_create(
+                user=user,
+                channel=channel,
+                defaults={"permission": ChannelMembership.PERM_READ_WRITE},
+            )
+            if was_created:
+                created += 1
+                self.stdout.write(
+                    self.style.SUCCESS(f"  + membership: {name} (read-write)")
+                )
+            else:
+                existed += 1
+                # Ensure permission is read-write even if it was previously
+                # demoted; the daemon needs to both read and post digests.
+                if membership.permission != ChannelMembership.PERM_READ_WRITE:
+                    membership.permission = ChannelMembership.PERM_READ_WRITE
+                    membership.save(update_fields=["permission"])
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  ~ upgraded to read-write: {name}"
+                        )
+                    )
+                else:
+                    self.stdout.write(f"  = membership exists: {name}")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"done: {created} created, {existed} existed, {skipped} skipped."
+            )
+        )

--- a/hub/tests/test_worker_progress_client.py
+++ b/hub/tests/test_worker_progress_client.py
@@ -1,0 +1,127 @@
+"""Tests for the worker-progress WS client stub (todo#272).
+
+We never make a real WS call. Instead we inject a fake ``connect``
+into :class:`HubWSClient` and verify:
+  - register frame is sent at connection time with the expected payload
+  - ``send_message`` emits a well-formed ``message`` frame
+  - ``dry_run=True`` short-circuits ``send_message`` without calling ws
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_SERVER = _REPO_ROOT / "scripts" / "server"
+if str(_SCRIPTS_SERVER) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_SERVER))
+
+from worker_progress_pkg._client import HubWSClient  # noqa: E402
+
+
+class FakeWS:
+    """Minimal duck-typed WS replacement for the client tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.incoming: list[str] = []
+        self.closed = False
+
+    async def send(self, raw: str) -> None:
+        self.sent.append(raw)
+
+    async def close(self) -> None:
+        self.closed = True
+
+    def __aiter__(self):
+        async def gen():
+            for item in list(self.incoming):
+                yield item
+
+        return gen()
+
+
+def _fake_connect_factory(ws: FakeWS):
+    async def _connect(_uri, *_a, **_kw):
+        return ws
+
+    return _connect
+
+
+class HubWSClientTest(TestCase):
+    def test_dry_run_send_message_does_not_touch_ws(self):
+        client = HubWSClient(
+            uri="wss://example.invalid/ws/agent/?token=x&agent=worker-progress",
+            agent_name="worker-progress",
+            dry_run=True,
+        )
+
+        async def go():
+            await client.send_message("#ywatanabe", "hello")
+
+        asyncio.run(go())
+        self.assertIsNone(client._ws)
+
+    def test_one_connection_sends_register_then_yields_frames(self):
+        ws = FakeWS()
+        ws.incoming = [
+            json.dumps(
+                {
+                    "type": "message",
+                    "channel": "#progress",
+                    "sender": "github",
+                    "text": "CI started",
+                }
+            )
+        ]
+        client = HubWSClient(
+            uri="wss://example.invalid/ws/agent/?token=x&agent=worker-progress",
+            agent_name="worker-progress",
+            channels=("#progress", "#heads", "#ywatanabe"),
+            ws_connect=_fake_connect_factory(ws),
+        )
+
+        async def go():
+            frames = []
+            async for frame in client._one_connection():
+                frames.append(frame)
+            return frames
+
+        frames = asyncio.run(go())
+        self.assertEqual(len(frames), 1)
+        self.assertEqual(frames[0]["channel"], "#progress")
+
+        # Register frame must have been sent before any receive.
+        self.assertGreaterEqual(len(ws.sent), 1)
+        reg = json.loads(ws.sent[0])
+        self.assertEqual(reg["type"], "register")
+        self.assertEqual(reg["payload"]["agent_id"], "worker-progress")
+        self.assertEqual(reg["payload"]["role"], "worker")
+        self.assertIn("#progress", reg["payload"]["channels"])
+        # Connection must have been closed at the end of _one_connection.
+        self.assertTrue(ws.closed)
+
+    def test_send_message_frame_shape(self):
+        ws = FakeWS()
+        client = HubWSClient(
+            uri="wss://example.invalid/ws/agent/?token=x&agent=worker-progress",
+            agent_name="worker-progress",
+            ws_connect=_fake_connect_factory(ws),
+        )
+
+        async def go():
+            # Manually attach the WS (skip the register dance).
+            client._ws = ws
+            await client.send_message("#ywatanabe", "digest line", {"k": "v"})
+
+        asyncio.run(go())
+        self.assertEqual(len(ws.sent), 1)
+        frame = json.loads(ws.sent[0])
+        self.assertEqual(frame["type"], "message")
+        self.assertEqual(frame["payload"]["channel"], "#ywatanabe")
+        self.assertEqual(frame["payload"]["text"], "digest line")
+        self.assertEqual(frame["payload"]["metadata"], {"k": "v"})

--- a/hub/tests/test_worker_progress_digest.py
+++ b/hub/tests/test_worker_progress_digest.py
@@ -1,0 +1,166 @@
+"""Tests for the worker-progress digest coalescer (todo#272).
+
+Covers:
+  - 60 s window → single emit
+  - Zero events in a window → ``flush`` returns ``None`` (no heartbeat)
+  - Identical signatures coalesce into ``Nx <summary>``
+  - ``@worker-progress`` mention triggers MentionPolicy bypass
+  - DM path is treated as a mention regardless of text
+
+No WebSocket I/O: the coalescer is pure and takes an injected clock so
+the test harness never sleeps.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import TestCase
+
+# The daemon lives under scripts/server/ (a sibling of the Django app
+# tree), so we have to surface that path before importing. Keeping the
+# path fiddle inside the test module is fine; hub.tests is never
+# imported by the production daemon.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPTS_SERVER = _REPO_ROOT / "scripts" / "server"
+if str(_SCRIPTS_SERVER) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_SERVER))
+
+from worker_progress_pkg._digest import (  # noqa: E402
+    DEFAULT_WINDOW_S,
+    DigestCoalescer,
+    InboundEvent,
+    MentionPolicy,
+)
+
+
+class FakeClock:
+    """Deterministic monotonic clock for the coalescer tests."""
+
+    def __init__(self) -> None:
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _ev(channel="#progress", sender="github", text="CI started", **kw):
+    return InboundEvent(
+        channel=channel,
+        sender=sender,
+        text=text,
+        ts=0.0,
+        is_dm=kw.get("is_dm", False),
+        mentions_self=kw.get("mentions_self", False),
+    )
+
+
+class DigestCoalescerTest(TestCase):
+    def test_empty_window_flushes_none(self):
+        clock = FakeClock()
+        c = DigestCoalescer(now=clock)
+        # Advance past the window with zero events.
+        clock.advance(DEFAULT_WINDOW_S + 1)
+        self.assertIsNone(c.flush())
+
+    def test_single_event_emits_one_line_per_window(self):
+        clock = FakeClock()
+        c = DigestCoalescer(now=clock)
+        c.push(_ev(text="CI started: foo/bar #1"))
+        # Not yet time to flush.
+        self.assertIsNone(c.flush())
+        clock.advance(DEFAULT_WINDOW_S + 1)
+        line = c.flush()
+        self.assertIsNotNone(line)
+        self.assertIn("[progress ", line)
+        self.assertIn("1 events", line)
+        self.assertIn("#progress", line)
+        # Next window starts empty.
+        self.assertIsNone(c.flush())
+
+    def test_identical_signatures_coalesce(self):
+        clock = FakeClock()
+        c = DigestCoalescer(now=clock)
+        # 40 "CI started" posts from the same sender/channel — same sig.
+        for _ in range(40):
+            c.push(_ev(text="CI started"))
+        clock.advance(DEFAULT_WINDOW_S + 0.1)
+        line = c.flush()
+        self.assertIsNotNone(line)
+        self.assertIn("40x", line)
+        self.assertIn("40 events", line)
+
+    def test_multiple_signatures_top_n_highlights(self):
+        clock = FakeClock()
+        c = DigestCoalescer(now=clock)
+        # Three distinct signatures with differing counts.
+        for _ in range(5):
+            c.push(_ev(text="A started"))
+        for _ in range(3):
+            c.push(_ev(text="B started"))
+        for _ in range(1):
+            c.push(_ev(text="C started"))
+        # A 4th, lower-ranked signature should roll into "+more".
+        c.push(_ev(text="D started"))
+        clock.advance(DEFAULT_WINDOW_S + 0.1)
+        line = c.flush()
+        self.assertIsNotNone(line)
+        self.assertIn("10 events", line)
+        # Top 3 visible by count.
+        self.assertIn("5x", line)
+        self.assertIn("3x", line)
+        self.assertIn("+1 more", line)
+
+    def test_line_cap_under_200_chars(self):
+        clock = FakeClock()
+        c = DigestCoalescer(now=clock)
+        for i in range(30):
+            # 30 distinct long signatures.
+            c.push(_ev(text=f"long event number {i:02d} with detail"))
+        clock.advance(DEFAULT_WINDOW_S + 0.1)
+        line = c.flush()
+        self.assertIsNotNone(line)
+        self.assertLessEqual(len(line), 200)
+
+
+class MentionPolicyTest(TestCase):
+    def test_at_mention_triggers_bypass(self):
+        ev = _ev(text="hey @worker-progress ping")
+        self.assertTrue(MentionPolicy.is_mention(ev))
+
+    def test_at_agent_prefix_form(self):
+        ev = _ev(text="FYI @agent-worker-progress")
+        self.assertTrue(MentionPolicy.is_mention(ev))
+
+    def test_no_mention_plain_text(self):
+        ev = _ev(text="unrelated update in #progress")
+        self.assertFalse(MentionPolicy.is_mention(ev))
+
+    def test_dm_is_always_mention(self):
+        ev = _ev(
+            channel="dm:ywatanabe|worker-progress",
+            sender="ywatanabe",
+            text="anything",
+            is_dm=True,
+        )
+        self.assertTrue(MentionPolicy.is_mention(ev))
+
+    def test_ack_line_renders_shortly(self):
+        ev = _ev(text="@worker-progress hi")
+        line = MentionPolicy.ack_line(ev)
+        self.assertIn("todo#272", line)
+        self.assertLessEqual(len(line), 200)
+
+    def test_ack_line_dm_path(self):
+        ev = _ev(
+            channel="dm:ywatanabe|worker-progress",
+            sender="ywatanabe",
+            text="hello",
+            is_dm=True,
+        )
+        line = MentionPolicy.ack_line(ev)
+        self.assertIn("received", line)
+        self.assertIn("todo#272", line)

--- a/hub/tests/test_worker_progress_seed.py
+++ b/hub/tests/test_worker_progress_seed.py
@@ -1,0 +1,89 @@
+"""Tests for ``manage.py seed_worker_progress`` (todo#272).
+
+Verifies:
+  - Creates the synthetic ``agent-worker-progress`` user + workspace
+    member + read-write ChannelMembership rows for #progress, #heads,
+    #ywatanabe.
+  - Idempotent: a second run creates no extra rows.
+  - ``#agent`` is explicitly skipped even if passed via --channels.
+  - Missing workspace raises CommandError.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from hub.models import Channel, ChannelMembership, Workspace, WorkspaceMember
+
+User = get_user_model()
+
+
+class SeedWorkerProgressTest(TestCase):
+    def setUp(self) -> None:
+        self.ws = Workspace.objects.create(name="default")
+
+    def _run(self, *args, **opts) -> str:
+        out = StringIO()
+        call_command("seed_worker_progress", *args, stdout=out, **opts)
+        return out.getvalue()
+
+    def test_creates_user_member_memberships(self):
+        output = self._run("--workspace", "default")
+        self.assertIn("created user", output)
+        user = User.objects.get(username="agent-worker-progress")
+        self.assertTrue(
+            WorkspaceMember.objects.filter(user=user, workspace=self.ws).exists()
+        )
+        for name in ("#progress", "#heads", "#ywatanabe"):
+            ch = Channel.objects.get(workspace=self.ws, name=name)
+            m = ChannelMembership.objects.get(user=user, channel=ch)
+            self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
+
+    def test_idempotent_no_duplicates(self):
+        self._run("--workspace", "default")
+        before_users = User.objects.count()
+        before_members = ChannelMembership.objects.count()
+        before_channels = Channel.objects.count()
+        # Second run.
+        output = self._run("--workspace", "default")
+        self.assertIn("user exists", output)
+        self.assertEqual(User.objects.count(), before_users)
+        self.assertEqual(ChannelMembership.objects.count(), before_members)
+        self.assertEqual(Channel.objects.count(), before_channels)
+
+    def test_skips_abolished_agent_channel(self):
+        output = self._run(
+            "--workspace",
+            "default",
+            "--channels",
+            "#progress",
+            "#agent",
+            "#heads",
+        )
+        self.assertIn("skipping abolished channel", output)
+        # #agent must NOT have any Channel row created, and certainly
+        # no ChannelMembership for agent-worker-progress.
+        self.assertFalse(
+            Channel.objects.filter(workspace=self.ws, name="#agent").exists()
+        )
+
+    def test_upgrades_read_only_to_read_write(self):
+        # Pre-existing read-only membership: seed must promote to RW.
+        user, _ = User.objects.get_or_create(username="agent-worker-progress")
+        WorkspaceMember.objects.create(user=user, workspace=self.ws)
+        ch = Channel.objects.create(workspace=self.ws, name="#progress")
+        ChannelMembership.objects.create(
+            user=user, channel=ch, permission=ChannelMembership.PERM_READ_ONLY
+        )
+        output = self._run("--workspace", "default")
+        self.assertIn("upgraded to read-write", output)
+        refreshed = ChannelMembership.objects.get(user=user, channel=ch)
+        self.assertEqual(refreshed.permission, ChannelMembership.PERM_READ_WRITE)
+
+    def test_missing_workspace_raises(self):
+        with self.assertRaises(CommandError):
+            self._run("--workspace", "does-not-exist")

--- a/scripts/client/install-worker-progress.sh
+++ b/scripts/client/install-worker-progress.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# install-worker-progress.sh
+#
+# Installer for the worker-progress headless daemon (todo#272).
+#   macOS: installs a LaunchAgent that KeepAlive=true runs the daemon.
+#   Linux: installs a systemd user unit that runs the daemon with
+#          Restart=always.
+#
+# Usage:
+#   ./scripts/client/install-worker-progress.sh           # install (live mode)
+#   ./scripts/client/install-worker-progress.sh --dry-run # install in dry-run smoke mode
+#   ./scripts/client/install-worker-progress.sh --uninstall
+#
+# Idempotent: safe to re-run.
+
+set -u
+set -o pipefail
+
+LABEL="com.scitex.worker-progress"
+# REPO_ROOT: this script lives at scripts/client/, so climb TWO levels
+# to reach the repo root. Mirrors the corrected two-level climb from
+# PR #297 (fix for the one-level bug introduced by PR #296's
+# install-fleet-host-liveness-probe.sh).
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+TEMPLATE_PLIST="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
+TEMPLATE_SYSTEMD="${REPO_ROOT}/deployment/host-setup/systemd/scitex-worker-progress.service"
+TARGET_LAUNCHD="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+SYSTEMD_USER_DIR="${HOME}/.config/systemd/user"
+TARGET_SYSTEMD="${SYSTEMD_USER_DIR}/scitex-worker-progress.service"
+MAC_LOG_DIR="${HOME}/Library/Logs/scitex"
+LINUX_LOG_DIR="${HOME}/.local/state/scitex"
+
+dry_run_flag=""
+action="install"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uninstall) action="uninstall"; shift ;;
+        --dry-run)   dry_run_flag="--dry-run"; shift ;;
+        -h|--help)
+            sed -n '2,16p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+OS="$(uname -s)"
+
+# -----------------------------------------------------------------------------
+# macOS (LaunchAgent)
+# -----------------------------------------------------------------------------
+install_macos() {
+    if [[ ! -f "$TEMPLATE_PLIST" ]]; then
+        echo "template missing: $TEMPLATE_PLIST" >&2
+        exit 1
+    fi
+    mkdir -p "$(dirname "$TARGET_LAUNCHD")" "$MAC_LOG_DIR"
+
+    local esc_home esc_repo
+    esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+    esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+
+    # __DRY_RUN__ is the placeholder for the optional --dry-run arg.
+    # When absent we replace with a repeat of the script path so the
+    # ProgramArguments array still parses (launchd treats an empty
+    # string argv entry as a literal "" which is fine, but we pick a
+    # harmless arg for clarity in `ps` output).
+    local dry_slot="${dry_run_flag:-}"
+    if [[ -z "$dry_slot" ]]; then
+        # Empty-string entry is valid; launchd/argparse just sees an empty
+        # positional which argparse ignores. Cleaner than padding.
+        dry_slot=""
+    fi
+    local esc_dry
+    esc_dry="$(printf '%s' "$dry_slot" | sed 's|[|&]|\\&|g')"
+
+    sed -e "s|__HOME__|${esc_home}|g" \
+        -e "s|__REPO__|${esc_repo}|g" \
+        -e "s|__DRY_RUN__|${esc_dry}|g" \
+        "$TEMPLATE_PLIST" > "$TARGET_LAUNCHD"
+
+    launchctl unload "$TARGET_LAUNCHD" 2>/dev/null || true
+    launchctl load "$TARGET_LAUNCHD"
+
+    echo "installed: $TARGET_LAUNCHD"
+    echo "mode:      ${dry_run_flag:-live}"
+    echo "log:       ${MAC_LOG_DIR}/worker-progress.log"
+    echo "status:    launchctl list | grep ${LABEL}"
+}
+
+uninstall_macos() {
+    if [[ -f "$TARGET_LAUNCHD" ]]; then
+        launchctl unload "$TARGET_LAUNCHD" 2>/dev/null || true
+        rm -f "$TARGET_LAUNCHD"
+        echo "uninstalled: $TARGET_LAUNCHD"
+    else
+        echo "nothing to uninstall (no $TARGET_LAUNCHD)"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Linux (systemd --user unit)
+# -----------------------------------------------------------------------------
+install_linux() {
+    if [[ ! -f "$TEMPLATE_SYSTEMD" ]]; then
+        echo "template missing: $TEMPLATE_SYSTEMD" >&2
+        exit 1
+    fi
+    mkdir -p "$SYSTEMD_USER_DIR" "$LINUX_LOG_DIR"
+
+    local esc_repo esc_dry
+    esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+    esc_dry="$(printf '%s' "${dry_run_flag:-}" | sed 's|[|&]|\\&|g')"
+
+    sed -e "s|__REPO__|${esc_repo}|g" \
+        -e "s|__DRY_RUN__|${esc_dry}|g" \
+        "$TEMPLATE_SYSTEMD" > "$TARGET_SYSTEMD"
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now scitex-worker-progress.service
+
+    echo "installed: $TARGET_SYSTEMD"
+    echo "mode:      ${dry_run_flag:-live}"
+    echo "log:       ${LINUX_LOG_DIR}/worker-progress.log"
+    echo "status:    systemctl --user status scitex-worker-progress.service"
+    echo "journal:   journalctl --user -u scitex-worker-progress.service -f"
+}
+
+uninstall_linux() {
+    if [[ ! -f "$TARGET_SYSTEMD" ]]; then
+        echo "nothing to uninstall (no $TARGET_SYSTEMD)"
+        return 0
+    fi
+    systemctl --user disable --now scitex-worker-progress.service 2>/dev/null || true
+    rm -f "$TARGET_SYSTEMD"
+    systemctl --user daemon-reload 2>/dev/null || true
+    echo "uninstalled: $TARGET_SYSTEMD"
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------------
+case "$OS" in
+    Darwin)
+        case "$action" in
+            install)   install_macos ;;
+            uninstall) uninstall_macos ;;
+        esac
+        ;;
+    Linux)
+        case "$action" in
+            install)   install_linux ;;
+            uninstall) uninstall_linux ;;
+        esac
+        ;;
+    *)
+        echo "install-worker-progress: unsupported OS ($OS)" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/server/worker-progress.py
+++ b/scripts/server/worker-progress.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env -S python3 -u
+"""worker-progress daemon — throttled digest relay for @ywatanabe (todo#272).
+
+This is a plain long-running Python daemon (NOT a Claude process, NOT an
+``sac``-managed agent, NOT a ``.claude/agents/*`` definition). It:
+
+1. Opens a WebSocket to the Orochi hub as the synthetic agent
+   ``worker-progress`` using the workspace token in
+   ``$SCITEX_OROCHI_TOKEN`` (same env used by every other hub client;
+   see ``scripts/client/agent_meta.py`` and
+   ``scripts/client/fleet-watch/fleet_watch.sh``).
+2. Hydrates its channel subscriptions from the server-authoritative
+   ``ChannelMembership`` rows (spec v3 §3.1 — register's client-side
+   ``channels`` array is ignored by the hub; run
+   ``python manage.py seed_worker_progress`` once to create the rows
+   for ``#progress``, ``#heads``, ``#ywatanabe``).
+3. Coalesces inbound events with a 60 s throttle and, on each tick,
+   emits ONE short summary line to ``#ywatanabe``. Zero events in a
+   window → silent (no heartbeat post).
+4. On ``@worker-progress`` mention or DM, bypasses the throttle and
+   posts a single-line polite-ack. The full ``claude-code`` spawn is
+   out of scope for v1 and tracked under todo#272.
+
+The daemon is split across sibling modules under
+``scripts/server/worker_progress_pkg/`` so each file stays under the
+512-line cap that the rest of the repo follows. Entry-point kept here
+so existing ``scripts/server/`` conventions still work; the real code
+lives next door.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from worker_progress_pkg._cli import cli_main  # noqa: E402
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/scripts/server/worker_progress_pkg/__init__.py
+++ b/scripts/server/worker_progress_pkg/__init__.py
@@ -1,0 +1,36 @@
+"""worker-progress daemon package (todo#272).
+
+Split out of ``scripts/server/worker-progress.py`` so each module stays
+well under the 512-line cap used by the rest of the repo.
+
+Modules:
+  - ``_cli``      : argparse + main entry point
+  - ``_config``   : env/URL resolution + log-path helpers
+  - ``_digest``   : 60 s throttle + dedup coalescer (pure, testable)
+  - ``_client``   : aiohttp-free websockets WS loop with reconnect
+  - ``_daemon``   : top-level ``run()`` glue
+
+Import surface is intentionally small; tests reach into ``_digest`` for
+the coalescer logic and into ``_config`` for path resolution. The
+``_client`` and ``_daemon`` modules require real network / event-loop
+scaffolding so tests stub them.
+"""
+
+from __future__ import annotations
+
+__all__ = ["AGENT_NAME", "SUBSCRIBE_CHANNELS"]
+
+# Synthetic agent name under which the daemon registers. Must match the
+# ``hub/management/commands/seed_worker_progress.py`` seed so the
+# ChannelMembership rows line up (agent user = ``agent-worker-progress``).
+AGENT_NAME = "worker-progress"
+
+# Canonical subscribe set for v1. ``#agent`` was abolished 2026-04-21
+# (lead directive, PR #293 follow-up) and is explicitly NOT in this
+# list. The server-side blocklist in ``hub/consumers/_helpers.py``
+# (``ABOLISHED_AGENT_CHANNELS``) would reject it anyway.
+SUBSCRIBE_CHANNELS = ("#progress", "#heads", "#ywatanabe")
+
+# The channel we emit digests / acks to. Must be in SUBSCRIBE_CHANNELS
+# (so we can actually write to it) and match the seed command.
+DIGEST_CHANNEL = "#ywatanabe"

--- a/scripts/server/worker_progress_pkg/__main__.py
+++ b/scripts/server/worker_progress_pkg/__main__.py
@@ -1,0 +1,11 @@
+"""Allow ``python -m worker_progress_pkg`` execution."""
+
+from __future__ import annotations
+
+import sys
+
+from ._cli import cli_main
+
+
+if __name__ == "__main__":
+    sys.exit(cli_main())

--- a/scripts/server/worker_progress_pkg/_cli.py
+++ b/scripts/server/worker_progress_pkg/_cli.py
@@ -1,0 +1,95 @@
+"""CLI entry point for the worker-progress daemon."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+from ._config import default_log_path
+from ._daemon import run
+
+
+def _setup_logging(log_path: Path, level: int = logging.INFO) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    root = logging.getLogger()
+    root.setLevel(level)
+    fmt = logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+    )
+    # File handler — persistent log.
+    fh = logging.FileHandler(log_path, encoding="utf-8")
+    fh.setFormatter(fmt)
+    root.addHandler(fh)
+    # Stderr handler — launchd / systemd also capture stderr.
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setFormatter(fmt)
+    root.addHandler(sh)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="worker-progress",
+        description=(
+            "Headless Orochi daemon that coalesces #progress / #heads / "
+            "#ywatanabe traffic into one 60 s digest line per window "
+            "(todo#272)."
+        ),
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Don't connect to the hub; log would-post lines to stderr "
+            "instead. Useful for install smoke-tests."
+        ),
+    )
+    p.add_argument(
+        "--once",
+        action="store_true",
+        help="Run one tick cycle, then exit (test harness only).",
+    )
+    p.add_argument(
+        "--url",
+        default="",
+        help=(
+            "Override the hub WS base URL (default: $SCITEX_OROCHI_URL_WS "
+            "else wss://scitex-orochi.com)."
+        ),
+    )
+    p.add_argument(
+        "--log-path",
+        default="",
+        help=(
+            "Override log file path (default: ~/Library/Logs/scitex/"
+            "worker-progress.log on macOS, ~/.local/state/scitex/"
+            "worker-progress.log on Linux)."
+        ),
+    )
+    p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="DEBUG-level logging.",
+    )
+    return p
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    log_path = Path(args.log_path) if args.log_path else default_log_path()
+    _setup_logging(log_path, logging.DEBUG if args.verbose else logging.INFO)
+    try:
+        return asyncio.run(
+            run(
+                dry_run=args.dry_run,
+                once=args.once,
+                url=args.url,
+            )
+        )
+    except KeyboardInterrupt:
+        logging.getLogger("worker-progress").info("KeyboardInterrupt → exiting")
+        return 0

--- a/scripts/server/worker_progress_pkg/_client.py
+++ b/scripts/server/worker_progress_pkg/_client.py
@@ -1,0 +1,191 @@
+"""Thin async WebSocket wrapper for the worker-progress daemon.
+
+We don't reuse ``scitex_orochi._client.OrochiClient`` because that
+module lives under ``src/scitex_orochi/`` and would drag the whole
+package (Django, channels, gitea helpers, ...) onto a daemon that only
+needs ``websockets``. The handshake shape is intentionally kept in
+lockstep with ``hub/consumers/_agent.py`` + ``hub/routing.py`` — if
+the hub-side register format ever drifts, both sides must update.
+
+The reconnect loop applies exponential backoff capped at 60 s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from typing import Any, AsyncIterator, Callable, Optional
+
+log = logging.getLogger("worker-progress.client")
+
+
+class HubWSClient:
+    """Minimal hub WS client.
+
+    Usage:
+
+        client = HubWSClient(uri, agent_name="worker-progress")
+        async for msg in client.run():
+            ...  # dict frame from the hub
+
+    ``run()`` owns the reconnect loop. If the WS drops, it sleeps with
+    exponential backoff and yields again once the connection is
+    re-established — the caller's iteration never has to handle
+    reconnect explicitly.
+    """
+
+    # Backoff ladder: 1, 2, 4, 8, 16, 32, 60, 60, ... (cap 60 s).
+    MIN_BACKOFF_S = 1.0
+    MAX_BACKOFF_S = 60.0
+
+    def __init__(
+        self,
+        uri: str,
+        agent_name: str,
+        channels: tuple[str, ...] = (),
+        machine: str = "",
+        project: str = "",
+        dry_run: bool = False,
+        ws_connect: Optional[Callable] = None,
+    ) -> None:
+        self.uri = uri
+        self.agent_name = agent_name
+        self.channels = list(channels)
+        self.machine = machine
+        self.project = project
+        self.dry_run = dry_run
+        # Injection point for tests.
+        self._ws_connect = ws_connect
+        self._ws: Any = None
+        self._stopping = False
+
+    # -- lifecycle ----------------------------------------------------
+
+    async def stop(self) -> None:
+        """Signal the run() loop to exit cleanly on next iteration."""
+        self._stopping = True
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:  # noqa: BLE001 — best-effort close
+                pass
+
+    # -- outbound -----------------------------------------------------
+
+    async def send_message(
+        self, channel: str, text: str, metadata: Optional[dict] = None
+    ) -> None:
+        """Post a text message to a channel.
+
+        When ``dry_run`` is set, the message is logged to stderr via
+        the package logger instead of being sent — useful for install
+        smoke-tests where you want to see what the daemon would emit.
+        """
+        if self.dry_run:
+            log.info("DRY-RUN: would send to %s: %s", channel, text)
+            return
+        if self._ws is None:
+            log.warning(
+                "send_message dropped — WS not connected (channel=%s)", channel
+            )
+            return
+        frame = {
+            "type": "message",
+            "payload": {
+                "channel": channel,
+                "text": text,
+                "metadata": metadata or {},
+            },
+        }
+        await self._ws.send(json.dumps(frame))
+
+    async def subscribe(self, channel: str) -> None:
+        """Persist a channel subscription server-side. No-op in dry-run."""
+        if self.dry_run or self._ws is None:
+            return
+        frame = {
+            "type": "subscribe",
+            "payload": {"channel": channel},
+        }
+        await self._ws.send(json.dumps(frame))
+
+    # -- main loop ----------------------------------------------------
+
+    async def run(self) -> AsyncIterator[dict]:
+        """Yield hub→client frames as ``dict``s, reconnecting forever.
+
+        Never raises on normal disconnects; only exits when ``stop()``
+        has been called.
+        """
+        backoff = self.MIN_BACKOFF_S
+        while not self._stopping:
+            try:
+                async for frame in self._one_connection():
+                    yield frame
+                # Clean exit from _one_connection (EOF or close).
+                if self._stopping:
+                    break
+                log.info("WS closed cleanly; reconnecting after %.1fs", backoff)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001 — log + retry
+                log.warning(
+                    "WS connection error: %s: %s — retrying in %.1fs",
+                    type(e).__name__,
+                    e,
+                    backoff,
+                )
+            if self._stopping:
+                break
+            # Jittered backoff so a whole fleet coming up after an
+            # outage doesn't stampede the hub.
+            await asyncio.sleep(backoff + random.uniform(0, 0.5))
+            backoff = min(self.MAX_BACKOFF_S, backoff * 2)
+        log.info("WS run() loop exiting")
+
+    async def _one_connection(self) -> AsyncIterator[dict]:
+        """One connect → register → listen cycle."""
+        connect = self._ws_connect
+        if connect is None:
+            import websockets  # deferred import so tests can stub
+
+            connect = websockets.connect
+        self._ws = await connect(self.uri)
+        try:
+            # Register frame. The hub ignores ``payload["channels"]``
+            # (see hub/consumers/_agent_handlers.handle_register) and
+            # hydrates from ChannelMembership rows instead — but we
+            # include it for forward-compat + to match the other
+            # clients on the wire.
+            reg = {
+                "type": "register",
+                "payload": {
+                    "channels": list(self.channels),
+                    "machine": self.machine,
+                    "role": "worker",
+                    "model": "",
+                    "agent_id": self.agent_name,
+                    "project": self.project,
+                    "workdir": self.project,
+                },
+            }
+            await self._ws.send(json.dumps(reg))
+            # Listen loop.
+            async for raw in self._ws:
+                if self._stopping:
+                    return
+                try:
+                    data = json.loads(raw)
+                except (TypeError, ValueError):
+                    continue
+                if not isinstance(data, dict):
+                    continue
+                yield data
+        finally:
+            try:
+                await self._ws.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._ws = None

--- a/scripts/server/worker_progress_pkg/_config.py
+++ b/scripts/server/worker_progress_pkg/_config.py
@@ -1,0 +1,74 @@
+"""Environment + path resolution for the worker-progress daemon.
+
+Keep this module side-effect free: callers decide when to mkdir / open
+log files. The test suite imports these helpers directly.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from pathlib import Path
+
+# WSS endpoint. Matches the hub-canonical URL used by
+# scripts/client/check_connection.py (DEFAULT_WSS) and the bun MCP
+# sidecar. Override with SCITEX_OROCHI_URL_WS if you're pointing at a
+# dev hub — don't hard-code a fleet-wide override here.
+DEFAULT_WSS = "wss://scitex-orochi.com"
+
+
+def resolve_ws_url() -> str:
+    """Return the WS base URL (without path/query)."""
+    for key in ("SCITEX_OROCHI_URL_WS", "SCITEX_OROCHI_HUB_URL"):
+        v = os.environ.get(key)
+        if v:
+            return v.rstrip("/")
+    # Legacy HTTP-style env → upgrade to wss://
+    http = os.environ.get("SCITEX_OROCHI_URL_HTTP", "").rstrip("/")
+    if http.startswith("https://"):
+        return "wss://" + http[len("https://") :]
+    if http.startswith("http://"):
+        return "ws://" + http[len("http://") :]
+    return DEFAULT_WSS
+
+
+def resolve_token() -> str:
+    """Read the workspace token from env.
+
+    Matches the env names used by scripts/client/agent_meta.py and
+    fleet-watch/fleet_watch.sh. Both SCITEX_OROCHI_WORKSPACE_TOKEN and
+    SCITEX_OROCHI_TOKEN are accepted; SCITEX_OROCHI_TOKEN wins if both
+    are set (it is the historically canonical name).
+    """
+    for key in ("SCITEX_OROCHI_TOKEN", "SCITEX_OROCHI_WORKSPACE_TOKEN"):
+        v = os.environ.get(key, "").strip()
+        if v:
+            return v
+    return ""
+
+
+def default_log_path() -> Path:
+    """Return the default log path for this OS.
+
+    macOS: ``~/Library/Logs/scitex/worker-progress.log``
+    Linux: ``~/.local/state/scitex/worker-progress.log``
+
+    Windows / other: fall back to the Linux shape so the daemon at
+    least logs somewhere deterministic.
+    """
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    if platform.system() == "Darwin":
+        return home / "Library/Logs/scitex/worker-progress.log"
+    # Linux / BSD / fallback
+    state = os.environ.get("XDG_STATE_HOME", "").strip()
+    base = Path(state) if state else home / ".local/state"
+    return base / "scitex/worker-progress.log"
+
+
+def build_ws_uri(base_url: str, token: str, agent_name: str) -> str:
+    """Compose the full ws URL that ``hub/routing.py`` expects.
+
+    Trailing slash matters: routing is ``re_path(r"ws/agent/$", ...)``.
+    """
+    base = base_url.rstrip("/")
+    return f"{base}/ws/agent/?token={token}&agent={agent_name}"

--- a/scripts/server/worker_progress_pkg/_daemon.py
+++ b/scripts/server/worker_progress_pkg/_daemon.py
@@ -1,0 +1,192 @@
+"""Top-level daemon glue for worker-progress (todo#272).
+
+Wires the ``_client.HubWSClient`` loop into the ``_digest.DigestCoalescer``
+and the ``_digest.MentionPolicy`` bypass path. Owns signal handling
+and the ~1 s tick that drains the coalescer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import time
+from typing import Optional
+
+from . import AGENT_NAME, DIGEST_CHANNEL, SUBSCRIBE_CHANNELS
+from ._client import HubWSClient
+from ._config import build_ws_uri, resolve_token, resolve_ws_url
+from ._digest import DigestCoalescer, InboundEvent, MentionPolicy
+
+log = logging.getLogger("worker-progress.daemon")
+
+# How often the tick loop wakes up to maybe flush a digest. Small
+# relative to the 60 s window so we emit close to the boundary.
+TICK_INTERVAL_S = 1.0
+
+
+def _as_inbound(frame: dict) -> Optional[InboundEvent]:
+    """Project a raw hub frame into an ``InboundEvent``.
+
+    Returns ``None`` for frames that aren't user messages (acks,
+    presence, info, pong, etc.).
+    """
+    if frame.get("type") != "message":
+        return None
+    channel = str(frame.get("channel") or "")
+    sender = str(frame.get("sender") or "")
+    text = str(frame.get("text") or "")
+    # Drop our own echoed posts so we never digest ourselves.
+    if sender == AGENT_NAME or sender == f"agent-{AGENT_NAME}":
+        return None
+    is_dm = channel.startswith("dm:")
+    ev = InboundEvent(
+        channel=channel,
+        sender=sender,
+        text=text,
+        ts=time.time(),
+        is_dm=is_dm,
+    )
+    ev.mentions_self = MentionPolicy.is_mention(ev)
+    return ev
+
+
+async def _tick_loop(
+    client: HubWSClient,
+    coalescer: DigestCoalescer,
+    stop_event: asyncio.Event,
+    once: bool = False,
+) -> None:
+    """Wake every ``TICK_INTERVAL_S`` and flush the coalescer.
+
+    With ``once=True``, runs one flush (honouring the window) then
+    exits — used by the ``--once`` smoke-test flag.
+    """
+    while not stop_event.is_set():
+        try:
+            line = coalescer.flush()
+            if line:
+                await client.send_message(DIGEST_CHANNEL, line)
+                log.info("digest emitted: %s", line)
+        except Exception:  # noqa: BLE001 — log + continue
+            log.exception("digest flush failed")
+        if once:
+            return
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=TICK_INTERVAL_S)
+        except asyncio.TimeoutError:
+            pass
+
+
+async def _ingest_loop(
+    client: HubWSClient,
+    coalescer: DigestCoalescer,
+    stop_event: asyncio.Event,
+) -> None:
+    """Consume hub frames, route mentions, push the rest into the coalescer."""
+    async for frame in client.run():
+        if stop_event.is_set():
+            break
+        ev = _as_inbound(frame)
+        if ev is None:
+            continue
+        if ev.mentions_self:
+            # Bypass the throttle — ack immediately.
+            reply_channel = ev.channel or DIGEST_CHANNEL
+            try:
+                await client.send_message(reply_channel, MentionPolicy.ack_line(ev))
+                log.info(
+                    "mention ack posted to %s (from %s)", reply_channel, ev.sender
+                )
+            except Exception:  # noqa: BLE001
+                log.exception("mention ack send failed")
+            # Also record in the coalescer so the digest still counts it.
+        coalescer.push(ev)
+
+
+async def run(
+    dry_run: bool = False,
+    once: bool = False,
+    url: str = "",
+    token: str = "",
+) -> int:
+    """Start the daemon. Returns process exit code."""
+    ws_base = url or resolve_ws_url()
+    tok = token or resolve_token()
+    if not tok and not dry_run:
+        log.error(
+            "no SCITEX_OROCHI_TOKEN / SCITEX_OROCHI_WORKSPACE_TOKEN in env; "
+            "refusing to connect. Set the env var (see scripts/client/install/"
+            "bootstrap-host.sh for the .env file shape) or pass --dry-run."
+        )
+        return 2
+    uri = build_ws_uri(ws_base, tok, AGENT_NAME)
+    log.info(
+        "worker-progress starting (dry_run=%s once=%s ws=%s)",
+        dry_run,
+        once,
+        ws_base,
+    )
+
+    client = HubWSClient(
+        uri=uri,
+        agent_name=AGENT_NAME,
+        channels=SUBSCRIBE_CHANNELS,
+        machine="",
+        project="scitex-orochi",
+        dry_run=dry_run,
+    )
+    coalescer = DigestCoalescer(now=time.monotonic)
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _handle_signal() -> None:
+        log.info("signal received, stopping…")
+        stop_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, _handle_signal)
+        except (NotImplementedError, RuntimeError):
+            # Windows / restricted environments — fall back to
+            # default handler and rely on KeyboardInterrupt.
+            pass
+
+    tick_task = asyncio.create_task(
+        _tick_loop(client, coalescer, stop_event, once=once)
+    )
+
+    if dry_run or once:
+        # Dry-run / once modes skip the real WS hookup; just emit the
+        # tick cycle (at most once) and exit. This is what the install
+        # smoke-test flag exercises.
+        try:
+            await tick_task
+        finally:
+            await client.stop()
+        return 0
+
+    ingest_task = asyncio.create_task(_ingest_loop(client, coalescer, stop_event))
+
+    try:
+        await stop_event.wait()
+    finally:
+        # Flush any pending digest before we tear down.
+        try:
+            final = coalescer.flush()
+            if final:
+                await client.send_message(DIGEST_CHANNEL, final)
+                log.info("final digest emitted on shutdown: %s", final)
+        except Exception:  # noqa: BLE001
+            log.exception("final flush failed")
+        await client.stop()
+        ingest_task.cancel()
+        tick_task.cancel()
+        for t in (ingest_task, tick_task):
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):
+                pass
+    log.info("worker-progress exited cleanly")
+    return 0

--- a/scripts/server/worker_progress_pkg/_digest.py
+++ b/scripts/server/worker_progress_pkg/_digest.py
@@ -1,0 +1,222 @@
+"""60-second throttled digest coalescer (pure, testable).
+
+No I/O. No asyncio. Callers push inbound events via
+:meth:`DigestCoalescer.push`, then periodically drain a digest line
+via :meth:`DigestCoalescer.flush`. The daemon ticks every ~1 s; flush
+returns ``None`` until the 60 s throttle window has elapsed AND at
+least one event was observed.
+
+Event signature = ``(channel, sender, leading-prefix-of-text)``. Bursts
+of identical signatures collapse into ``{N}x <summary>`` so 40
+consecutive "CI started" webhook posts render as one line instead of
+40.
+
+Mention / DM handling lives in :class:`MentionPolicy` and is
+deliberately distinct from the throttle: mentions bypass the window
+and return an immediate ack string.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+from . import AGENT_NAME
+
+# Digest window; matches the lead directive in #heads msg#15399.
+DEFAULT_WINDOW_S = 60.0
+
+# Max chars in an emitted digest line. Kept under 200 per the spec.
+MAX_LINE_CHARS = 200
+
+# How many chars of the event text we use as the dedup-prefix / summary.
+# Short enough that "CI started: foo/bar #123" and "CI started: foo/baz
+# #124" collapse to the same bucket; long enough to stay human-readable.
+SIG_PREFIX_CHARS = 48
+
+# Number of distinct signatures we surface per digest line. The rest
+# are rolled into " ...+M more".
+TOP_N_HIGHLIGHTS = 3
+
+
+@dataclass
+class InboundEvent:
+    """A minimal view of an inbound WS message — just what the
+    coalescer needs. Full frames stay in the daemon layer."""
+
+    channel: str
+    sender: str
+    text: str
+    ts: float  # unix seconds
+    is_dm: bool = False
+    mentions_self: bool = False
+
+
+@dataclass
+class _Bucket:
+    """Per-signature accumulator inside a single window."""
+
+    signature: str
+    count: int = 0
+    last_text: str = ""
+    last_channel: str = ""
+    last_sender: str = ""
+
+
+@dataclass
+class DigestCoalescer:
+    """Time-windowed event coalescer with signature-based dedup.
+
+    The coalescer carries a ``now()`` callable so tests can inject a
+    deterministic clock. In production this is ``time.monotonic``.
+    """
+
+    window_s: float = DEFAULT_WINDOW_S
+    now: Callable[[], float] = field(default=lambda: 0.0)
+    _window_start: float = field(default=0.0, init=False)
+    _buckets: "OrderedDict[str, _Bucket]" = field(
+        default_factory=OrderedDict, init=False
+    )
+    _total: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        self._window_start = self.now()
+
+    # -- inbound -------------------------------------------------------
+
+    def push(self, ev: InboundEvent) -> None:
+        """Record an inbound event. Mentions are NOT added here — the
+        daemon routes those through :class:`MentionPolicy` before the
+        throttle layer."""
+        sig = _signature(ev)
+        bucket = self._buckets.get(sig)
+        if bucket is None:
+            bucket = _Bucket(signature=sig)
+            self._buckets[sig] = bucket
+        bucket.count += 1
+        bucket.last_text = ev.text
+        bucket.last_channel = ev.channel
+        bucket.last_sender = ev.sender
+        self._total += 1
+
+    # -- tick ----------------------------------------------------------
+
+    def flush(self) -> Optional[str]:
+        """Return a digest line if the window has closed AND had
+        events, else ``None``. Always resets the window when it closes
+        (even with zero events) so the next window starts fresh."""
+        if self.now() - self._window_start < self.window_s:
+            return None
+        line = self._render() if self._total > 0 else None
+        self._reset()
+        return line
+
+    # -- rendering -----------------------------------------------------
+
+    def _render(self) -> str:
+        ts_tag = _hhmm(self._window_start + self.window_s)
+        total = self._total
+        # Sort buckets by count desc, then insertion order (stable
+        # since OrderedDict) so ties preserve arrival order.
+        ranked = sorted(
+            self._buckets.values(),
+            key=lambda b: (-b.count, list(self._buckets.keys()).index(b.signature)),
+        )
+        top = ranked[:TOP_N_HIGHLIGHTS]
+        rest = ranked[TOP_N_HIGHLIGHTS:]
+        highlights = []
+        for b in top:
+            summary = _summarize(b)
+            if b.count > 1:
+                summary = f"{b.count}x {summary}"
+            highlights.append(summary)
+        extra = sum(b.count for b in rest)
+        line = f"[progress {ts_tag}] {total} events: " + " | ".join(highlights)
+        if extra > 0:
+            line += f" ...+{extra} more"
+        if len(line) > MAX_LINE_CHARS:
+            line = line[: MAX_LINE_CHARS - 1] + "..."
+        return line
+
+    def _reset(self) -> None:
+        self._window_start = self.now()
+        self._buckets.clear()
+        self._total = 0
+
+
+# -- helpers ---------------------------------------------------------------
+
+
+def _signature(ev: InboundEvent) -> str:
+    """Dedup key — (channel, sender, leading text prefix)."""
+    prefix = (ev.text or "").strip()[:SIG_PREFIX_CHARS]
+    return f"{ev.channel}|{ev.sender}|{prefix}"
+
+
+def _summarize(b: _Bucket) -> str:
+    """Short inline summary used inside a digest highlight."""
+    text = (b.last_text or "").strip().replace("\n", " ")
+    if len(text) > SIG_PREFIX_CHARS:
+        text = text[: SIG_PREFIX_CHARS - 1] + "..."
+    return f"{b.last_channel} {b.last_sender}: {text}"
+
+
+def _hhmm(ts: float) -> str:
+    """Format a UTC-ish HH:MM tag for the digest prefix.
+
+    We use ``time.strftime`` on the local clock; the ``[progress ts]``
+    tag is decorative, not an audit field, so absolute timezone does
+    not matter. The test suite passes a fake monotonic clock so we
+    fall back to a stable placeholder in that case.
+    """
+    import time
+
+    try:
+        return time.strftime("%H:%M", time.localtime(ts))
+    except (ValueError, OSError, OverflowError):
+        return "--:--"
+
+
+# -- mention / DM bypass ---------------------------------------------------
+
+
+class MentionPolicy:
+    """Decides whether an inbound event is a mention or DM that should
+    bypass the throttle and trigger an immediate ack.
+
+    v1 scope: single-line polite ack. The full claude-code spawn is
+    tracked under todo#272 and explicitly out of scope here.
+    """
+
+    #: Mention tokens that trigger bypass. Kept deliberately broad —
+    #: exact-match variants plus the ``@<name>`` form.
+    MENTION_TOKENS = (
+        f"@{AGENT_NAME}",
+        f"@agent-{AGENT_NAME}",
+    )
+
+    @classmethod
+    def is_mention(cls, ev: InboundEvent) -> bool:
+        if ev.is_dm:
+            return True
+        text = (ev.text or "").lower()
+        for tok in cls.MENTION_TOKENS:
+            if tok.lower() in text:
+                return True
+        return False
+
+    @classmethod
+    def ack_line(cls, ev: InboundEvent) -> str:
+        """Render the single-line ack. The daemon posts this to the
+        channel the event came from (if group) or back into the DM.
+        """
+        who = ev.sender or "there"
+        if ev.is_dm:
+            return (
+                f"ack @{who}: received, queued for richer reply. Full handoff "
+                "to claude-code is tracked under todo#272."
+            )
+        return (
+            f"ack @{who}: received mention, queued for richer reply (todo#272)."
+        )


### PR DESCRIPTION
## Summary

Implements the `worker-progress` headless Python daemon per lead dispatch (`#heads` msg#15399 → ywatanabe `#ywatanabe` msg#15395) for **todo#272**.

This is a plain long-running Python daemon — **NOT** a Claude process, **NOT** an `sac`-managed agent, and **NOT** a `.claude/agents/*` definition. It opens an Orochi WebSocket as `worker-progress`, subscribes (via server-authoritative `ChannelMembership` rows) to `#progress`, `#heads`, and `#ywatanabe`, and:

- **Passive digest mode (default)**: coalesces inbound events with a **60 s throttle** and, on each tick, emits ONE short summary line to `#ywatanabe`. Zero events → silent (no heartbeat post).
- **Mention / DM escalate**: `@worker-progress` mention or DM bypasses the throttle and posts a single-line polite-ack. The full `claude-code` spawn is **out of scope for v1** and remains tracked under todo#272.
- **Dedup**: bursts of identical event signatures collapse into `Nx <summary>`. Top-3 highlights + `...+M more` roll-up. Line cap 200 chars.

## Files added / modified

**Daemon** (`scripts/server/worker_progress_pkg/` — option (A) per task brief, no sibling worker pkg exists in `src/`)

- `scripts/server/worker-progress.py` — thin entry-point shim
- `scripts/server/worker_progress_pkg/__init__.py` — constants + agent name
- `scripts/server/worker_progress_pkg/__main__.py` — `python -m` entry
- `scripts/server/worker_progress_pkg/_cli.py` — argparse + logging
- `scripts/server/worker_progress_pkg/_config.py` — env + path resolution
- `scripts/server/worker_progress_pkg/_client.py` — WS + reconnect loop (exp backoff cap 60 s)
- `scripts/server/worker_progress_pkg/_daemon.py` — tick + ingest glue
- `scripts/server/worker_progress_pkg/_digest.py` — pure coalescer + mention policy

**Seed management command**
- `hub/management/commands/seed_worker_progress.py` — idempotent; creates `agent-worker-progress` synthetic user + RW ChannelMembership rows; skips abolished `#agent`.

**Install helper + scheduling** (mirrors `install-fleet-host-liveness-probe.sh` + fixes PR #296's REPO_ROOT bug via PR #297's two-level climb pattern)
- `scripts/client/install-worker-progress.sh` — idempotent, `--dry-run`, `--uninstall`
- `deployment/host-setup/launchd/com.scitex.worker-progress.plist` — `KeepAlive=true`, no `StartInterval`
- `deployment/host-setup/systemd/scitex-worker-progress.service` — `Type=simple`, `Restart=always`
- `deployment/host-setup/launchd/README.md` (updated)
- `deployment/host-setup/systemd/README.md` (new)

**Tests**
- `hub/tests/test_worker_progress_digest.py` — 11 cases: window, dedup, top-N, line cap, mention bypass, DM path.
- `hub/tests/test_worker_progress_client.py` — 3 cases: register shape, dry-run guard, message frame shape. Stubbed WS (no real network).
- `hub/tests/test_worker_progress_seed.py` — 5 cases: creation, idempotency, #agent skip, RO→RW upgrade, missing workspace.

## Out of scope (explicit)

- **Full `claude-code` spawn on mention** — v1 is a single-line polite ack only. Tracked under todo#272.
- **`orochi-machines.yaml` entry** — this daemon is not an sac-managed agent; yaml stays untouched per task directive.

## Judgment calls

- **Option (A) vs (B)**: chose (A) (`scripts/server/worker-progress.py` + sibling pkg) because no sibling worker-* module exists under `src/scitex_orochi/`. The daemon stays independent of the Django/Channels import chain — only needs `websockets`.
- **No reuse of `src/scitex_orochi/_client.OrochiClient`** — that module transitively pulls in `_config`, `_models`, and eventually Django. A 191-line hand-rolled WS wrapper keeps the daemon's dependency surface minimal.
- **Register frame still sends `channels`** — even though the hub ignores it (per PR #251), the frame shape matches every other client on the wire so forward-compat stays intact.

## Test plan

- [ ] CI runs the full `hub.tests` suite (digest + client + seed) — mba `.venv` is a broken Linux symlink so we can't run Django tests locally.
- [ ] Merge → head-mba runs `python manage.py seed_worker_progress --workspace <ws>` on the hub.
- [ ] Head-mba runs `./scripts/client/install-worker-progress.sh --dry-run` first for smoke-test visibility, then `--uninstall && install` for live mode.
- [ ] Watch `~/Library/Logs/scitex/worker-progress.log` for one digest line within 60 s of the next #progress event.
- [ ] DM `worker-progress` from ywatanabe; confirm polite-ack lands within a few seconds (throttle bypass).

Local verification:
- `ast.parse` clean on all 12 new Python files
- Digest suite: 11/11 pass under stock Python
- WS client stub suite: 3/3 pass
- `plutil -lint` on the plist: OK
- `bash -n` on install-worker-progress.sh: OK
- `python3 scripts/server/worker-progress.py --dry-run --once` exits cleanly with the expected log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
