### PR TITLE
feat(quota-watch): wire threshold state machine into heartbeat (todo#272)

### DIFF
--- a/hub/quota_watch.py
+++ b/hub/quota_watch.py
@@ -1,18 +1,27 @@
 """Quota pressure escalation consumer (todo#272 hub side).
 
-Producer side (head-spartan, branch feat/quota-pressure-producer) polls
-`/api/oauth/usage` from each agent and pushes utilization figures into
-the heartbeat. This module owns the *consumer* logic: it decides when
-those figures cross thresholds and posts escalation messages.
+Producer side (agent-container `agent_meta.py --push` loop) reads the
+Anthropic `/api/oauth/usage` endpoint + Claude Code statusline and
+pushes utilization figures into the heartbeat as
+``quota_5h_used_pct`` / ``quota_7d_used_pct`` +
+``quota_5h_reset_at`` / ``quota_7d_reset_at``. This module owns the
+*consumer* logic: it decides when those figures cross thresholds and
+posts escalation messages so the fleet (or ywatanabe) can migrate
+accounts *before* the hard cap triggers a 100% wedge.
 
 State machine per (agent, window):
     ok -> warn        : post to #progress
     warn -> escalate  : post to #escalation AND #ywatanabe
     escalate -> ok    : post recovery to #progress (once)
-    other transitions: silent
+    other transitions: silent (no spam on downshifts / partial recovery)
 
 State is in-memory only via registry transient fields:
     quota_state_5h, quota_state_7d.
+
+Entry point for the heartbeat hot path is
+:func:`check_agent_quota_pressure` — it reads the current utilization
+off the in-memory registry, runs :func:`evaluate`, and writes the new
+per-window state back so transitions fire exactly once per crossing.
 """
 
 from __future__ import annotations
@@ -69,13 +78,38 @@ def _format_reset(reset_at: Optional[str]) -> str:
 PostFn = Callable[[str, str], None]
 
 
-def _default_post(channel: str, text: str) -> None:  # pragma: no cover - exercised at integration time
-    """Persist a system message into the workspace channel.
+def _make_workspace_post(workspace_id: int) -> PostFn:
+    """Build a PostFn that writes to a specific workspace.
 
     Best-effort: swallow errors so quota_watch never breaks the heartbeat
-    hot path. Workspace resolution is left to the caller (we post into
-    the most recently registered workspace's channel by name).
+    hot path. The workspace id is captured at heartbeat time so
+    multi-workspace hubs can't cross-post quota warnings into the wrong
+    workspace (matches the per-agent ``workspace_id`` stored in the
+    registry).
     """
+
+    def _post(channel: str, text: str) -> None:
+        try:
+            from hub.models import Channel, Message
+
+            ch, _ = Channel.objects.get_or_create(
+                workspace_id=workspace_id, name=channel
+            )
+            Message.objects.create(
+                workspace_id=workspace_id,
+                channel=ch,
+                sender="orochi-quota-watch",
+                sender_type="agent",
+                content=text,
+            )
+        except Exception:
+            log.exception("quota_watch post failed for %s", channel)
+
+    return _post
+
+
+def _default_post(channel: str, text: str) -> None:  # pragma: no cover - exercised at integration time
+    """Fallback post used when no workspace_id is known."""
     try:
         from hub.models import Channel, Message, Workspace
 
@@ -84,7 +118,11 @@ def _default_post(channel: str, text: str) -> None:  # pragma: no cover - exerci
             return
         ch, _ = Channel.objects.get_or_create(workspace=ws, name=channel)
         Message.objects.create(
-            workspace=ws, channel=ch, sender="orochi-quota-watch", content=text
+            workspace=ws,
+            channel=ch,
+            sender="orochi-quota-watch",
+            sender_type="agent",
+            content=text,
         )
     except Exception:
         log.exception("quota_watch default_post failed for %s", channel)
@@ -166,3 +204,94 @@ def _transition_messages(
     # escalate->warn is partial recovery; we only ping on full recovery
     # to avoid spam per ywatanabe msg#7788).
     return []
+
+
+def _coerce_utilization(value) -> Optional[float]:
+    """Normalize quota payload value to a 0..1 utilization float.
+
+    Producers push either a fraction (0..1) or a percentage (0..100).
+    Accept both so quota_watch doesn't misfire when the producer
+    convention changes. Returns ``None`` for non-numeric / missing
+    values so classify() can leave the state unchanged.
+    """
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    # Treat anything > 1.5 as a percentage (0..100 scale) and rescale.
+    # Threshold chosen conservatively so a legitimate over-quota value
+    # like 1.05 (5% into hard cap) is still read as a fraction.
+    if f > 1.5:
+        f = f / 100.0
+    if f < 0.0:
+        return 0.0
+    return f
+
+
+def check_agent_quota_pressure(name: str, post: Optional[PostFn] = None) -> None:
+    """Run the quota state machine for one agent based on registry state.
+
+    Called from the heartbeat hot path (REST
+    ``/api/agents/register/`` + WS ``agent_heartbeat`` handler). Reads
+    the agent's current quota utilization + reset timestamps + previous
+    per-window state from the in-memory registry, calls
+    :func:`evaluate`, and writes back the new per-window state so the
+    state machine transitions fire exactly once per crossing.
+
+    Best-effort: any exception is logged and swallowed — quota_watch
+    must never block or crash the heartbeat path.
+
+    Args:
+        name: agent name as registered in ``hub.registry._agents``.
+        post: override for the post callback (mainly for tests). When
+            ``None``, a post function scoped to the agent's
+            ``workspace_id`` is constructed on the fly.
+    """
+    try:
+        from hub.registry import _agents, _lock
+
+        with _lock:
+            agent = _agents.get(name)
+            if not agent:
+                return
+            util_5h_raw = agent.get("quota_5h_used_pct")
+            util_7d_raw = agent.get("quota_7d_used_pct")
+            reset_5h = agent.get("quota_5h_reset_at") or None
+            reset_7d = agent.get("quota_7d_reset_at") or None
+            prev_5h = agent.get("quota_state_5h") or STATE_OK
+            prev_7d = agent.get("quota_state_7d") or STATE_OK
+            workspace_id = agent.get("workspace_id")
+
+        util_5h = _coerce_utilization(util_5h_raw)
+        util_7d = _coerce_utilization(util_7d_raw)
+        if util_5h is None and util_7d is None:
+            return
+
+        if post is None:
+            if workspace_id is None:
+                post = _default_post
+            else:
+                post = _make_workspace_post(int(workspace_id))
+
+        new_5h, new_7d, _ = evaluate(
+            name,
+            util_5h=util_5h,
+            util_7d=util_7d,
+            reset_5h=reset_5h,
+            reset_7d=reset_7d,
+            prev_state_5h=prev_5h,
+            prev_state_7d=prev_7d,
+            post=post,
+        )
+
+        with _lock:
+            agent = _agents.get(name)
+            if agent is not None:
+                agent["quota_state_5h"] = new_5h
+                agent["quota_state_7d"] = new_7d
+    except Exception:
+        log.exception("check_agent_quota_pressure failed for %s", name)

--- a/hub/registry/_heartbeat.py
+++ b/hub/registry/_heartbeat.py
@@ -125,13 +125,35 @@ def set_health(
 
 
 def update_heartbeat(name: str, metrics: dict | None = None) -> None:
-    """Update heartbeat timestamp and optional metrics."""
+    """Update heartbeat timestamp and optional metrics.
+
+    todo#272: after the timestamp/metric write, run the quota-pressure
+    state machine for this agent. The check reads the quota fields that
+    ``register_agent()`` just wrote (``quota_5h_used_pct`` / ``quota_7d_used_pct``
+    + reset timestamps + prior state) and posts a threshold-crossing
+    message to ``#progress`` / ``#escalation`` / ``#ywatanabe`` when a
+    window crosses the warn / escalate bands. Best-effort — the check
+    never raises into the heartbeat hot path.
+    """
     with _lock:
         if name in _agents:
             _agents[name]["last_heartbeat"] = time.time()
             _agents[name]["status"] = "online"
             if metrics:
                 _agents[name]["metrics"] = metrics
+            has_agent = True
+        else:
+            has_agent = False
+
+    if has_agent:
+        # Deferred import — avoid circular (``hub.quota_watch`` itself
+        # imports ``hub.registry``).
+        try:
+            from hub.quota_watch import check_agent_quota_pressure
+
+            check_agent_quota_pressure(name)
+        except Exception:  # pragma: no cover — defense in depth
+            pass
 
 
 def update_pong(name: str, rtt_ms: float) -> None:

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -317,6 +317,15 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             "quota_7d_reset_at": info.get("quota_7d_reset_at")
             or prev.get("quota_7d_reset_at")
             or "",
+            # todo#272 — per-window quota state machine slot (ok / warn /
+            # escalate). Owned by ``hub.quota_watch.check_agent_quota_pressure``
+            # which reads it before evaluate() and writes the new state
+            # after. Preserved across heartbeats so threshold transitions
+            # fire exactly once per crossing — without the prev-preserve
+            # the state machine would reset to "ok" every heartbeat and
+            # re-post warn / escalate on every poll (spam regression).
+            "quota_state_5h": prev.get("quota_state_5h") or "ok",
+            "quota_state_7d": prev.get("quota_state_7d") or "ok",
             "mcp_servers": (
                 list(info.get("mcp_servers"))
                 if isinstance(info.get("mcp_servers"), (list, tuple))

--- a/hub/tests/test_quota_watch.py
+++ b/hub/tests/test_quota_watch.py
@@ -1,0 +1,385 @@
+"""Tests for todo#272 — proactive quota pressure detection + escalation.
+
+Covers three layers:
+
+1. :func:`_classify` — threshold → state mapping for the 5h / 7d
+   windows (warn at 0.80 / 0.85, escalate at 0.95).
+2. :func:`evaluate` — the per-heartbeat state-machine transitions:
+   ok→warn posts to ``#progress``, warn→escalate posts to
+   ``#escalation`` + ``#ywatanabe``, escalate→ok posts recovery,
+   other transitions are silent (no spam on partial recovery /
+   downshift per ywatanabe msg#7788).
+3. :func:`check_agent_quota_pressure` — the heartbeat-hot-path entry
+   point that reads the registry, runs :func:`evaluate`, and writes
+   the new state back. The test doubles exercise the integration via
+   ``register_agent`` + ``update_heartbeat`` (the same call chain the
+   REST / WS handlers use) to prove end-to-end wiring.
+
+Regression anchors:
+
+- Prev-preserve of ``quota_state_5h`` / ``quota_state_7d`` across
+  re-registers — without it, every heartbeat resets to ``ok`` and
+  re-posts the warn / escalate message (spam).
+- Silent downshift: escalate→warn must NOT post.
+- Percentage input (0..100) is accepted as well as fractional (0..1)
+  so the consumer doesn't misfire when producers use either
+  convention.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from hub.quota_watch import (
+    ESCALATE_5H,
+    ESCALATE_7D,
+    STATE_ESCALATE,
+    STATE_OK,
+    STATE_WARN,
+    WARN_5H,
+    WARN_7D,
+    _classify,
+    _coerce_utilization,
+    check_agent_quota_pressure,
+    evaluate,
+)
+from hub.registry import _agents, register_agent, update_heartbeat
+
+
+class ClassifyTest(TestCase):
+    """Pure threshold classification."""
+
+    def test_5h_boundaries(self):
+        self.assertEqual(_classify(0.0, "5h"), STATE_OK)
+        self.assertEqual(_classify(WARN_5H - 0.01, "5h"), STATE_OK)
+        self.assertEqual(_classify(WARN_5H, "5h"), STATE_WARN)
+        self.assertEqual(_classify(0.90, "5h"), STATE_WARN)
+        self.assertEqual(_classify(ESCALATE_5H, "5h"), STATE_ESCALATE)
+        self.assertEqual(_classify(1.0, "5h"), STATE_ESCALATE)
+
+    def test_7d_boundaries(self):
+        self.assertEqual(_classify(0.0, "7d"), STATE_OK)
+        self.assertEqual(_classify(WARN_7D - 0.01, "7d"), STATE_OK)
+        self.assertEqual(_classify(WARN_7D, "7d"), STATE_WARN)
+        self.assertEqual(_classify(0.92, "7d"), STATE_WARN)
+        self.assertEqual(_classify(ESCALATE_7D, "7d"), STATE_ESCALATE)
+
+    def test_none_utilization_falls_back_to_ok(self):
+        self.assertEqual(_classify(None, "5h"), STATE_OK)
+        self.assertEqual(_classify(None, "7d"), STATE_OK)
+
+
+class CoerceUtilizationTest(TestCase):
+    """Producers may push 0..1 or 0..100; accept both."""
+
+    def test_fraction_passthrough(self):
+        self.assertAlmostEqual(_coerce_utilization(0.82), 0.82)
+        self.assertAlmostEqual(_coerce_utilization(0.95), 0.95)
+
+    def test_percentage_rescaled(self):
+        self.assertAlmostEqual(_coerce_utilization(82), 0.82)
+        self.assertAlmostEqual(_coerce_utilization(95.0), 0.95)
+
+    def test_none_and_garbage_return_none(self):
+        self.assertIsNone(_coerce_utilization(None))
+        self.assertIsNone(_coerce_utilization(""))
+        self.assertIsNone(_coerce_utilization("nan-value"))
+
+    def test_negative_clamped_to_zero(self):
+        self.assertEqual(_coerce_utilization(-0.01), 0.0)
+
+
+class EvaluateStateMachineTest(TestCase):
+    """Transition rules for the per-(agent, window) state machine."""
+
+    def setUp(self):
+        self.posts: list[tuple[str, str]] = []
+
+    def _post(self, channel: str, text: str) -> None:
+        self.posts.append((channel, text))
+
+    def test_ok_to_warn_posts_progress(self):
+        new_5h, new_7d, emitted = evaluate(
+            "agent-burn",
+            util_5h=0.81,
+            util_7d=None,
+            reset_5h="2026-04-22T01:00:00Z",
+            reset_7d=None,
+            prev_state_5h=STATE_OK,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(new_7d, STATE_OK)
+        self.assertEqual(len(self.posts), 1)
+        channel, text = self.posts[0]
+        self.assertEqual(channel, "#progress")
+        self.assertIn("agent-burn", text)
+        self.assertIn("5h", text)
+        self.assertIn("81%", text)
+
+    def test_warn_to_escalate_posts_escalation_and_ywatanabe(self):
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.96,
+            util_7d=None,
+            reset_5h="2026-04-22T01:00:00Z",
+            reset_7d=None,
+            prev_state_5h=STATE_WARN,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_ESCALATE)
+        channels = [c for c, _ in self.posts]
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+        # Every emitted message names the agent + quota window so the
+        # recipient can act (account rotation, migration decision).
+        for _, text in self.posts:
+            self.assertIn("agent-burn", text)
+            self.assertIn("ESCALATE", text)
+
+    def test_ok_to_escalate_skips_warn_but_still_escalates(self):
+        """If a heartbeat gap makes the agent jump straight from ok to
+        escalate (e.g. 10-minute poll lands after a burst), we still
+        escalate rather than silently dropping the transition."""
+        new_5h, _, _ = evaluate(
+            "agent-burst",
+            util_5h=0.97,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_OK,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_ESCALATE)
+        channels = [c for c, _ in self.posts]
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+
+    def test_escalate_to_ok_posts_recovery(self):
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.05,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_ESCALATE,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_OK)
+        self.assertEqual(len(self.posts), 1)
+        channel, text = self.posts[0]
+        self.assertEqual(channel, "#progress")
+        self.assertIn("recovered", text)
+
+    def test_escalate_to_warn_silent(self):
+        """Partial recovery must not spam — only full recovery pings."""
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.85,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_ESCALATE,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(self.posts, [])
+
+    def test_warn_to_ok_silent(self):
+        """Downshift is silent — only escalate→ok triggers recovery ping."""
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.10,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_WARN,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_OK)
+        self.assertEqual(self.posts, [])
+
+    def test_same_state_no_posts(self):
+        """Repeated polls within the same band must not re-fire."""
+        new_5h, new_7d, emitted = evaluate(
+            "agent-burn",
+            util_5h=0.82,
+            util_7d=0.86,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_WARN,
+            prev_state_7d=STATE_WARN,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(new_7d, STATE_WARN)
+        self.assertEqual(self.posts, [])
+        self.assertEqual(emitted, [])
+
+    def test_both_windows_fire_independently(self):
+        """5h and 7d transitions are evaluated + posted independently."""
+        new_5h, new_7d, _ = evaluate(
+            "agent-burn",
+            util_5h=0.82,  # ok -> warn
+            util_7d=0.96,  # ok -> escalate
+            reset_5h="2026-04-22T01:00:00Z",
+            reset_7d="2026-04-28T01:00:00Z",
+            prev_state_5h=STATE_OK,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(new_7d, STATE_ESCALATE)
+        channels = [c for c, _ in self.posts]
+        # 5h: warn -> #progress
+        self.assertIn("#progress", channels)
+        # 7d: escalate -> #escalation + #ywatanabe
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+
+
+class CheckAgentQuotaPressureWiringTest(TestCase):
+    """End-to-end wiring: register_agent + update_heartbeat triggers
+    :func:`check_agent_quota_pressure` with prev-preserve of the state
+    across heartbeats."""
+
+    def setUp(self):
+        _agents.clear()
+        self.posts: list[tuple[str, str]] = []
+
+    def _post(self, channel: str, text: str) -> None:
+        self.posts.append((channel, text))
+
+    def _register(self, name: str, **extra) -> None:
+        info = {
+            "machine": "test-host",
+            "role": "head",
+        }
+        info.update(extra)
+        register_agent(name, workspace_id=1, info=info)
+
+    def test_unknown_agent_is_noop(self):
+        check_agent_quota_pressure("missing-agent", post=self._post)
+        self.assertEqual(self.posts, [])
+
+    def test_missing_quota_fields_noop(self):
+        self._register("agent-a")
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(self.posts, [])
+        self.assertEqual(_agents["agent-a"].get("quota_state_5h"), STATE_OK)
+
+    def test_first_warn_crossing_posts_once(self):
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.82,
+            quota_5h_reset_at="2026-04-22T01:00:00Z",
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_WARN)
+        channels = [c for c, _ in self.posts]
+        self.assertEqual(channels.count("#progress"), 1)
+
+    def test_repeat_poll_same_band_does_not_repost(self):
+        """Second heartbeat in the same warn band must be silent —
+        otherwise each 10-minute poll spams #progress."""
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.82,
+            quota_5h_reset_at="2026-04-22T01:00:00Z",
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        first_count = len(self.posts)
+
+        # Second heartbeat — re-register + update_heartbeat style, same
+        # quota figures. State must survive the re-register.
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.84,
+            quota_5h_reset_at="2026-04-22T01:00:00Z",
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(len(self.posts), first_count)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_WARN)
+
+    def test_state_preserved_across_reregister(self):
+        """Prev-preserve regression guard — the state slot must survive
+        a register_agent call with the quota fields omitted entirely."""
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.96,
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(
+            _agents["agent-a"]["quota_state_5h"], STATE_ESCALATE
+        )
+
+        # Re-register without the quota keys (e.g. WS reconnect
+        # heartbeat from a path that doesn't carry quota telemetry).
+        self._register("agent-a")
+        self.assertEqual(
+            _agents["agent-a"]["quota_state_5h"], STATE_ESCALATE
+        )
+
+    def test_update_heartbeat_triggers_check(self):
+        """The heartbeat hot path (update_heartbeat) fires the state
+        machine without the caller having to invoke quota_watch
+        explicitly. This is the production wiring — REST handler +
+        WS handler both go through update_heartbeat."""
+        import hub.quota_watch as quota_watch
+
+        captured: list[tuple[str, str]] = []
+
+        def capture(channel: str, text: str) -> None:
+            captured.append((channel, text))
+
+        original_make = quota_watch._make_workspace_post
+        quota_watch._make_workspace_post = lambda ws_id: capture
+        try:
+            self._register(
+                "agent-a",
+                quota_7d_used_pct=0.97,
+                quota_7d_reset_at="2026-04-28T01:00:00Z",
+            )
+            update_heartbeat("agent-a")
+        finally:
+            quota_watch._make_workspace_post = original_make
+
+        channels = [c for c, _ in captured]
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+        self.assertEqual(
+            _agents["agent-a"]["quota_state_7d"], STATE_ESCALATE
+        )
+
+    def test_percentage_input_is_normalized(self):
+        """Producer-agnostic — 0..100 percentages are rescaled."""
+        self._register("agent-a", quota_5h_used_pct=82)
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_WARN)
+
+    def test_full_lifecycle_ok_warn_escalate_recover(self):
+        """End-to-end sequence a real agent might traverse over a 5h
+        window: ok → warn → escalate → ok. Each transition fires once."""
+        # ok → warn
+        self._register("agent-a", quota_5h_used_pct=0.82)
+        check_agent_quota_pressure("agent-a", post=self._post)
+        # warn → escalate
+        self._register("agent-a", quota_5h_used_pct=0.97)
+        check_agent_quota_pressure("agent-a", post=self._post)
+        # escalate → ok (reset fired)
+        self._register("agent-a", quota_5h_used_pct=0.01)
+        check_agent_quota_pressure("agent-a", post=self._post)
+
+        channels = [c for c, _ in self.posts]
+        # Exactly: warn #progress, escalate #escalation + #ywatanabe,
+        # recovery #progress.
+        self.assertEqual(channels.count("#progress"), 2)  # warn + recovery
+        self.assertEqual(channels.count("#escalation"), 1)
+        self.assertEqual(channels.count("#ywatanabe"), 1)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_OK)


