### PR TITLE
feat(mcp): expose react tool in MCP instructions (todo#159)

### DIFF
--- a/src/scitex_orochi/_ts/mcp_channel.ts
+++ b/src/scitex_orochi/_ts/mcp_channel.ts
@@ -65,8 +65,21 @@ const mcp = new Server(
       tools: {},
     },
     instructions: `Messages from the Orochi agent hub arrive as <channel source="orochi"> tags.
-Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp).
-Use the reply tool to send messages back. Pass chat_id from the inbound message.
+Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp), and msg_id (integer message ID).
+
+Two ways to respond:
+  1. reply(chat_id, content) — send a full text reply. Use only when you have new content to add.
+  2. react(message_id, emoji) — attach a lightweight emoji reaction to the inbound msg_id.
+     Prefer react over text for pure acknowledgement. It is cheaper, quieter, and shows attention without adding a channel row.
+
+Reaction vocabulary (fleet convention):
+  👀 seen / watching        ✅ done / verified         👍 agree / ack
+  🚫 blocked / refused      🔄 retrying / in progress  🧠 learned / saved
+  ❓ unclear / need info     🎉 celebrate                ❌ disagree / broken
+
+Rule: if your only intent is "ack", "noted", "thanks", or "seen", react — do not reply.
+Save reply for content: dispatches, answers, commits, findings, decisions.
+
 Orochi is a real-time communication hub for AI agents across different machines.`,
   },
 );

--- a/ts/mcp_channel.ts
+++ b/ts/mcp_channel.ts
@@ -34,8 +34,21 @@ const mcp = new Server(
       tools: {},
     },
     instructions: `Messages from the Orochi agent hub arrive as <channel source="orochi"> tags.
-Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp).
-Use the reply tool to send messages back. Pass chat_id from the inbound message.
+Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp), and msg_id (integer message ID).
+
+Two ways to respond:
+  1. reply(chat_id, content) — send a full text reply. Use only when you have new content to add.
+  2. react(message_id, emoji) — attach a lightweight emoji reaction to the inbound msg_id.
+     Prefer react over text for pure acknowledgement. It is cheaper, quieter, and shows attention without adding a channel row.
+
+Reaction vocabulary (fleet convention):
+  👀 seen / watching        ✅ done / verified         👍 agree / ack
+  🚫 blocked / refused      🔄 retrying / in progress  🧠 learned / saved
+  ❓ unclear / need info     🎉 celebrate                ❌ disagree / broken
+
+Rule: if your only intent is "ack", "noted", "thanks", or "seen", react — do not reply.
+Save reply for content: dispatches, answers, commits, findings, decisions.
+
 Orochi is a real-time communication hub for AI agents across different machines.`,
   },
 );


### PR DESCRIPTION
## Summary

- Fixes [todo#159](https://github.com/ywatanabe1989/todo/issues/159) — agents never use the `react` MCP tool in normal discourse.
- Root cause: the MCP server's startup `instructions` string only mentioned `reply`. Agents discover tool semantics from those instructions, so they never learned that `react(msg_id, emoji)` is the preferred ack path.
- Updates both copies of `mcp_channel.ts` (`ts/` live + `src/scitex_orochi/_ts/` packaged) to document `msg_id`, describe `reply` vs `react`, list the reaction vocabulary, and state the react-first rule for ack-style responses.

## Companion change

- Strengthened rule #15 in `scitex-orochi-private/fleet-communication-discipline.md` (dotfiles repo) to cross-reference the MCP-instruction layer and make the tool contract explicit. PR in dotfiles follows separately.

## Test plan

- [x] `bun build ts/mcp_channel.ts` succeeds (syntax check)
- [ ] Restart one head sidecar (e.g. head-ywata-note-win) and observe that `react` appears in the tool list exposed to the Claude Code session
- [ ] Over 24 h, verify reaction count on recent `#agent` messages is non-zero (screenshots in dashboard)
- [ ] If reactions are posted but not rendered inline → file a separate frontend issue (todo#159 already lists this as a requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)