### PR TITLE
fix(orochi-machines.yaml): scrub deprecated mamba-* agent names from expected_agents (#298)

### DIFF
--- a/orochi-machines.yaml
+++ b/orochi-machines.yaml
@@ -1,9 +1,10 @@
 # Orochi Fleet Machine Inventory (todo#283 / Task #2)
 #
 # Source-of-truth manifest for the four fleet hosts. Producer/consumer roles:
-#   - Producers (per-host healers, fleet_watch.sh) read this to know what
-#     they're supposed to see (expected sessions, expected resources).
-#   - Consumers (mamba-healer-*, MCP `connectivity_matrix`, future hub UI
+#   - Producers (per-host healers, fleet_watch.sh, host-liveness-probe.sh)
+#     read this to know what they're supposed to see (expected sessions,
+#     expected resources).
+#   - Consumers (healer-<host>, MCP `connectivity_matrix`, future hub UI
 #     Machines tab) read this to render labels and to flag drift.
 #
 # This file is intentionally human-curated, not auto-generated. The drifted
@@ -64,22 +65,37 @@ machines:
       hostname: bastion-mba.scitex-orochi.com
       cloudflared_running: true
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all)
       - head-mba
-      - mamba-auth-manager-mba
-      - mamba-explorer-mba
-      - mamba-healer-mba
-      - mamba-quality-checker-mba
-      - mamba-skill-manager
-      - mamba-synchronizer-mba
-      - mamba-todo-manager
-      - mamba-verifier-mba
+      - healer-mba
+      # Fleet-wide singletons currently pinned on mba (host: priority chain,
+      # first-available wins; mba is primary for all six mgr-* + expert-* +
+      # lead + proj-* today — see #298).
+      - expert-scitex
+      - lead
+      - mgr-auth
+      - mgr-code-quality
+      - mgr-memory
+      - mgr-pkg
+      - mgr-secretary
+      - mgr-todo
+      - proj-neurovista
+      - proj-ripple-wm
+      - proj-scitex-clew
+      - proj-scitex-cloud
+      - proj-scitex-orochi
+      # Host-pinned + per-host workers on mba
+      - worker-iOS-simulator   # host: [mba] — only Mac in fleet has Xcode
+      - worker-playwright-mba  # hosts: all
+      - worker-progress        # host: [mba] — #301
+      - worker-todo-mirror     # singleton; lives on mba today
     process_caps:
       ulimit_u: 4000         # macOS hard cap (msg#8043 confirmed); raise via launchctl limit maxproc
       pid_max: ~             # macOS uses kern.maxproc, not /proc/sys/kernel/pid_max
     notes:
       - "Hub origin: scitex-orochi.com Cloudflare tunnel terminates here."
       - "Fork pressure observed at 18.5% (739/4000) during today's session — well under cap but cap is hard."
-      - "All 9 head + mamba sessions auto-start via launchd plist staged in ~/.dotfiles/src/launchd/."
+      - "All head + mgr-*/proj-*/worker-* sessions auto-start via launchd plist staged in ~/.dotfiles/src/launchd/."
 
   # ---------------------------------------------------------------------------
   - canonical_name: nas
@@ -123,8 +139,11 @@ machines:
       hostname: bastion-nas.scitex-orochi.com
       cloudflared_running: true
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all)
       - head-nas
-      - mamba-healer-nas
+      - healer-nas
+      # Per-host worker (hosts: all)
+      - worker-playwright-nas
     process_caps:
       ulimit_u: ~              # ulimit -u inherited from systemd, no hard cap observed
       pid_max: 4194304         # /proc/sys/kernel/pid_max
@@ -175,7 +194,11 @@ machines:
       hostname: bastion-spartan.scitex-orochi.com
       cloudflared_running: false   # tier-2, requires HPC admin policy verification
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all). Minimal roster on spartan
+      # today — login node has cgroup CPU=1 cap so heavy agents dispatch via
+      # salloc/srun rather than running on login1 directly.
       - head-spartan
+      - healer-spartan
     process_caps:
       ulimit_u: ~              # cgroup 1 CPU on login1 per HPC policy
       pid_max: 303104          # observed at session start (Linux default class)
@@ -224,8 +247,12 @@ machines:
       hostname: bastion-ywata-note-win.scitex-orochi.com
       cloudflared_running: false   # tier-3, future
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all). Other fleet-wide agents may
+      # land here later if mba is offline and the singleton priority chain
+      # drifts over (host: [ywata-note-win, mba, nas, spartan]) — don't
+      # pre-list them; let the probe's advisory path catch transients.
       - head-ywata-note-win
-      - mamba-healer-ywata-note-win
+      - healer-ywata-note-win
     process_caps:
       ulimit_u: ~
       pid_max: 4194304
@@ -235,7 +262,7 @@ machines:
       - "mamba-healer-ywata-note-win identity drift fixed via SCITEX_OROCHI_AGENT env (todo#304)."
 
 # ---------------------------------------------------------------------------
-# Fleet-wide preflight thresholds (consumed by mamba-healer-* + fleet_watch.sh)
+# Fleet-wide preflight thresholds (consumed by healer-<host> + fleet_watch.sh)
 # ---------------------------------------------------------------------------
 preflight:
   fork_pressure_warn_pct: 60