### PR DESCRIPTION
## Summary

The quota-pressure state-machine primitive in `hub/quota_watch.py` (classify + evaluate) has been in the tree since head-spartan's branch but was never wired into the hot path — no heartbeat invokes it, so warn / escalate messages never actually fire. This PR is the minimum-viable consumer-side completion of **todo#272** (proactive quota pressure detection + escalation before quota cap): it connects the existing pure logic to the heartbeat, preserves state across re-registers, and ships tests that exercise the full lifecycle.

PR #301 (sibling, merged) seeded the **worker-progress** digest agent. This PR is orthogonal — it's the threshold-detection layer that will post into `#progress` / `#escalation` / `#ywatanabe` so worker-progress has material to summarize and ywatanabe has lead time to rotate accounts before the hard cap.

## Changes

- **`hub/quota_watch.py`**: add `check_agent_quota_pressure(name)` as the heartbeat entry point (reads registry, runs `evaluate()`, writes new state back). Add `_coerce_utilization()` so 0..1 fractions and 0..100 percentages both work. Add `_make_workspace_post()` so posts go to the agent's workspace (replaces "first workspace" fallback).
- **`hub/registry/_register.py`**: prev-preserve `quota_state_5h` / `quota_state_7d` across re-registers (same regression pattern as `last_pong_ts` — without it the machine would reset to `ok` every heartbeat and re-spam warn / escalate).
- **`hub/registry/_heartbeat.py`**: `update_heartbeat()` calls `check_agent_quota_pressure()` after the timestamp write. Deferred import (quota_watch itself imports registry). Best-effort — never raises into the hot path.
- **`hub/tests/test_quota_watch.py`**: 23 new cases — classifier boundaries, percentage coercion, 8 state-machine transition cases, 9 end-to-end wiring cases (prev-preserve regression guard, same-band-no-repost, full `ok→warn→escalate→recover` lifecycle via the REST/WS hot path).

