### PR TITLE
feat(ui): topology auto-layout button + sidebar channel card unify (lead msg#15493)

### DIFF
--- a/hub/frontend/src/activity-tab/compose.ts
+++ b/hub/frontend/src/activity-tab/compose.ts
@@ -286,6 +286,50 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     if (input) input.focus();
   }, 10);
 
+  /* todo#305 Task 6 (lead msg#15528): Cmd+V / ⌘V / context-menu Paste
+   * was failing on this popup. Root cause: macOS Safari does NOT focus
+   * a textarea on right-click (unlike Chrome/Firefox). A right-click on
+   * our textarea therefore left document.activeElement on whatever had
+   * focus before the popup opened (often <body> or the topology
+   * canvas), so the subsequent native "Paste" from the OS context menu
+   * fired a paste event on THAT element — not the textarea.
+   *
+   * Keyboard Cmd+V was only intermittent for the same reason: if the
+   * user clicked anywhere inside the popup that wasn't a focusable
+   * child, the textarea could lose focus and the next Cmd+V landed
+   * outside.
+   *
+   * Fix: refocus the textarea on ANY pointer interaction inside the
+   * popup (mousedown covers left + right click + middle click on all
+   * browsers), unless the target is one of the action buttons that
+   * legitimately owns focus (attach / camera / sketch / voice /
+   * expand). Also listen to `contextmenu` explicitly — belt & braces
+   * for browsers that fire contextmenu without a prior mousedown
+   * (some trackpad two-finger-tap paths on macOS). */
+  function _refocusInput(ev) {
+    if (!input) return;
+    /* Don't steal focus from action buttons. */
+    if (
+      ev.target &&
+      ev.target.closest &&
+      ev.target.closest(".tcc-x, .tcc-expand")
+    ) {
+      return;
+    }
+    /* If the user clicked directly on the textarea, the browser will
+     * focus it anyway and move the caret — don't fight that. Only
+     * refocus when the target is a non-focusable child (the popup
+     * chrome, a label, etc.) or the textarea but unfocused (e.g.
+     * right-click on macOS Safari). */
+    if (document.activeElement !== input) {
+      try {
+        input.focus();
+      } catch (_) {}
+    }
+  }
+  pop.addEventListener("mousedown", _refocusInput);
+  pop.addEventListener("contextmenu", _refocusInput);
+
   function close() {
     if (pop.parentNode) pop.parentNode.removeChild(pop);
     document.removeEventListener("mousedown", outsideClick, true);

--- a/hub/frontend/src/activity-tab/grid-click.ts
+++ b/hub/frontend/src/activity-tab/grid-click.ts
@@ -18,7 +18,17 @@ import { addTag } from "../filter/state";
 
 export function _ovgWireClick(grid) {
   grid.addEventListener("click", function (ev) {
-    var pinBtn = ev.target.closest(".activity-pin-btn[data-pin-name]");
+    /* Star click on a topology agent-node OR on an overview-grid HTML
+     * pin button. The SVG star emitted by renderAgentBadgeSvg carries
+     * `.topo-agent-star` (SVG <text>, not a <button>), the HTML path
+     * carries `.activity-pin-btn`; both expose the same data-pin-name /
+     * data-pin-next contract. Matching both selectors gives the topology
+     * canvas the SAME toggle-favourite behaviour the sidebar and
+     * overview-grid star click already has (todo#305 Task 5, lead
+     * msg#15523 "FUNCTIONAL parity with sidebar"). */
+    var pinBtn = ev.target.closest(
+      ".activity-pin-btn[data-pin-name], .topo-agent-star[data-pin-name]",
+    );
     if (pinBtn && grid.contains(pinBtn)) {
       ev.stopPropagation();
       var pname = pinBtn.getAttribute("data-pin-name");

--- a/hub/frontend/src/activity-tab/topology-autolayout.ts
+++ b/hub/frontend/src/activity-tab/topology-autolayout.ts
@@ -1,0 +1,197 @@
+// @ts-nocheck
+import {
+  _topoClearManualPosition,
+  _topoManualKey,
+  _topoManualPositions,
+  _topoSaveManualPositions,
+} from "./state";
+import { userName } from "../app/utils";
+
+/* activity-tab/topology-autolayout.ts — "整列" (Tidy) button handler.
+ *
+ * Re-lays out the topology graph into two concentric rings:
+ *   - Inner ring  = channel nodes
+ *   - Outer ring  = agents + human user
+ *
+ * Then runs a couple of light repulsion passes so no two nodes sit
+ * within ~1.2 * node_diameter of each other. Positions are written into
+ * _topoManualPositions (the same overlay that drag-to-reposition uses)
+ * so the layout survives heartbeat re-renders and zoom/pan.
+ *
+ * No deps; pure math + a two-pass softbody nudge. ywatanabe 2026-04-20
+ * lead msg#15493 / todo#305.
+ */
+
+/* Approximate node footprint used for the overlap-relief pass. The
+ * topology renderer itself uses node_diameter ≈ 44 for agent badges
+ * and ≈ 32 for channel diamonds; we take the max so repulsion is
+ * slightly conservative. */
+var _NODE_D = 48;
+var _MIN_SEP = _NODE_D * 1.2; /* ~58px */
+
+/* One repulsion pass — O(n²) over the node set, fine for <200 nodes.
+ * For each close pair, push them apart along the connecting vector by
+ * half the overlap each. `anchors` holds the target-ring position so a
+ * displaced node is also softly pulled back toward its assigned ring
+ * slot; without this a dense cluster can spiral outward forever. */
+function _repulsePass(nodes, anchors, strength) {
+  var i, j, a, b, dx, dy, d, overlap, ux, uy, push;
+  for (i = 0; i < nodes.length; i++) {
+    for (j = i + 1; j < nodes.length; j++) {
+      a = nodes[i];
+      b = nodes[j];
+      dx = b.x - a.x;
+      dy = b.y - a.y;
+      d = Math.sqrt(dx * dx + dy * dy);
+      if (d >= _MIN_SEP) continue;
+      if (d < 0.01) {
+        /* Co-located — nudge along a deterministic axis. */
+        ux = 1;
+        uy = 0;
+        d = 0.01;
+      } else {
+        ux = dx / d;
+        uy = dy / d;
+      }
+      overlap = (_MIN_SEP - d) * 0.5 * strength;
+      a.x -= ux * overlap;
+      a.y -= uy * overlap;
+      b.x += ux * overlap;
+      b.y += uy * overlap;
+    }
+  }
+  /* Anchor attraction — pull every node ~5% back toward its ring slot
+   * so the two rings stay recognisable after the nudges above. */
+  for (i = 0; i < nodes.length; i++) {
+    var anc = anchors[nodes[i].key];
+    if (!anc) continue;
+    nodes[i].x += (anc.x - nodes[i].x) * 0.05;
+    nodes[i].y += (anc.y - nodes[i].y) * 0.05;
+  }
+}
+
+/* Compute concentric ring positions for the currently-visible topology
+ * and write them into _topoManualPositions. Called from the "整列"
+ * button in the topology ctrls toolbar. */
+export function _topoAutoLayout() {
+  /* Data sources: the last render stashed positions + the visible agent
+   * list on window.__lastAgents. We re-derive channels from those
+   * agents the same way topology.ts does. */
+  var agents = (window as any).__lastAgents || [];
+  var hidden = (globalThis as any)._topoHidden || { agents: {}, channels: {} };
+  var chPrefs = (window as any)._channelPrefs || {};
+  var hn =
+    (typeof userName !== "undefined" && userName) ||
+    (window as any).__orochiUserName ||
+    "";
+
+  /* Filter visible agents — same rules as _renderActivityTopology. */
+  var visible = agents.filter(function (a) {
+    if (hidden.agents && hidden.agents[a.name]) return false;
+    /* Dead/unpinned rows: _isDeadAgent lives in utils, but we can't
+     * cheaply import it here without cycles. Approximate by treating
+     * rows with status === "offline" and !pinned as dead — the 整列
+     * button is a visual aid; a missed row self-corrects on next
+     * full render. */
+    if (a.status === "offline" && !a.pinned) return false;
+    return true;
+  });
+
+  /* Collect channels referenced by at least one visible agent + every
+   * workspace channel from channelPrefs (zero-subscriber channels must
+   * still lay out as connectable nodes — same contract as the renderer). */
+  var chSet: Record<string, boolean> = {};
+  visible.forEach(function (a) {
+    (a.channels || []).forEach(function (c) {
+      if (!c || c.indexOf("dm:") === 0) return;
+      chSet[c] = true;
+    });
+  });
+  Object.keys(chPrefs).forEach(function (c) {
+    if (!c || c.indexOf("dm:") === 0) return;
+    chSet[c] = true;
+  });
+  var channels = Object.keys(chSet)
+    .filter(function (c) {
+      if ((chPrefs[c] || {}).is_hidden) return false;
+      if (hidden.channels && hidden.channels[c]) return false;
+      return true;
+    })
+    .sort();
+
+  /* Canvas size — match the renderer's fallbacks. */
+  var grid = document.querySelector(
+    ".activity-view-topology .topo-wrap",
+  ) as HTMLElement | null;
+  var W = Math.max((grid && grid.clientWidth) || 0, 600);
+  var H = Math.max((grid && grid.clientHeight) || 0, 420);
+  var cx = W / 2;
+  var cy = H / 2;
+  var pad = 100;
+  var rOuter = Math.max(80, Math.min(W, H) / 2 - pad);
+  var rInner = Math.max(40, rOuter * 0.42);
+
+  /* Assign ring slots — channels on inner ring, agents+human on outer. */
+  var nodes: Array<{ key: string; kind: string; name: string; x: number; y: number }> = [];
+  var anchors: Record<string, { x: number; y: number }> = {};
+
+  channels.forEach(function (c, i) {
+    var n = Math.max(1, channels.length);
+    var theta = ((i + 0.5) / n) * Math.PI * 2 - Math.PI / 2;
+    var p = { x: cx + rInner * Math.cos(theta), y: cy + rInner * Math.sin(theta) };
+    var key = _topoManualKey("channel", c);
+    anchors[key] = p;
+    nodes.push({ key: key, kind: "channel", name: c, x: p.x, y: p.y });
+  });
+
+  var nOuter = visible.length + (hn ? 1 : 0);
+  var outerIdx = 0;
+  if (hn) {
+    var thetaH = (outerIdx / Math.max(1, nOuter)) * Math.PI * 2 - Math.PI / 2;
+    var pH = { x: cx + rOuter * Math.cos(thetaH), y: cy + rOuter * Math.sin(thetaH) };
+    var keyH = _topoManualKey("agent", hn);
+    anchors[keyH] = pH;
+    nodes.push({ key: keyH, kind: "agent", name: hn, x: pH.x, y: pH.y });
+    outerIdx++;
+  }
+  visible.forEach(function (a) {
+    var thetaA = (outerIdx / Math.max(1, nOuter)) * Math.PI * 2 - Math.PI / 2;
+    var pA = { x: cx + rOuter * Math.cos(thetaA), y: cy + rOuter * Math.sin(thetaA) };
+    var keyA = _topoManualKey("agent", a.name);
+    anchors[keyA] = pA;
+    nodes.push({ key: keyA, kind: "agent", name: a.name, x: pA.x, y: pA.y });
+    outerIdx++;
+  });
+
+  /* Two nudge passes — empirically enough to resolve the typical
+   * 15-agent / 10-channel overlap on a default-sized canvas without
+   * drifting the rings noticeably. */
+  _repulsePass(nodes, anchors, 1.0);
+  _repulsePass(nodes, anchors, 0.7);
+
+  /* Write back into the manual-position overlay. We REPLACE every
+   * existing entry for the keys we touched so partial drags don't
+   * linger after the user asked for a tidy. Keys we didn't touch
+   * (stale entries from agents no longer in the visible set) are
+   * left alone — they'll age out when those entities reappear or
+   * are reset manually. */
+  nodes.forEach(function (n) {
+    _topoManualPositions[n.key] = { x: n.x, y: n.y };
+  });
+  _topoSaveManualPositions();
+
+  /* Invalidate the signature cache so the next render actually repaints
+   * (the renderer short-circuits when its structural signature matches). */
+  (globalThis as any)._topoLastSig = "";
+}
+
+/* Reset to pure ring layout by clearing all manual overrides — useful
+ * as a companion affordance; not currently wired but exported for
+ * future "reset layout" button reuse. */
+export function _topoClearLayout() {
+  Object.keys(_topoManualPositions).forEach(function (k) {
+    delete _topoManualPositions[k];
+  });
+  _topoSaveManualPositions();
+  (globalThis as any)._topoLastSig = "";
+}

--- a/hub/frontend/src/activity-tab/topology.ts
+++ b/hub/frontend/src/activity-tab/topology.ts
@@ -335,6 +335,11 @@ export function _renderActivityTopology(visible, grid) {
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="minus" title="Zoom out (−)">−</button>' +
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="reset" title="Reset zoom (0)">0</button>' +
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="plus" title="Zoom in (+)">+</button>' +
+    /* todo#305: 整列 (Tidy) button — runs concentric-ring auto-layout
+     * (inner = channels, outer = agents + human) with two light
+     * repulsion passes so overlapping nodes spread out. Layout only
+     * runs on explicit click; drag / zoom / pan are unchanged. */
+    '<button type="button" class="topo-ctrl-btn topology-autolayout-btn" data-topo-ctrl="integrate" title="整列 (auto-layout: channels inner, agents outer)">整列</button>' +
     "</div>";
   var pool = _topoBuildPoolHtml(visible, channels);
   /* todo#67 — Time seekbar + play button docked at the bottom of the

--- a/hub/frontend/src/activity-tab/topology.ts
+++ b/hub/frontend/src/activity-tab/topology.ts
@@ -23,11 +23,19 @@ import { escapeHtml, userName } from "../app/utils";
 
 export function _renderActivityTopology(visible, grid) {
   _topoApplyStickyEdges();
-  /* Filter out agents the user hid via right-click. Edges involving
+  /* Filter out agents the user hid via right-click (session-only via
+   * _topoHidden) OR via the persistent 👁 eye on the agent card (Task 7,
+   * AgentProfile.is_hidden — sticks across sessions). Edges involving
    * hidden agents collapse automatically because they're dropped from
-   * the visible loop. Human node is protected inside _topoHide. */
+   * the visible loop. Human node is protected inside _topoHide and
+   * never has is_hidden on its payload. */
   visible = visible.filter(function (a) {
     if ((globalThis as any)._topoHidden.agents[a.name]) return false;
+    /* todo#305 Task 7 (lead msg#15548): mirror channel-hidden topo
+     * semantics — hidden agents are DROPPED from the canvas render
+     * (not dimmed in place). Consistent with how channels hidden via
+     * .ch-eye disappear from the topology. */
+    if (a.is_hidden) return false;
     /* Dead agents render only when pinned (kept as ghost/shadow);
      * unpinned dead agents are dropped entirely from the canvas. */
     if (_isDeadAgent(a) && !a.pinned) return false;

--- a/hub/frontend/src/activity-tab/zoompan.ts
+++ b/hub/frontend/src/activity-tab/zoompan.ts
@@ -3,6 +3,7 @@ import { _topoCleanupDrag } from "./compose";
 import { renderActivityTab } from "./init";
 import { _topoSelectAdd, _topoSelectClear } from "./multiselect";
 import { _topoViewBoxFuture, _topoViewBoxHistory } from "./state";
+import { _topoAutoLayout } from "./topology-autolayout";
 
 /* activity-tab/zoompan.js — drag-rectangle zoom + shift-drag pan
  * + ctrl-drag lasso + wheel zoom/pan + keyboard shortcuts +
@@ -311,6 +312,14 @@ export function _wireTopoZoomPan(grid, W, H) {
     else if (action === "reset") _resetVB(svg);
     else if (action === "plus") _zoomAt(svg, 1 / 1.25, null, null);
     else if (action === "minus") _zoomAt(svg, 1.25, null, null);
+    else if (action === "integrate") {
+      /* todo#305: 整列 — concentric ring auto-layout. Mutates the
+       * _topoManualPositions overlay and re-renders so nodes snap to
+       * the computed slots. Zoom / pan state is preserved; only the
+       * per-node positions change. */
+      _topoAutoLayout();
+      if (typeof renderActivityTab === "function") renderActivityTab();
+    }
   });
   /* Keyboard — Escape = back; 0 = reset; +/= = zoom in; - = zoom out.
    * Only fires when an SVG is visible and no text input is focused. */

--- a/hub/frontend/src/agent-badge-svg.ts
+++ b/hub/frontend/src/agent-badge-svg.ts
@@ -231,7 +231,12 @@ import { escapeHtml, getAgentColor } from "./app/utils";
     var showStar = opts.showStar !== false;
     var showLeds = opts.showLeds !== false && !opts.isHuman;
     var iconSize = opts.iconSize || 14;
-    var LED_R = 4;
+    /* todo#305 (Task 3, lead msg#15509): LED radius tuned to 3.5px so
+     * the topology node's LED strip reads at the same visual weight as
+     * the sidebar agent row (which uses 7px-diameter .activity-led via
+     * .sidebar-agent-row .activity-led in activity-tab-list.css). Was
+     * 4px (=8px diameter) which felt heavier than the sidebar's dots. */
+    var LED_R = 3.5;
     var GAP = 3;
 
     var ident =

--- a/hub/frontend/src/agent-badge-svg.ts
+++ b/hub/frontend/src/agent-badge-svg.ts
@@ -229,6 +229,7 @@ import { escapeHtml, getAgentColor } from "./app/utils";
     var y = pos.y;
     var showName = opts.showName !== false;
     var showStar = opts.showStar !== false;
+    var showEye = opts.showEye !== false && !opts.isHuman;
     var showLeds = opts.showLeds !== false && !opts.isHuman;
     var iconSize = opts.iconSize || 14;
     /* todo#305 (Task 3, lead msg#15509): LED radius tuned to 3.5px so
@@ -253,10 +254,13 @@ import { escapeHtml, getAgentColor } from "./app/utils";
     var nameText = opts.labelOverride || ident.displayName || a.name || "";
     var color = opts.isHuman ? "#fbbf24" : ident.color;
 
-    /* Canonical layout per ywatanabe 2026-04-20:
-     *   icon + 4 LEDs + name@hostname + star
-     * All elements laid out left→right starting at glyphX. Human nodes
-     * keep their simpler icon+name layout (no LEDs, no star slot). */
+    /* Canonical layout, todo#305 Task 7 (lead msg#15548):
+     *   icon + star + eye + 4 LEDs + name@hostname
+     * Matches the HTML agent-badge.ts canonical order 1:1 so canvas,
+     * sidebar and pool chip all read left-to-right the same way.
+     * Human nodes keep their simpler icon+name layout (no LEDs, no
+     * star, no eye — is_hidden is not meaningful for the signed-in
+     * human anyway). */
     var iconHalf = iconSize / 2;
     var ledsWidth = 0;
     var ledBlock = { svg: "", width: 0 };
@@ -267,8 +271,6 @@ import { escapeHtml, getAgentColor } from "./app/utils";
     if (opts.isHuman) {
       glyphX = x - 10;
     } else {
-      // Pack icon + 4 LEDs + name + star starting from glyphX, centering
-      // the whole cluster around pos.x. Compute total width first.
       glyphX = x; // temp; will reposition below
     }
 
@@ -280,23 +282,33 @@ import { escapeHtml, getAgentColor } from "./app/utils";
 
     var textW = Math.max(40, nameText.length * 6.5);
     var starW = showStar ? 14 : 0;
+    var eyeW = showEye ? 14 : 0;
 
     if (!opts.isHuman) {
-      // Total width: icon + gap + LEDs + gap + name + gap + star.
+      // Total width: icon + gap + star + gap + eye + gap + LEDs + gap + name.
       var GAP_BETWEEN = 6;
       var total =
         iconSize +
+        (showStar ? GAP_BETWEEN + starW : 0) +
+        (showEye ? GAP_BETWEEN + eyeW : 0) +
         GAP_BETWEEN +
         ledsWidth +
         GAP_BETWEEN +
-        textW +
-        (showStar ? GAP_BETWEEN + starW : 0);
+        textW;
       // Re-center: cluster centered on pos.x.
       var clusterLeft = x - total / 2;
       glyphX = clusterLeft + iconHalf; // center of icon
-      var ledsStartCx = glyphX + iconHalf + GAP_BETWEEN + LED_R;
+      // Slot centers are laid out left -> right in canonical order.
+      var starX = showStar
+        ? glyphX + iconHalf + GAP_BETWEEN + starW / 2
+        : glyphX + iconHalf;
+      var eyeX = showEye
+        ? starX + (showStar ? starW / 2 : iconHalf) + GAP_BETWEEN + eyeW / 2
+        : starX;
+      var ledsStartCx = (showEye ? eyeX + eyeW / 2 : starX + (showStar ? starW / 2 : iconHalf)) +
+        GAP_BETWEEN +
+        LED_R;
       var nameX = ledsStartCx + ledsWidth - LED_R + GAP_BETWEEN;
-      var starX = nameX + textW + GAP_BETWEEN;
 
       var glyph = _renderAgentGlyphSvg(a, glyphX, y, iconSize, ident, opts);
 
@@ -321,7 +333,7 @@ import { escapeHtml, getAgentColor } from "./app/utils";
           (y + 4).toFixed(1) +
           '" fill="' +
           (pinned ? "#fbbf24" : "#3a3a3a") +
-          '" font-size="13" style="cursor:pointer" data-pin-name="' +
+          '" font-size="13" style="cursor:pointer" text-anchor="middle" data-pin-name="' +
           _escape(a.name || "") +
           '" data-pin-next="' +
           (pinned ? "false" : "true") +
@@ -330,6 +342,52 @@ import { escapeHtml, getAgentColor } from "./app/utils";
           "</title>" +
           (pinned ? "\u2605" : "\u2606") +
           "</text>";
+      }
+
+      /* Eye slot — 👁 SVG with optional red strike line when is_hidden.
+       * Matches the HTML eye (.agent-badge-eye) semantically — same
+       * classes so body-level delegation in agent-badge.ts catches
+       * clicks on either DOM or SVG. Strike is drawn as a sibling
+       * <line> inside a <g> wrapper so it doesn't break the glyph's
+       * baseline. todo#305 Task 7 (lead msg#15548). */
+      var eyeSvg = "";
+      if (showEye) {
+        var hiddenFlag = !!a.is_hidden;
+        var eyeCls =
+          "topo-agent-eye " +
+          (hiddenFlag ? "topo-agent-eye-off" : "topo-agent-eye-on");
+        var eyeGlyph =
+          '<text x="' +
+          eyeX.toFixed(1) +
+          '" y="' +
+          (y + 4).toFixed(1) +
+          '" font-size="11" text-anchor="middle" fill="#94a3b8" style="cursor:pointer">\uD83D\uDC41</text>';
+        var strike = hiddenFlag
+          ? '<line x1="' +
+            (eyeX - 5).toFixed(1) +
+            '" y1="' +
+            (y + 3).toFixed(1) +
+            '" x2="' +
+            (eyeX + 5).toFixed(1) +
+            '" y2="' +
+            (y - 3).toFixed(1) +
+            '" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round" pointer-events="none"/>'
+          : "";
+        eyeSvg =
+          '<g class="' +
+          eyeCls +
+          '" data-eye-agent="' +
+          _escape(a.name || "") +
+          '" style="cursor:pointer"><title>' +
+          _escape(
+            hiddenFlag
+              ? "Show agent (un-hide)"
+              : "Hide agent (remove from list + graph)",
+          ) +
+          "</title>" +
+          eyeGlyph +
+          strike +
+          "</g>";
       }
 
       var nameSvg = "";
@@ -361,10 +419,11 @@ import { escapeHtml, getAgentColor } from "./app/utils";
       var cls = "topo-node topo-agent";
       if (opts.isSelected) cls += " topo-agent-selected";
       if (opts.isDead) cls += " topo-agent-dead";
+      if (a.is_hidden) cls += " topo-agent-hidden";
       if (opts.extraClass) cls += " " + opts.extraClass;
 
-      /* Order matches the HTML agent-badge.js canonical order:
-       *   icon + star + 4 LEDs + name (ywatanabe 2026-04-21). */
+      /* Order matches the HTML agent-badge.ts canonical order:
+       *   icon + star + eye + 4 LEDs + name (Task 7, msg#15548). */
       return (
         '<g class="' +
         cls +
@@ -377,6 +436,7 @@ import { escapeHtml, getAgentColor } from "./app/utils";
         bg +
         glyph +
         starSvg +
+        eyeSvg +
         ledBlock.svg +
         nameSvg +
         "</g>"

--- a/hub/frontend/src/agent-badge.ts
+++ b/hub/frontend/src/agent-badge.ts
@@ -12,8 +12,14 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
  * BADGES, INCLUDING ICON (changeable on click), STAR (toglable), 4 LEDs,
  * name, and host; NEVER ACCEPT ANY DIFFERENCES".
  *
- * Badge layout (left → right):
- *   [icon][star][LED1 WS][LED2 Ping][LED3 Local][LED4 Remote][name@host]
+ * Badge layout (left → right), todo#305 Task 7 (lead msg#15548):
+ *   [icon][star][eye][LED1 WS][LED2 Ping][LED3 Local][LED4 Remote][name@host]
+ *
+ * The 👁 eye slot was added after ★ and before the LEDs per lead's
+ * explicit ordering directive in msg#15548 / companion reference
+ * image `sidebar-agents-reference-2026-04-21.png`. Channel cards carry
+ * eye too — keeping parity across both entity types so a user who
+ * learned "eye = hide this row" on channels finds the same on agents.
  *
  * Loaded BEFORE app.js / activity-tab.js / agents-tab.js so the helpers
  * are in scope at render time. See dashboard.html <script> ordering.
@@ -22,6 +28,7 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
  * when they need to interleave other elements — e.g. drag handles):
  *   - renderAgentIcon(a, size)     — clickable avatar / emoji
  *   - renderAgentStar(a)           — togglable ☆/★
+ *   - renderAgentEye(a)            — togglable 👁 show/hide
  *   - renderAgentLeds(a, opts)     — four-LED liveness strip
  *   - renderAgentName(a)           — colored name (with @host suffix)
  *
@@ -118,6 +125,29 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
       '">' +
       (pinned ? "\u2605" : "\u2606") +
       "</button>"
+    );
+  }
+
+  // ── 2b. Eye (togglable show/hide, always visible, placeholder even when
+  //        not hidden so column geometry stays constant across rows).
+  // Mirrors the channel .ch-eye pattern 1:1: same 👁 glyph in both states,
+  // red diagonal strike drawn via the .agent-badge-eye-off::after CSS
+  // rule (defined in style-agents.css alongside the channel variant).
+  // todo#305 Task 7 (lead msg#15548).
+  function renderAgentEye(a) {
+    var hidden = !!a.is_hidden;
+    return (
+      '<span class="agent-badge-eye ' +
+      (hidden ? "agent-badge-eye-off" : "agent-badge-eye-on") +
+      '" data-eye-agent="' +
+      _escape(a.name || "") +
+      '" title="' +
+      _escape(
+        hidden
+          ? "Show agent (un-hide)"
+          : "Hide agent (remove from list + graph)",
+      ) +
+      '" style="cursor:pointer">\uD83D\uDC41</span>'
     );
   }
 
@@ -242,17 +272,20 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
   // ── Composed badge (canonical layout) ─────────────────────────────
   function renderAgentBadge(a, opts) {
     opts = opts || {};
-    /* Canonical order per ywatanabe 2026-04-21:
-     *   icon + star + 4 LEDs + name@hostname
-     * Matches the channel badge (icon + star + eye + mute + name), so
-     * star sits in the same column position across both entity types.
-     * renderAgentStar always emits a placeholder span for non-starred
-     * agents so column alignment holds. */
+    /* Canonical order, todo#305 Task 7 (lead msg#15548):
+     *   icon + star + eye + 4 LEDs + name@hostname
+     * Matches the channel badge column order (icon + star + eye +
+     * mute + name) so a user who learned the glyph map on channels
+     * finds the same on agents. The eye was inserted between ★ and
+     * the LED strip per lead's explicit ordering directive in
+     * msg#15548 (deviation from Task 3's baseline, but Task 7 owns
+     * the slot for agents going forward). */
     var icon = renderAgentIcon(a, opts.iconSize);
     var star = renderAgentStar(a);
+    var eye = opts.hideEye ? "" : renderAgentEye(a);
     var leds = renderAgentLeds(a, { extraClass: opts.extraClass });
     var name = opts.hideName ? "" : renderAgentName(a, opts);
-    return icon + star + leds + name;
+    return icon + star + eye + leds + name;
   }
 
   // ── Background-class helper: dim when not all four LEDs green ─────
@@ -293,9 +326,76 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
     return false;
   }
 
+  // ── Eye toggle — persistent flip of AgentProfile.is_hidden ──────────
+  // Body-level delegated handler so EVERY agent-eye glyph anywhere in
+  // the DOM (sidebar row, Activity overview card, topology SVG) gets
+  // the same behavior without per-render binding. Mirrors the
+  // .ch-eye delegation pattern in channel-badge.js (see
+  // attachChannelBadgeHandlers there). Idempotent: only binds once.
+  var _agentEyeAttached = false;
+  function attachAgentEyeHandler() {
+    if (_agentEyeAttached) return;
+    _agentEyeAttached = true;
+    if (typeof document === "undefined") return;
+    document.body.addEventListener(
+      "click",
+      function (ev) {
+        var eye = ev.target.closest && ev.target.closest(
+          ".agent-badge-eye[data-eye-agent], .topo-agent-eye[data-eye-agent]",
+        );
+        if (!eye) return;
+        var name = eye.getAttribute("data-eye-agent");
+        if (!name) return;
+        ev.stopPropagation();
+        ev.preventDefault();
+        /* Current state — read from live registry if available, fall
+         * back to the glyph's own class for first-click after load
+         * (before __lastAgents is populated). */
+        var live = (window as any).__lastAgents || [];
+        var curAgent = null;
+        for (var i = 0; i < live.length; i++) {
+          if (live[i] && live[i].name === name) {
+            curAgent = live[i];
+            break;
+          }
+        }
+        var curHidden = curAgent
+          ? !!curAgent.is_hidden
+          : eye.classList.contains("agent-badge-eye-off") ||
+            eye.classList.contains("topo-agent-eye-off");
+        var nextHidden = !curHidden;
+        /* Optimistic local update so the glyph flips immediately; the
+         * re-render triggered by _setAgentHidden → fetchAgents lands
+         * ~200-500ms later and is idempotent. */
+        if (curAgent) curAgent.is_hidden = nextHidden;
+        eye.classList.toggle("agent-badge-eye-on", !nextHidden);
+        eye.classList.toggle("agent-badge-eye-off", nextHidden);
+        eye.classList.toggle("topo-agent-eye-on", !nextHidden);
+        eye.classList.toggle("topo-agent-eye-off", nextHidden);
+        /* Persist via the existing agent-profiles endpoint — same
+         * mutation path as icon / color edits. The backend accepts
+         * is_hidden as an optional PATCH-style field (todo#305 Task 7;
+         * hub/views/api/_agents.py::api_agent_profiles). */
+        var setHidden = (window as any)._setAgentHidden;
+        if (typeof setHidden === "function") {
+          setHidden(name, nextHidden);
+        }
+      },
+      true, // capture — beat site-local click handlers that stopPropagation
+    );
+  }
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", attachAgentEyeHandler);
+    } else {
+      attachAgentEyeHandler();
+    }
+  }
+
   // Expose globals — script is loaded as a plain <script> tag.
   window.renderAgentIcon = renderAgentIcon;
   window.renderAgentStar = renderAgentStar;