### PR DESCRIPTION
## Summary
- Rewrites per-host `expected_tmux_sessions` in `orochi-machines.yaml` to match the current fleet roster after the `mamba-*` → short-name migration. Unblocks `host-liveness-probe.sh --yes` auto-revive (#296) by eliminating the false-positive `missing=[mamba-*]` floods that every host was emitting.
- Ground truth: `~/.dotfiles/src/.scitex/orochi/shared/agents/<name>/<name>.yaml` `spec.host` / `spec.hosts` fields. Singleton agents with `host: [ywata-note-win, mba, nas, spartan]` (priority chain) are listed only on the host currently holding them (`mba` today) — listing them on every host would flip every secondary host back into `warn` for a missing singleton.
- Scrubs a handful of stale `mamba-*` doc comments in the same file.

## Old vs new roster (per host)

### mba — `ok` after edit (was `warn`)
Removed (deprecated): `mamba-auth-manager-mba`, `mamba-explorer-mba`, `mamba-healer-mba`, `mamba-quality-checker-mba`, `mamba-skill-manager`, `mamba-synchronizer-mba`, `mamba-todo-manager`, `mamba-verifier-mba`

Added (current roster): `healer-mba`, `expert-scitex`, `lead`, `mgr-auth`, `mgr-code-quality`, `mgr-memory`, `mgr-pkg`, `mgr-secretary`, `mgr-todo`, `proj-neurovista`, `proj-ripple-wm`, `proj-scitex-clew`, `proj-scitex-cloud`, `proj-scitex-orochi`, `worker-iOS-simulator`, `worker-playwright-mba`, `worker-progress`, `worker-todo-mirror`

### nas — `advisory` after edit (was `warn`)
Removed: `mamba-healer-nas`

Added: `healer-nas`, `worker-playwright-nas`

### spartan — `critical` (tmux dead, pre-existing, orthogonal to #298)
Added: `healer-spartan` (`hosts: all`)

### ywata-note-win — `ok` after edit (was `warn`)
Removed: `mamba-healer-ywata-note-win`

Added: `healer-ywata-note-win`

## Post-edit probe evidence
`bash scripts/client/fleet-watch/host-liveness-probe.sh --dry-run` (2026-04-21T10:17:31Z):

```ndjson
{"schema":"scitex-orochi/host-liveness-probe/v1","host":"mba","severity":"ok","tmux_state":"running","missing":[],"unexpected":[],"revive_path":"none","actions_taken":[]}
{"schema":"scitex-orochi/host-liveness-probe/v1","host":"nas","severity":"advisory","tmux_state":"running","missing":[],"unexpected":["expert-scitex","lead","mgr-auth","mgr-code-quality","mgr-memory","mgr-pkg","mgr-secretary","mgr-todo","proj-neurovista","proj-ripple-wm","proj-scitex-clew","proj-scitex-orochi","worker-todo-mirror"],"revive_path":"none","actions_taken":[]}
{"schema":"scitex-orochi/host-liveness-probe/v1","host":"spartan","severity":"critical","tmux_state":"dead","missing":[],"unexpected":[],"revive_path":"none","actions_taken":[]}
{"schema":"scitex-orochi/host-liveness-probe/v1","host":"ywata-note-win","severity":"ok","tmux_state":"running","missing":[],"unexpected":[],"revive_path":"none","actions_taken":[]}
```

Full (non-truncated) NDJSON captured in commit `67b28fe` verification run.

## Known drift I chose NOT to encode (nas `advisory`)

nas's live tmux has every fleet-wide singleton (`expert-scitex`, `lead`, all six `mgr-*`, all five `proj-*`, `worker-todo-mirror`) running alongside mba. Per `spec.host` priority-chain semantics these agents are supposed to be cardinality-1 fleet-wide — the duplication is a real-world drift, not an orochi-machines.yaml spec question. Options:
1. List them on both mba + nas in the yaml — turns the singleton invariant into a lie, and the probe's `missing=` logic would start (correctly) warning when only one instance is live.
2. Leave them off nas — nas is flagged `advisory` for the unexpected sessions. **This is what the PR does.**

Option 2 is safe for #298's goal because `host-liveness-probe.sh --yes` only revives agents in `missing[]`; `unexpected[]` never triggers a revive action (see probe lines 320-350). So `--yes` install is now operator-safe.

The underlying fleet drift (why does nas have a second copy of every singleton running?) is a separate operator concern; I'll file a follow-up issue once I've confirmed via `head-nas` whether those sessions are intentional dev-pairing spares or orphaned auto-starts.

## Schema key edited
`machines[].expected_tmux_sessions` — per-host list consumed by `parse_machines_yaml` in `scripts/client/fleet-watch/host-liveness-probe.sh` (both the `yaml.safe_load` path and the regex fallback).

## Test plan
- [x] `bash scripts/client/fleet-watch/host-liveness-probe.sh --dry-run` — verified above; mba + ywata-note-win `ok`, nas `advisory` (drift, documented), spartan `critical` (tmux dead).
- [x] `grep -n mamba orochi-machines.yaml` — only the historical note at L262 remains (event record for todo#304; intentional).
- [ ] After merge, operator runs `./scripts/client/install-fleet-host-liveness-probe.sh --yes` to cut over the launchd schedule from `--dry-run-only` to `--yes`. Not in scope for this PR.

## Refs
- Closes #298
- Follow-up to #296 (probe), #297 (install fix), #301 (worker-progress landed just before this branch)

Generated with [Claude Code](https://claude.com/claude-code)
