### PR TITLE
feat(liveness): auto-green 4th LED on any inbound agent message (msg#15538)

### DIFF
--- a/hub/consumers/_agent_message.py
+++ b/hub/consumers/_agent_message.py
@@ -109,9 +109,21 @@ async def handle_agent_message(consumer, content):
 
     # Update activity timestamp — this is a meaningful action,
     # distinct from a passive heartbeat.
-    from hub.registry import mark_activity
+    from hub.registry import mark_activity, mark_echo_alive
 
     mark_activity(consumer.agent_name, action=text[:120])
+
+    # msg#15538 — auto-green the 4th LED (ECHO) on any inbound agent
+    # message. Previously the LED only turned green after the hub→agent
+    # nonce round-trip in ``_hub_echo_loop`` succeeded; if the agent's
+    # MCP-client couldn't reply to the nonce the LED stayed amber / red
+    # even though the agent was obviously alive — it had just sent a
+    # chat message. ``mark_echo_alive`` advances the same
+    # ``last_nonce_echo_at`` timestamp the nonce-probe setter writes,
+    # so the existing LED renderer (no frontend change needed) sees the
+    # hot timestamp regardless of nonce-probe success. The two
+    # mechanisms together are a strictly stronger liveness signal.
+    mark_echo_alive(consumer.agent_name)
 
     # Persist message
     msg = await consumer._save_message(

--- a/hub/frontend/src/agent-badge.ts
+++ b/hub/frontend/src/agent-badge.ts
@@ -184,7 +184,12 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
           ")\n  Heuristic from local pane text; not fully reliable.\n  green = running, yellow = idle, blue = waiting,\n  red = auth_error, orange = stale.",
       ) +
       '"></span>';
-    // 4. Remote functional state — nonce-echo (publisher TBD)
+    // 4. Remote functional state — "last proof of life".
+    // msg#15538: ``last_nonce_echo_at`` is advanced by EITHER the
+    // hub→agent nonce round-trip (hub/consumers/_echo.py) OR by any
+    // inbound agent message (hub/consumers/_agent_message.py via
+    // mark_echo_alive). The renderer does not need to know which
+    // mechanism wrote the timestamp — either path turns the LED green.
     var echo = a.last_nonce_echo_at;
     var echoAge =
       echo != null ? (Date.now() - new Date(echo).getTime()) / 1000 : null;

--- a/hub/registry/__init__.py
+++ b/hub/registry/__init__.py
@@ -27,6 +27,7 @@ The full pre-split public surface is re-exported here so
 
 from ._heartbeat import (
     mark_activity,
+    mark_echo_alive,
     set_current_task,
     set_health,
     set_subagent_count,
@@ -100,6 +101,7 @@ __all__ = [
     "update_pong",
     "update_echo_pong",
     "mark_activity",
+    "mark_echo_alive",
     "set_current_task",
     "set_subagents",
     "set_subagent_count",

--- a/hub/registry/_heartbeat.py
+++ b/hub/registry/_heartbeat.py
@@ -183,6 +183,12 @@ def update_echo_pong(name: str, rtt_ms: float) -> None:
 
     All three are written atomically so a partial update can't leave
     the LED rendering off a fresher timestamp than the RTT it cites.
+
+    Semantic note (msg#15538 — 4th-LED auto-green on inbound message):
+    ``last_nonce_echo_at`` is now the "last proof of life" timestamp,
+    written either by this setter (successful nonce probe, carries RTT)
+    OR by ``mark_echo_alive()`` (any inbound agent message, no RTT).
+    Both paths feed the same LED field so either signal turns it green.
     """
     from datetime import datetime, timezone
 
@@ -191,5 +197,39 @@ def update_echo_pong(name: str, rtt_ms: float) -> None:
     with _lock:
         if name in _agents:
             _agents[name]["last_echo_rtt_ms"] = float(rtt_ms)
+            _agents[name]["last_echo_ok_ts"] = now
+            _agents[name]["last_nonce_echo_at"] = iso_now
+
+
+def mark_echo_alive(name: str) -> None:
+    """Record proof-of-life from an inbound agent message (msg#15538).
+
+    The 4th LED (ECHO / ``last_nonce_echo_at``) was previously only
+    driven by the hub→agent nonce round-trip in ``_hub_echo_loop`` /
+    ``handle_echo_pong``. If the agent's MCP-client could not reply to
+    the nonce (e.g. the sidecar was down) the LED stayed amber / red
+    even though the agent was clearly alive — we had just received a
+    chat message from it.
+
+    This setter is called from ``handle_agent_message`` when a
+    ``type: "message"`` frame lands on the WS (after ACL + membership
+    checks pass, so only authenticated inbound traffic is credited).
+    It advances the same ``last_nonce_echo_at`` / ``last_echo_ok_ts``
+    pair the nonce-probe setter writes — the LED renderer needs no
+    change; it just sees the hot timestamp regardless of which
+    mechanism produced it.
+
+    Does NOT touch ``last_echo_rtt_ms`` — an inbound message has no
+    round-trip measurement, and overwriting a real RTT with a sentinel
+    would make the per-agent detail panel's RTT display misleading.
+    The two mechanisms together are a strictly stronger liveness signal
+    than nonce-probe alone (either path turns the LED green).
+    """
+    from datetime import datetime, timezone
+
+    now = time.time()
+    iso_now = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+    with _lock:
+        if name in _agents:
             _agents[name]["last_echo_ok_ts"] = now
             _agents[name]["last_nonce_echo_at"] = iso_now

--- a/hub/static/hub/agent-badge.js
+++ b/hub/static/hub/agent-badge.js
@@ -180,7 +180,12 @@
           ")\n  Heuristic from local pane text; not fully reliable.\n  green = running, yellow = idle, blue = waiting,\n  red = auth_error, orange = stale.",
       ) +
       '"></span>';
-    // 4. Remote functional state — nonce-echo (publisher TBD)
+    // 4. Remote functional state — "last proof of life".
+    // msg#15538: ``last_nonce_echo_at`` is advanced by EITHER the
+    // hub→agent nonce round-trip (hub/consumers/_echo.py) OR by any
+    // inbound agent message (hub/consumers/_agent_message.py via
+    // mark_echo_alive). The renderer does not need to know which
+    // mechanism wrote the timestamp — either path turns the LED green.
     var echo = a.last_nonce_echo_at;
     var echoAge =
       echo != null ? (Date.now() - new Date(echo).getTime()) / 1000 : null;

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -13,6 +13,7 @@ top level. Django's default test discovery walks the sub-packages.
 
 # Top-level cross-cutting tests
 # Mirror-package tests
+from hub.tests.consumers.test_agent_message_echo import *  # noqa: F401,F403
 from hub.tests.consumers.test_agent_subscription import *  # noqa: F401,F403
 from hub.tests.consumers.test_dm import *  # noqa: F401,F403
 from hub.tests.consumers.test_mentions import *  # noqa: F401,F403

--- a/hub/tests/consumers/test_agent_message_echo.py
+++ b/hub/tests/consumers/test_agent_message_echo.py
@@ -1,0 +1,234 @@
+"""Tests for msg#15538 — 4th LED (ECHO) auto-green on inbound agent message.
+
+Before this change the ``last_nonce_echo_at`` timestamp (which the 4th
+liveness LED renders against) was only advanced when the hub→agent
+nonce round-trip probe in ``_hub_echo_loop`` completed successfully.
+If an agent's MCP-client could not reply to the nonce (e.g. the
+sidecar was down, or the agent never implemented the handler) the LED
+stayed amber / red even though the agent was clearly alive — it was
+sending chat messages every few seconds.
+
+The fix: every authenticated inbound ``message`` frame now also
+advances ``last_nonce_echo_at`` (and the sibling ``last_echo_ok_ts``)
+via ``mark_echo_alive``. The LED renderer does not need to know which
+mechanism wrote the timestamp — either path turns the LED green.
+
+These tests drive the ``handle_agent_message`` coroutine directly with
+a fake consumer (mirrors the ``test_reconnect_resubscribe.py`` style)
+so the behaviour is exercised at the seam where the new call was added.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Workspace,
+)
+
+
+def _fake_consumer(agent_name: str, workspace_id: int):
+    """Minimal AgentConsumer stub capable of driving handle_agent_message.
+
+    Provides the bound attributes the handler reads (agent_name,
+    workspace_id, workspace_group, channel_layer, send_json) plus an
+    ``_save_message`` AsyncMock so the handler's persistence step
+    becomes a no-op. Keeping persistence out of the test isolates the
+    registry-side contract.
+    """
+    from hub.consumers._agent import AgentConsumer
+
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_name = agent_name
+    consumer.workspace_id = workspace_id
+    consumer.workspace_group = f"workspace_{workspace_id}"
+    consumer.channel_name = f"test-ch-{agent_name}"
+    consumer._registered = True
+    consumer.agent_meta = {"channels": ["#general"]}
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    consumer.send_json = AsyncMock()
+    consumer._save_message = AsyncMock(
+        return_value={"id": 1, "ts": "2026-04-20T00:00:00+00:00"}
+    )
+    return consumer
+
+
+class InboundMessageAdvancesEchoTimestampTest(TestCase):
+    """A ``type: "message"`` frame must advance ``last_nonce_echo_at``.
+
+    This is the core contract of msg#15538: any authenticated inbound
+    agent message counts as proof of life and should turn the 4th LED
+    green, independent of whether the nonce probe ever completes.
+    """
+
+    def setUp(self):
+        from hub.registry import _agents, _connections, register_agent
+
+        _agents.clear()
+        _connections.clear()
+
+        self.ws = Workspace.objects.create(name="echo-auto-ws")
+        self.channel = Channel.objects.create(workspace=self.ws, name="#general")
+
+        # ChannelMembership row so the non-member ACL doesn't block the
+        # message — the consumer authenticates as ``agent-<name>``.
+        self.agent_user = User.objects.create(username="agent-worker-m")
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.channel
+        )
+
+        register_agent(
+            "worker-m",
+            self.ws.id,
+            {"agent_id": "worker-m", "machine": "TEST", "role": "worker"},
+        )
+
+    def test_inbound_message_sets_last_nonce_echo_at(self):
+        """Sending a message frame populates ``last_nonce_echo_at``.
+
+        A freshly-registered agent has no echo fields yet (all None).
+        After one ``message`` frame the ISO timestamp must be written
+        so the LED renderer flips from grey-pending to green.
+        """
+        from hub.consumers._agent_message import handle_agent_message
+        from hub.registry import _agents
+
+        # Pre-condition: never probed, never messaged.
+        self.assertIsNone(_agents["worker-m"].get("last_nonce_echo_at"))
+        self.assertIsNone(_agents["worker-m"].get("last_echo_ok_ts"))
+
+        consumer = _fake_consumer("worker-m", self.ws.id)
+        async_to_sync(handle_agent_message)(
+            consumer,
+            {
+                "type": "message",
+                "payload": {"channel": "#general", "text": "hello"},
+            },
+        )
+
+        # Both the ISO string (LED renderer) and the unix float (API
+        # layer / tooling) must be populated after one inbound message.
+        self.assertIsInstance(
+            _agents["worker-m"]["last_nonce_echo_at"], str
+        )
+        self.assertTrue(
+            _agents["worker-m"]["last_nonce_echo_at"].endswith("+00:00")
+        )
+        self.assertIsInstance(
+            _agents["worker-m"]["last_echo_ok_ts"], float
+        )
+
+    def test_inbound_message_does_not_overwrite_rtt(self):
+        """An inbound message has no RTT — must not wipe a real one.
+
+        If ``update_echo_pong`` previously ran (real nonce probe), its
+        ``last_echo_rtt_ms`` value must survive subsequent inbound
+        messages so the per-agent detail panel keeps showing a real RTT.
+        Overwriting with None would make the display misleading.
+        """
+        from hub.consumers._agent_message import handle_agent_message
+        from hub.registry import _agents, update_echo_pong
+
+        update_echo_pong("worker-m", 42.5)
+        self.assertEqual(_agents["worker-m"]["last_echo_rtt_ms"], 42.5)
+        probed_iso = _agents["worker-m"]["last_nonce_echo_at"]
+
+        consumer = _fake_consumer("worker-m", self.ws.id)
+        async_to_sync(handle_agent_message)(
+            consumer,
+            {
+                "type": "message",
+                "payload": {"channel": "#general", "text": "later"},
+            },
+        )
+
+        # RTT preserved, ISO timestamp advanced (or equal — clock
+        # resolution on CI might give the same string).
+        self.assertEqual(_agents["worker-m"]["last_echo_rtt_ms"], 42.5)
+        self.assertGreaterEqual(
+            _agents["worker-m"]["last_nonce_echo_at"], probed_iso
+        )
+
+
+class NonceProbeIndependenceTest(TestCase):
+    """The timestamp advances even if the nonce probe never completes.
+
+    Confirms the core value proposition of msg#15538: agent-message-only
+    is enough to turn the LED green. Exercises the registry seam alone
+    so the test is fast and doesn't need an asyncio echo loop.
+    """
+
+    def setUp(self):
+        from hub.registry import _agents, _connections, register_agent
+
+        _agents.clear()
+        _connections.clear()
+
+        self.ws = Workspace.objects.create(name="echo-auto-nopong-ws")
+        self.channel = Channel.objects.create(workspace=self.ws, name="#general")
+        self.agent_user = User.objects.create(username="agent-lonely-n")
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.channel
+        )
+        register_agent(
+            "lonely-n",
+            self.ws.id,
+            {"agent_id": "lonely-n", "machine": "TEST", "role": "worker"},
+        )
+
+    def test_mark_echo_alive_alone_populates_led_field(self):
+        """``mark_echo_alive`` is sufficient — no nonce pong required."""
+        from hub.registry import _agents, mark_echo_alive
+
+        # Never call update_echo_pong — simulate an agent whose MCP
+        # sidecar is down or whose echo_pong handler never fires.
+        self.assertIsNone(_agents["lonely-n"].get("last_nonce_echo_at"))
+        self.assertIsNone(_agents["lonely-n"].get("last_echo_rtt_ms"))
+
+        mark_echo_alive("lonely-n")
+
+        # LED field populated — renderer will flip to green.
+        self.assertIsInstance(
+            _agents["lonely-n"]["last_nonce_echo_at"], str
+        )
+        self.assertIsInstance(
+            _agents["lonely-n"]["last_echo_ok_ts"], float
+        )
+        # RTT still absent — nothing to overwrite with and no round-trip
+        # was actually measured. The per-agent detail panel renders
+        # this as "no RTT recorded yet" rather than "0ms".
+        self.assertIsNone(_agents["lonely-n"].get("last_echo_rtt_ms"))
+
+    def test_mark_echo_alive_unknown_agent_is_noop(self):
+        """Mirrors ``update_echo_pong`` — unknown agent must not raise."""
+        from hub.registry import _agents, mark_echo_alive
+
+        mark_echo_alive("never-registered")
+        self.assertNotIn("never-registered", _agents)
+
+    def test_payload_surfaces_field_without_rtt(self):
+        """``get_agents`` must surface the inbound-only timestamp.
+
+        Regression guard: the payload layer must include
+        ``last_nonce_echo_at`` when it was set via ``mark_echo_alive``
+        (not just when ``update_echo_pong`` ran). Otherwise the LED
+        never sees the timestamp even though the registry has it.
+        """
+        from hub.registry import get_agents, mark_echo_alive
+
+        mark_echo_alive("lonely-n")
+        payload = next(
+            a for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "lonely-n"
+        )
+        self.assertIsNotNone(payload["last_nonce_echo_at"])
+        self.assertIsNone(payload["last_echo_rtt_ms"])


### PR DESCRIPTION
## Root cause

The 4th LED (ECHO) on every agent card only turned green after a server→agent→server **nonce round-trip probe** (``_hub_echo_loop`` / ``handle_echo_pong``). If an agent's MCP-client could not reply to the nonce (sidecar down, older client, transient hiccup) the LED stayed amber / red — even though the agent was clearly alive and sending chat messages every few seconds. Lead ``#heads msg#15538`` flagged this as misleading.

## Fix

Every authenticated inbound ``message`` frame now also advances ``last_nonce_echo_at`` (the timestamp the LED renderer pins on), via a new ``mark_echo_alive(name)`` setter called from ``handle_agent_message`` right after the existing ``mark_activity(...)`` call. The nonce probe keeps running in parallel — the two mechanisms together are a strictly stronger liveness signal than either alone.

## Field-name decision

**Reused ``last_nonce_echo_at``** (did not invent a new ``last_inbound_at``). Rationale:

- Field is already surfaced in the ``/api/agents/`` payload and consumed directly by ``renderAgentLeds`` / the ``isAgentAllGreen`` evaluator — reusing it means the frontend does not need a ``Math.max(...)`` dance.
- Already in the ``register_agent`` prev-preserve list — no new prev-preserve entry required.
- Semantic note in the ``update_echo_pong`` docstring now clarifies the field means "last proof of life" (nonce probe OR inbound message).
- ``mark_echo_alive`` deliberately does NOT touch ``last_echo_rtt_ms`` — an inbound message has no RTT, and overwriting a real RTT with a sentinel would mislead the per-agent detail panel.

## Files touched

**Python backend**
- ``hub/registry/_heartbeat.py`` — new ``mark_echo_alive`` setter; docstring refresh on ``update_echo_pong``
- ``hub/registry/__init__.py`` — export ``mark_echo_alive``
- ``hub/consumers/_agent_message.py`` — call ``mark_echo_alive`` next to ``mark_activity``

**Frontend (hand-maintained JS mirror convention)**
- ``hub/frontend/src/agent-badge.ts`` — docstring refresh on the 4th-LED renderer
- ``hub/static/hub/agent-badge.js`` — identical docstring refresh

**Tests**
- ``hub/tests/consumers/test_agent_message_echo.py`` — new file, 5 tests
- ``hub/tests/__init__.py`` — re-export the new test module

## Tests added

1. ``InboundMessageAdvancesEchoTimestampTest.test_inbound_message_sets_last_nonce_echo_at`` — drives ``handle_agent_message`` and asserts the timestamp advances from None.
2. ``InboundMessageAdvancesEchoTimestampTest.test_inbound_message_does_not_overwrite_rtt`` — a real RTT from a prior nonce probe survives a later inbound message.
3. ``NonceProbeIndependenceTest.test_mark_echo_alive_alone_populates_led_field`` — core value of the fix: agent-message-only is enough to turn the LED green, nonce probe never needed.
4. ``NonceProbeIndependenceTest.test_mark_echo_alive_unknown_agent_is_noop`` — mirrors the ``update_echo_pong`` contract.
5. ``NonceProbeIndependenceTest.test_payload_surfaces_field_without_rtt`` — regression guard on the ``get_agents`` payload layer.

## Verification

- ``cd hub/frontend && npm run typecheck`` — pass
- ``cd hub/frontend && npm run build`` — pass (107 modules transformed)
- ``python3 manage.py test hub.tests.registry hub.tests.consumers --keepdb`` — 106 pass, 0 fail
- New 5 tests pass in isolation

## Scope

- Narrow, focused — ~300 LOC touching 7 files; 5 tests.
- Orthogonal to PR #306 (UI bundle) and the in-flight ``ts-migration-v2``; did not touch those branches or files.

Generated with Claude Code (https://claude.com/claude-code)