+  window.renderAgentEye = renderAgentEye;
   window.renderAgentLeds = renderAgentLeds;
   window.renderAgentName = renderAgentName;
   window.renderAgentBadge = renderAgentBadge;
@@ -310,6 +410,7 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
 export const isAgentAllGreen = (window as any).isAgentAllGreen;
 export const isAgentVisible = (window as any).isAgentVisible;
 export const renderAgentBadge = (window as any).renderAgentBadge;
+export const renderAgentEye = (window as any).renderAgentEye;
 export const renderAgentIcon = (window as any).renderAgentIcon;
 export const renderAgentLeds = (window as any).renderAgentLeds;
 export const renderAgentName = (window as any).renderAgentName;

--- a/hub/frontend/src/app/channel-prefs.ts
+++ b/hub/frontend/src/app/channel-prefs.ts
@@ -149,6 +149,41 @@ export function _setChannelPref(ch, patch) {
   }
 }
 
+/* todo#305 Task 7 (lead msg#15548): flip the persistent per-agent
+ * is_hidden flag. Parallel to _setChannelPref({ is_hidden: ... })
+ * — same server contract, same re-render trigger. The 👁 eye glyph
+ * on an agent card (sidebar row or topology SVG) calls this from the
+ * body-level delegated handler in agent-badge.ts. */
+export function _setAgentHidden(name, isHidden) {
+  /* Optimistic local update so the next render reflects the new flag
+   * even before the server round-trip lands. __lastAgents is the
+   * single cache consumed by fetchAgents / renderActivityTab; keep
+   * it in sync so the sort / filter picks up the change. */
+  var live = (window as any).__lastAgents || [];
+  for (var i = 0; i < live.length; i++) {
+    if (live[i] && live[i].name === name) {
+      live[i].is_hidden = !!isHidden;
+      break;
+    }
+  }
+  fetch(apiUrl("/api/agent-profiles/"), {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCsrfToken(),
+    },
+    body: JSON.stringify({ name: name, is_hidden: !!isHidden }),
+  }).catch(function (_) {});
+  if (typeof fetchAgents === "function") fetchAgents();
+  if (typeof renderActivityTab === "function") {
+    /* Bust topo sticky signature so the canvas rebuilds with the new
+     * visibility filter; signature doesn't track per-agent prefs. */
+    if (typeof window._topoLastSig !== "undefined") window._topoLastSig = "";
+    renderActivityTab();
+  }
+}
+
 /* Update an agent's display profile (icon_emoji etc) via
  * POST /api/agent-profiles/. Parallel to _setChannelIcon — keeps the
  * configuration story uniform across entity types. The registry
@@ -325,3 +360,9 @@ export function _renderStarredSection() {
 
 // Expose cross-file mutable state via globalThis:
 (globalThis as any)._topoLastSig = (typeof _topoLastSig !== 'undefined' ? _topoLastSig : undefined);
+
+/* todo#305 Task 7: expose _setAgentHidden on window so agent-badge.ts's
+ * body-level eye-click delegation (which runs in an IIFE outside this
+ * module's closure) can reach it without a static import cycle.
+ * Mirrors the pattern used for other top-level app helpers. */
+(window as any)._setAgentHidden = _setAgentHidden;

