### PR TITLE
fix(hub/consumers): ensure channel memberships are re-established on WS reconnect (#451)

### DIFF
--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -31,6 +31,7 @@ from ._agent_handlers import (
     handle_subscription,
     handle_task_update,
 )
+from ._agent_refresh import prehydrate_channels as _prehydrate_channels
 from ._echo import _hub_echo_loop
 from ._groups import _hub_ping_loop, _sanitize_group, log
 from ._helpers import (
@@ -94,6 +95,13 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         for ch_name in self._dm_channel_names:
             group = _sanitize_group(f"channel_{self.workspace_id}_{ch_name}")
             await self.channel_layer.group_add(group, self.channel_name)
+
+        # scitex-orochi#451 — eager channel-membership rehydration.
+        # Pre-hydrates persisted group memberships + seeds agent_meta so
+        # group messages aren't silently dropped during the window between
+        # connect and the client's register frame (or permanently, if the
+        # register frame never arrives). See ``_prehydrate_channels``.
+        await _prehydrate_channels(self)
 
         await self.accept()
 
@@ -315,6 +323,26 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         elif msg_type == "subagents_update":
             await handle_subagents_update(self, content)
         elif msg_type == "message":
+            # scitex-orochi#451 — deny message frames from un-registered
+            # connections. This makes the "orphan on reconnect" failure
+            # mode break LOUDLY (error response the client can log and
+            # surface) instead of silently (write succeeds but the agent
+            # never sees replies because it isn't in the reply groups).
+            # Clients MUST send a ``register`` frame on every reconnect
+            # and await the ``registered`` ack before sending messages.
+            if not getattr(self, "_registered", False):
+                await self.send_json(
+                    {
+                        "type": "error",
+                        "code": "not_registered",
+                        "message": (
+                            "send a `register` frame and await the "
+                            "`registered` ack before sending messages "
+                            "(scitex-orochi#451)"
+                        ),
+                    }
+                )
+                return
             from ._agent_message import handle_agent_message
 
             await handle_agent_message(self, content)

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -63,6 +63,15 @@ async def handle_register(consumer, content):
 
     register_agent(consumer.agent_name, consumer.workspace_id, consumer.agent_meta)
 
+    # scitex-orochi#451 — mark the consumer as registered. The
+    # ``receive_json`` dispatch uses this flag to deny ``message`` frames
+    # from un-registered connections so orphan-on-reconnect failures
+    # surface as a loud error instead of a silent deafness. The flag
+    # flips True only AFTER agent_meta + group_adds are in place, so a
+    # concurrent message frame either arrives before register completes
+    # (rejected) or after (accepted + delivered).
+    consumer._registered = True
+
     await consumer.channel_layer.group_send(
         consumer.workspace_group,
         {

--- a/hub/consumers/_agent_refresh.py
+++ b/hub/consumers/_agent_refresh.py
@@ -4,12 +4,77 @@ Fired from ``hub.signals`` post_save/post_delete on ``ChannelMembership``
 (issue #282) so out-of-band subscription changes propagate to live WS
 consumers without waiting for reconnect. Extracted from ``_agent.py``
 to stay under the 512-line cap.
+
+This module also hosts :func:`prehydrate_channels` (scitex-orochi#451),
+the connect-time rehydration helper used by :class:`AgentConsumer` to
+make group-channel delivery robust to missing ``register`` frames.
 """
 
 from __future__ import annotations
 
-from ._groups import _sanitize_group
+from ._groups import _sanitize_group, log
 from ._helpers import _load_agent_channel_subs
+
+
+async def prehydrate_channels(consumer) -> None:
+    """Rejoin persisted group channels + seed ``agent_meta`` at connect.
+
+    scitex-orochi#451 — closes the orphan-on-reconnect deafness window.
+
+    Background. On a WS reconnect, the authoritative sequence is:
+
+        client  connects → server connect()              → joins DM groups
+        client  sends register                             → server handle_register
+                                                              → loads group subs from DB
+                                                              → group_add(each)
+                                                              → sets agent_meta["channels"]
+
+    Between ``connect()`` completing and ``handle_register`` running,
+    ``agent_meta`` is absent. The ``chat_message`` filter in
+    :class:`AgentConsumer` requires ``agent_meta["channels"]`` to contain
+    the target channel for group messages; without it every group
+    message is silently dropped. If the client never sends ``register``
+    (buggy reconnect logic, network blip between open and first send),
+    the agent is silently deaf forever — it appears connected but
+    receives no group-channel messages.
+
+    This helper runs at the end of ``connect()`` and makes the server
+    robust to both races: it pre-joins persisted group memberships from
+    the DB and seeds ``agent_meta["channels"]`` with the union of DM
+    channels + persisted group memberships. ``handle_register`` remains
+    idempotent and will refresh the same state (plus the richer metadata
+    payload) when the client's register frame arrives.
+
+    ``consumer._registered`` is set to False here; ``handle_register``
+    flips it True on success. The ``message``-frame dispatch guards on
+    ``_registered`` so un-registered connections can't silently succeed
+    at writes while missing replies (scitex-orochi#451 contract).
+    """
+    consumer._registered = False
+    try:
+        persisted = await _load_agent_channel_subs(
+            consumer.workspace_id, consumer.agent_name
+        )
+    except Exception:  # noqa: BLE001 — DB hiccups at connect must not tear down
+        log.exception(
+            "connect: pre-hydrate group channels failed for %s",
+            consumer.agent_name,
+        )
+        persisted = []
+
+    dm_names = list(getattr(consumer, "_dm_channel_names", []) or [])
+    channels = list(dm_names) + [c for c in persisted if c not in dm_names]
+
+    for ch_name in persisted:
+        group = _sanitize_group(
+            f"channel_{consumer.workspace_id}_{ch_name}"
+        )
+        await consumer.channel_layer.group_add(group, consumer.channel_name)
+
+    # Seed a minimal agent_meta so chat_message's membership filter
+    # works before ``handle_register`` runs. ``handle_register`` (which
+    # is idempotent) will replace this dict with the full payload.
+    consumer.agent_meta = {"channels": channels}
 
 
 async def handle_agent_subs_refresh(consumer, event):

--- a/hub/tests/consumers/test_dm.py
+++ b/hub/tests/consumers/test_dm.py
@@ -379,6 +379,9 @@ class DMConsumerRoutingTest(TestCase):
         consumer.agent_name = "alice"
         consumer.agent_meta = {"channels": ["dm:alice|bob"]}
         consumer.workspace_member_id = self.mem_alice.id
+        # scitex-orochi#451 — message dispatch gates on _registered; the
+        # synthetic consumer here represents a fully-registered agent.
+        consumer._registered = True
 
         sent = []
 
@@ -444,6 +447,9 @@ class DMConsumerRoutingTest(TestCase):
         consumer.agent_name = "alice"
         consumer.agent_meta = {"channels": ["#general"]}
         consumer.workspace_member_id = self.mem_alice.id
+        # scitex-orochi#451 — message dispatch gates on _registered; the
+        # synthetic consumer here represents a fully-registered agent.
+        consumer._registered = True
 
         sent = []
 

--- a/hub/tests/consumers/test_reconnect_resubscribe.py
+++ b/hub/tests/consumers/test_reconnect_resubscribe.py
@@ -1,0 +1,400 @@
+"""Tests for scitex-orochi#451 — WS reconnect must not orphan channel subs.
+
+Background. On a WS reconnect, the authoritative sequence is:
+
+    client connect → server AgentConsumer.connect()
+                       → joins workspace group
+                       → joins DM groups from DMParticipant rows
+                       → (#451) rehydrates persisted group memberships
+                       → (#451) seeds agent_meta["channels"]
+                       → (#451) consumer._registered = False
+    client register   → server handle_register
+                       → reloads group subs from DB + joins groups
+                       → sets the full agent_meta payload
+                       → flips consumer._registered = True
+                       → sends a ``registered`` ack
+
+Before #451, the connect() path joined DM groups but did NOT seed
+agent_meta["channels"], so group-channel messages arriving between
+connect and register were silently dropped by the chat_message filter.
+If the client never sent ``register`` (bug, blip, race), the deafness
+was permanent — the agent appeared connected but never received group
+messages. This file covers the three contracts introduced by #451:
+
+1. connect() pre-hydrates persisted group memberships + agent_meta.
+2. handle_register remains idempotent under repeated calls (reconnect).
+3. message-frame dispatch refuses writes from un-registered connections.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    DMParticipant,
+    Workspace,
+    WorkspaceMember,
+)
+
+
+def _fake_consumer(agent_name, workspace_id, dm_channels=()):
+    """Return a minimal AgentConsumer stub suitable for the async helpers.
+
+    ``prehydrate_channels`` and ``handle_register`` read a handful of
+    attributes (``agent_name``, ``workspace_id``, ``channel_name``,
+    ``channel_layer``, ``_dm_channel_names``) and call async methods on
+    the channel layer. We mimic the surface with AsyncMock stubs so the
+    async helpers can be driven from a sync test body via async_to_sync.
+    """
+    from hub.consumers._agent import AgentConsumer
+
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_name = agent_name
+    consumer.workspace_id = workspace_id
+    consumer.workspace_group = f"workspace_{workspace_id}"
+    consumer.channel_name = f"test-ch-{agent_name}"
+    consumer._dm_channel_names = list(dm_channels)
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    consumer.send_json = AsyncMock()
+    return consumer
+
+
+class ReconnectPrehydrateTest(TestCase):
+    """connect() must pre-join persisted group memberships and seed agent_meta."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="reconnect-ws")
+        self.ch_alpha = Channel.objects.create(workspace=self.ws, name="#alpha")
+        self.ch_beta = Channel.objects.create(workspace=self.ws, name="#beta")
+        self.agent_user = User.objects.create(username="agent-worker-r")
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_alpha)
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_beta)
+
+    def test_prehydrate_joins_each_persisted_group_channel(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-r", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+
+        joined = [
+            call.args[0]
+            for call in consumer.channel_layer.group_add.await_args_list
+        ]
+        # Both persisted channels must be group_added at connect.
+        self.assertTrue(any("alpha" in g for g in joined))
+        self.assertTrue(any("beta" in g for g in joined))
+        # agent_meta["channels"] contains both persisted channels so the
+        # chat_message membership filter lets group events through before
+        # the client's register frame arrives.
+        self.assertIn("#alpha", consumer.agent_meta["channels"])
+        self.assertIn("#beta", consumer.agent_meta["channels"])
+
+    def test_prehydrate_sets_registered_false(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-r", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+        self.assertFalse(consumer._registered)
+
+    def test_prehydrate_preserves_dm_channels_in_meta(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer(
+            "worker-r", self.ws.id, dm_channels=["dm:worker-r|alice"]
+        )
+        async_to_sync(prehydrate_channels)(consumer)
+        # DM channel is already joined by the earlier connect() step;
+        # prehydrate must still include it in the seeded meta so the
+        # chat_message DM filter + the visibility check both work.
+        self.assertIn("dm:worker-r|alice", consumer.agent_meta["channels"])
+        self.assertIn("#alpha", consumer.agent_meta["channels"])
+
+    def test_prehydrate_swallows_db_errors_so_connect_does_not_abort(self):
+        """DB hiccups at connect must NOT tear down the WebSocket.
+
+        A DB blip would previously crash-bubble through connect() and
+        close the socket, which is much worse than a transient deafness
+        we can recover from when the client sends register. Ensure the
+        helper logs and falls back to an empty channel list.
+        """
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-r", self.ws.id)
+        with patch(
+            "hub.consumers._agent_refresh._load_agent_channel_subs",
+            side_effect=RuntimeError("db unavailable"),
+        ):
+            async_to_sync(prehydrate_channels)(consumer)
+
+        # No groups joined — but also no unhandled exception.
+        self.assertEqual(consumer.agent_meta["channels"], [])
+        self.assertFalse(consumer._registered)
+
+
+class ReconnectRegisterIdempotencyTest(TestCase):
+    """handle_register must be safe to invoke on every reconnect."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="idempotency-ws")
+        self.ch_ops = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.agent_user = User.objects.create(username="agent-worker-s")
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_ops)
+
+    def _drive_register(self, consumer):
+        from hub.consumers._agent_handlers import handle_register
+
+        async_to_sync(handle_register)(consumer, {"type": "register", "payload": {}})
+
+    def test_register_restores_meta_and_joins_groups_after_reconnect(self):
+        """Simulate: connect → register → disconnect → reconnect → register."""
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        # First connection lifecycle.
+        first = _fake_consumer("worker-s", self.ws.id)
+        async_to_sync(prehydrate_channels)(first)
+        self._drive_register(first)
+        first_channels = list(first.agent_meta["channels"])
+        self.assertIn("#ops", first_channels)
+        self.assertTrue(first._registered)
+
+        # Simulated disconnect is implicit — the consumer instance goes
+        # away. A reconnect spins up a fresh consumer with no retained
+        # state, then repeats the same sequence.
+        second = _fake_consumer("worker-s", self.ws.id)
+        async_to_sync(prehydrate_channels)(second)
+        self._drive_register(second)
+
+        # agent_meta["channels"] after reconnect must match the persisted
+        # DB state (same set as first register).
+        self.assertEqual(
+            set(second.agent_meta["channels"]), set(first_channels)
+        )
+        self.assertTrue(second._registered)
+
+        # group_add was called for each persisted channel on the SECOND
+        # consumer (matters because Django Channels requires the re-join;
+        # group membership is per-(group,channel_name) and the new
+        # consumer has a different channel_name).
+        joined = [
+            call.args[0]
+            for call in second.channel_layer.group_add.await_args_list
+        ]
+        self.assertTrue(any("ops" in g for g in joined))
+
+    def test_register_repeated_on_same_consumer_is_idempotent(self):
+        """Paranoid case: two register frames in a row on one consumer."""
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-s", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+        self._drive_register(consumer)
+        first_channels = list(consumer.agent_meta["channels"])
+        self._drive_register(consumer)
+        self.assertEqual(
+            list(consumer.agent_meta["channels"]), first_channels
+        )
+        # Ack sent twice (one per call) — clients are free to expect that.
+        ack_frames = [
+            call.args[0]
+            for call in consumer.send_json.await_args_list
+            if call.args and call.args[0].get("type") == "registered"
+        ]
+        self.assertEqual(len(ack_frames), 2)
+
+
+class ReconnectMessageContractTest(TestCase):
+    """message-frame dispatch must refuse writes from un-registered consumers.
+
+    Before #451 the server accepted message frames regardless of
+    registration state, so a client that reconnected and forgot to send
+    register could still write (ACL-permitting) but be silently deaf to
+    replies (not in any reply group). This breaks the contract loudly
+    via an error ack instead.
+    """
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="contract-ws")
+
+    def test_message_frame_rejected_when_not_registered(self):
+        from hub.consumers._agent import AgentConsumer
+
+        consumer = AgentConsumer.__new__(AgentConsumer)
+        consumer.agent_name = "worker-t"
+        consumer.workspace_id = self.ws.id
+        consumer.workspace_group = f"workspace_{self.ws.id}"
+        consumer.channel_name = "test-ch-worker-t"
+        consumer._registered = False  # simulate missing-register state
+        consumer.agent_meta = {"channels": []}
+        consumer.send_json = AsyncMock()
+
+        async_to_sync(consumer.receive_json)(
+            {
+                "type": "message",
+                "payload": {"channel": "#general", "text": "hello"},
+            }
+        )
+
+        # Message was NOT persisted nor broadcast — the dispatch bailed
+        # before importing handle_agent_message. We can't inspect the
+        # import directly, but an error ack on send_json is the contract.
+        sent = [
+            call.args[0] for call in consumer.send_json.await_args_list
+        ]
+        err = [
+            frame for frame in sent if frame.get("type") == "error"
+        ]
+        self.assertTrue(err, "expected an error ack on un-registered send")
+        self.assertEqual(err[0]["code"], "not_registered")
+
+    def test_message_frame_accepted_after_register(self):
+        """Positive control: once handle_register runs, messages flow."""
+        from hub.consumers._agent import AgentConsumer
+
+        consumer = AgentConsumer.__new__(AgentConsumer)
+        consumer.agent_name = "worker-t"
+        consumer.workspace_id = self.ws.id
+        consumer.workspace_group = f"workspace_{self.ws.id}"
+        consumer.channel_name = "test-ch-worker-t"
+        consumer._registered = True  # handle_register already flipped this
+        consumer.agent_meta = {"channels": ["#general"]}
+        consumer.send_json = AsyncMock()
+
+        with patch(
+            "hub.consumers._agent_message.handle_agent_message",
+            new=AsyncMock(),
+        ) as mocked:
+            async_to_sync(consumer.receive_json)(
+                {
+                    "type": "message",
+                    "payload": {"channel": "#general", "text": "hello"},
+                }
+            )
+            mocked.assert_awaited_once()
+
+
+class ReconnectGroupDeliveryTest(TestCase):
+    """End-to-end-ish: after reconnect a subscribed group message is delivered.
+
+    Uses the real ``chat_message`` method on a hydrated fake consumer —
+    mirrors the filter behaviour that was dropping messages pre-#451.
+    """
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="delivery-ws")
+        self.ch_ops = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.agent_user = User.objects.create(username="agent-worker-u")
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_ops)
+
+    def test_group_message_delivered_after_reconnect_prehydrate(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-u", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+        # NB: we do NOT call handle_register here — the fix guarantees
+        # delivery works on the strength of prehydrate alone, which
+        # defuses the "client hasn't sent register yet" race.
+
+        event = {
+            "type": "chat.message",
+            "id": 1,
+            "sender": "other-agent",
+            "sender_type": "agent",
+            "channel": "#ops",
+            "kind": "group",
+            "text": "hello ops",
+            "ts": "2026-04-20T00:00:00Z",
+            "metadata": {},
+        }
+        async_to_sync(consumer.chat_message)(event)
+
+        sent = [
+            call.args[0] for call in consumer.send_json.await_args_list
+        ]
+        delivered = [
+            frame
+            for frame in sent
+            if frame.get("type") == "message" and frame.get("channel") == "#ops"
+        ]
+        self.assertTrue(
+            delivered,
+            "prehydrate must seed agent_meta so group messages pass the "
+            "chat_message filter even before handle_register runs (#451)",
+        )
+
+
+class ReconnectDMDeliveryTest(TestCase):
+    """DM delivery must keep working during the prehydrate → register window.
+
+    DMs take the DMParticipant filter path (not the agent_meta filter),
+    so they worked before #451 too. Regression guard so the new
+    prehydrate path doesn't accidentally tighten DM filtering.
+    """
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="dm-delivery-ws")
+        self.agent_user = User.objects.create(username="agent-worker-v")
+        self.other_user = User.objects.create(username="someone")
+        self.mem_agent = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.agent_user, role="member"
+        )
+        self.mem_other = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.other_user, role="member"
+        )
+        self.dm = Channel.objects.create(
+            workspace=self.ws,
+            name="dm:worker-v|someone",
+            kind=Channel.KIND_DM,
+        )
+        DMParticipant.objects.create(
+            channel=self.dm,
+            member=self.mem_agent,
+            principal_type=DMParticipant.PRINCIPAL_AGENT,
+            identity_name="worker-v",
+        )
+        DMParticipant.objects.create(
+            channel=self.dm,
+            member=self.mem_other,
+            principal_type=DMParticipant.PRINCIPAL_HUMAN,
+            identity_name="someone",
+        )
+
+    def test_dm_delivered_after_reconnect_prehydrate(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer(
+            "worker-v",
+            self.ws.id,
+            dm_channels=["dm:worker-v|someone"],
+        )
+        consumer.workspace_member_id = self.mem_agent.id
+        async_to_sync(prehydrate_channels)(consumer)
+
+        event = {
+            "type": "chat.message",
+            "id": 2,
+            "sender": "someone",
+            "sender_type": "human",
+            "channel": "dm:worker-v|someone",
+            "kind": "dm",
+            "text": "hi",
+            "ts": "2026-04-20T00:00:00Z",
+            "metadata": {},
+        }
+        async_to_sync(consumer.chat_message)(event)
+
+        delivered = [
+            call.args[0]
+            for call in consumer.send_json.await_args_list
+            if call.args[0].get("type") == "message"
+            and call.args[0].get("channel") == "dm:worker-v|someone"
+        ]
+        self.assertTrue(delivered)


### PR DESCRIPTION
## Root cause

On WS reconnect, `AgentConsumer.connect()` joined the workspace group and DM groups but did NOT initialise `agent_meta["channels"]` or rejoin persisted group-channel memberships — that work lived exclusively in `handle_register`, which only runs when the client's `register` frame arrives.

Between `connect()` completing and `handle_register` running (normally sub-second but can be multi-second on slow links), every inbound group message hit the `chat_message` filter, found `agent_meta` absent, and was silently dropped. If the `register` frame was lost entirely (client bug, blip between open and first send), the agent appeared connected but was silently deaf on every group channel forever — the "orphan on WS reconnect" failure mode described in #451.

PR #293's signal-driven refresh (#282) covered **out-of-band** subscription changes on a live socket; the **reconnect** surface was never wired to the same rehydration path.

Both shipped clients (Python `OrochiClient`, `ts/src/connection.ts`, `ts/mcp_channel/connection.ts`) correctly re-send `register` on every WS open, and `handle_register` is idempotent. The leak is entirely in the window between connect and register — and in the silent failure mode if register is never delivered. This PR narrows the fix to that surface.

## Fix (server-side, narrow)

1. **Eager rehydration at `connect()`.** New `prehydrate_channels` helper in `_agent_refresh.py` pre-joins every persisted `ChannelMembership` group and seeds `agent_meta["channels"]` with the DM + group union, symmetric with the DM auto-subscribe already there. `handle_register` remains authoritative when the register frame arrives (and is idempotent under repeat invocation via Channels' set-semantic `group_add`).
2. **Loud contract enforcement.** Dispatch now gates `message` frames on a per-consumer `_registered` flag. `prehydrate_channels` sets it `False`; `handle_register` flips it `True` after `agent_meta + group_adds` are in place. A message frame from an un-registered connection now receives a structured `{type: error, code: not_registered}` ack instead of silently succeeding at the write while missing every reply because the socket isn't in the reply group.
3. **DB-failure resilience.** DB hiccups inside prehydrate are logged and swallowed so a transient outage at `connect()` cannot tear down the WebSocket.

## Before / after

| | before #451 | after #451 |
|---|---|---|
| WS reconnect, register fast | group msgs between connect + register silently dropped | delivered immediately (prehydrate) |
| WS reconnect, register lost | permanent silent deafness on all group channels | delivered via prehydrate; writes fail loudly with `not_registered` |
| WS reconnect, register delivered | works (status quo) | works (prehydrate is idempotent with handle_register) |
| DM delivery during window | worked (DM-participant path) | works (regression-guarded) |
| Out-of-band sub change | worked (PR #293) | works (regression-guarded) |

## Files touched

**Python** (hub):
- `hub/consumers/_agent.py` — `connect()` calls `prehydrate_channels`; `receive_json` gates `message` frames on `_registered`.
- `hub/consumers/_agent_handlers.py` — `handle_register` flips `_registered=True` after `agent_meta` + `group_adds` land.
- `hub/consumers/_agent_refresh.py` — new `prehydrate_channels` helper.

**Tests**:
- `hub/tests/consumers/test_reconnect_resubscribe.py` (new, 10 tests across 5 classes).
- `hub/tests/consumers/test_dm.py` — 2 synthetic-consumer tests set `_registered=True` so the new dispatch gate doesn't drop their simulated writes.

**TS / JS**: none. Both client reconnect paths were already re-sending `register` correctly; fix is purely server-side so any client (python, bun sidecar, future ones) benefits automatically.

## Tests

10 new tests in `hub/tests/consumers/test_reconnect_resubscribe.py`:

- `ReconnectPrehydrateTest`:
  - `test_prehydrate_joins_each_persisted_group_channel`
  - `test_prehydrate_sets_registered_false`
  - `test_prehydrate_preserves_dm_channels_in_meta`
  - `test_prehydrate_swallows_db_errors_so_connect_does_not_abort`
- `ReconnectRegisterIdempotencyTest`:
  - `test_register_restores_meta_and_joins_groups_after_reconnect` (the connect → register → disconnect → reconnect → register contract test)
  - `test_register_repeated_on_same_consumer_is_idempotent`
- `ReconnectMessageContractTest`:
  - `test_message_frame_rejected_when_not_registered` (the regression-guard the task brief asked for — "prefer: deny message frames from un-registered connections so the contract breaks loudly, not silently")
  - `test_message_frame_accepted_after_register`
- `ReconnectGroupDeliveryTest`:
  - `test_group_message_delivered_after_reconnect_prehydrate` (the core #451 fix — group delivery before register)
- `ReconnectDMDeliveryTest`:
  - `test_dm_delivered_after_reconnect_prehydrate` (#282 regression guard)

Local run:

```
hub/tests/consumers/  50 passed
hub/tests/            244 passed, 6 pre-existing failures (test_auth + test_push,
                      both env-issue — pywebpush module + allauth version skew,
                      unrelated to this PR and fail identically on origin/develop)
```

## Out of scope

- ts-migration-v2 dashboard rewrite (untouched per task constraint).
- singleton_evict / #255 — a different surface.
- Scaling / clustering — this is a single-hub correctness bug.

## Judgment calls

- Chose server-side prehydrate over requiring the Python `OrochiClient` to be smarter. Both shipped clients already re-send `register` on reconnect; moving the robustness to the server means any future client (including third-party) gets the same guarantee.
- Added `_registered` gate on `message` only, not on `subscribe` / `heartbeat` etc. Those are low-risk (no fan-out, no persistence side-effects that could silently fail); messaging is where silent deafness bites.
- Extracted `prehydrate_channels` to `_agent_refresh.py` (alongside `handle_agent_subs_refresh`) rather than inlining in `_agent.py` — same refresh-from-DB conceptual surface, keeps `_agent.py` near its 512-line soft cap.

Generated with [Claude Code](https://claude.com/claude-code)