## Thresholds (unchanged, per head-spartan msg#7770)

| window | warn → #progress | escalate → #escalation + #ywatanabe |
|---|---|---|
| 5h  | >= 0.80 | >= 0.95 |
| 7d  | >= 0.85 | >= 0.95 |

Downshifts (warn→ok) and partial recovery (escalate→warn) are silent; only full `escalate→ok` posts a recovery ping (per ywatanabe msg#7788).

## Local verification

- `python manage.py test hub.tests.test_quota_watch -v 2` — **23/23 pass** in 0.04s.
- `python manage.py test hub.tests.registry -v 0` — **51/51 pass** (no regressions).
- `python manage.py test hub.tests -v 0` — **225/225 pass** (full suite, incl. existing consumer + heartbeat tests that exercise `update_heartbeat`).

## Out of scope (explicit)

- **Agents-tab UI bars** (5h / 7d per-agent). Fields already flow through `_payload.get_agents()`; the render change is a follow-up ("Child 2" per issue parent comment).
- **Producer-side `/api/oauth/usage` polling**. Assumed already pushed by `agent_meta.py --push` (scope of PR #299 MCP tool path). This PR is consumer-only.
- **Web-push fan-out on escalate**. `#ywatanabe` post is persisted as a Message; push delivery lives in `hub/push.py` / todo#263 and is independent of quota_watch.
- **Per-model breakdowns** (seven_day_sonnet vs seven_day_opus) — v2, per issue non-goals.

## Test plan

- [ ] CI runs the full `hub.tests` suite (incl. the 23 new cases).
- [ ] Merge + deploy → `agent_meta.py --push` quota figures start routing through `check_agent_quota_pressure`.
- [ ] First real threshold crossing observed in `#progress` (warn) or `#escalation` + `#ywatanabe` (escalate) with exactly-one-post semantics.
- [ ] No spam: agent sustaining 0.82 util for an hour produces one `#progress` post, not six.

## References

- Parent issue: todo#272 (proactive quota pressure detection + escalation before quota cap).
- Sibling PR: #301 (worker-progress sac agent; merged).
- Prior art: head-spartan's quota-watch logic on branch `feat/quota-pressure-producer` (landed as `hub/quota_watch.py` skeleton in develop but was never wired).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>