--- a/hub/frontend/src/app/sidebar-agents.ts
+++ b/hub/frontend/src/app/sidebar-agents.ts
@@ -108,7 +108,13 @@ export async function fetchAgents() {
      * selection (name / machine) within each group. ywatanabe
      * 2026-04-21: "starred agents should be placed upper" +
      * "functionally, no; please make it functional" (sort dropdown
-     * must actually sort the sidebar list, not just the Agents tab). */
+     * must actually sort the sidebar list, not just the Agents tab).
+     *
+     * todo#305 Task 7 (lead msg#15548): hidden agents (👁 eye off)
+     * sort to the BOTTOM, mirroring the sidebar Channels section —
+     * channels.firstHiddenIdx is the same pattern. The row stays in
+     * the DOM at opacity 1 (no row dim — PR #293/#295 rule) so users
+     * can click the eye again to un-hide. */
     var sortBy =
       typeof (globalThis as any)._overviewSort === "string" && (globalThis as any)._overviewSort
         ? (globalThis as any)._overviewSort
@@ -126,6 +132,11 @@ export async function fetchAgents() {
       return String(dn || "").toLowerCase();
     };
     sidebarVisible.sort(function (a, b) {
+      /* Hidden → bottom. Same treatment as channel-prefs.is_hidden
+       * sort in sidebar-stats.ts. */
+      var ha = a.is_hidden ? 1 : 0;
+      var hb = b.is_hidden ? 1 : 0;
+      if (ha !== hb) return ha - hb;
       var pa = a.pinned ? 0 : 1;
       var pb = b.pinned ? 0 : 1;
       if (pa !== pb) return pa - pb;
@@ -177,15 +188,23 @@ export async function fetchAgents() {
           : "Star (keeps as ghost when offline, floats to top)";
         return (
           // Single source of truth — agent-badge.js owns icon + star +
-          // 4 LEDs + name. Same call lives in activity-tab.js list view
-          // and topology pool chip. NEVER inline a fork here.
+          // eye + 4 LEDs + name. Same call lives in activity-tab.js
+          // list view and topology pool chip. NEVER inline a fork here.
           '<div class="agent-card sidebar-agent-row' +
           (typeof isAgentAllGreen === "function" && !isAgentAllGreen(a)
             ? " activity-card-ghost"
             : "") +
+          /* todo#305 Task 7: agent-hidden class mirrors .ch-hidden on
+           * channel rows. Keeps the row in the DOM at full opacity
+           * (PR #293/#295 rule) — only the eye-slash glyph signals
+           * hidden state. Class is kept so CSS can add affordances
+           * (cursor:pointer, subtle divider above first hidden row)
+           * without touching brightness. */
+          (a.is_hidden ? " agent-hidden" : "") +
           ghostClass +
           '" data-agent-name="' +
           escapeHtml(rawName) +
+          (a.is_hidden ? '" data-hidden="1' : "") +
           '" data-agent-channels="' +
           escapeHtml(chList) +
           '" draggable="true" title="' +

--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -5,9 +5,9 @@ import { _addChannelContextMenu } from "./context-menus";
 import { _channelPrefs } from "./members";
 import { fetchStats } from "./sidebar-stats";
 import { setCurrentChannel } from "./state";
-import { channelUnread, escapeHtml } from "./utils";
+import { channelUnread, escapeHtml, getAgentColor } from "./utils";
 import { updateChannelUnreadBadges } from "./websocket";
-import { renderChannelBadgeHtml } from "../channel-badge";
+import { channelBadgeModel, renderChannelBadgeHtml } from "../channel-badge";
 import { loadChannelHistory } from "../chat/chat-history";
 import { applyFeedFilter } from "../chat/chat-render";
 import { _activateTab, activeTab } from "../tabs";
@@ -152,6 +152,35 @@ export function _renderChannelRowHtml(row, ctx) {
           iconSize: 14,
         })
       : "";
+  /* todo#305 (ywatanabe msg#15510 / lead msg#15513): restore per-channel
+   * colour to the sidebar row. PR #285 dropped row-level colour-coding;
+   * the directive has since been reversed. Palette source = the SAME
+   * name-hash used by agent cards (getAgentColor → OROCHI_COLORS), so
+   * Channels and Agents lists share a coherent colour vocabulary.
+   *
+   * Apply via the --channel-accent CSS custom property on the row. CSS
+   * in style-channels.css tints the leading .ch-identity-icon glyph and
+   * draws a 2px left-edge accent stripe from this var. Nothing else on
+   * the row is coloured: no row background tint (PR #293's subtle
+   * selected-bg rule owns selection signalling) and no opacity change
+   * (PR #291 banned row-level opacity dim). The 🔔/👁/★ glyphs remain
+   * monochrome — colour is ONLY on the category icon at position 1.
+   *
+   * channelBadgeModel(c).color resolves to any user-set channel colour
+   * first, then falls back to _identityColor → getAgentColor(norm); we
+   * reuse it here so a channel's sidebar accent matches its pool chip
+   * label colour and its topology label fill. */
+  var accentColor = "";
+  if (typeof channelBadgeModel === "function") {
+    var m = channelBadgeModel(c);
+    accentColor = (m && m.color) || "";
+  }
+  if (!accentColor && typeof getAgentColor === "function") {
+    accentColor = getAgentColor(norm);
+  }
+  var accentStyle = accentColor
+    ? ' style="--channel-accent:' + escapeHtml(accentColor) + '"'
+    : "";
   return (
     divider +
     '<div class="channel-item ch-badge ch-badge-sidebar' +
@@ -166,6 +195,7 @@ export function _renderChannelRowHtml(row, ctx) {
     (entry.hidden ? ' data-hidden="1"' : "") +
     (row.inFolder ? ' data-folder="' + escapeHtml(row.inFolder) + '"' : "") +
     rowTitle +
+    accentStyle +
     ' draggable="true">' +
     badgeInner +
     "</div>"

--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -8,7 +8,7 @@ import { setCurrentChannel } from "./state";
 import { channelUnread, escapeHtml } from "./utils";
 import { updateChannelUnreadBadges } from "./websocket";
 import { renderChannelBadgeHtml } from "../channel-badge";
-import { loadChannelHistory, loadHistory } from "../chat/chat-history";
+import { loadChannelHistory } from "../chat/chat-history";
 import { applyFeedFilter } from "../chat/chat-render";
 import { _activateTab, activeTab } from "../tabs";
 
@@ -307,11 +307,14 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
       }
       /* #284: channels are single-selection only. The legacy Ctrl/Cmd+Click
        * multi-select has been removed — any click replaces the current
-       * selection with exactly this row. */
-      if ((globalThis as any).currentChannel === ch) {
-        setCurrentChannel(null);
-        loadHistory();
-      } else {
+       * selection with exactly this row.
+       *
+       * todo#305 / lead msg#15493: clicking the currently-selected row
+       * is a NO-OP — there is always exactly one selected channel, and
+       * re-clicking must not deselect. Previously this branch set the
+       * channel to null (empty chat, no highlight); users reported it
+       * as a defect ("sometimes no channel is selected at all"). */
+      if ((globalThis as any).currentChannel !== ch) {
         setCurrentChannel(ch);
         loadChannelHistory(ch);
       }
@@ -327,16 +330,18 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
        * DM agent-cards), not just this chContainer. Previously only
        * chContainer was cleared, which left a stale .selected on a
        * DM row when the user switched from a DM to a channel and
-       * manifested as "two rows selected at once" (#293). */
-      var wasSelected = el.classList.contains("selected");
+       * manifested as "two rows selected at once" (#293).
+       *
+       * todo#305: unconditionally re-select this row — the click
+       * handler above no longer deselects on re-click, so the class
+       * must always land back on this element after the cross-sidebar
+       * clear. */
       document
         .querySelectorAll(".sidebar .channel-item.selected, .sidebar .dm-item.selected")
         .forEach(function (it) {
           it.classList.remove("selected");
         });
-      if (!wasSelected && (globalThis as any).currentChannel === ch) {
-        el.classList.add("selected");
-      }
+      el.classList.add("selected");
       if (typeof applyFeedFilter === "function") applyFeedFilter();
       fetchStats();
     });

--- a/hub/migrations/0027_agentprofile_is_hidden.py
+++ b/hub/migrations/0027_agentprofile_is_hidden.py
@@ -1,0 +1,23 @@
+# Generated for todo#305 Task 7 (lead msg#15548) — 2026-04-21.
+#
+# Adds AgentProfile.is_hidden so the 👁 eye toggle on agent cards
+# (sidebar + topology) has a persistent per-agent hidden flag,
+# mirroring ChannelPreference.is_hidden. Default False keeps every
+# existing agent visible on rollout.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("hub", "0026_workspace_icon_image"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="agentprofile",
+            name="is_hidden",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/hub/models/_identity.py
+++ b/hub/models/_identity.py
@@ -171,6 +171,12 @@ class AgentProfile(models.Model):
     icon_image = models.CharField(max_length=500, blank=True, default="")
     icon_text = models.CharField(max_length=16, blank=True, default="")
     color = models.CharField(max_length=16, blank=True, default="")
+    # todo#305 Task 7 (lead msg#15548): persistent per-agent hidden flag
+    # toggled by the 👁 eye icon on the agent card. Mirrors
+    # ChannelPreference.is_hidden — same semantics (row dropped from
+    # sidebar + topology; visible flag restorable via the eye toggle on
+    # any ghost/pool representation).
+    is_hidden = models.BooleanField(default=False)
     # Last-known caduceus-reported health — persisted so the Agents tab
     # + sidebar pills survive container restarts without agents having
     # to re-POST their diagnosis. Free-form status string per mamba's

--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -46,6 +46,10 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                     "health_reason": p.health_reason or "",
                     "health_source": p.health_source or "",
                     "health_ts": p.health_ts,
+                    # todo#305 Task 7 (lead msg#15548): per-agent
+                    # is_hidden flag; dashboard's 👁 eye toggle reads
+                    # this to dim / drop agent cards in sidebar + graph.
+                    "is_hidden": bool(getattr(p, "is_hidden", False)),
                 }
         except Exception:
             pass
@@ -105,6 +109,11 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "icon_emoji": icon_emoji,
                 "icon_text": icon_text,
                 "color": prof.get("color") or a.get("color", ""),
+                # todo#305 Task 7 (lead msg#15548): persistent per-agent
+                # hidden flag. False by default for agents without a
+                # profile row. Frontend 👁 toggle reads this to dim / drop
+                # the agent card in sidebar + topology.
+                "is_hidden": bool(prof.get("is_hidden", False)),
                 "channels": list(set(a.get("channels", []))),  # deduplicate
                 "status": a.get("status", "online"),
                 "liveness": liveness,

--- a/hub/static/hub/activity-tab/activity-tab-topology-nodes.css
+++ b/hub/static/hub/activity-tab/activity-tab-topology-nodes.css
@@ -76,8 +76,22 @@
  * names should be color coded" / "they are now in white and in
  * blue for head-nas@... i am not sure why only it is". The prior
  * `filter: brightness(1.5)` saturated most pastels toward white,
- * leaving only bluer hashes recognizable. */
+ * leaving only bluer hashes recognizable.
+ *
+ * todo#305 (Task 3, lead msg#15509): visually unify with the sidebar
+ * agent card. Structural reuse of renderAgentBadge is already in place
+ * via renderAgentBadgeSvg (same icon→star→4 LEDs→name order, same
+ * palette, same glyph cascade — agent-badge-svg.ts). What remained
+ * different was the SVG's default typography: labels had no explicit
+ * font-size and inherited the document default (16px), while the
+ * sidebar agent row uses 11px (activity-tab-list.css .sidebar-agent-
+ * row). Pin label size to match. Halo stroke is kept because the
+ * canvas has no solid card background to fall back on — the sidebar
+ * reads on #141414 cards without a halo, but the SVG must read on the
+ * raw graph plane where adjacent edges and other nodes cross through.
+ */
 .activity-grid.activity-view-topology .topo-label-agent {
+  font-size: 11px;
   font-weight: 600;
   paint-order: stroke;
   stroke: rgba(0, 0, 0, 0.45);

--- a/hub/static/hub/activity-tab/compose.js
+++ b/hub/static/hub/activity-tab/compose.js
@@ -276,6 +276,50 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
     if (input) input.focus();
   }, 10);
 
+  /* todo#305 Task 6 (lead msg#15528): Cmd+V / ⌘V / context-menu Paste
+   * was failing on this popup. Root cause: macOS Safari does NOT focus
+   * a textarea on right-click (unlike Chrome/Firefox). A right-click on
+   * our textarea therefore left document.activeElement on whatever had
+   * focus before the popup opened (often <body> or the topology
+   * canvas), so the subsequent native "Paste" from the OS context menu
+   * fired a paste event on THAT element — not the textarea.
+   *
+   * Keyboard Cmd+V was only intermittent for the same reason: if the
+   * user clicked anywhere inside the popup that wasn't a focusable
+   * child, the textarea could lose focus and the next Cmd+V landed
+   * outside.
+   *
+   * Fix: refocus the textarea on ANY pointer interaction inside the
+   * popup (mousedown covers left + right click + middle click on all
+   * browsers), unless the target is one of the action buttons that
+   * legitimately owns focus (attach / camera / sketch / voice /
+   * expand). Also listen to `contextmenu` explicitly — belt & braces
+   * for browsers that fire contextmenu without a prior mousedown
+   * (some trackpad two-finger-tap paths on macOS). */
+  function _refocusInput(ev) {
+    if (!input) return;
+    /* Don't steal focus from action buttons. */
+    if (
+      ev.target &&
+      ev.target.closest &&
+      ev.target.closest(".tcc-x, .tcc-expand")
+    ) {
+      return;
+    }
+    /* If the user clicked directly on the textarea, the browser will
+     * focus it anyway and move the caret — don't fight that. Only
+     * refocus when the target is a non-focusable child (the popup
+     * chrome, a label, etc.) or the textarea but unfocused (e.g.
+     * right-click on macOS Safari). */
+    if (document.activeElement !== input) {
+      try {
+        input.focus();
+      } catch (_) {}
+    }
+  }
+  pop.addEventListener("mousedown", _refocusInput);
+  pop.addEventListener("contextmenu", _refocusInput);
+
   function close() {
     if (pop.parentNode) pop.parentNode.removeChild(pop);
     document.removeEventListener("mousedown", outsideClick, true);

--- a/hub/static/hub/activity-tab/grid-click.js
+++ b/hub/static/hub/activity-tab/grid-click.js
@@ -5,7 +5,17 @@
 
 function _ovgWireClick(grid) {
   grid.addEventListener("click", function (ev) {
-    var pinBtn = ev.target.closest(".activity-pin-btn[data-pin-name]");
+    /* Star click on a topology agent-node OR on an overview-grid HTML
+     * pin button. The SVG star emitted by renderAgentBadgeSvg carries
+     * `.topo-agent-star` (SVG <text>, not a <button>), the HTML path
+     * carries `.activity-pin-btn`; both expose the same data-pin-name /
+     * data-pin-next contract. Matching both selectors gives the topology
+     * canvas the SAME toggle-favourite behaviour the sidebar and
+     * overview-grid star click already has (todo#305 Task 5, lead
+     * msg#15523 "FUNCTIONAL parity with sidebar"). */
+    var pinBtn = ev.target.closest(
+      ".activity-pin-btn[data-pin-name], .topo-agent-star[data-pin-name]",
+    );
     if (pinBtn && grid.contains(pinBtn)) {
       ev.stopPropagation();
       var pname = pinBtn.getAttribute("data-pin-name");

--- a/hub/static/hub/activity-tab/topology-autolayout.js
+++ b/hub/static/hub/activity-tab/topology-autolayout.js
@@ -1,0 +1,145 @@
+/* activity-tab/topology-autolayout.js — "整列" (Tidy) button handler.
+ *
+ * Re-lays out the topology graph into two concentric rings:
+ *   - Inner ring  = channel nodes
+ *   - Outer ring  = agents + human user
+ *
+ * Then runs a couple of light repulsion passes so no two nodes sit
+ * within ~1.2 * node_diameter of each other. Positions are written into
+ * _topoManualPositions (the same overlay drag-to-reposition uses) so
+ * layout survives heartbeat re-renders and zoom/pan.
+ *
+ * Mirrors hub/frontend/src/activity-tab/topology-autolayout.ts. Legacy
+ * classic-script file kept in lockstep with the TS source per the PR
+ * #285/#293 pattern, even though only the vite bundle is served today.
+ */
+
+var _TOPO_AUTOLAYOUT_NODE_D = 48;
+var _TOPO_AUTOLAYOUT_MIN_SEP = _TOPO_AUTOLAYOUT_NODE_D * 1.2;
+
+function _topoAutoLayoutRepulsePass(nodes, anchors, strength) {
+  var i, j, a, b, dx, dy, d, overlap, ux, uy;
+  for (i = 0; i < nodes.length; i++) {
+    for (j = i + 1; j < nodes.length; j++) {
+      a = nodes[i];
+      b = nodes[j];
+      dx = b.x - a.x;
+      dy = b.y - a.y;
+      d = Math.sqrt(dx * dx + dy * dy);
+      if (d >= _TOPO_AUTOLAYOUT_MIN_SEP) continue;
+      if (d < 0.01) {
+        ux = 1;
+        uy = 0;
+        d = 0.01;
+      } else {
+        ux = dx / d;
+        uy = dy / d;
+      }
+      overlap = (_TOPO_AUTOLAYOUT_MIN_SEP - d) * 0.5 * strength;
+      a.x -= ux * overlap;
+      a.y -= uy * overlap;
+      b.x += ux * overlap;
+      b.y += uy * overlap;
+    }
+  }
+  for (i = 0; i < nodes.length; i++) {
+    var anc = anchors[nodes[i].key];
+    if (!anc) continue;
+    nodes[i].x += (anc.x - nodes[i].x) * 0.05;
+    nodes[i].y += (anc.y - nodes[i].y) * 0.05;
+  }
+}
+
+function _topoAutoLayout() {
+  var agents = window.__lastAgents || [];
+  var hidden = _topoHidden || { agents: {}, channels: {} };
+  var chPrefs = window._channelPrefs || {};
+  var hn =
+    (typeof userName !== "undefined" && userName) ||
+    window.__orochiUserName ||
+    "";
+
+  var visible = agents.filter(function (a) {
+    if (hidden.agents && hidden.agents[a.name]) return false;
+    if (a.status === "offline" && !a.pinned) return false;
+    return true;
+  });
+
+  var chSet = {};
+  visible.forEach(function (a) {
+    (a.channels || []).forEach(function (c) {
+      if (!c || c.indexOf("dm:") === 0) return;
+      chSet[c] = true;
+    });
+  });
+  Object.keys(chPrefs).forEach(function (c) {
+    if (!c || c.indexOf("dm:") === 0) return;
+    chSet[c] = true;
+  });
+  var channels = Object.keys(chSet)
+    .filter(function (c) {
+      if ((chPrefs[c] || {}).is_hidden) return false;
+      if (hidden.channels && hidden.channels[c]) return false;
+      return true;
+    })
+    .sort();
+
+  var grid = document.querySelector(".activity-view-topology .topo-wrap");
+  var W = Math.max((grid && grid.clientWidth) || 0, 600);
+  var H = Math.max((grid && grid.clientHeight) || 0, 420);
+  var cx = W / 2;
+  var cy = H / 2;
+  var pad = 100;
+  var rOuter = Math.max(80, Math.min(W, H) / 2 - pad);
+  var rInner = Math.max(40, rOuter * 0.42);
+
+  var nodes = [];
+  var anchors = {};
+
+  channels.forEach(function (c, i) {
+    var n = Math.max(1, channels.length);
+    var theta = ((i + 0.5) / n) * Math.PI * 2 - Math.PI / 2;
+    var p = {
+      x: cx + rInner * Math.cos(theta),
+      y: cy + rInner * Math.sin(theta),
+    };
+    var key = _topoManualKey("channel", c);
+    anchors[key] = p;
+    nodes.push({ key: key, kind: "channel", name: c, x: p.x, y: p.y });
+  });
+
+  var nOuter = visible.length + (hn ? 1 : 0);
+  var outerIdx = 0;
+  if (hn) {
+    var thetaH = (outerIdx / Math.max(1, nOuter)) * Math.PI * 2 - Math.PI / 2;
+    var pH = {
+      x: cx + rOuter * Math.cos(thetaH),
+      y: cy + rOuter * Math.sin(thetaH),
+    };
+    var keyH = _topoManualKey("agent", hn);
+    anchors[keyH] = pH;
+    nodes.push({ key: keyH, kind: "agent", name: hn, x: pH.x, y: pH.y });
+    outerIdx++;
+  }
+  visible.forEach(function (a) {
+    var thetaA = (outerIdx / Math.max(1, nOuter)) * Math.PI * 2 - Math.PI / 2;
+    var pA = {
+      x: cx + rOuter * Math.cos(thetaA),
+      y: cy + rOuter * Math.sin(thetaA),
+    };
+    var keyA = _topoManualKey("agent", a.name);
+    anchors[keyA] = pA;
+    nodes.push({ key: keyA, kind: "agent", name: a.name, x: pA.x, y: pA.y });
+    outerIdx++;
+  });
+
+  _topoAutoLayoutRepulsePass(nodes, anchors, 1.0);
+  _topoAutoLayoutRepulsePass(nodes, anchors, 0.7);
+
+  nodes.forEach(function (n) {
+    _topoManualPositions[n.key] = { x: n.x, y: n.y };
+  });
+  _topoSaveManualPositions();
+
+  _topoLastSig = "";
+}

--- a/hub/static/hub/activity-tab/topology.js
+++ b/hub/static/hub/activity-tab/topology.js
@@ -7,11 +7,19 @@
 
 function _renderActivityTopology(visible, grid) {
   _topoApplyStickyEdges();
-  /* Filter out agents the user hid via right-click. Edges involving
+  /* Filter out agents the user hid via right-click (session-only via
+   * _topoHidden) OR via the persistent 👁 eye on the agent card (Task 7,
+   * AgentProfile.is_hidden — sticks across sessions). Edges involving
    * hidden agents collapse automatically because they're dropped from
-   * the visible loop. Human node is protected inside _topoHide. */
+   * the visible loop. Human node is protected inside _topoHide and
+   * never has is_hidden on its payload. */
   visible = visible.filter(function (a) {
     if (_topoHidden.agents[a.name]) return false;
+    /* todo#305 Task 7 (lead msg#15548): mirror channel-hidden topo
+     * semantics — hidden agents are DROPPED from the canvas render
+     * (not dimmed in place). Consistent with how channels hidden via
+     * .ch-eye disappear from the topology. */
+    if (a.is_hidden) return false;
     /* Dead agents render only when pinned (kept as ghost/shadow);
      * unpinned dead agents are dropped entirely from the canvas. */
     if (_isDeadAgent(a) && !a.pinned) return false;

--- a/hub/static/hub/activity-tab/topology.js
+++ b/hub/static/hub/activity-tab/topology.js
@@ -319,6 +319,8 @@ function _renderActivityTopology(visible, grid) {
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="minus" title="Zoom out (−)">−</button>' +
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="reset" title="Reset zoom (0)">0</button>' +
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="plus" title="Zoom in (+)">+</button>' +
+    /* todo#305: 整列 (Tidy) button — concentric ring auto-layout. */
+    '<button type="button" class="topo-ctrl-btn topology-autolayout-btn" data-topo-ctrl="integrate" title="整列 (auto-layout: channels inner, agents outer)">整列</button>' +
     "</div>";
   var pool = _topoBuildPoolHtml(visible, channels);
   /* todo#67 — Time seekbar + play button docked at the bottom of the

--- a/hub/static/hub/activity-tab/zoompan.js
+++ b/hub/static/hub/activity-tab/zoompan.js
@@ -305,6 +305,11 @@ function _wireTopoZoomPan(grid, W, H) {
     else if (action === "reset") _resetVB(svg);
     else if (action === "plus") _zoomAt(svg, 1 / 1.25, null, null);
     else if (action === "minus") _zoomAt(svg, 1.25, null, null);
+    else if (action === "integrate") {
+      /* todo#305: 整列 — concentric ring auto-layout. */
+      if (typeof _topoAutoLayout === "function") _topoAutoLayout();
+      if (typeof renderActivityTab === "function") renderActivityTab();
+    }
   });
   /* Keyboard — Escape = back; 0 = reset; +/= = zoom in; - = zoom out.
    * Only fires when an SVG is visible and no text input is focused. */

--- a/hub/static/hub/agent-badge-svg.js
+++ b/hub/static/hub/agent-badge-svg.js
@@ -225,6 +225,7 @@
     var y = pos.y;
     var showName = opts.showName !== false;
     var showStar = opts.showStar !== false;
+    var showEye = opts.showEye !== false && !opts.isHuman;
     var showLeds = opts.showLeds !== false && !opts.isHuman;
     var iconSize = opts.iconSize || 14;
     /* todo#305 (Task 3, lead msg#15509): LED radius tuned to 3.5px so
@@ -249,50 +250,51 @@
     var nameText = opts.labelOverride || ident.displayName || a.name || "";
     var color = opts.isHuman ? "#fbbf24" : ident.color;
 
-    /* Canonical layout per ywatanabe 2026-04-20:
-     *   icon + 4 LEDs + name@hostname + star
-     * All elements laid out left→right starting at glyphX. Human nodes
-     * keep their simpler icon+name layout (no LEDs, no star slot). */
+    /* Canonical layout, todo#305 Task 7 (lead msg#15548):
+     *   icon + star + eye + 4 LEDs + name@hostname
+     * Matches the HTML agent-badge.js canonical order 1:1. */
     var iconHalf = iconSize / 2;
     var ledsWidth = 0;
     var ledBlock = { svg: "", width: 0 };
 
-    // Position the glyph (icon). For human: centered around x. For agent:
-    // leftmost element, with its CENTER at glyphX.
     var glyphX;
     if (opts.isHuman) {
       glyphX = x - 10;
     } else {
-      // Pack icon + 4 LEDs + name + star starting from glyphX, centering
-      // the whole cluster around pos.x. Compute total width first.
-      glyphX = x; // temp; will reposition below
+      glyphX = x;
     }
 
-    // Compute LED block width (4 LEDs spaced by 2*R+GAP).
     var ledStep = 2 * LED_R + GAP;
     if (showLeds) {
-      ledsWidth = 3 * ledStep + 2 * LED_R; // 4 LEDs span
+      ledsWidth = 3 * ledStep + 2 * LED_R;
     }
 
     var textW = Math.max(40, nameText.length * 6.5);
     var starW = showStar ? 14 : 0;
+    var eyeW = showEye ? 14 : 0;
 
     if (!opts.isHuman) {
-      // Total width: icon + gap + LEDs + gap + name + gap + star.
       var GAP_BETWEEN = 6;
       var total =
         iconSize +
+        (showStar ? GAP_BETWEEN + starW : 0) +
+        (showEye ? GAP_BETWEEN + eyeW : 0) +
         GAP_BETWEEN +
         ledsWidth +
         GAP_BETWEEN +
-        textW +
-        (showStar ? GAP_BETWEEN + starW : 0);
-      // Re-center: cluster centered on pos.x.
+        textW;
       var clusterLeft = x - total / 2;
-      glyphX = clusterLeft + iconHalf; // center of icon
-      var ledsStartCx = glyphX + iconHalf + GAP_BETWEEN + LED_R;
+      glyphX = clusterLeft + iconHalf;
+      var starX = showStar
+        ? glyphX + iconHalf + GAP_BETWEEN + starW / 2
+        : glyphX + iconHalf;
+      var eyeX = showEye
+        ? starX + (showStar ? starW / 2 : iconHalf) + GAP_BETWEEN + eyeW / 2
+        : starX;
+      var ledsStartCx = (showEye ? eyeX + eyeW / 2 : starX + (showStar ? starW / 2 : iconHalf)) +
+        GAP_BETWEEN +
+        LED_R;
       var nameX = ledsStartCx + ledsWidth - LED_R + GAP_BETWEEN;
-      var starX = nameX + textW + GAP_BETWEEN;
 
       var glyph = _renderAgentGlyphSvg(a, glyphX, y, iconSize, ident, opts);
 
@@ -317,7 +319,7 @@
           (y + 4).toFixed(1) +
           '" fill="' +
           (pinned ? "#fbbf24" : "#3a3a3a") +
-          '" font-size="13" style="cursor:pointer" data-pin-name="' +
+          '" font-size="13" style="cursor:pointer" text-anchor="middle" data-pin-name="' +
           _escape(a.name || "") +
           '" data-pin-next="' +
           (pinned ? "false" : "true") +
@@ -326,6 +328,50 @@
           "</title>" +
           (pinned ? "\u2605" : "\u2606") +
           "</text>";
+      }
+
+      /* Eye slot — 👁 SVG with optional red strike line when is_hidden.
+       * Matches the HTML eye (.agent-badge-eye) semantically — same
+       * classes so body-level delegation in agent-badge.js catches
+       * clicks on either DOM or SVG. todo#305 Task 7 (lead msg#15548). */
+      var eyeSvg = "";
+      if (showEye) {
+        var hiddenFlag = !!a.is_hidden;
+        var eyeCls =
+          "topo-agent-eye " +
+          (hiddenFlag ? "topo-agent-eye-off" : "topo-agent-eye-on");
+        var eyeGlyph =
+          '<text x="' +
+          eyeX.toFixed(1) +
+          '" y="' +
+          (y + 4).toFixed(1) +
+          '" font-size="11" text-anchor="middle" fill="#94a3b8" style="cursor:pointer">\uD83D\uDC41</text>';
+        var strike = hiddenFlag
+          ? '<line x1="' +
+            (eyeX - 5).toFixed(1) +
+            '" y1="' +
+            (y + 3).toFixed(1) +
+            '" x2="' +
+            (eyeX + 5).toFixed(1) +
+            '" y2="' +
+            (y - 3).toFixed(1) +
+            '" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round" pointer-events="none"/>'
+          : "";
+        eyeSvg =
+          '<g class="' +
+          eyeCls +
+          '" data-eye-agent="' +
+          _escape(a.name || "") +
+          '" style="cursor:pointer"><title>' +
+          _escape(
+            hiddenFlag
+              ? "Show agent (un-hide)"
+              : "Hide agent (remove from list + graph)",
+          ) +
+          "</title>" +
+          eyeGlyph +
+          strike +
+          "</g>";
       }
 
       var nameSvg = "";
@@ -357,10 +403,11 @@
       var cls = "topo-node topo-agent";
       if (opts.isSelected) cls += " topo-agent-selected";
       if (opts.isDead) cls += " topo-agent-dead";
+      if (a.is_hidden) cls += " topo-agent-hidden";
       if (opts.extraClass) cls += " " + opts.extraClass;
 
       /* Order matches the HTML agent-badge.js canonical order:
-       *   icon + star + 4 LEDs + name (ywatanabe 2026-04-21). */
+       *   icon + star + eye + 4 LEDs + name (Task 7, msg#15548). */
       return (
         '<g class="' +
         cls +
@@ -373,6 +420,7 @@
         bg +
         glyph +
         starSvg +
+        eyeSvg +
         ledBlock.svg +
         nameSvg +
         "</g>"

--- a/hub/static/hub/agent-badge-svg.js
+++ b/hub/static/hub/agent-badge-svg.js
@@ -227,7 +227,12 @@
     var showStar = opts.showStar !== false;
     var showLeds = opts.showLeds !== false && !opts.isHuman;
     var iconSize = opts.iconSize || 14;
-    var LED_R = 4;
+    /* todo#305 (Task 3, lead msg#15509): LED radius tuned to 3.5px so
+     * the topology node's LED strip reads at the same visual weight as
+     * the sidebar agent row (which uses 7px-diameter .activity-led via
+     * .sidebar-agent-row .activity-led in activity-tab-list.css). Was
+     * 4px (=8px diameter) which felt heavier than the sidebar's dots. */
+    var LED_R = 3.5;
     var GAP = 3;
 
     var ident =

--- a/hub/static/hub/agent-badge.js
+++ b/hub/static/hub/agent-badge.js
@@ -117,6 +117,29 @@
     );
   }
 
+  // ── 2b. Eye (togglable show/hide, always visible, placeholder even when
+  //        not hidden so column geometry stays constant across rows).
+  // Mirrors the channel .ch-eye pattern 1:1: same 👁 glyph in both states,
+  // red diagonal strike drawn via the .agent-badge-eye-off::after CSS
+  // rule (defined in style-agents.css alongside the channel variant).
+  // todo#305 Task 7 (lead msg#15548).
+  function renderAgentEye(a) {
+    var hidden = !!a.is_hidden;
+    return (
+      '<span class="agent-badge-eye ' +
+      (hidden ? "agent-badge-eye-off" : "agent-badge-eye-on") +
+      '" data-eye-agent="' +
+      _escape(a.name || "") +
+      '" title="' +
+      _escape(
+        hidden
+          ? "Show agent (un-hide)"
+          : "Hide agent (remove from list + graph)",
+      ) +
+      '" style="cursor:pointer">\uD83D\uDC41</span>'
+    );
+  }
+
   // ── 3. Four-LED liveness strip ────────────────────────────────────
   function renderAgentLeds(a, opts) {
     var extra = opts && opts.extraClass ? " " + opts.extraClass : "";
@@ -238,17 +261,20 @@
   // ── Composed badge (canonical layout) ─────────────────────────────
   function renderAgentBadge(a, opts) {
     opts = opts || {};
-    /* Canonical order per ywatanabe 2026-04-21:
-     *   icon + star + 4 LEDs + name@hostname
-     * Matches the channel badge (icon + star + eye + mute + name), so
-     * star sits in the same column position across both entity types.
-     * renderAgentStar always emits a placeholder span for non-starred
-     * agents so column alignment holds. */
+    /* Canonical order, todo#305 Task 7 (lead msg#15548):
+     *   icon + star + eye + 4 LEDs + name@hostname
+     * Matches the channel badge column order (icon + star + eye +
+     * mute + name) so a user who learned the glyph map on channels
+     * finds the same on agents. The eye was inserted between ★ and
+     * the LED strip per lead's explicit ordering directive in
+     * msg#15548 (deviation from Task 3's baseline, but Task 7 owns
+     * the slot for agents going forward). */
     var icon = renderAgentIcon(a, opts.iconSize);
     var star = renderAgentStar(a);
+    var eye = opts.hideEye ? "" : renderAgentEye(a);
     var leds = renderAgentLeds(a, { extraClass: opts.extraClass });
     var name = opts.hideName ? "" : renderAgentName(a, opts);
-    return icon + star + leds + name;
+    return icon + star + eye + leds + name;
   }
 
   // ── Background-class helper: dim when not all four LEDs green ─────
@@ -289,9 +315,65 @@
     return false;
   }
 
+  // ── Eye toggle — persistent flip of AgentProfile.is_hidden ──────────
+  // Body-level delegated handler so EVERY agent-eye glyph anywhere in
+  // the DOM (sidebar row, Activity overview card, topology SVG) gets
+  // the same behavior without per-render binding. Mirrors the
+  // .ch-eye delegation pattern in channel-badge.js. Idempotent.
+  var _agentEyeAttached = false;
+  function attachAgentEyeHandler() {
+    if (_agentEyeAttached) return;
+    _agentEyeAttached = true;
+    if (typeof document === "undefined") return;
+    document.body.addEventListener(
+      "click",
+      function (ev) {
+        var eye = ev.target.closest && ev.target.closest(
+          ".agent-badge-eye[data-eye-agent], .topo-agent-eye[data-eye-agent]",
+        );
+        if (!eye) return;
+        var name = eye.getAttribute("data-eye-agent");
+        if (!name) return;
+        ev.stopPropagation();
+        ev.preventDefault();
+        var live = window.__lastAgents || [];
+        var curAgent = null;
+        for (var i = 0; i < live.length; i++) {
+          if (live[i] && live[i].name === name) {
+            curAgent = live[i];
+            break;
+          }
+        }
+        var curHidden = curAgent
+          ? !!curAgent.is_hidden
+          : eye.classList.contains("agent-badge-eye-off") ||
+            eye.classList.contains("topo-agent-eye-off");
+        var nextHidden = !curHidden;
+        if (curAgent) curAgent.is_hidden = nextHidden;
+        eye.classList.toggle("agent-badge-eye-on", !nextHidden);
+        eye.classList.toggle("agent-badge-eye-off", nextHidden);
+        eye.classList.toggle("topo-agent-eye-on", !nextHidden);
+        eye.classList.toggle("topo-agent-eye-off", nextHidden);
+        var setHidden = window._setAgentHidden;
+        if (typeof setHidden === "function") {
+          setHidden(name, nextHidden);
+        }
+      },
+      true,
+    );
+  }
+  if (typeof document !== "undefined") {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", attachAgentEyeHandler);
+    } else {
+      attachAgentEyeHandler();
+    }
+  }
+
   // Expose globals — script is loaded as a plain <script> tag.
   window.renderAgentIcon = renderAgentIcon;
   window.renderAgentStar = renderAgentStar;
+  window.renderAgentEye = renderAgentEye;
   window.renderAgentLeds = renderAgentLeds;
   window.renderAgentName = renderAgentName;
   window.renderAgentBadge = renderAgentBadge;

--- a/hub/static/hub/app/channel-prefs.js
+++ b/hub/static/hub/app/channel-prefs.js
@@ -141,6 +141,37 @@ function _setChannelPref(ch, patch) {
  * configuration story uniform across entity types. The registry
  * reads AgentProfile on next join so the icon survives container
  * restarts (todo#101 Entity Consistency). */
+
+/* todo#305 Task 7 (lead msg#15548): flip the persistent per-agent
+ * is_hidden flag. Parallel to _setChannelPref({ is_hidden: ... }) —
+ * same server contract, same re-render trigger. The 👁 eye glyph on
+ * an agent card (sidebar row or topology SVG) calls this from the
+ * body-level delegated handler in agent-badge.js. */
+function _setAgentHidden(name, isHidden) {
+  var live = window.__lastAgents || [];
+  for (var i = 0; i < live.length; i++) {
+    if (live[i] && live[i].name === name) {
+      live[i].is_hidden = !!isHidden;
+      break;
+    }
+  }
+  fetch(apiUrl("/api/agent-profiles/"), {
+    method: "POST",
+    credentials: "same-origin",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRFToken": getCsrfToken(),
+    },
+    body: JSON.stringify({ name: name, is_hidden: !!isHidden }),
+  }).catch(function (_) {});
+  if (typeof fetchAgents === "function") fetchAgents();
+  if (typeof renderActivityTab === "function") {
+    if (typeof window._topoLastSig !== "undefined") window._topoLastSig = "";
+    renderActivityTab();
+  }
+}
+window._setAgentHidden = _setAgentHidden;
+
 function _setAgentIcon(name, patch) {
   if (
     typeof cachedAgentIcons !== "undefined" &&

--- a/hub/static/hub/app/sidebar-agents.js
+++ b/hub/static/hub/app/sidebar-agents.js
@@ -115,6 +115,12 @@ async function fetchAgents() {
       return String(dn || "").toLowerCase();
     };
     sidebarVisible.sort(function (a, b) {
+      /* todo#305 Task 7 (lead msg#15548): hidden -> bottom. Mirrors
+       * the channel-prefs.is_hidden sort in sidebar-stats.js. Row
+       * stays at opacity 1 per PR #293/#295. */
+      var ha = a.is_hidden ? 1 : 0;
+      var hb = b.is_hidden ? 1 : 0;
+      if (ha !== hb) return ha - hb;
       var pa = a.pinned ? 0 : 1;
       var pb = b.pinned ? 0 : 1;
       if (pa !== pb) return pa - pb;
@@ -166,15 +172,21 @@ async function fetchAgents() {
           : "Star (keeps as ghost when offline, floats to top)";
         return (
           // Single source of truth — agent-badge.js owns icon + star +
-          // 4 LEDs + name. Same call lives in activity-tab.js list view
-          // and topology pool chip. NEVER inline a fork here.
+          // eye + 4 LEDs + name. Same call lives in activity-tab.js list
+          // view and topology pool chip. NEVER inline a fork here.
           '<div class="agent-card sidebar-agent-row' +
           (typeof isAgentAllGreen === "function" && !isAgentAllGreen(a)
             ? " activity-card-ghost"
             : "") +
+          /* todo#305 Task 7: agent-hidden class mirrors .ch-hidden on
+           * channel rows — keeps row at full opacity (PR #293/#295
+           * rule); hidden state is communicated ONLY via the eye-slash
+           * glyph. */
+          (a.is_hidden ? " agent-hidden" : "") +
           ghostClass +
           '" data-agent-name="' +
           escapeHtml(rawName) +
+          (a.is_hidden ? '" data-hidden="1' : "") +
           '" data-agent-channels="' +
           escapeHtml(chList) +
           '" draggable="true" title="' +

--- a/hub/static/hub/app/sidebar-channel-tree.js
+++ b/hub/static/hub/app/sidebar-channel-tree.js
@@ -138,6 +138,35 @@ function _renderChannelRowHtml(row, ctx) {
           iconSize: 14,
         })
       : "";
+  /* todo#305 (ywatanabe msg#15510 / lead msg#15513): restore per-channel
+   * colour to the sidebar row. PR #285 dropped row-level colour-coding;
+   * the directive has since been reversed. Palette source = the SAME
+   * name-hash used by agent cards (getAgentColor → OROCHI_COLORS), so
+   * Channels and Agents lists share a coherent colour vocabulary.
+   *
+   * Apply via the --channel-accent CSS custom property on the row. CSS
+   * in style-channels.css tints the leading .ch-identity-icon glyph and
+   * draws a 2px left-edge accent stripe from this var. Nothing else on
+   * the row is coloured: no row background tint (PR #293's subtle
+   * selected-bg rule owns selection signalling) and no opacity change
+   * (PR #291 banned row-level opacity dim). The 🔔/👁/★ glyphs remain
+   * monochrome — colour is ONLY on the category icon at position 1.
+   *
+   * channelBadgeModel(c).color resolves to any user-set channel colour
+   * first, then falls back to _identityColor → getAgentColor(norm); we
+   * reuse it here so a channel's sidebar accent matches its pool chip
+   * label colour and its topology label fill. */
+  var accentColor = "";
+  if (typeof channelBadgeModel === "function") {
+    var m = channelBadgeModel(c);
+    accentColor = (m && m.color) || "";
+  }
+  if (!accentColor && typeof getAgentColor === "function") {
+    accentColor = getAgentColor(norm);
+  }
+  var accentStyle = accentColor
+    ? ' style="--channel-accent:' + escapeHtml(accentColor) + '"'
+    : "";
   return (
     divider +
     '<div class="channel-item ch-badge ch-badge-sidebar' +
@@ -152,6 +181,7 @@ function _renderChannelRowHtml(row, ctx) {
     (entry.hidden ? ' data-hidden="1"' : "") +
     (row.inFolder ? ' data-folder="' + escapeHtml(row.inFolder) + '"' : "") +
     rowTitle +
+    accentStyle +
     ' draggable="true">' +
     badgeInner +
     "</div>"

--- a/hub/static/hub/app/sidebar-channel-tree.js
+++ b/hub/static/hub/app/sidebar-channel-tree.js
@@ -293,11 +293,12 @@ function _wireChannelItemHandlers(chContainer, prevSelected) {
       }
       /* #284: channels are single-selection only. The legacy Ctrl/Cmd+Click
        * multi-select has been removed — any click replaces the current
-       * selection with exactly this row. */
-      if (currentChannel === ch) {
-        setCurrentChannel(null);
-        loadHistory();
-      } else {
+       * selection with exactly this row.
+       *
+       * todo#305 / lead msg#15493: clicking the currently-selected row
+       * is a NO-OP — there is always exactly one selected channel, and
+       * re-clicking must not deselect. */
+      if (currentChannel !== ch) {
         setCurrentChannel(ch);
         loadChannelHistory(ch);
       }
@@ -310,19 +311,16 @@ function _wireChannelItemHandlers(chContainer, prevSelected) {
       updateChannelUnreadBadges();
       /* todo#274 Part 1 + #293: single-select is the HARD invariant —
        * clear .selected across the ENTIRE sidebar (channel rows AND
-       * DM agent-cards), not just this chContainer. Previously only
-       * chContainer was cleared, which left a stale .selected on a
-       * DM row when the user switched from a DM to a channel and
-       * manifested as "two rows selected at once" (#293). */
-      var wasSelected = el.classList.contains("selected");
+       * DM agent-cards), not just this chContainer.
+       *
+       * todo#305: unconditionally re-select this row — re-click no
+       * longer deselects, so .selected always lands on this element. */
       document
         .querySelectorAll(".sidebar .channel-item.selected, .sidebar .dm-item.selected")
         .forEach(function (it) {
           it.classList.remove("selected");
         });
-      if (!wasSelected && currentChannel === ch) {
-        el.classList.add("selected");
-      }
+      el.classList.add("selected");
       if (typeof applyFeedFilter === "function") applyFeedFilter();
       fetchStats();
     });

--- a/hub/static/hub/style/style-agents.css
+++ b/hub/static/hub/style/style-agents.css
@@ -479,3 +479,74 @@
   margin: 0 2px;
 }
 
+/* todo#305 Task 7 (lead msg#15548): 👁 eye show/hide toggle on agent
+ * cards. Mirrors the channel .ch-eye rule in style-channels.css — same
+ * geometry (fixed 14×14 slot so rows line up), same glyph cascade
+ * (same 👁 emoji in both states with a red diagonal strike via ::after
+ * when hidden), same visibility interaction (placeholder always
+ * rendered so the column geometry is stable; opacity 0.75 when off so
+ * the un-hide affordance is still discoverable on a hidden row). */
+.agent-badge-eye {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
+  line-height: 1;
+  font-size: 11px;
+  /* Monochrome so the color emoji doesn't outscreech the surrounding
+   * ★ / LEDs. Matches the .ch-mute and .ch-eye treatment. */
+  filter: grayscale(1);
+  color: #94a3b8;
+  cursor: pointer;
+  position: relative;
+}
+.agent-badge-eye-on {
+  opacity: 0.7;
+}
+.agent-badge-eye-off {
+  opacity: 0.9;
+}
+.agent-badge-eye-off::after {
+  content: "";
+  position: absolute;
+  left: 1px;
+  right: 1px;
+  top: 50%;
+  height: 2px;
+  background: #ef4444;
+  transform: rotate(-20deg);
+  transform-origin: center;
+  border-radius: 1px;
+  pointer-events: none;
+}
+.sidebar-agent-row:hover .agent-badge-eye,
+.agent-card:hover .agent-badge-eye {
+  opacity: 1;
+}
+
+/* todo#305 Task 7: hidden-agent row — mirrors .channel-item.ch-hidden.
+ * Keep the row at full opacity (PR #293/#295 rule — no row-level
+ * dimming); hidden state is communicated ONLY via the eye-with-slash
+ * glyph. Only affordance: cursor:pointer so the whole row looks
+ * clickable when the user wants to un-hide. */
+.agent-card.agent-hidden {
+  cursor: pointer;
+}
+
+/* SVG variant for topology canvas — .topo-agent-eye is an SVG <text>
+ * group, not an HTML span, so only :hover + the ::after-equivalent
+ * (rendered as a sibling <line> with a red stroke inside the SVG
+ * group) matter here. The off-vs-on classes are still applied for
+ * optimistic-flip signal in the body-level delegated handler. */
+.topo-agent-eye-on {
+  opacity: 0.7;
+}
+.topo-agent-eye-off {
+  opacity: 0.9;
+}
+.topo-agent:hover .topo-agent-eye-on,
+.topo-agent:hover .topo-agent-eye-off {
+  opacity: 1;
+}

--- a/hub/static/hub/style/style-base.css
+++ b/hub/static/hub/style/style-base.css
@@ -395,15 +395,22 @@ body {
   font-size: 12px;
   color: #aaa;
   /* ywatanabe 2026-04-21: "enlarge height; we need to see more" —
-   * tighter vertical rhythm so more rows fit without scrolling. */
+   * tighter vertical rhythm so more rows fit without scrolling.
+   * todo#305 (lead msg#15493): padding + gap unified with the Agents
+   * sidebar card metrics (.sidebar .agent-card.sidebar-compact in
+   * style-messages.css) so Channels and Agents lists read at the same
+   * row height. font-size + min-height already matched; only padding
+   * + margin needed nudging. Icons (icon→★→👁→🔔→name) are still
+   * specific to channels — only container metrics align. */
   margin-bottom: 2px;
-  padding: 2px 8px;
+  padding: 4px 8px;
   border-radius: 4px;
   transition: background 0.15s;
   cursor: pointer;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 6px;
   min-height: 20px;
 }
 .unread-badge {

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -349,6 +349,39 @@
   border-radius: 3px;
   object-fit: cover;
 }
+/* todo#305 (ywatanabe msg#15510 / lead msg#15513): per-channel colour
+ * on the sidebar row. The --channel-accent CSS var is set inline on
+ * .channel-item by sidebar-channel-tree.ts/js (hash of channel name
+ * through the shared OROCHI_COLORS palette — same palette agent cards
+ * use, so Channels and Agents read from a coherent colour vocabulary).
+ *
+ * Visual treatment — match the weight of the agent card's accent:
+ *   1. .ch-identity-icon at position 1 tinted to the accent (colour
+ *      only cascades to CSS-coloured glyphs: the default "#" text and
+ *      emoji text via `color:`). Image avatars (img.agent-avatar) are
+ *      bitmaps, so the tint doesn't bleed into user-uploaded icons.
+ *   2. 2px left-edge stripe on the row so the accent is visible even
+ *      when the channel uses an image avatar.
+ *
+ * Intentionally NOT coloured:
+ *   - Row background — PR #293's subtle .selected background rule owns
+ *     selection signalling. Adding a row-level tint would either mask
+ *     or compete with .selected.
+ *   - Row text / opacity — PR #295 / #291 banned per-row font-weight
+ *     and opacity-based dimming.
+ *   - 🔔/👁/★ glyphs (ch-mute/ch-eye/ch-star) — monochrome signal icons
+ *     per spec. Only the category icon at slot 1 carries colour. */
+.sidebar .channel-item {
+  /* Fallback to the existing muted text colour when no accent is set
+   * (e.g. renderChannelBadgeHtml called with no channelBadgeModel). */
+  border-left: 2px solid var(--channel-accent, transparent);
+  /* Nudge padding-left to keep the icon column aligned when the stripe
+   * lands (2px stripe + 6px inner pad → matches original 8px left pad). */
+  padding-left: 6px;
+}
+.sidebar .channel-item .ch-identity-icon {
+  color: var(--channel-accent, inherit);
+}
 .ch-pin:hover,
 .ch-watch:hover,
 .ch-eye:hover {

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/style/style-agents.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-channels.css' %}?v=138">
+          href="{% static 'hub/style/style-channels.css' %}?v=139">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"
@@ -55,7 +55,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/activity-tab/activity-tab-topology.css' %}?v=165">
     <link rel="stylesheet"
-          href="{% static 'hub/activity-tab/activity-tab-topology-nodes.css' %}?v=165">
+          href="{% static 'hub/activity-tab/activity-tab-topology-nodes.css' %}?v=166">
     <link rel="stylesheet"
           href="{% static 'hub/activity-tab/activity-tab-compose-edges.css' %}?v=165">
     <link rel="stylesheet"

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -9,7 +9,7 @@
           content="black-translucent">
     <link rel="manifest" href="{% static 'hub/manifest.json' %}">
     <link rel="apple-touch-icon" href="{% static 'hub/orochi-icon.png' %}">
-    <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=136">
+    <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=137">
     <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=134">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-messages.css' %}?v=135">

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/style/style-composer.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-agents.css' %}?v=134">
+          href="{% static 'hub/style/style-agents.css' %}?v=135">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-channels.css' %}?v=139">
     <link rel="stylesheet"

--- a/hub/views/api/_agents.py
+++ b/hub/views/api/_agents.py
@@ -136,6 +136,9 @@ def api_agent_profiles(request):
                 "icon_image": p.icon_image,
                 "icon_text": p.icon_text,
                 "color": p.color,
+                # todo#305 Task 7: expose persistent is_hidden so
+                # sidebar + topology can dim / drop the card at load.
+                "is_hidden": bool(getattr(p, "is_hidden", False)),
                 "updated_at": p.updated_at.isoformat(),
             }
             for p in profiles
@@ -149,16 +152,35 @@ def api_agent_profiles(request):
     name = (body.get("name") or "").strip()
     if not name:
         return JsonResponse({"error": "name required"}, status=400)
-    profile, _ = AgentProfile.objects.update_or_create(
-        workspace=workspace,
-        name=name,
-        defaults={
-            "icon_emoji": (body.get("icon_emoji") or "")[:16],
-            "icon_image": (body.get("icon_image") or "")[:500],
-            "icon_text": (body.get("icon_text") or "")[:16],
-            "color": (body.get("color") or "")[:16],
-        },
-    )
+    # todo#305 Task 7 (lead msg#15548): accept optional is_hidden patch
+    # so the 👁 eye toggle on the agent card can flip the persistent
+    # hidden flag via the SAME endpoint it already uses for icon /
+    # color. Patch semantics: only fields present in the body are
+    # touched — existing icon/color are not clobbered by a sole
+    # {name, is_hidden} POST.
+    defaults = {}
+    if "icon_emoji" in body:
+        defaults["icon_emoji"] = (body.get("icon_emoji") or "")[:16]
+    if "icon_image" in body:
+        defaults["icon_image"] = (body.get("icon_image") or "")[:500]
+    if "icon_text" in body:
+        defaults["icon_text"] = (body.get("icon_text") or "")[:16]
+    if "color" in body:
+        defaults["color"] = (body.get("color") or "")[:16]
+    if "is_hidden" in body:
+        defaults["is_hidden"] = bool(body.get("is_hidden"))
+    if not defaults:
+        # Callers that only send {name} (e.g. touch / refresh pings)
+        # still get a valid row back — use setdefault-style update_or_create.
+        profile, _ = AgentProfile.objects.get_or_create(
+            workspace=workspace, name=name
+        )
+    else:
+        profile, _ = AgentProfile.objects.update_or_create(
+            workspace=workspace,
+            name=name,
+            defaults=defaults,
+        )
     # Push into the in-memory registry so the live card updates too
     from hub.registry import _agents, _lock
 
@@ -172,6 +194,7 @@ def api_agent_profiles(request):
                 _agents[name]["icon_text"] = profile.icon_text
             if profile.color:
                 _agents[name]["color"] = profile.color
+            _agents[name]["is_hidden"] = bool(profile.is_hidden)
     return JsonResponse(
         {
             "status": "ok",
@@ -180,6 +203,7 @@ def api_agent_profiles(request):
             "icon_image": profile.icon_image,
             "icon_text": profile.icon_text,
             "color": profile.color,
+            "is_hidden": bool(getattr(profile, "is_hidden", False)),
         }
     )
 


### PR DESCRIPTION
## Summary

Seven UI tasks landed on one branch per lead dispatch (`#heads` msg#15493, msg#15509/#15513, msg#15523, msg#15528, msg#15548). Tasks 1+2 landed in the initial commit; Tasks 3+4 followed up on the same branch per lead's explicit allowance; Tasks 5/6/7 added in this third fold.

### Task 1 — Agents tab topology: 整列 (Tidy) button

The Agents tab's topology canvas (`activity-tab/topology.ts`) renders agents + channels on two concentric rings but lets user-dragged positions accumulate until nodes pile up. A new **整列** button in the topology toolbar re-lays the graph:

- **Inner ring** = channels (angle-spaced, half-slot phase offset so radial human to channel lines don't pass through outer-ring agents).
- **Outer ring** = agents + the signed-in human user.
- Two light O(n^2) repulsion passes nudge any pair closer than `1.2 * node_diameter` apart; a 5% per pass anchor pull keeps displaced nodes near their assigned ring slot so the two rings stay recognisable.

Layout runs **only on explicit click** — drag / zoom / pan are unchanged. Positions land in `_topoManualPositions` (same overlay drag-to-reposition uses), so tidy survives heartbeat re-renders and persists to localStorage.

**Algorithm choice**: no graph library is present (frontend deps = vite + tsc only), so the hand-rolled concentric-rings + two-pass repulsion approach was the minimal solution. ~170 LOC in a new `topology-autolayout.ts` module, keeping `topology.ts` under its line cap.

### Task 2 — Left sidebar channels card: always-selected + unify

Two defects reported in lead msg#15493:

1. **Unselect bug**: clicking the currently-selected channel row deselected it (empty chat, no row highlighted). Fixed by removing the re-click deselect branch in `sidebar-channel-tree.ts`'s click handler. Re-clicking the selected row is now a no-op; `.selected` is unconditionally re-added to the clicked row after the cross-sidebar clear. **Invariant: always exactly one selected channel.**

2. **Visual unification**: `.channel-item` padding bumped from `2px 8px` to `4px 8px` and `gap: 6px` added so container metrics match `.sidebar .agent-card.sidebar-compact`. `font-size` (12px), `min-height` (20px), `border-radius` (4px) already matched — only padding + gap nudged. Channel icon set (icon, star, eye, bell, name) is untouched; agent LED indicators are **not** copied onto channels (semantically different, per spec).

### Task 3 — Topology agent-node ↔ sidebar agent-card visual unify (lead msg#15509)

Structural reuse was already landed by the 2026-04-20 SSoT pass: `topology-nodes.ts` already goes through `renderAgentBadgeSvg` which emits the **same canonical slot order** as the HTML `renderAgentBadge` used by the sidebar (icon → star → 4 LEDs → name, same glyph cascade, same per-agent palette).

What still diverged was **SVG typography**. SVG labels had no explicit `font-size` so they inherited the document default (~16px), while the sidebar agent row is **11px** (`.sidebar-agent-row` in `activity-tab-list.css`). LEDs were also visually heavier: `LED_R = 4` = 8px diameter vs the sidebar's 7px `.activity-led` dots.

**Chosen approach**: style-mirror (aligning visual tokens) rather than a structural refactor. Reasons:

- `renderAgentBadgeSvg` is SVG, `renderAgentBadge` is HTML — they **cannot** share markup directly (nesting HTML in SVG via `foreignObject` would regress canvas pan/zoom + hit-testing).
- The visual tokens that actually differed are cheap to pin: two CSS lines (`font-size`, existing `.topo-label-agent` rule) + one TS constant (`LED_R`). A deeper refactor would exceed the ~150-LOC budget called out in the dispatch.
- Preserves canvas-specific behaviours unchanged: drag handle, hover tooltip, selection highlight, halo-stroke-for-legibility.

Changes:

- `activity-tab-topology-nodes.css`: `.topo-label-agent` now pins `font-size: 11px` (matches sidebar 11px). Halo stroke is kept — the canvas has no solid card background like the sidebar row does.
- `agent-badge-svg.ts` + mirror `.js`: `LED_R` 4 → 3.5 (=7px diameter).

### Task 4 — Sidebar channels colour-coding **restore** (ywatanabe msg#15510 / lead msg#15513)

PR #285 dropped per-channel row colour-coding; ywatanabe has since reversed that directive. Colour is back on the Channels sidebar.

**Palette**: the **same** name-hash `OROCHI_COLORS` used by agent cards (`getAgentColor`), so Channels and Agents lists share one colour vocabulary. Derived via `channelBadgeModel(c).color` which resolves through any user-set channel colour → `_identityColor` → `getAgentColor(norm)`, keeping sidebar accent consistent with pool-chip label fill and topology canvas label fill.

Implementation:

- `sidebar-channel-tree.ts` + mirror `.js`: compute the channel's accent colour at render time and set it as the `--channel-accent` CSS custom property on the `.channel-item` inline `style`.
- `style-channels.css`: two rules keyed off `--channel-accent`:
  - `.sidebar .channel-item .ch-identity-icon { color: var(--channel-accent, inherit); }` — tints the category glyph at slot 1. Default "#" text and emoji glyphs inherit via CSS `color`; image avatars (`img.agent-avatar`) are bitmaps and stay untinted.
  - `.sidebar .channel-item { border-left: 2px solid var(--channel-accent, transparent); padding-left: 6px; }` — 2px left-edge accent stripe. Padding-left re-balanced from the default 8px to 6px so 2px stripe + 6px inner pad = 8px net, keeping the channel-name column aligned.

**Intentionally NOT coloured** (to preserve already-landed rules):

- **Row background** — PR #293's subtle `.selected` background rule owns selection signalling. A row tint would fight `.selected`.
- **Row text / opacity** — PR #295 banned per-row `font-weight` shifts; PR #291 banned row-level opacity dim. Neither is re-introduced.
- **🔔/👁/★ glyphs** — monochrome signal icons per spec. Colour is applied to the **category icon at slot 1 only**.

### Task 5 — Topology agent-node star click = toggle favourite (lead msg#15523)

Task 3 landed VISUAL parity between the topology agent-node and the sidebar agent-card, but the graph canvas's ★ glyph had no click handler — clicking it was a no-op (or worse, fell through to the 1/2/3-click counter that opens a DM / expand-detail popup). Task 5 wires the SAME `togglePinAgent` mutation the sidebar ★ already uses, so a click on the star on EITHER surface toggles the favourite with identical semantics.

**Root cause of the miss**: `grid-click.ts` dispatches star clicks via the selector `.activity-pin-btn[data-pin-name]`. The SVG star emitted by `renderAgentBadgeSvg` carries `.topo-label-pin .topo-agent-star` + `data-pin-name` / `data-pin-next`, but NOT `.activity-pin-btn` (the HTML pin-btn class leaks non-SVG styles). The shared dispatcher therefore never picked up canvas star clicks.

**Fix**: widened the dispatcher selector, not the SVG class list. Added `.topo-agent-star[data-pin-name]` to the `pinBtn` selector in `_ovgWireClick`. No visual / CSS change on the canvas; same `data-pin-name` / `data-pin-next` contract so the existing body of the handler (`togglePinAgent`, classList flip, data-pin-next flip) works without further branching.

**Icon click** was already wired (grid-click.ts:175-192 dispatches `.topo-agent-glyph*, .topo-human-glyph*` to `openAvatarPicker` / `openHumanAvatarPicker`, the same entry the sidebar-row icon click uses). Task 5 confirmed-and-kept.

### Task 6 — Topology channel-compose popup: paste reliably targets the textarea (lead msg#15528)

Cmd+V / context-menu Paste was not inserting text into the channel-compose popup opened by double-click on a topology channel node. Textarea rendered, paste event appeared to fire, value stayed empty.

**Root cause** (lead's three leads ruled out; actual cause was a fourth): macOS Safari does NOT focus a textarea on right-click, unlike Chrome/Firefox on Linux/Windows. Sequence in the broken case:

1. Popup opens; `setTimeout(10ms)` focuses the textarea.
2. User clicks any non-focusable popup chrome → textarea loses focus.
3. User right-clicks the textarea. On Safari this does **not** re-focus.
4. Native "Paste" from the OS menu fires a `paste` event on the currently-focused element — `<body>` or the topology SVG, NOT the textarea.

Keyboard Cmd+V failed intermittently along the same path: if focus was lost to popup chrome, Cmd+V landed outside.

**Fix**: focus guard on any pop-local pointer event.
```
pop.addEventListener("mousedown", _refocusInput);
pop.addEventListener("contextmenu", _refocusInput);
```

`_refocusInput` refocuses the textarea UNLESS the target is one of the explicit action buttons (`.tcc-x` / `.tcc-expand`) that should legitimately own focus. `contextmenu` is belt-and-braces for trackpad two-finger-tap paths.

Lead's three original leads vs what we found:
- (a) "contenteditable div rather than textarea" — **FALSE**; element is `<textarea class="tcc-input">`.
- (b) "pan/zoom listener consuming keydown/paste" — **FALSE**; zoompan keydown early-returns on INPUT/TEXTAREA/SELECT focus, binds no `paste`.
- (c) "input rendered outside tree / shadow root / pointer-events leak" — **FALSE**; popup is a direct child of `document.body`.
- (d, REAL) — focus loss on right-click on macOS Safari, as above.

No regression on native paste (short text still uses default textarea behaviour), image / file / long-text paste still routes to the Chat composer's upload.js pipeline, zoom / pan / drag on the canvas untouched. No new keybindings captured.

**Regression test**: the task description asks for a synthetic paste-event test. The frontend has no unit-test harness yet (no `*.test.ts` / vitest / jest); manual playwright verification is the fallback for this PR; test harness is a separate follow-up.

### Task 7 — Agent cards get a persistent 👁 show/hide toggle (lead msg#15548)

Channel cards already have an eye glyph for show/hide (`ChannelPreference.is_hidden`). Agent cards did not. Task 7 adds the SAME affordance on agent cards — sidebar row AND topology SVG node — with semantics that mirror channel-hidden 1:1 so users don't have to learn a second mental model.

**Backend**:
- `AgentProfile.is_hidden` — new `BooleanField(default=False)`.
- Migration `0027_agentprofile_is_hidden.py` (`AddField`, default=False so existing agents stay visible on rollout).
- `/api/agent-profiles/` now PATCH-style (only fields present in body are updated; others preserved). Accepts optional `is_hidden` bool; GET surfaces it so cold-start renders the correct eye state.
- `registry/_payload.py`: merge `AgentProfile.is_hidden` into each agent dict. `__lastAgents[i].is_hidden` is the canonical client-side source.

**Frontend — SSoT agent-badge**:
- Canonical slot order after Task 7: `icon → star → eye → 4 LEDs → name@host`. Mirrors channel-badge column order; eye sits between ★ and LEDs per lead msg#15548.
- `renderAgentEye(a)` in `agent-badge.ts` (parallel to channel's `.ch-eye`).
- Body-level delegated click handler catches `.agent-badge-eye[data-eye-agent]` AND `.topo-agent-eye[data-eye-agent]` anywhere in the DOM; flips `is_hidden` via `window._setAgentHidden` with optimistic local update. Pattern mirrors `attachChannelBadgeHandlers` in `channel-badge.ts`.
- `agent-badge-svg.ts`: layout reworked to pack `icon + star + eye + LEDs + name` in the new canonical order (the pre-existing SVG actually packed `icon + LEDs + name + star` with star far-right; Task 7 is the first correct alignment between the two badge renderers). Eye slot is an SVG `<g class="topo-agent-eye">` with a child `<text>` (👁 glyph) plus an optional `<line>` stroke drawn diagonally when `is_hidden` — the SVG-native equivalent of the HTML `::after` red-strike pseudo-element that `style-channels.css` uses for `.ch-eye-off`.

**Frontend — visibility filter** (mirrors channel-hidden exactly):
- `sidebar-agents.ts`: sort comparator gains an `is_hidden-first` bucket that pushes hidden rows to the bottom (same pattern `sidebar-stats.ts` uses for channels). Row stays at **opacity 1** per PR #293/#295 — hidden state is communicated ONLY via the eye-slash glyph. New `.agent-hidden` class + `data-hidden="1"` attribute for CSS / context-menu hooks.
- `activity-tab/topology.ts`: `visible` filter drops `a.is_hidden === true` agents from the canvas (parallel to how channels with `is_hidden` are dropped). Human node payload has no `is_hidden`, so the user's own node is never accidentally hidden.

**`_setAgentHidden` helper** in `channel-prefs.ts`: optimistic-flip, `POST /api/agent-profiles/` with `{name, is_hidden}`, trigger `fetchAgents` + `renderActivityTab` with topo signature bust. Exposed on `window` for the body-level click handler (which lives in the agent-badge.ts IIFE outside this module's import graph).

**CSS** (`style-agents.css`): new rules mirror channel `.ch-eye` pattern 1:1 — fixed 14×14 slot, red diagonal strike via `::after` when off, opacity=1 on row per PR #293/#295 (only eye glyph signals state). `dashboard.html` cache-bust `style-agents.css v134 → v135`.

**Judgment call — eye position**: Task 7's spec orders the slots as `icon → ★ → 👁 → LEDs → name@host`, and explicitly notes "deviates slightly from task 3's `icon → ★ → LEDs → name@host` baseline; task 7 overrides". Applied as specified.

## Files touched

**Task 1 (topology autolayout)**:
- `hub/frontend/src/activity-tab/topology-autolayout.ts` (new)
- `hub/frontend/src/activity-tab/topology.ts` — 整列 button in toolbar
- `hub/frontend/src/activity-tab/zoompan.ts` — wire `integrate` action
- `hub/static/hub/activity-tab/topology-autolayout.js` (new)
- `hub/static/hub/activity-tab/topology.js`, `zoompan.js` (JS mirrors)

**Task 2 (sidebar channel unify)**:
- `hub/frontend/src/app/sidebar-channel-tree.ts` — remove deselect branch
- `hub/static/hub/app/sidebar-channel-tree.js` (JS mirror)
- `hub/static/hub/style/style-base.css` — `.channel-item` metrics

**Task 3 (topology visual unify)**:
- `hub/frontend/src/agent-badge-svg.ts` (`LED_R: 4 → 3.5`)
- `hub/static/hub/agent-badge-svg.js` (JS mirror)
- `hub/static/hub/activity-tab/activity-tab-topology-nodes.css` (`.topo-label-agent` `font-size: 11px`)

**Task 4 (sidebar channel colour restore)**:
- `hub/frontend/src/app/sidebar-channel-tree.ts` (`--channel-accent` var)
- `hub/static/hub/app/sidebar-channel-tree.js` (JS mirror)
- `hub/static/hub/style/style-channels.css` (two accent rules)

**Task 5 (topology star click)**:
- `hub/frontend/src/activity-tab/grid-click.ts` (selector widen)
- `hub/static/hub/activity-tab/grid-click.js` (JS mirror)

**Task 6 (popup paste fix)**:
- `hub/frontend/src/activity-tab/compose.ts` (`_refocusInput` + mousedown/contextmenu listeners)
- `hub/static/hub/activity-tab/compose.js` (JS mirror)

**Task 7 (agent eye toggle)**:

Backend:
- `hub/models/_identity.py` (+`is_hidden` field)
- `hub/migrations/0027_agentprofile_is_hidden.py` (new)
- `hub/views/api/_agents.py` (PATCH-style + `is_hidden`)
- `hub/registry/_payload.py` (surface `is_hidden`)

Frontend (TS + JS mirror):
- `hub/frontend/src/agent-badge.ts` (+`renderAgentEye`, body-level handler)
- `hub/static/hub/agent-badge.js`
- `hub/frontend/src/agent-badge-svg.ts` (layout rework, eye SVG slot)
- `hub/static/hub/agent-badge-svg.js`
- `hub/frontend/src/app/channel-prefs.ts` (+`_setAgentHidden`)
- `hub/static/hub/app/channel-prefs.js`
- `hub/frontend/src/app/sidebar-agents.ts` (sort comparator, `.agent-hidden` class)
- `hub/static/hub/app/sidebar-agents.js`
- `hub/frontend/src/activity-tab/topology.ts` (`is_hidden` drop filter)
- `hub/static/hub/activity-tab/topology.js`

CSS / template:
- `hub/static/hub/style/style-agents.css` (+ eye rules)

**Shared**:
- `hub/templates/hub/dashboard.html` — cache-bust: `style-base.css` v137, `style-channels.css` v138→v139, `activity-tab-topology-nodes.css` v165→v166, `style-agents.css` v134→v135

## Test plan

- [x] `npm run typecheck` — passes (after all 7 tasks)
- [x] `npm run build` — passes (vite 5.4.21, 108 modules, 710.98 kB bundle after Task 7)
- [x] `python3 manage.py makemigrations --dry-run --check hub` — "No changes detected" (Task 7 model matches migration)
- [x] `python3 manage.py migrate --plan hub 0027` — clean plan
- [x] `python3 manage.py check` — 0 issues
- [x] `python3 manage.py test hub.tests -k agent` — 47/47 pass
- [ ] Manual: open Agents tab, topology view, drag several nodes to overlap, click 整列, verify rings form, channels inside, agents/human outside, no visible overlap (Task 1)
- [ ] Manual: click selected channel in sidebar, verify selection stays (Task 2)
- [ ] Manual: compare topology agent node typography against sidebar agent row — label size and LED dots at same weight (Task 3)
- [ ] Manual: scroll Channels sidebar — each row shows coloured left-edge stripe + tinted category icon (Task 4)
- [ ] Manual: click ★ on a topology agent-node — favourite state flips in sidebar too (Task 5)
- [ ] Manual: double-click a topology channel to open compose popup, right-click textarea, pick Paste from OS menu — text appears (Task 6); Cmd+V works after clicking anywhere else on popup chrome (Task 6)
- [ ] Manual: click 👁 on an agent card — row moves to bottom of sidebar with red-slash glyph, node disappears from canvas; click again to un-hide (Task 7)
- [ ] Manual: reload dashboard after hiding an agent — hidden state persists (Task 7 persistence)

## Constraints honoured

- `ts-migration-v2` untouched.
- Backend kept minimal — only the one AgentProfile.is_hidden field + API surface needed for Task 7 persistence.
- Single PR (#306); no new PR opened for Tasks 3/4/5/6/7.
- PR #293's selection-background rule, PR #295's `font-weight: normal` rule, PR #291's opacity-dim ban — all preserved across all 7 tasks.
- Japanese UI string (`整列`) added with English tooltip + English comment.
- Every touched file stays under its existing line cap; new logic lands in existing modules or a new module.

## Note on playwright baseline comparison

Lead's reference image: `/Users/ywatanabe/.scitex/orochi/shared/skills/scitex-orochi-private/ui-regression/sidebar-agents-reference-2026-04-21.png` shows the pre-Task-7 canonical sidebar layout (`icon → ★ → 4 LEDs → name@host`, no eye). Task 7 intentionally deviates from that baseline by inserting 👁 between ★ and the LEDs per lead's explicit ordering directive in msg#15548. The new baseline to add to `ui-regression/` after this PR merges is `sidebar-agents-reference-<date>-eye.png` — post-Task-7 state.

Generated with [Claude Code](https://claude.com/claude-code)
