### PR TITLE
feat(worker-progress): sac agent for throttled progress digest (todo#272)

### DIFF
--- a/hub/management/commands/seed_worker_progress.py
+++ b/hub/management/commands/seed_worker_progress.py
@@ -1,0 +1,176 @@
+"""Seed the synthetic ``agent-worker-progress`` user + ChannelMemberships.
+
+Implements the data-plane side of todo#272 (sac-managed Claude agent
+re-spec, `#heads` msg#15416 — replaces closed PR #300 which shipped a
+Python daemon). Idempotent: running multiple times is a no-op.
+
+The synthetic ``agent-worker-progress`` user is granted ``read-write``
+``ChannelMembership`` on:
+
+  - ``#progress``
+  - ``#heads``
+  - ``#ywatanabe``
+  - every ``#proj-*`` channel that exists in the DB **at seed time**
+
+The ``#proj-*`` set is enumerated at runtime (not hardcoded) so new
+project channels are picked up without code changes — just re-run the
+seed after creating a new ``#proj-foo``.
+
+``#agent`` was abolished 2026-04-21 (PR #293 follow-up) and the
+server-side blocklist in ``ABOLISHED_AGENT_CHANNELS`` rejects it; we
+never subscribe to it here either.
+
+Usage:
+    python manage.py seed_worker_progress [--workspace <name>]
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from hub.consumers._helpers import ABOLISHED_AGENT_CHANNELS
+from hub.models import Channel, ChannelMembership, Workspace, WorkspaceMember
+
+User = get_user_model()
+
+AGENT_NAME = "worker-progress"
+AGENT_USERNAME = f"agent-{AGENT_NAME}"
+
+# Base channels are always seeded (created if missing).
+BASE_CHANNELS = ("#progress", "#heads", "#ywatanabe")
+
+# Prefix for per-project channels. All existing channels whose name
+# starts with this prefix are added to the worker's membership set.
+PROJ_CHANNEL_PREFIX = "#proj-"
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed agent-worker-progress synthetic user + read-write "
+        "memberships for #progress, #heads, #ywatanabe, and all "
+        "#proj-* channels that currently exist in the workspace "
+        "(todo#272). Idempotent."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--workspace",
+            default="default",
+            help="Workspace slug to seed into (default: default)",
+        )
+
+    def handle(self, *args, **options):
+        ws_name = options["workspace"]
+        try:
+            workspace = Workspace.objects.get(name=ws_name)
+        except Workspace.DoesNotExist as exc:
+            raise CommandError(f"Workspace '{ws_name}' does not exist") from exc
+
+        user, user_created = User.objects.get_or_create(
+            username=AGENT_USERNAME,
+            defaults={
+                "email": f"{AGENT_USERNAME}@agents.orochi.local",
+                "is_active": True,
+                "is_staff": False,
+            },
+        )
+        if user_created:
+            self.stdout.write(self.style.SUCCESS(f"created user: {AGENT_USERNAME}"))
+        else:
+            self.stdout.write(f"user exists: {AGENT_USERNAME}")
+
+        _, member_created = WorkspaceMember.objects.get_or_create(
+            workspace=workspace,
+            user=user,
+            defaults={"role": "member"},
+        )
+        if member_created:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"added {AGENT_USERNAME} to workspace '{ws_name}'"
+                )
+            )
+        else:
+            self.stdout.write(
+                f"{AGENT_USERNAME} already in workspace '{ws_name}'"
+            )
+
+        channels = self._collect_channels(workspace)
+
+        created, existed, skipped = 0, 0, 0
+        for name in channels:
+            if name in ABOLISHED_AGENT_CHANNELS:
+                self.stdout.write(
+                    self.style.WARNING(f"skipping abolished channel: {name}")
+                )
+                skipped += 1
+                continue
+
+            # Base channels are created if missing; project channels
+            # are only enumerated if they already exist, so they will
+            # always resolve to an existing row.
+            channel, _ = Channel.objects.get_or_create(
+                workspace=workspace,
+                name=name,
+                defaults={"kind": Channel.KIND_GROUP},
+            )
+            membership, was_created = ChannelMembership.objects.get_or_create(
+                user=user,
+                channel=channel,
+                defaults={"permission": ChannelMembership.PERM_READ_WRITE},
+            )
+            if was_created:
+                created += 1
+                self.stdout.write(
+                    self.style.SUCCESS(f"  + membership: {name} (read-write)")
+                )
+            else:
+                existed += 1
+                if membership.permission != ChannelMembership.PERM_READ_WRITE:
+                    membership.permission = ChannelMembership.PERM_READ_WRITE
+                    membership.save(update_fields=["permission"])
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  ~ upgraded to read-write: {name}"
+                        )
+                    )
+                else:
+                    self.stdout.write(f"  = membership exists: {name}")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"done: {created} created, {existed} existed, {skipped} skipped."
+            )
+        )
+
+    def _collect_channels(self, workspace: Workspace) -> list[str]:
+        """Return the ordered channel-name set to seed.
+
+        Base channels first (so they always land, even in a pristine
+        DB), then every ``#proj-*`` channel that already exists in
+        the workspace. De-duplicated while preserving order.
+        """
+        seen: set[str] = set()
+        ordered: list[str] = []
+
+        for name in BASE_CHANNELS:
+            if name not in seen:
+                seen.add(name)
+                ordered.append(name)
+
+        proj_names = (
+            Channel.objects.filter(
+                workspace=workspace,
+                kind=Channel.KIND_GROUP,
+                name__startswith=PROJ_CHANNEL_PREFIX,
+            )
+            .order_by("name")
+            .values_list("name", flat=True)
+        )
+        for name in proj_names:
+            if name not in seen:
+                seen.add(name)
+                ordered.append(name)
+
+        return ordered

--- a/hub/tests/test_worker_progress_seed.py
+++ b/hub/tests/test_worker_progress_seed.py
@@ -1,0 +1,157 @@
+"""Tests for ``manage.py seed_worker_progress`` (todo#272).
+
+Covers:
+  - Creates the synthetic ``agent-worker-progress`` user + workspace
+    member + read-write ChannelMembership rows for the three base
+    channels (#progress, #heads, #ywatanabe).
+  - Dynamically enumerates ``#proj-*`` channels that exist in the
+    workspace at seed time (no hardcoded list).
+  - New ``#proj-*`` channels added after a seed run are picked up on
+    the next run (forward-compatibility).
+  - Idempotent: a second run creates no extra rows.
+  - ``#agent`` is never subscribed (server-side blocklist protection).
+  - ``read-only`` memberships are promoted to ``read-write``.
+  - Missing workspace raises ``CommandError``.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from hub.models import Channel, ChannelMembership, Workspace, WorkspaceMember
+
+User = get_user_model()
+
+
+class SeedWorkerProgressTest(TestCase):
+    def setUp(self) -> None:
+        self.ws = Workspace.objects.create(name="default")
+
+    def _run(self, *args, **opts) -> str:
+        out = StringIO()
+        call_command("seed_worker_progress", *args, stdout=out, **opts)
+        return out.getvalue()
+
+    def _agent_user(self):
+        return User.objects.get(username="agent-worker-progress")
+
+    # --- base channels ---------------------------------------------------
+
+    def test_creates_user_member_and_base_memberships(self):
+        output = self._run("--workspace", "default")
+        self.assertIn("created user", output)
+        user = self._agent_user()
+        self.assertTrue(
+            WorkspaceMember.objects.filter(user=user, workspace=self.ws).exists()
+        )
+        for name in ("#progress", "#heads", "#ywatanabe"):
+            ch = Channel.objects.get(workspace=self.ws, name=name)
+            m = ChannelMembership.objects.get(user=user, channel=ch)
+            self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
+
+    # --- dynamic #proj-* enumeration -------------------------------------
+
+    def test_enumerates_existing_proj_channels(self):
+        # Pre-existing project channels in the DB at seed time.
+        Channel.objects.create(workspace=self.ws, name="#proj-alpha")
+        Channel.objects.create(workspace=self.ws, name="#proj-beta")
+        # A lookalike that MUST NOT match the #proj- prefix.
+        Channel.objects.create(workspace=self.ws, name="#project-other")
+
+        self._run("--workspace", "default")
+        user = self._agent_user()
+
+        # #proj-* subscribed.
+        for name in ("#proj-alpha", "#proj-beta"):
+            ch = Channel.objects.get(workspace=self.ws, name=name)
+            m = ChannelMembership.objects.get(user=user, channel=ch)
+            self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
+
+        # Non-matching lookalike must NOT be subscribed.
+        other = Channel.objects.get(workspace=self.ws, name="#project-other")
+        self.assertFalse(
+            ChannelMembership.objects.filter(user=user, channel=other).exists()
+        )
+
+    def test_does_not_create_proj_channels_it_does_not_see(self):
+        # Fresh DB: no #proj-* rows. Seeding must NOT invent any.
+        self._run("--workspace", "default")
+        self.assertFalse(
+            Channel.objects.filter(
+                workspace=self.ws, name__startswith="#proj-"
+            ).exists()
+        )
+
+    def test_picks_up_new_proj_channel_on_rerun(self):
+        # First run, nothing project-related.
+        self._run("--workspace", "default")
+        user = self._agent_user()
+        self.assertFalse(
+            ChannelMembership.objects.filter(
+                user=user, channel__name__startswith="#proj-"
+            ).exists()
+        )
+
+        # Someone creates a new project channel after first seed.
+        new_ch = Channel.objects.create(workspace=self.ws, name="#proj-gamma")
+
+        # Second run should pick it up.
+        self._run("--workspace", "default")
+        self.assertTrue(
+            ChannelMembership.objects.filter(user=user, channel=new_ch).exists()
+        )
+
+    # --- idempotency -----------------------------------------------------
+
+    def test_idempotent_no_duplicates(self):
+        Channel.objects.create(workspace=self.ws, name="#proj-alpha")
+
+        self._run("--workspace", "default")
+        before_users = User.objects.count()
+        before_members = ChannelMembership.objects.count()
+        before_channels = Channel.objects.count()
+
+        output = self._run("--workspace", "default")
+        self.assertIn("user exists", output)
+        self.assertEqual(User.objects.count(), before_users)
+        self.assertEqual(ChannelMembership.objects.count(), before_members)
+        self.assertEqual(Channel.objects.count(), before_channels)
+
+    # --- abolished #agent ------------------------------------------------
+
+    def test_abolished_agent_channel_never_subscribed(self):
+        # Even if a stray '#agent' Channel row exists (pre-abolition),
+        # the seed command must not create a ChannelMembership for it.
+        Channel.objects.create(workspace=self.ws, name="#agent")
+        self._run("--workspace", "default")
+        user = self._agent_user()
+        agent_ch = Channel.objects.get(workspace=self.ws, name="#agent")
+        self.assertFalse(
+            ChannelMembership.objects.filter(
+                user=user, channel=agent_ch
+            ).exists()
+        )
+
+    # --- read-only → read-write promotion --------------------------------
+
+    def test_upgrades_read_only_to_read_write(self):
+        user, _ = User.objects.get_or_create(username="agent-worker-progress")
+        WorkspaceMember.objects.create(user=user, workspace=self.ws)
+        ch = Channel.objects.create(workspace=self.ws, name="#progress")
+        ChannelMembership.objects.create(
+            user=user, channel=ch, permission=ChannelMembership.PERM_READ_ONLY
+        )
+        output = self._run("--workspace", "default")
+        self.assertIn("upgraded to read-write", output)
+        refreshed = ChannelMembership.objects.get(user=user, channel=ch)
+        self.assertEqual(refreshed.permission, ChannelMembership.PERM_READ_WRITE)
+
+    # --- error handling --------------------------------------------------
+
+    def test_missing_workspace_raises(self):
+        with self.assertRaises(CommandError):
+            self._run("--workspace", "does-not-exist")


### PR DESCRIPTION
## Summary

Replaces closed PR #300 (headless Python daemon attempt) per lead
re-spec in `#heads` msg#15416 — authoritative after three flip-flops.
`worker-progress` is now a **standard sac-managed Claude agent**
(tmux + `claude-code`, `model=sonnet` — NOT `sonnet[1m]`, NOT `opus`),
host-restricted to `mba`.

This PR is hub-side only. The agent YAML / README / `src_CLAUDE.md`
live in the dotfiles tree (canonical source:
`~/.dotfiles/src/.scitex/orochi/shared/agents/worker-progress/`).

- **Dotfiles companion commit**: `b1121e9873a7ccb7453161bb0d99290b1ed19138`
  (committed locally; SSH push from mba was blocked by key policy,
  surfaced in the implementing agent's report so ywatanabe can push
  the dotfiles side manually when convenient).

## Files added

### Seed management command

- `hub/management/commands/seed_worker_progress.py` — idempotent.
  Creates the synthetic `agent-worker-progress` user, adds it to the
  workspace, and sets `read-write` `ChannelMembership` rows for:
  - `#progress`, `#heads`, `#ywatanabe` (base set — created if missing)
  - **every `#proj-*` channel that currently exists in the DB** —
    enumerated at runtime (not hardcoded) so new project channels
    are picked up by re-running the command
  - `#agent` is never subscribed (abolished 2026-04-21, PR #293
    server-side blocklist).

Read-only memberships are promoted to read-write. Missing workspace
raises `CommandError`.

### Test

- `hub/tests/test_worker_progress_seed.py` — 8 cases:
  - base-channel creation + RW permission
  - dynamic `#proj-*` enumeration
  - lookalike-prefix guard (`#project-other` must NOT match)
  - seed does NOT invent `#proj-*` channels the DB doesn't already have
  - forward-compat (new `#proj-*` created after first seed is picked
    up on second run)
  - idempotency (no duplicate users / members / channels / memberships)
  - abolished `#agent` never gets a `ChannelMembership`, even if a
    stray `Channel` row exists
  - read-only → read-write promotion
  - missing-workspace `CommandError`

## No sac registry edit

`sac` discovers agents by YAML file under each agent directory (see
`scitex_agent_container/cli_pkg/lifecycle_cmds._iter_agent_yamls`);
dotfiles ↔ `~/.scitex/orochi/shared/agents/` symlink is the single
source. No central registry, no entry-append needed.

`orochi-machines.yaml` is a `FleetMachineInventory` (per-host
hardware / tunnel / tmux inventory), **not** an agent registry; its
drift (tracked under #298) is explicitly out of scope for this PR.

## Out of scope (explicit)

- Live `sac start worker-progress` smoke-test — per task directive,
  head-mba runs this after merge, not the implementing PR.
- Reviving any of PR #300's Python-daemon machinery (daemon package,
  install script, launchd / systemd units, WS client tests). None
  of it is carried forward; only the `seed_worker_progress`
  management command survives (re-worked for dynamic `#proj-*`
  enumeration and simpler CLI surface).

## Local verification

- `python3 -c "import ast; ..."` — both new Python files parse clean.
- `python manage.py test hub.tests.test_worker_progress_seed -v 2` —
  8/8 pass under the `.venv` on mba (Django 5.2.13).

## Test plan

- [ ] CI runs the full `hub.tests` suite (includes the 8 new cases).
- [ ] Merge → head-mba runs
      `python manage.py seed_worker_progress --workspace <ws>` on
      the hub.
- [ ] Head-mba cherry-picks / pushes the dotfiles companion commit
      so the agent directory lands on every host.
- [ ] Head-mba runs `sac start worker-progress` on `mba`; watches
      for the first coalesced digest within 5 minutes of the next
      `#progress` event.
- [ ] DM `@worker-progress` from ywatanabe; confirm the dialog reply
      lands in the DM (NOT `#ywatanabe`) within a few seconds.

## References

- `#heads` msg#15416 — final spec (sonnet, not 1M, not opus; sac-managed
  Claude agent; 60 s throttle; 6–10-line digest to `#ywatanabe`).
- PR #300 — closed; replaced by this PR.
- todo#272 — parent task.

Generated with Claude Code.
