### PR TITLE
fix(host-identity): prefer live hostname() over env vars in heartbeat (msg#15578)

### DIFF
--- a/deployment/host-setup/launchd/README.md
+++ b/deployment/host-setup/launchd/README.md
@@ -1,0 +1,38 @@
+# LaunchAgents
+
+macOS LaunchAgent templates installed per-user to protect host disk /
+run client-side maintenance without interfering with the container.
+
+## `com.scitex.chrome-codesign-watchdog.plist`
+
+scitex-orochi#286 item 2. Periodically reaps the Chrome
+`code_sign_clone` cache leak that contributed to the 2026-04-21
+full-disk outage.
+
+Install:
+
+```bash
+./scripts/client/install-chrome-codesign-watchdog.sh
+```
+
+Uninstall:
+
+```bash
+./scripts/client/install-chrome-codesign-watchdog.sh --uninstall
+```
+
+Status / logs:
+
+```bash
+launchctl list | grep com.scitex.chrome-codesign-watchdog
+tail -n 50 ~/Library/Logs/scitex/chrome-codesign-watchdog.log
+```
+
+Thresholds (tune per host by editing the `EnvironmentVariables` block
+in the installed plist and re-running the install helper):
+
+- `ADVISE_GIB` (default 2) — log an advisory at this size
+- `REAP_GIB` (default 5) — `rm -rf` the cache at this size
+
+See `skills/infra-hub-docker-disk-full.md` for why this cache is
+reaper-safe.

--- a/deployment/host-setup/launchd/README.md
+++ b/deployment/host-setup/launchd/README.md
@@ -3,6 +3,56 @@
 macOS LaunchAgent templates installed per-user to protect host disk /
 run client-side maintenance without interfering with the container.
 
+## `com.scitex.fleet-host-liveness-probe.plist`
+
+scitex-orochi#271. Runs the fleet host-liveness probe every 5 minutes
+to detect tmux-server death and missing expected agents across the
+fleet, then auto-revives via healer delegation or direct SSH.
+
+Authored after the 2026-04-20 incident where both `ywata-note-win`
+and `spartan` lost their tmux servers and nobody noticed for hours.
+The memory / discipline layer did not save us; this is an
+implementation lever that actually runs every ~5 min.
+
+Install (default: auto-revive enabled):
+
+```bash
+./scripts/client/install-fleet-host-liveness-probe.sh
+```
+
+Install in observation-only mode (no revive):
+
+```bash
+./scripts/client/install-fleet-host-liveness-probe.sh --dry-run-only
+```
+
+Uninstall:
+
+```bash
+./scripts/client/install-fleet-host-liveness-probe.sh --uninstall
+```
+
+Status / logs:
+
+```bash
+launchctl list | grep com.scitex.fleet-host-liveness-probe
+tail -n 200 ~/Library/Logs/scitex/fleet-host-liveness-probe.log
+```
+
+Output:
+- `stdout` — one NDJSON line per fleet host (schema
+  `scitex-orochi/host-liveness-probe/v1`) with severity, expected vs.
+  alive agents, missing, unexpected, and actions taken.
+- `stderr` — human-readable advisories for non-OK hosts.
+- Exit code follows the disk-pressure-probe convention: 0 ok,
+  1 advisory, 2 warn, 3 critical. LaunchAgent ignores exit code; the
+  signal is in the NDJSON and the revive actions.
+
+Source of truth for "expected agents" per host: the
+`expected_tmux_sessions:` key in `orochi-machines.yaml` at the repo
+root. Keep that file in sync with live fleet naming to avoid false
+"missing"/"unexpected" drift.
+
 ## `com.scitex.chrome-codesign-watchdog.plist`
 
 scitex-orochi#286 item 2. Periodically reaps the Chrome

--- a/deployment/host-setup/launchd/com.scitex.chrome-codesign-watchdog.plist
+++ b/deployment/host-setup/launchd/com.scitex.chrome-codesign-watchdog.plist
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent: Chrome code_sign_clone watchdog (scitex-orochi#286 item 2).
+
+  Runs scripts/client/chrome-codesign-clone-watchdog.sh hourly on this
+  user's login session. Default thresholds: advise at >=2 GiB, reap at
+  >=5 GiB. See the script's header for threshold env-var overrides.
+
+  Install:
+    cp deployment/host-setup/launchd/com.scitex.chrome-codesign-watchdog.plist \
+       ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.scitex.chrome-codesign-watchdog.plist
+
+  Logs: ~/Library/Logs/scitex/chrome-codesign-watchdog.log (rotated by
+  macOS launchd; rotate manually if the file grows — `tail -n 2000` is
+  usually plenty of history).
+
+  Replace __HOME__ and __REPO__ with your actual paths before `launchctl
+  load`. The companion install helper
+  scripts/client/install-chrome-codesign-watchdog.sh does this rewrite
+  automatically.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.scitex.chrome-codesign-watchdog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>__REPO__/scripts/client/chrome-codesign-clone-watchdog.sh</string>
+    </array>
+
+    <!-- Every hour on login sessions. macOS schedules a single run at
+         load time, then on the interval thereafter. -->
+    <key>StartInterval</key>
+    <integer>3600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Don't respawn in a tight loop if the script exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/scitex/chrome-codesign-watchdog.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/scitex/chrome-codesign-watchdog.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <!-- Override here to tune thresholds on a specific host; leave
+           commented-out to inherit the script's defaults
+           (advise 2 GiB / reap 5 GiB). -->
+      <!--
+      <key>ADVISE_GIB</key>
+      <string>2</string>
+      <key>REAP_GIB</key>
+      <string>5</string>
+      -->
+    </dict>
+  </dict>
+</plist>

--- a/deployment/host-setup/launchd/com.scitex.fleet-host-liveness-probe.plist
+++ b/deployment/host-setup/launchd/com.scitex.fleet-host-liveness-probe.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent: fleet host-liveness probe with auto-revive (todo#271).
+
+  Runs scripts/client/fleet-watch/host-liveness-probe.sh every 5 minutes
+  on this user's login session. Detects tmux-server death and missing
+  expected agents, then delegates revive to the local healer (if alive)
+  or runs `scitex-agent-container start <agent>` directly via SSH.
+
+  Install:
+    ./scripts/client/install-fleet-host-liveness-probe.sh
+
+  Logs: ~/Library/Logs/scitex/fleet-host-liveness-probe.log (both stdout
+  NDJSON and stderr advisories tee there; rotate manually when large).
+
+  Replace __HOME__ and __REPO__ with your actual paths before `launchctl
+  load`. The companion install helper
+  scripts/client/install-fleet-host-liveness-probe.sh does this rewrite
+  automatically.
+
+  Why --yes in production: the whole point of this LaunchAgent is to
+  auto-revive dead agents without waiting for humans. The install helper
+  provides --dry-run-only if you want to observe before committing to
+  automatic revive.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.scitex.fleet-host-liveness-probe</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>__REPO__/scripts/client/fleet-watch/host-liveness-probe.sh</string>
+      <string>__PROBE_MODE__</string>
+    </array>
+
+    <!-- Every 5 minutes. matches orochi-machines.yaml preflight.fleet_watch_cycle_seconds. -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Don't respawn in a tight loop if the script exits non-zero -->
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/scitex/fleet-host-liveness-probe.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/scitex/fleet-host-liveness-probe.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+  </dict>
+</plist>

--- a/hub/channel_acl.py
+++ b/hub/channel_acl.py
@@ -198,6 +198,62 @@ def _check_dm_write_allowed(
     return False
 
 
+def check_membership_allowed(
+    sender: str, channel: str, workspace_id: int | None = None
+) -> bool:
+    """Return True if ``sender`` is allowed to write to ``channel`` per
+    :class:`hub.models.ChannelMembership`.
+
+    Semantics (issue #276 — closing the REST/WS write-path ACL gap):
+
+    * DMs are handled by :func:`_check_dm_write_allowed`; this helper
+      returns ``True`` for ``dm:`` channels (deferring to the caller's
+      existing DM gate).
+    * If the caller did not supply ``workspace_id`` we cannot scope the
+      lookup and fall back to ``True`` (preserves non-WS test fixtures).
+    * If an explicit :class:`ChannelMembership` row exists with
+      ``permission = "read-only"`` the write is **denied**.
+    * If the sender is a synthetic agent user (``agent-*`` — see
+      ``hub/views/auth.py``) and *no* membership row exists for the
+      target non-DM channel, the write is **denied**. Agents must be
+      explicitly added (ywatanabe policy msg#11866 — "by default no
+      agent subscribes anywhere"). Human users keep the permissive
+      default so humans continue to post through the UI without a
+      pre-seeded row.
+    """
+    if channel.startswith("dm:") or workspace_id is None:
+        return True
+
+    try:
+        from hub.models import Channel as _Channel
+        from hub.models import ChannelMembership as _Membership
+    except Exception:
+        return True
+
+    ch = (
+        _Channel.objects.filter(workspace_id=workspace_id, name=channel)
+        .only("id", "kind")
+        .first()
+    )
+    if ch is None or ch.kind == _Channel.KIND_DM:
+        # Channel does not exist yet, or is a DM row without dm: prefix —
+        # let the caller's other gates decide.
+        return True
+
+    row = (
+        _Membership.objects.filter(channel_id=ch.id, user__username=sender)
+        .only("permission")
+        .first()
+    )
+    if row is not None:
+        return row.permission != _Membership.PERM_READ_ONLY
+
+    # No explicit row. Agents must be explicitly added; humans default-allow.
+    if sender.startswith("agent-"):
+        return False
+    return True
+
+
 def reload() -> int:
     """Force reload of ACL from disk. Returns number of channel rules loaded."""
     global _last_load

--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -31,6 +31,7 @@ from ._agent_handlers import (
     handle_subscription,
     handle_task_update,
 )
+from ._agent_refresh import prehydrate_channels as _prehydrate_channels
 from ._echo import _hub_echo_loop
 from ._groups import _hub_ping_loop, _sanitize_group, log
 from ._helpers import (
@@ -94,6 +95,13 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         for ch_name in self._dm_channel_names:
             group = _sanitize_group(f"channel_{self.workspace_id}_{ch_name}")
             await self.channel_layer.group_add(group, self.channel_name)
+
+        # scitex-orochi#451 — eager channel-membership rehydration.
+        # Pre-hydrates persisted group memberships + seeds agent_meta so
+        # group messages aren't silently dropped during the window between
+        # connect and the client's register frame (or permanently, if the
+        # register frame never arrives). See ``_prehydrate_channels``.
+        await _prehydrate_channels(self)
 
         await self.accept()
 
@@ -315,6 +323,26 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         elif msg_type == "subagents_update":
             await handle_subagents_update(self, content)
         elif msg_type == "message":
+            # scitex-orochi#451 — deny message frames from un-registered
+            # connections. This makes the "orphan on reconnect" failure
+            # mode break LOUDLY (error response the client can log and
+            # surface) instead of silently (write succeeds but the agent
+            # never sees replies because it isn't in the reply groups).
+            # Clients MUST send a ``register`` frame on every reconnect
+            # and await the ``registered`` ack before sending messages.
+            if not getattr(self, "_registered", False):
+                await self.send_json(
+                    {
+                        "type": "error",
+                        "code": "not_registered",
+                        "message": (
+                            "send a `register` frame and await the "
+                            "`registered` ack before sending messages "
+                            "(scitex-orochi#451)"
+                        ),
+                    }
+                )
+                return
             from ._agent_message import handle_agent_message
 
             await handle_agent_message(self, content)

--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -58,6 +58,18 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         self.workspace_name = result["workspace_name"]
         self.agent_name = qs.get("agent", ["anonymous"])[0]
 
+        # scitex-orochi#255: per-process identity captured at connect so
+        # the singleton enforcer can decide who wins when two WS claim
+        # the same agent name. Both fields are optional in the URL —
+        # legacy clients (pre-#257) omit them and fall through to the
+        # permissive "no enforcement" path with a logged WARNING.
+        self._instance_id = qs.get("instance_id", [""])[0] or ""
+        _start_raw = qs.get("start_ts_unix", [""])[0]
+        try:
+            self._start_ts_unix = float(_start_raw) if _start_raw else None
+        except (TypeError, ValueError):
+            self._start_ts_unix = None
+
         # Spec v3 §2.3 — idempotently ensure a WorkspaceMember row exists
         # for this agent so DMParticipant FKs have a stable target.
         self.workspace_member = await _ensure_agent_member(
@@ -85,11 +97,117 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
 
         await self.accept()
 
+        # scitex-orochi#255: singleton cardinality enforcement.
+        #
+        # Before recording this connection in the registry, decide
+        # whether to enforce singleton cardinality: only one WS per
+        # agent name should remain alive. The decision rests on
+        # (instance_id, start_ts_unix) captured per-connection — the
+        # older start_ts_unix wins (the original process keeps its
+        # claim). Legacy clients without identity fall through to the
+        # permissive multi-connection behaviour with a WARNING.
+        from hub.registry import (
+            decide_singleton_winner,
+            get_connection_identity,
+            list_sibling_channels,
+            record_singleton_conflict,
+            set_connection_identity,
+        )
+
+        decision = decide_singleton_winner(
+            self.agent_name, self._instance_id, self._start_ts_unix
+        )
+        if decision == "challenger":
+            # Newcomer is older → it wins. Close every incumbent WS
+            # under the same name with the singleton-conflict close
+            # frame, record the event, then proceed to register the
+            # newcomer below as the surviving connection.
+            for inc_ch in list_sibling_channels(self.agent_name):
+                inc_ident = get_connection_identity(inc_ch) or {}
+                inc_iid = inc_ident.get("instance_id", "")
+                try:
+                    await self.channel_layer.send(
+                        inc_ch,
+                        {
+                            "type": "agent.singleton_evict",
+                            "code": 4409,
+                            "reason": "duplicate_identity",
+                        },
+                    )
+                except Exception:  # noqa: BLE001 — best-effort eviction
+                    log.exception(
+                        "Failed to send singleton-evict to incumbent %s for %s",
+                        inc_ch,
+                        self.agent_name,
+                    )
+                record_singleton_conflict(
+                    self.agent_name,
+                    winner_instance_id=self._instance_id,
+                    loser_instance_id=inc_iid,
+                    reason="duplicate_identity",
+                )
+                log.warning(
+                    "Singleton conflict on %s: incumbent %s evicted by older "
+                    "challenger (winner=%s, loser=%s).",
+                    self.agent_name,
+                    inc_ch,
+                    self._instance_id,
+                    inc_iid,
+                )
+        elif decision == "incumbent":
+            # An older incumbent already holds the claim — close THIS
+            # socket with the singleton-conflict frame and record the
+            # event. The incumbent's identity is the most-recent
+            # full-identity sibling.
+            inc_iid = ""
+            for inc_ch in list_sibling_channels(self.agent_name):
+                inc_ident = get_connection_identity(inc_ch) or {}
+                if inc_ident.get("instance_id"):
+                    inc_iid = inc_ident["instance_id"]
+                    break
+            record_singleton_conflict(
+                self.agent_name,
+                winner_instance_id=inc_iid,
+                loser_instance_id=self._instance_id,
+                reason="duplicate_identity",
+            )
+            log.warning(
+                "Singleton conflict on %s: challenger %s rejected (incumbent=%s, "
+                "loser=%s).",
+                self.agent_name,
+                self.channel_name,
+                inc_iid,
+                self._instance_id,
+            )
+            await self.close(code=4409, reason="duplicate_identity")
+            return
+        elif decision == "no_enforcement" and list_sibling_channels(self.agent_name):
+            # Legacy client (or first connection missing identity) —
+            # don't enforce, but log so multi-instance hazards stay
+            # visible in the operator log.
+            log.warning(
+                "Multi-instance hazard on %s: %d sibling connection(s) but "
+                "missing instance_id/start_ts_unix on this or incumbent — "
+                "falling back to permissive multi-connection behaviour "
+                "(scitex-orochi#255).",
+                self.agent_name,
+                len(list_sibling_channels(self.agent_name)),
+            )
+
         # scitex-orochi#144 fix path 4: track this WebSocket as one of N
         # active connections under self.agent_name, so the registry can
         # surface concurrent-instance situations without altering identity.
         from hub.registry import register_connection
 
+        # Record identity BEFORE register_connection so that subsequent
+        # connections coming in concurrently can see this one's identity
+        # via decide_singleton_winner.
+        set_connection_identity(
+            self.channel_name,
+            self.agent_name,
+            self._instance_id,
+            self._start_ts_unix,
+        )
         active_sessions = register_connection(self.agent_name, self.channel_name)
 
         log.info(
@@ -142,9 +260,15 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             # scitex-orochi#144 fix path 4: drop only THIS connection from
             # the per-agent set, not the whole agent record. The agent only
             # transitions to offline when its last sibling connection drops.
-            from hub.registry import unregister_connection
+            from hub.registry import (
+                clear_connection_identity,
+                unregister_connection,
+            )
 
             agent_name = getattr(self, "agent_name", "?")
+            # scitex-orochi#255: drop the per-channel identity row so a
+            # later challenger doesn't compare against a dead socket.
+            clear_connection_identity(self.channel_name)
             remaining = unregister_connection(agent_name, self.channel_name)
             if remaining > 0:
                 log.info(
@@ -234,6 +358,30 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         )
 
     # --- channel-layer events ignored on the agent socket ----------------
+
+    async def agent_singleton_evict(self, event):
+        """scitex-orochi#255 — close this WS because a newer/older twin won.
+
+        Sent to the LOSING incumbent socket from the connect handler of a
+        challenger that wins the singleton-cardinality decision. The
+        message-name uses an underscore (``agent_singleton_evict``)
+        because Channels rewrites the dotted ``agent.singleton_evict``
+        type into this method name.
+        """
+        code = int(event.get("code") or 4409)
+        reason = str(event.get("reason") or "duplicate_identity")
+        log.info(
+            "Closing WS for %s by singleton-eviction (code=%d reason=%s)",
+            getattr(self, "agent_name", "?"),
+            code,
+            reason,
+        )
+        try:
+            await self.close(code=code, reason=reason)
+        except TypeError:
+            # Some versions of channels.AsyncJsonWebsocketConsumer.close
+            # don't accept a `reason` kwarg — fall back to code-only.
+            await self.close(code=code)
 
     async def agent_presence(self, event):
         pass

--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -397,6 +397,24 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
 
     # --- channel-layer events forwarded to the agent WebSocket -----------
 
+    async def _is_channel_visible(self, ch_name: str) -> bool:
+        """Issue #277 — read-side ACL: apply the chat.message filter shape.
+
+        Mirrors ``chat_message`` (DM participant check for dm:* channels,
+        subscription-membership check for group channels) so thread /
+        reaction / edit / delete fan-out cannot leak cross-channel.
+        The write-side companion is #276 / PR #279.
+        """
+        is_dm = ch_name.startswith("dm:")
+        if is_dm:
+            return await _is_dm_participant_by_member(
+                channel_name=ch_name,
+                workspace_id=self.workspace_id,
+                member_id=getattr(self, "workspace_member_id", None),
+            )
+        agent_channels = getattr(self, "agent_meta", {}).get("channels", [])
+        return ch_name in agent_channels
+
     async def reaction_update(self, event):
         """Forward reaction add/remove events to agent WebSocket.
 
@@ -405,6 +423,9 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         thumbs-up to mean "received, no further action needed") without
         having to write a full reply.
         """
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "reaction_update",
@@ -416,24 +437,30 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         )
 
     async def message_edit(self, event):
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "message_edit",
                 "message_id": event["message_id"],
                 "sender": event["sender"],
-                "channel": event.get("channel", ""),
+                "channel": ch_name,
                 "text": event["text"],
                 "edited_at": event.get("edited_at"),
             }
         )
 
     async def message_delete(self, event):
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "message_delete",
                 "message_id": event["message_id"],
                 "sender": event["sender"],
-                "channel": event.get("channel", ""),
+                "channel": ch_name,
             }
         )
 
@@ -443,6 +470,9 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         The MCP sidecar rewrites thread_reply into a message with parent
         context, so agents can recognise and respond to threaded replies.
         """
+        ch_name = event.get("channel", "")
+        if ch_name and not await self._is_channel_visible(ch_name):
+            return
         await self.send_json(
             {
                 "type": "thread_reply",
@@ -450,7 +480,7 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
                 "reply_id": event["reply_id"],
                 "sender": event["sender"],
                 "sender_type": event.get("sender_type", "human"),
-                "channel": event.get("channel", ""),
+                "channel": ch_name,
                 "text": event.get("text", ""),
                 "ts": event.get("ts"),
                 "metadata": event.get("metadata", {}),

--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -395,6 +395,16 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
     async def system_message(self, event):
         pass
 
+    async def agent_subs_refresh(self, event):
+        """Re-sync ``agent_meta["channels"]`` from DB (#282).
+
+        Delegates to :func:`handle_agent_subs_refresh` in
+        ``_agent_refresh`` to keep this file under the 512-line cap.
+        """
+        from ._agent_refresh import handle_agent_subs_refresh
+
+        await handle_agent_subs_refresh(self, event)
+
     # --- channel-layer events forwarded to the agent WebSocket -----------
 
     async def _is_channel_visible(self, ch_name: str) -> bool:

--- a/hub/consumers/_agent.py
+++ b/hub/consumers/_agent.py
@@ -23,6 +23,7 @@ from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncJsonWebsocketConsumer
 
 from ._agent_handlers import (
+    handle_echo_pong,
     handle_heartbeat,
     handle_pong,
     handle_register,
@@ -30,6 +31,7 @@ from ._agent_handlers import (
     handle_subscription,
     handle_task_update,
 )
+from ._echo import _hub_echo_loop
 from ._groups import _hub_ping_loop, _sanitize_group, log
 from ._helpers import (
     _ensure_agent_member,
@@ -123,12 +125,19 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
         # live RTT and flag hub-side drops without waiting for the 30s
         # heartbeat-stale timeout.
         self._ping_task = asyncio.create_task(_hub_ping_loop(self))
+        # #259 — start hub→agent echo round-trip loop. Independent task
+        # so a transport hiccup in one loop can't starve the other.
+        # Cancelled in disconnect() alongside _ping_task.
+        self._echo_task = asyncio.create_task(_hub_echo_loop(self))
 
     async def disconnect(self, code):
         # Stop the ping task first so we don't race with the WS close.
         ping_task = getattr(self, "_ping_task", None)
         if ping_task is not None:
             ping_task.cancel()
+        echo_task = getattr(self, "_echo_task", None)
+        if echo_task is not None:
+            echo_task.cancel()
         if hasattr(self, "workspace_group"):
             # scitex-orochi#144 fix path 4: drop only THIS connection from
             # the per-agent set, not the whole agent record. The agent only
@@ -173,6 +182,8 @@ class AgentConsumer(AsyncJsonWebsocketConsumer):
             )
         elif msg_type == "pong":
             await handle_pong(self, content)
+        elif msg_type == "echo_pong":
+            await handle_echo_pong(self, content)
         elif msg_type == "heartbeat":
             await handle_heartbeat(self, content)
         elif msg_type == "task_update":

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -63,6 +63,15 @@ async def handle_register(consumer, content):
 
     register_agent(consumer.agent_name, consumer.workspace_id, consumer.agent_meta)
 
+    # scitex-orochi#451 — mark the consumer as registered. The
+    # ``receive_json`` dispatch uses this flag to deny ``message`` frames
+    # from un-registered connections so orphan-on-reconnect failures
+    # surface as a loud error instead of a silent deafness. The flag
+    # flips True only AFTER agent_meta + group_adds are in place, so a
+    # concurrent message frame either arrives before register completes
+    # (rejected) or after (accepted + delivered).
+    consumer._registered = True
+
     await consumer.channel_layer.group_send(
         consumer.workspace_group,
         {

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -45,6 +45,13 @@ async def handle_register(consumer, content):
         "agent_id": payload.get("agent_id", consumer.agent_name),
         "project": payload.get("project", ""),
         "machine": payload.get("machine", ""),
+        # #257 / lead msg#15578 — live hostname(1) reported by the
+        # client. Never derived from auth / source IP on the hub side;
+        # always what the agent process's own ``socket.gethostname()``
+        # / ``os.hostname()`` returned. Surfaced in the dashboard
+        # payload as the authoritative "where is this agent running"
+        # field (distinct from the YAML ``machine`` config label).
+        "hostname": payload.get("hostname", ""),
         # todo#55: canonical FQDN from the heartbeat (display-only).
         "hostname_canonical": payload.get("hostname_canonical", ""),
         "role": payload.get("role", ""),

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -157,6 +157,33 @@ async def handle_pong(consumer, content):
         )
 
 
+async def handle_echo_pong(consumer, content):
+    """Lookup the nonce, compute RTT, update echo registry fields (#259).
+
+    The hub publisher (in ``_echo._hub_echo_loop``) keeps a per-consumer
+    ``_echo_inflight`` dict mapping nonce -> sent_at. A matching
+    ``echo_pong`` frame yields the round-trip time and triggers
+    ``update_echo_pong``, which is what flips the 4th LED green.
+
+    Unknown nonces are dropped silently — they happen naturally on
+    reconnects (publisher state is per-consumer, lost on disconnect)
+    and shouldn't disturb the dashboard or log noise.
+    """
+    nonce = content.get("nonce")
+    if not isinstance(nonce, str) or not nonce:
+        return
+    inflight = getattr(consumer, "_echo_inflight", None)
+    if not inflight:
+        return
+    sent_at = inflight.pop(nonce, None)
+    if sent_at is None:
+        return
+    rtt_ms = max(0.0, (time.time() - float(sent_at)) * 1000.0)
+    from hub.registry import update_echo_pong
+
+    update_echo_pong(consumer.agent_name, rtt_ms)
+
+
 async def handle_heartbeat(consumer, content):
     """Persist resource metrics + optional narrative fields, then broadcast."""
     payload = content.get("payload", {})

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -17,13 +17,20 @@ from ._helpers import _load_agent_channel_subs, _persist_agent_subscription
 
 
 async def handle_register(consumer, content):
-    """Hydrate channel subscriptions + agent metadata, then announce."""
+    """Hydrate channel subscriptions + agent metadata, then announce.
+
+    Subscription state is sourced **only** from the persisted
+    ``ChannelMembership`` rows. Client-supplied ``channels`` arrays in the
+    register frame (``content["channels"]`` / ``payload["channels"]``) are
+    **ignored** — accepting them would let any agent opt itself into any
+    channel by self-declaration, bypassing the ACL gate on subscribe.
+    Fix for scitex-orochi#251 (private-channel delivery leak).
+    """
     payload = content.get("payload", {})
-    legacy_channels = list(content.get("channels") or payload.get("channels", []) or [])
     persisted = await _load_agent_channel_subs(
         consumer.workspace_id, consumer.agent_name
     )
-    channels = list(dict.fromkeys([*persisted, *legacy_channels]))
+    channels = list(persisted)
     # Spec v3 §3.1 — DM channels auto-subscribed at connect must also
     # appear in agent_meta["channels"] so the chat_message filter
     # forwards DM events.

--- a/hub/consumers/_agent_message.py
+++ b/hub/consumers/_agent_message.py
@@ -9,7 +9,7 @@ without becoming a method.
 
 from __future__ import annotations
 
-from hub.channel_acl import check_write_allowed
+from hub.channel_acl import check_membership_allowed, check_write_allowed
 from hub.models import Workspace
 
 from ._groups import _sanitize_group, log
@@ -73,6 +73,29 @@ async def handle_agent_message(consumer, content):
                 "type": "error",
                 "code": "acl_denied",
                 "message": f"You are not allowed to write to {ch_name}",
+            }
+        )
+        return
+
+    # Issue #276 — close the WS write-path ACL gap. AgentConsumer
+    # authenticates as the synthetic ``agent-<name>`` user; the
+    # membership gate requires an explicit ChannelMembership row for
+    # non-DM channels so agents cannot write to channels they were
+    # never subscribed to.
+    _member_allowed = await _sta(check_membership_allowed)(
+        f"agent-{consumer.agent_name}", ch_name, consumer.workspace_id
+    )
+    if not _member_allowed:
+        log.warning(
+            "[ACL] blocked non-member write from %s to %s",
+            consumer.agent_name,
+            ch_name,
+        )
+        await consumer.send_json(
+            {
+                "type": "error",
+                "code": "not_a_member",
+                "message": f"You are not a member of {ch_name}",
             }
         )
         return

--- a/hub/consumers/_agent_message.py
+++ b/hub/consumers/_agent_message.py
@@ -109,9 +109,21 @@ async def handle_agent_message(consumer, content):
 
     # Update activity timestamp — this is a meaningful action,
     # distinct from a passive heartbeat.
-    from hub.registry import mark_activity
+    from hub.registry import mark_activity, mark_echo_alive
 
     mark_activity(consumer.agent_name, action=text[:120])
+
+    # msg#15538 — auto-green the 4th LED (ECHO) on any inbound agent
+    # message. Previously the LED only turned green after the hub→agent
+    # nonce round-trip in ``_hub_echo_loop`` succeeded; if the agent's
+    # MCP-client couldn't reply to the nonce the LED stayed amber / red
+    # even though the agent was obviously alive — it had just sent a
+    # chat message. ``mark_echo_alive`` advances the same
+    # ``last_nonce_echo_at`` timestamp the nonce-probe setter writes,
+    # so the existing LED renderer (no frontend change needed) sees the
+    # hot timestamp regardless of nonce-probe success. The two
+    # mechanisms together are a strictly stronger liveness signal.
+    mark_echo_alive(consumer.agent_name)
 
     # Persist message
     msg = await consumer._save_message(

--- a/hub/consumers/_agent_refresh.py
+++ b/hub/consumers/_agent_refresh.py
@@ -1,0 +1,74 @@
+"""``agent.subs_refresh`` channel-layer event handler for AgentConsumer.
+
+Fired from ``hub.signals`` post_save/post_delete on ``ChannelMembership``
+(issue #282) so out-of-band subscription changes propagate to live WS
+consumers without waiting for reconnect. Extracted from ``_agent.py``
+to stay under the 512-line cap.
+"""
+
+from __future__ import annotations
+
+from ._groups import _sanitize_group
+from ._helpers import _load_agent_channel_subs
+
+
+async def handle_agent_subs_refresh(consumer, event):
+    """Re-sync ``consumer.agent_meta["channels"]`` + group joins from DB.
+
+    Events whose ``workspace_id`` doesn't match this connection are
+    ignored — the signal broadcasts globally via
+    ``list_sibling_channels`` which is not workspace-scoped.
+    """
+    event_ws = event.get("workspace_id")
+    if event_ws is not None and event_ws != consumer.workspace_id:
+        return
+    if event.get("agent") and event["agent"] != consumer.agent_name:
+        return
+
+    persisted = await _load_agent_channel_subs(
+        consumer.workspace_id, consumer.agent_name
+    )
+    dm_names = list(getattr(consumer, "_dm_channel_names", []) or [])
+    desired = list(dict.fromkeys(list(dm_names) + list(persisted)))
+    current = list(
+        getattr(consumer, "agent_meta", {}).get("channels", []) or []
+    )
+
+    desired_set = set(desired)
+    current_set = set(current)
+    to_add = desired_set - current_set
+    # Never group_discard DM channels — those are auto-subscribed at
+    # connect based on DMParticipant and must not be affected by a
+    # refresh driven by a group-channel ChannelMembership change.
+    to_remove = {
+        ch for ch in (current_set - desired_set) if not ch.startswith("dm:")
+    }
+
+    for ch_name in to_add:
+        group = _sanitize_group(f"channel_{consumer.workspace_id}_{ch_name}")
+        await consumer.channel_layer.group_add(group, consumer.channel_name)
+    for ch_name in to_remove:
+        group = _sanitize_group(f"channel_{consumer.workspace_id}_{ch_name}")
+        await consumer.channel_layer.group_discard(
+            group, consumer.channel_name
+        )
+
+    if hasattr(consumer, "agent_meta"):
+        consumer.agent_meta["channels"] = desired
+    else:
+        consumer.agent_meta = {"channels": desired}
+
+    if to_add or to_remove:
+        from hub.registry import register_agent
+
+        register_agent(
+            consumer.agent_name, consumer.workspace_id, consumer.agent_meta
+        )
+        await consumer.channel_layer.group_send(
+            consumer.workspace_group,
+            {
+                "type": "agent.info",
+                "agent": consumer.agent_name,
+                "info": consumer.agent_meta,
+            },
+        )

--- a/hub/consumers/_agent_refresh.py
+++ b/hub/consumers/_agent_refresh.py
@@ -4,12 +4,77 @@ Fired from ``hub.signals`` post_save/post_delete on ``ChannelMembership``
 (issue #282) so out-of-band subscription changes propagate to live WS
 consumers without waiting for reconnect. Extracted from ``_agent.py``
 to stay under the 512-line cap.
+
+This module also hosts :func:`prehydrate_channels` (scitex-orochi#451),
+the connect-time rehydration helper used by :class:`AgentConsumer` to
+make group-channel delivery robust to missing ``register`` frames.
 """
 
 from __future__ import annotations
 
-from ._groups import _sanitize_group
+from ._groups import _sanitize_group, log
 from ._helpers import _load_agent_channel_subs
+
+
+async def prehydrate_channels(consumer) -> None:
+    """Rejoin persisted group channels + seed ``agent_meta`` at connect.
+
+    scitex-orochi#451 — closes the orphan-on-reconnect deafness window.
+
+    Background. On a WS reconnect, the authoritative sequence is:
+
+        client  connects → server connect()              → joins DM groups
+        client  sends register                             → server handle_register
+                                                              → loads group subs from DB
+                                                              → group_add(each)
+                                                              → sets agent_meta["channels"]
+
+    Between ``connect()`` completing and ``handle_register`` running,
+    ``agent_meta`` is absent. The ``chat_message`` filter in
+    :class:`AgentConsumer` requires ``agent_meta["channels"]`` to contain
+    the target channel for group messages; without it every group
+    message is silently dropped. If the client never sends ``register``
+    (buggy reconnect logic, network blip between open and first send),
+    the agent is silently deaf forever — it appears connected but
+    receives no group-channel messages.
+
+    This helper runs at the end of ``connect()`` and makes the server
+    robust to both races: it pre-joins persisted group memberships from
+    the DB and seeds ``agent_meta["channels"]`` with the union of DM
+    channels + persisted group memberships. ``handle_register`` remains
+    idempotent and will refresh the same state (plus the richer metadata
+    payload) when the client's register frame arrives.
+
+    ``consumer._registered`` is set to False here; ``handle_register``
+    flips it True on success. The ``message``-frame dispatch guards on
+    ``_registered`` so un-registered connections can't silently succeed
+    at writes while missing replies (scitex-orochi#451 contract).
+    """
+    consumer._registered = False
+    try:
+        persisted = await _load_agent_channel_subs(
+            consumer.workspace_id, consumer.agent_name
+        )
+    except Exception:  # noqa: BLE001 — DB hiccups at connect must not tear down
+        log.exception(
+            "connect: pre-hydrate group channels failed for %s",
+            consumer.agent_name,
+        )
+        persisted = []
+
+    dm_names = list(getattr(consumer, "_dm_channel_names", []) or [])
+    channels = list(dm_names) + [c for c in persisted if c not in dm_names]
+
+    for ch_name in persisted:
+        group = _sanitize_group(
+            f"channel_{consumer.workspace_id}_{ch_name}"
+        )
+        await consumer.channel_layer.group_add(group, consumer.channel_name)
+
+    # Seed a minimal agent_meta so chat_message's membership filter
+    # works before ``handle_register`` runs. ``handle_register`` (which
+    # is idempotent) will replace this dict with the full payload.
+    consumer.agent_meta = {"channels": channels}
 
 
 async def handle_agent_subs_refresh(consumer, event):

--- a/hub/consumers/_echo.py
+++ b/hub/consumers/_echo.py
@@ -1,0 +1,120 @@
+"""Hub→agent echo round-trip publisher loop (#259, indicator #4).
+
+Periodically sends a `{"type":"echo","nonce":"<uuid>"}` frame to every
+connected agent. The agent's MCP-channel WebSocket client auto-replies
+with `{"type":"echo_pong","nonce":"<same>","ts":<unix>}` (handled at
+the WS-client layer — *not* a Claude round-trip).
+
+The hub measures round-trip time, records ``last_echo_rtt_ms`` +
+``last_echo_ok_ts`` + ``last_nonce_echo_at`` on the agent's registry
+entry. The Agents-tab LED renderer (``renderAgentLeds`` in
+``hub/static/hub/agent-badge.js``) reads ``last_nonce_echo_at`` and
+flips the 4th LED from grey-dashed "pending" to green / yellow / red
+based on age, with no further frontend changes.
+
+Cadence is configurable via the ``OROCHI_ECHO_INTERVAL_SECONDS``
+environment variable (default 30s — matched to the existing
+``_hub_ping_loop`` cadence so a complete loss is noticed by both
+indicators within one cycle, not two).
+
+Backward-compatible: agents that never echo back keep functioning
+(their 4th LED stays grey-pending). We never disconnect on a missing
+echo. Unknown nonces in inbound ``echo_pong`` frames are dropped
+silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+import uuid
+
+log = logging.getLogger("orochi.consumers")
+
+
+def _read_interval_seconds() -> int:
+    """Read the publisher cadence from the environment (default 30s).
+
+    Constrained to a sane range — we don't want a misconfigured env
+    var to flood the WS or, conversely, push the cadence above the
+    LED's "stale" threshold (90s) and make every agent appear yellow.
+    """
+    raw = os.environ.get("OROCHI_ECHO_INTERVAL_SECONDS", "30")
+    try:
+        v = int(raw)
+    except (TypeError, ValueError):
+        v = 30
+    if v < 5:
+        v = 5
+    if v > 60:
+        v = 60
+    return v
+
+
+ECHO_INTERVAL_SECONDS = _read_interval_seconds()
+
+# Bound on the per-agent in-flight nonce dict. Each entry is small
+# (uuid + float) but unbounded growth would be a slow leak if an agent
+# never replies. The cap is deliberately ~10× the expected steady-state
+# in-flight count so transient bursts (network hiccups) don't evict
+# legitimate replies.
+MAX_INFLIGHT_NONCES = 32
+
+# Drop nonces older than this many seconds — we'll never accept a pong
+# that took longer than this anyway, and stale entries are pure noise
+# in the in-flight dict.
+NONCE_EXPIRY_SECONDS = 120
+
+
+def _prune_expired(inflight: dict[str, float], now: float) -> None:
+    """Remove entries older than NONCE_EXPIRY_SECONDS from inflight dict."""
+    expired = [
+        nonce
+        for nonce, sent_at in inflight.items()
+        if now - sent_at > NONCE_EXPIRY_SECONDS
+    ]
+    for n in expired:
+        inflight.pop(n, None)
+
+
+async def _hub_echo_loop(consumer) -> None:
+    """Send periodic ``{"type":"echo","nonce":"<uuid>"}`` frames.
+
+    Runs for the lifetime of the WebSocket connection. Cancelled from
+    ``AgentConsumer.disconnect``. Exceptions other than
+    ``CancelledError`` are logged and swallowed so a publisher crash
+    cannot tear down the consumer (matches ``_hub_ping_loop`` semantics).
+
+    The per-consumer in-flight nonce dict (``_echo_inflight``) is
+    initialised lazily here so the consumer's ``__init__`` doesn't need
+    to know about it. It's read by ``handle_echo_pong`` to compute RTT.
+    """
+    if not hasattr(consumer, "_echo_inflight"):
+        consumer._echo_inflight = {}
+    inflight: dict[str, float] = consumer._echo_inflight
+
+    try:
+        while True:
+            await asyncio.sleep(ECHO_INTERVAL_SECONDS)
+            now = time.time()
+            _prune_expired(inflight, now)
+            # If we've hit the cap, evict the oldest entry so a single
+            # silent agent can't permanently lock new probes out.
+            if len(inflight) >= MAX_INFLIGHT_NONCES:
+                oldest = min(inflight, key=inflight.get)
+                inflight.pop(oldest, None)
+
+            nonce = uuid.uuid4().hex
+            inflight[nonce] = now
+            try:
+                await consumer.send_json({"type": "echo", "nonce": nonce})
+            except Exception:  # noqa: BLE001
+                log.exception(
+                    "echo send failed for %s",
+                    getattr(consumer, "agent_name", "?"),
+                )
+                return
+    except asyncio.CancelledError:
+        raise

--- a/hub/consumers/_helpers.py
+++ b/hub/consumers/_helpers.py
@@ -26,6 +26,11 @@ from hub.models import (
     WorkspaceToken,
 )
 
+# ``#agent`` was abolished 2026-04-21 (lead directive, PR #293 follow-up).
+# Keep a module-level constant so both the hub/views path and the
+# WebSocket-consumer path share a single source of truth for the blocklist.
+ABOLISHED_AGENT_CHANNELS = frozenset({"#agent"})
+
 
 @database_sync_to_async
 def _load_agent_channel_subs(workspace_id, agent_name):
@@ -49,7 +54,14 @@ def _load_agent_channel_subs(workspace_id, agent_name):
         user=user,
         channel__workspace_id=workspace_id,
     ).select_related("channel")
-    return [m.channel.name for m in memberships]
+    # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293 follow-up).
+    # Filter out any stale DB rows so a leftover membership can't resurrect
+    # the subscription on the next register() / agent-consumer connect.
+    return [
+        m.channel.name
+        for m in memberships
+        if m.channel.name not in ABOLISHED_AGENT_CHANNELS
+    ]
 
 
 @database_sync_to_async
@@ -60,6 +72,12 @@ def _persist_agent_subscription(workspace_id, agent_name, ch_name, subscribe):
     be resolved. Creates the channel if missing (group kind).
     """
     from django.contrib.auth.models import User
+
+    # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293 follow-up).
+    # Hard-block the channel on the server so no agent can re-create the
+    # row via a subscribe WebSocket op, regardless of what the client sends.
+    if ch_name in ABOLISHED_AGENT_CHANNELS:
+        return False
 
     try:
         workspace = Workspace.objects.get(id=workspace_id)

--- a/hub/frontend/src/activity-tab/detail.ts
+++ b/hub/frontend/src/activity-tab/detail.ts
@@ -103,9 +103,37 @@ export function _renderActivityAgentDetail(a, grid) {
     _rawModel.charAt(_rawModel.length - 1) === ">"
       ? "—"
       : _rawModel || "-";
+  /* #257 + #261: surface the canonical heartbeat metadata. See the
+   * matching block in hub/static/hub/activity-tab/detail.js. */
+  var _launchSigil = {
+    "sac": "🤖 sac",
+    "sac-ssh": "🛰 sac-ssh",
+    "sbatch": "💼 sbatch",
+    "manual-tmux": "👤 tmux",
+    "manual-direct": "👤 direct",
+    "unknown": "?",
+  };
+  var _launchDisplay = a.launch_method
+    ? (_launchSigil[a.launch_method] || a.launch_method)
+    : "-";
+  var _instanceShort = a.instance_id
+    ? String(a.instance_id).slice(0, 8) + "…"
+    : "-";
+  var _proxyDisplay = a.is_proxy
+    ? "yes (rank " + (a.priority_rank != null ? a.priority_rank : "?") + ")"
+    : (a.priority_rank === 0 ? "no (primary)" : "-");
+  var _priorityListDisplay = (a.priority_list && a.priority_list.length)
+    ? a.priority_list.join(" → ")
+    : "-";
   var metaFields = [
     ["Role", a.role || "agent"],
     ["Machine", _machineDisplay],
+    ["Hostname", a.hostname || "-"],
+    ["Uname", a.uname || "-"],
+    ["Instance", _instanceShort],
+    ["Launch", _launchDisplay],
+    ["Proxy?", _proxyDisplay],
+    ["Priority list", _priorityListDisplay],
     ["Model", _modelDisplay],
     ["Multiplexer", a.multiplexer || "-"],
     ["PID", a.pid || "-"],

--- a/hub/frontend/src/agent-badge.ts
+++ b/hub/frontend/src/agent-badge.ts
@@ -184,7 +184,12 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
           ")\n  Heuristic from local pane text; not fully reliable.\n  green = running, yellow = idle, blue = waiting,\n  red = auth_error, orange = stale.",
       ) +
       '"></span>';
-    // 4. Remote functional state — nonce-echo (publisher TBD)
+    // 4. Remote functional state — "last proof of life".
+    // msg#15538: ``last_nonce_echo_at`` is advanced by EITHER the
+    // hub→agent nonce round-trip (hub/consumers/_echo.py) OR by any
+    // inbound agent message (hub/consumers/_agent_message.py via
+    // mark_echo_alive). The renderer does not need to know which
+    // mechanism wrote the timestamp — either path turns the LED green.
     var echo = a.last_nonce_echo_at;
     var echoAge =
       echo != null ? (Date.now() - new Date(echo).getTime()) / 1000 : null;

--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -177,7 +177,10 @@ export function _renderChannelRowHtml(row, ctx) {
  * the file-size budget without changing any observable behavior. */
 export function _wireChannelItemHandlers(chContainer, prevSelected) {
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render */
+    /* Restore selected state from before re-render. Channels are single-
+     * selection only (#284): at most one channel-item ever carries the
+     * .selected class. prevSelected is retained across renders so the
+     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
     if (elCh && prevSelected[elCh]) el.classList.add("selected");
     /* Pin icon click — toggle is_starred (pinned-to-top) */
@@ -288,41 +291,9 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
         _setChannelPref(ch, { is_hidden: false });
         return;
       }
-      var multi = ev.ctrlKey || ev.metaKey;
-      /* todo#274 Part 2: Ctrl/Cmd+Click toggles multi-select without
-       * disturbing siblings; plain click keeps legacy single-select. */
-      if (multi) {
-        el.classList.toggle("selected");
-        /* When multi-select is active, the DOM may only have messages from
-         * (globalThis as any).currentChannel. Switch to all-channel history so messages from
-         * every selected channel are present, then let applyFeedFilter
-         * show the merged subset. (#366) */
-        var _selCount = chContainer.querySelectorAll(
-          ".channel-item.selected[data-channel]",
-        ).length;
-        if (_selCount >= 2) {
-          /* Load all messages; applyFeedFilter handles visible subset */
-          setCurrentChannel(null);
-          var _applyAfter = function () {
-            if (typeof applyFeedFilter === "function") applyFeedFilter();
-          };
-          loadHistory().then
-            ? loadHistory().then(_applyAfter)
-            : (loadHistory(), _applyAfter());
-        } else if (_selCount === 1) {
-          var _onlyCh = chContainer.querySelector(
-            ".channel-item.selected[data-channel]",
-          );
-          if (_onlyCh) {
-            setCurrentChannel(_onlyCh.getAttribute("data-channel"));
-            loadChannelHistory(_onlyCh.getAttribute("data-channel"));
-          }
-        } else {
-          /* All deselected */
-          if (typeof applyFeedFilter === "function") applyFeedFilter();
-        }
-        return;
-      }
+      /* #284: channels are single-selection only. The legacy Ctrl/Cmd+Click
+       * multi-select has been removed — any click replaces the current
+       * selection with exactly this row. */
       if ((globalThis as any).currentChannel === ch) {
         setCurrentChannel(null);
         loadHistory();

--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -176,13 +176,27 @@ export function _renderChannelRowHtml(row, ctx) {
  * chContainer. Pulled out of fetchStats so the main entry point stays under
  * the file-size budget without changing any observable behavior. */
 export function _wireChannelItemHandlers(chContainer, prevSelected) {
+  /* #293: enforce single-select hard invariant on restore. Even if
+   * prevSelected contained multiple entries (from a stale DOM where
+   * two rows both carried .selected — the regression this PR fixes),
+   * we restore .selected to AT MOST ONE row, preferring the current
+   * channel. Anything else is dropped on the floor. */
+  var restoredOne = false;
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render. Channels are single-
-     * selection only (#284): at most one channel-item ever carries the
-     * .selected class. prevSelected is retained across renders so the
-     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
-    if (elCh && prevSelected[elCh]) el.classList.add("selected");
+    if (
+      !restoredOne &&
+      elCh &&
+      prevSelected[elCh] &&
+      (globalThis as any).currentChannel === elCh
+    ) {
+      el.classList.add("selected");
+      restoredOne = true;
+    } else {
+      /* Defensive: make sure NO row carries .selected unless we just
+       * added it above. Belt-and-braces against any stale DOM state. */
+      el.classList.remove("selected");
+    }
     /* Pin icon click — toggle is_starred (pinned-to-top) */
     var pinEl = el.querySelector(".ch-pin");
     if (pinEl) {
@@ -308,12 +322,18 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
       /* Clear unread for this channel (#322) */
       channelUnread[ch] = 0;
       updateChannelUnreadBadges();
-      /* todo#274 Part 1: pure visual highlight, toggle on second click. */
-      var items = chContainer.querySelectorAll(".channel-item");
+      /* todo#274 Part 1 + #293: single-select is the HARD invariant —
+       * clear .selected across the ENTIRE sidebar (channel rows AND
+       * DM agent-cards), not just this chContainer. Previously only
+       * chContainer was cleared, which left a stale .selected on a
+       * DM row when the user switched from a DM to a channel and
+       * manifested as "two rows selected at once" (#293). */
       var wasSelected = el.classList.contains("selected");
-      items.forEach(function (it) {
-        it.classList.remove("selected");
-      });
+      document
+        .querySelectorAll(".sidebar .channel-item.selected, .sidebar .dm-item.selected")
+        .forEach(function (it) {
+          it.classList.remove("selected");
+        });
       if (!wasSelected && (globalThis as any).currentChannel === ch) {
         el.classList.add("selected");
       }

--- a/hub/frontend/src/app/sidebar-stats.ts
+++ b/hub/frontend/src/app/sidebar-stats.ts
@@ -22,17 +22,24 @@ export async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* #284: channels are single-select only. prevSelected keeps the one
-     * currently-selected row marked .selected across DOM re-renders so the
-     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
-     * multi-select — #274 Part 2 — has been removed for channels.) */
+    /* #284/#293: channels are single-select only. prevSelected keeps
+     * the ONE currently-selected row marked .selected across DOM re-
+     * renders so the selection indicator doesn't flicker mid-refresh.
+     *
+     * Hard invariant: at most one key ever lands in prevSelected. The
+     * source of truth is (globalThis as any).currentChannel — even if
+     * the DOM somehow accumulated .selected on multiple rows (the
+     * regression this PR fixes), we only ever carry the current-channel
+     * pointer forward. _wireChannelItemHandlers enforces the same rule
+     * on restore. */
     var prevSelected = {};
-    chContainer
-      .querySelectorAll(".channel-item.selected")
-      .forEach(function (el) {
-        var ch = el.getAttribute("data-channel");
-        if (ch) prevSelected[ch] = true;
-      });
+    var _curCh = (globalThis as any).currentChannel;
+    if (_curCh) {
+      var _hasSelected = !!chContainer.querySelector(
+        '.channel-item.selected[data-channel="' + String(_curCh).replace(/"/g, '\\"') + '"]',
+      );
+      if (_hasSelected) prevSelected[_curCh] = true;
+    }
     /* todo#325: hide dm:* channels from the public Channels list
      * (they still render in the DM tab via its own path).
      * todo#326: normalize "general" -> "#general" and dedupe by

--- a/hub/frontend/src/app/sidebar-stats.ts
+++ b/hub/frontend/src/app/sidebar-stats.ts
@@ -22,7 +22,10 @@ export async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* Preserve Ctrl+Click multi-select state across re-renders (#274 Part 2) */
+    /* #284: channels are single-select only. prevSelected keeps the one
+     * currently-selected row marked .selected across DOM re-renders so the
+     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
+     * multi-select — #274 Part 2 — has been removed for channels.) */
     var prevSelected = {};
     chContainer
       .querySelectorAll(".channel-item.selected")

--- a/hub/frontend/src/app/state.ts
+++ b/hub/frontend/src/app/state.ts
@@ -57,6 +57,14 @@ try {
 export function setCurrentChannel(ch) {
   currentChannel = ch;
   if (ch) lastActiveChannel = ch;
+  /* #278: other modules read `(globalThis as any).currentChannel` — the
+   * module-local `var currentChannel` is a private binding that the rest
+   * of the app can't see. Without this write, a sidebar channel switch
+   * updates the local var but leaves the global pinned at its page-load
+   * value, causing the feed to stay stale, the WS filter to pass the wrong
+   * channel, and sendMessage() to post to the original channel instead of
+   * the one the sidebar highlights. Mirror every update to the global. */
+  (globalThis as any).currentChannel = ch;
   try {
     localStorage.setItem("orochi_active_channel", ch == null ? "__all__" : ch);
   } catch (_) {}

--- a/hub/frontend/src/app/utils.ts
+++ b/hub/frontend/src/app/utils.ts
@@ -164,7 +164,13 @@ export function hostedAgentName(a) {
   var name = a && a.name ? a.name : "";
   if (!name) return name;
   if (name.indexOf("@") !== -1) return cleanAgentName(name);
-  var host = a && a.machine ? a.machine : "";
+  /* #256 — host label MUST come from the live `hostname(1)` reported
+   * in the heartbeat (#257), NOT from the YAML config `machine` field.
+   * Pre-fix, an agent_handlers `machine: mba` line in YAML caused the
+   * dashboard to show `proj-neurovista@mba` even when no process was
+   * running on mba (the ghost-mba bug). Falls back to `machine` for
+   * legacy agents whose heartbeat hasn't been upgraded yet. */
+  var host = a && a.hostname ? a.hostname : a && a.machine ? a.machine : "";
   /* Always pipe the constructed "<name>@<host>" string through
    * cleanAgentName so the role-host suffix gets collapsed
    * (head-mba@mba → head@mba). The earlier form returned the raw
@@ -381,7 +387,11 @@ export function sendOrochiMessage(msgData) {
 }
 
 // Expose cross-file mutable state via globalThis:
-(globalThis as any).cachedAgentNames = (typeof cachedAgentNames !== 'undefined' ? cachedAgentNames : undefined);
-(globalThis as any).historyLoaded = (typeof historyLoaded !== 'undefined' ? historyLoaded : undefined);
-(globalThis as any).knownMessageKeys = (typeof knownMessageKeys !== 'undefined' ? knownMessageKeys : undefined);
-(globalThis as any).unreadCount = (typeof unreadCount !== 'undefined' ? unreadCount : undefined);
+(globalThis as any).cachedAgentNames =
+  typeof cachedAgentNames !== "undefined" ? cachedAgentNames : undefined;
+(globalThis as any).historyLoaded =
+  typeof historyLoaded !== "undefined" ? historyLoaded : undefined;
+(globalThis as any).knownMessageKeys =
+  typeof knownMessageKeys !== "undefined" ? knownMessageKeys : undefined;
+(globalThis as any).unreadCount =
+  typeof unreadCount !== "undefined" ? unreadCount : undefined;

--- a/hub/frontend/src/chat/chat-markdown.ts
+++ b/hub/frontend/src/chat/chat-markdown.ts
@@ -5,7 +5,17 @@ import { cachedMemberNames } from "../mention";
 /* Chat module -- markdown / mention / link / code-block content rendering.
  * Extracted from appendMessage() so chat-render.js stays under the JS
  * line limit. Pure helper: takes raw content text, returns the
- * highlighted/escaped HTML string ready to drop into a .content div. */
+ * highlighted/escaped HTML string ready to drop into a .content div.
+ *
+ * Issue-reference linking policy (see #275):
+ *   - `owner/repo#N`  → linked + title-annotated via /api/github/issue-title.
+ *     This is the CANONICAL form. Users MUST write the repo prefix.
+ *   - bare `#N`       → left as plain text, NOT auto-linked. The old
+ *     behaviour of auto-linking `#N` to ywatanabe1989/todo issue N was
+ *     removed because cross-repo references (e.g. a scitex-orochi PR
+ *     number) were silently mislabelled with the wrong repo's title.
+ *   - `msg#NNN`       → still becomes a thread-jump link.
+ *   - `#general/#todo/...` (channel names) → still highlighted. */
 
 export function _processMessageMarkdown(content) {
   var escaped = escapeHtml(content);
@@ -180,8 +190,7 @@ export function _processMessageMarkdown(content) {
       '<span class="channel-highlight">$1</span>',
     )
     /* Cross-repo references: `owner/repo#N` → GitHub issue link.
-     * Must run before the bare `#N` rule so the slash-prefixed form wins
-     * (the bare rule has a `(?<![\/\w])` guard that lets this pass). */
+     * Bare `#N` is intentionally NOT linked (see top-of-file note / #275). */
     .replace(
       /(^|[^\w\/])([\w.-]+\/[\w.-]+)#(\d+)\b/g,
       function (_m, lead, repo, num) {
@@ -203,10 +212,6 @@ export function _processMessageMarkdown(content) {
           "</a>"
         );
       },
-    )
-    .replace(
-      /(?<![\/\w])#(\d+)\b/g,
-      '<a class="issue-link" data-issue-num="$1" data-issue-label="#$1" href="https://github.com/ywatanabe1989/todo/issues/$1" target="_blank">#$1</a>',
     )
     /* Auto-link plain URLs. The lookbehind only blocks URLs that are
      * already inside an HTML attribute value (`="...` or `'...`); the

--- a/hub/frontend/src/chat/chat-render.ts
+++ b/hub/frontend/src/chat/chat-render.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { getResolvedAgentColor, getSenderIcon } from "../agent-icons";
-import { cleanAgentName, escapeHtml, timeAgo, userName } from "../app/utils";
+import { cleanAgentName, escapeHtml, hostedAgentName, timeAgo, userName } from "../app/utils";
 import { _renderMermaidIn, buildAttachmentsHtml } from "./chat-attachments";
 import { _processMessageMarkdown } from "./chat-markdown";
 import { _chatFilterQuery, _mentionRegex, _pulseSidebarRow, _voiceDeferQueue, applyIssueTitleHints, isKnownAgent } from "./chat-state";
@@ -162,7 +162,22 @@ export function appendMessage(msg) {
     '<span class="sender" style="color:' +
     senderColor +
     '">' +
-    escapeHtml(cleanAgentName(senderName)) +
+    /* #238: include @hostname in chat-feed sender headers, mirroring
+     * the sidebar Agents list. Look up the agent record in the live
+     * cache (window.__lastAgents) and pass to hostedAgentName so
+     * cleanAgentName collapses redundant role-host suffixes
+     * (head-mba@mba → head@mba). Falls back to bare cleanAgentName
+     * for humans / unknown senders. */
+    escapeHtml(
+      isAgent
+        ? (function () {
+            var rec = (window.__lastAgents || []).find(function (a) {
+              return a && a.name === senderName;
+            });
+            return rec ? hostedAgentName(rec) : cleanAgentName(senderName);
+          })()
+        : cleanAgentName(senderName),
+    ) +
     "</span>" +
     youTag +
     roleBadge +

--- a/hub/frontend/src/chat/chat-state.ts
+++ b/hub/frontend/src/chat/chat-state.ts
@@ -136,13 +136,72 @@ export function isKnownAgent(name) {
 }
 
 /* Cache of GitHub issue titles.
- *   issueTitleCache[number]            → title for the default repo
- *                                        (ywatanabe1989/todo, legacy `#N`)
  *   issueTitleCache["owner/repo#N"]    → title for cross-repo references
+ * (Bare `#N` legacy entries are no longer produced; see #275.)
  * Negative lookups are stored as the literal string "" so we stop retrying
- * missing issues on every render pass. */
-export var issueTitleCache = {};
-export var issueTitleInflight = {};
+ * missing issues on every render pass.
+ *
+ * Persistence (#275 Part 2): the cache is mirrored to
+ * localStorage['orochi.issueTitleCache.v1'] as {key: {title, ts}} with a
+ * 24h TTL per entry. On module load we hydrate the in-memory cache from
+ * localStorage, dropping expired entries. On every successful title
+ * fetch we write the cache back. Storage failures are swallowed (quota,
+ * privacy-mode, corrupted JSON — never break the chat UI). */
+export var issueTitleCache: Record<string, string> = {};
+export var issueTitleInflight: Record<string, boolean> = {};
+
+var ISSUE_TITLE_LS_KEY = "orochi.issueTitleCache.v1";
+var ISSUE_TITLE_TTL_MS = 24 * 60 * 60 * 1000; /* 24 hours */
+
+/* Pull persisted entries into the in-memory cache. Called once at module
+ * load. Expired or malformed entries are silently discarded. */
+(function _hydrateIssueTitleCacheFromLS() {
+  try {
+    var raw = localStorage.getItem(ISSUE_TITLE_LS_KEY);
+    if (!raw) return;
+    var obj = JSON.parse(raw);
+    if (!obj || typeof obj !== "object") return;
+    var now = Date.now();
+    Object.keys(obj).forEach(function (k) {
+      var v = obj[k];
+      if (!v || typeof v !== "object") return;
+      if (typeof v.ts !== "number") return;
+      if (now - v.ts > ISSUE_TITLE_TTL_MS) return;
+      if (typeof v.title === "string") issueTitleCache[k] = v.title;
+    });
+  } catch (_e) {
+    /* ignore: corrupt JSON, storage denied, etc. */
+  }
+})();
+
+/* Rewrite the persisted cache from the current in-memory state.
+ * Debounced via rAF to coalesce bursts of writes from prefetch loops. */
+var _issueTitleLSWritePending = false;
+function _persistIssueTitleCache() {
+  if (_issueTitleLSWritePending) return;
+  _issueTitleLSWritePending = true;
+  var flush = function () {
+    _issueTitleLSWritePending = false;
+    try {
+      var now = Date.now();
+      var out: Record<string, { title: string; ts: number }> = {};
+      Object.keys(issueTitleCache).forEach(function (k) {
+        /* Persist only positive lookups — negative ("") entries are
+         * cheap to re-derive and would pollute storage. */
+        var t = issueTitleCache[k];
+        if (t) out[k] = { title: t, ts: now };
+      });
+      localStorage.setItem(ISSUE_TITLE_LS_KEY, JSON.stringify(out));
+    } catch (_e) {
+      /* ignore: quota, privacy, etc. */
+    }
+  };
+  if (typeof requestAnimationFrame === "function") {
+    requestAnimationFrame(flush);
+  } else {
+    setTimeout(flush, 0);
+  }
+}
 
 export function _hydrateIssueLink(a, title) {
   if (!title || a.dataset.hinted) return;
@@ -169,7 +228,7 @@ export function _hydrateIssueLink(a, title) {
 export function _fetchCrossRepoTitle(repo, num, cb) {
   var key = repo + "#" + num;
   if (issueTitleCache[key] !== undefined) {
-    cb(issueTitleCache[key] || null);
+    if (cb) cb(issueTitleCache[key] || null);
     return;
   }
   if (issueTitleInflight[key]) return;
@@ -192,15 +251,82 @@ export function _fetchCrossRepoTitle(repo, num, cb) {
       delete issueTitleInflight[key];
       var title = (data && data.title) || "";
       issueTitleCache[key] = title;
-      if (title) cb(title);
+      if (title) {
+        _persistIssueTitleCache();
+        if (cb) cb(title);
+      }
     })
     .catch(function () {
       delete issueTitleInflight[key];
     });
 }
 
+/* Background prefetch for `owner/repo#N` references in freshly-rendered
+ * message HTML (#275 Part 2). Batches cache misses so a burst of new
+ * messages coalesces into a single debounced flush (50ms) rather than
+ * N independent network calls. The inflight guard inside
+ * _fetchCrossRepoTitle prevents duplicate network calls for the same
+ * key, so re-enqueueing is safe. */
+var _prefetchQueue: Array<{ repo: string; num: string }> = [];
+var _prefetchCallbacks: Array<(title: string, key: string) => void> = [];
+var _prefetchTimer: any = null;
+
+function _schedulePrefetchFlush(cb?: (title: string, key: string) => void) {
+  if (cb) _prefetchCallbacks.push(cb);
+  if (_prefetchTimer) return;
+  _prefetchTimer = setTimeout(function () {
+    _prefetchTimer = null;
+    var batch = _prefetchQueue.splice(0);
+    var callbacks = _prefetchCallbacks.splice(0);
+    /* Dedup within the batch */
+    var seen: Record<string, boolean> = {};
+    batch.forEach(function (p) {
+      var k = p.repo + "#" + p.num;
+      if (seen[k]) return;
+      seen[k] = true;
+      _fetchCrossRepoTitle(p.repo, p.num, function (title) {
+        callbacks.forEach(function (c) {
+          try {
+            c(title, k);
+          } catch (_e) {
+            /* swallow */
+          }
+        });
+      });
+    });
+  }, 50);
+}
+
+export function prefetchIssueTitlesFromHtml(htmlOrNode: string | Element) {
+  var html =
+    typeof htmlOrNode === "string"
+      ? htmlOrNode
+      : (htmlOrNode as Element).innerHTML || "";
+  if (!html) return;
+  /* The rendered <a class="issue-link"> carries data-issue-repo +
+   * data-issue-num — easier to parse than re-running the markdown regex.
+   * Match both attribute orderings just in case. */
+  var re =
+    /data-issue-repo="([^"]+)"[^>]*data-issue-num="([^"]+)"|data-issue-num="([^"]+)"[^>]*data-issue-repo="([^"]+)"/g;
+  var m: RegExpExecArray | null;
+  var found = 0;
+  while ((m = re.exec(html)) !== null) {
+    var repo = m[1] || m[4];
+    var num = m[2] || m[3];
+    if (!repo || !num) continue;
+    var key = repo + "#" + num;
+    if (issueTitleCache[key] !== undefined) continue;
+    if (issueTitleInflight[key]) continue;
+    _prefetchQueue.push({ repo: repo, num: num });
+    found++;
+  }
+  if (found > 0) _schedulePrefetchFlush();
+}
+(globalThis as any).prefetchIssueTitlesFromHtml = prefetchIssueTitlesFromHtml;
+
 export function applyIssueTitleHints(scope) {
   var root = scope || document;
+  var uncached: Array<{ a: Element; repo: string; num: string }> = [];
   root.querySelectorAll(".issue-link").forEach(function (a) {
     if (a.dataset.hinted) return;
     var repo = a.getAttribute("data-issue-repo");
@@ -211,46 +337,42 @@ export function applyIssueTitleHints(scope) {
       num = m[1];
       a.setAttribute("data-issue-num", num);
     }
-    if (repo) {
-      /* Cross-repo: hit the per-issue endpoint lazily. */
-      var key = repo + "#" + num;
-      var cached = issueTitleCache[key];
-      if (cached) {
-        _hydrateIssueLink(a, cached);
-      } else if (cached === undefined) {
-        _fetchCrossRepoTitle(repo, num, function (title) {
-          _hydrateIssueLink(a, title);
-        });
-      }
-    } else {
-      /* Legacy bare `#N` → ywatanabe1989/todo, served from the list cache. */
-      var title = issueTitleCache[num];
-      if (title) _hydrateIssueLink(a, title);
+    /* Only cross-repo `owner/repo#N` links carry a hint now (#275).
+     * Links without data-issue-repo are legacy/external and stay unhinted. */
+    if (!repo) return;
+    var key = repo + "#" + num;
+    var cached = issueTitleCache[key];
+    if (cached) {
+      _hydrateIssueLink(a, cached);
+    } else if (cached === undefined) {
+      uncached.push({ a: a, repo: repo, num: num });
     }
   });
-}
-
-export async function refreshIssueTitleCache() {
-  try {
-    var res = await fetch(apiUrl("/api/github/issues"), {
-      credentials: "same-origin",
+  /* Dispatch the misses through the debounced prefetch queue so a burst
+   * of new messages coalesces into a single batch of fetches (#275). */
+  if (uncached.length > 0) {
+    uncached.forEach(function (u) {
+      _prefetchQueue.push({ repo: u.repo, num: u.num });
     });
-    if (!res.ok) return;
-    var issues = await res.json();
-    if (Array.isArray(issues)) {
-      issues.forEach(function (i) {
-        if (i && i.number && i.title)
-          issueTitleCache[String(i.number)] = i.title;
+    _schedulePrefetchFlush(function (title, key) {
+      /* Hydrate all matching links now that the fetch resolved. */
+      uncached.forEach(function (u) {
+        if (u.repo + "#" + u.num === key && title) {
+          _hydrateIssueLink(u.a, title);
+        }
       });
-      applyIssueTitleHints();
-    }
-  } catch (e) {
-    /* ignore */
+    });
   }
 }
-/* Refresh on load and every 2 minutes */
-refreshIssueTitleCache();
-setInterval(refreshIssueTitleCache, 120000);
+
+/* Kept as a named export for back-compat with modules that still import
+ * it. The legacy body (pre-seeding the cache with a GET /api/github/issues
+ * dump of ywatanabe1989/todo) was removed along with the bare `#N`
+ * auto-linker (#275) — cross-repo refs populate the cache on demand and
+ * are now persisted via localStorage instead. */
+export async function refreshIssueTitleCache() {
+  /* no-op retained for import compatibility */
+}
 
 // Expose cross-file mutable state via globalThis:
 (globalThis as any)._initialLoadComplete = (typeof _initialLoadComplete !== 'undefined' ? _initialLoadComplete : undefined);

--- a/hub/frontend/src/dms.ts
+++ b/hub/frontend/src/dms.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { renderAgentBadge } from "./agent-badge";
 import { _setChannelPref } from "./app/channel-prefs";
 import { _channelPrefs } from "./app/members";
 import { fetchStats } from "./app/sidebar-stats";
@@ -40,12 +41,70 @@ import { loadChannelHistory, loadHistory } from "./chat/chat-history";
       .join(", ");
   }
 
-  function dmBadgeHtml(row) {
+  /* #284: DM card === Agent card.
+   *
+   * DM rows render through the shared renderAgentBadge() so markup,
+   * CSS classes and icon/star/LEDs/name layout are IDENTICAL to the
+   * Agent card. For DMs where the counterparty is a live agent, we
+   * pick up its record from window.__lastAgents so real liveness LEDs
+   * light up. For human-to-human DMs, we synthesise a minimal agent-
+   * shaped object keyed off the human's name — the same badge renders
+   * with all LEDs off/unknown (humans don't have a WS/ping/pane/echo
+   * signal) and the star/name columns line up with the agent sidebar.
+   *
+   * Returns a plain object shaped like an agent-registry row. Never
+   * forks the markup — see agent-badge.ts renderAgentBadge. */
+  function dmCounterpartyAgentLike(row) {
     var others = (row && row.other_participants) || [];
-    if (others.length === 0) return "";
-    var t = others[0].type === "agent" ? "agent" : "human";
-    var label = t === "agent" ? "AI" : "U";
-    return '<span class="dm-principal-badge ' + t + '">' + label + "</span>";
+    /* Empty DM (no counterparty yet): fall back to the channel key as
+     * name so at least the row shows something stable. */
+    if (others.length === 0) {
+      return {
+        name: row && row.name ? row.name : "(empty DM)",
+        status: "offline",
+        liveness: "offline",
+      };
+    }
+    /* Collapse multi-participant DMs to the first counterparty so we
+     * always render one badge. The remaining names still appear in the
+     * fallback label via the data-channel tooltip. */
+    var p = others[0];
+    var label = (p && p.identity_name) || "?";
+    /* Agent principal: look up the live record so LEDs reflect truth. */
+    if (p && p.type === "agent") {
+      var live = Array.isArray(window.__lastAgents) ? window.__lastAgents : [];
+      var match = null;
+      for (var i = 0; i < live.length; i++) {
+        var a = live[i];
+        if (!a || !a.name) continue;
+        var bare = String(a.name).split("@")[0];
+        if (bare === label || a.name === label) {
+          match = a;
+          break;
+        }
+      }
+      if (match) return match;
+      /* Agent is listed in the DM but not currently in __lastAgents
+       * (offline / not yet registered) — synth an offline-agent-like
+       * record so the badge still renders. */
+      return {
+        name: label,
+        status: "offline",
+        liveness: "offline",
+        machine: (p && p.machine) || "",
+      };
+    }
+    /* Human principal: synthesise a minimal agent-shape object. All
+     * LEDs render grey/off because there's no WS/ping/pane/echo signal
+     * for humans. Star + icon + name layout match the agent card. */
+    return {
+      name: label,
+      status: "offline",
+      liveness: "offline",
+      /* Keep the type hint so CSS can style humans differently if it
+       * ever needs to (today it does not — identity is identical). */
+      _dm_counterparty_type: "human",
+    };
   }
 
   function renderDms(rows) {
@@ -65,70 +124,73 @@ import { loadChannelHistory, loadHistory } from "./chat/chat-history";
            * pin/mute state is shared between the Channels and DM sidebars. */
           var prefs =
             (typeof _channelPrefs !== "undefined" && _channelPrefs[ch]) || {};
-          var pinned = !!prefs.is_starred;
           var muted = !!prefs.is_muted;
+          var pinned = !!prefs.is_starred;
+          var counterparty = dmCounterpartyAgentLike(row);
+          /* Override .pinned so the star glyph reflects the DM-channel's
+           * is_starred pref rather than the underlying agent's own pin
+           * state — DMs are pinned on the conversation, not on the agent. */
+          var cpWithDmPin = {};
+          for (var k in counterparty)
+            if (Object.prototype.hasOwnProperty.call(counterparty, k))
+              cpWithDmPin[k] = counterparty[k];
+          cpWithDmPin.pinned = pinned;
+          /* DM card shares the .agent-card markup + class so CSS rules
+           * (hover, selected, drag affordances) apply uniformly across
+           * the Agent sidebar and the DM sidebar. .dm-item is retained
+           * as an extra hook for DM-specific behaviours (the per-row
+           * click handler attaches by that class); markup underneath
+           * is rendered by renderAgentBadge exactly as on the Agents
+           * sidebar. */
           return (
-            '<div class="dm-item' +
+            '<div class="dm-item agent-card' +
             active +
             (muted ? " ch-muted" : "") +
             '" data-channel="' +
             escapeHtml(ch) +
+            '" data-agent-name="' +
+            escapeHtml(counterparty.name || "") +
             '" title="' +
             escapeHtml(ch) +
             '">' +
-            '<span class="ch-pin ' +
-            (pinned ? "ch-pin-on" : "ch-pin-off") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (pinned ? "Unstar" : "Star (float to top)") +
-            '">' +
-            (pinned ? "\u2605" : "\u2606") +
-            "</span>" +
-            '<span class="ch-watch ' +
-            (muted ? "ch-watch-off" : "ch-watch-on") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (muted
-              ? "Unmute (watch this DM)"
-              : "Mute (stop DM notifications)") +
-            '">\uD83D\uDC41</span>' +
-            dmBadgeHtml(row) +
-            escapeHtml(dmDisplayName(row)) +
+            (typeof renderAgentBadge === "function"
+              ? renderAgentBadge(cpWithDmPin, { iconSize: 14 })
+              : escapeHtml(dmDisplayName(row))) +
             "</div>"
           );
         })
         .join("");
       container.querySelectorAll(".dm-item").forEach(function (el) {
-        /* Pin icon toggles is_starred via the shared _setChannelPref. */
-        var pinEl = el.querySelector(".ch-pin");
-        if (pinEl && typeof _setChannelPref === "function") {
-          pinEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = pinEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_starred: !pref.is_starred });
-          });
-        }
-        /* Eye icon toggles is_muted. */
-        var watchEl = el.querySelector(".ch-watch");
-        if (watchEl && typeof _setChannelPref === "function") {
-          watchEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = watchEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_muted: !pref.is_muted });
-          });
+        /* Star inside the shared agent-badge markup — override the
+         * default agent-pin behaviour so clicking the star on a DM row
+         * toggles is_starred on the CHANNEL pref (pin the conversation)
+         * rather than pin-to-top the underlying agent. Uses the .dm-item
+         * row's data-channel, not the button's own data-pin-name which
+         * points at the counterparty agent. Runs on capture phase so we
+         * beat the global agent-pin handler wired elsewhere. */
+        var starEl = el.querySelector(".agent-badge-star");
+        if (starEl && typeof _setChannelPref === "function") {
+          starEl.addEventListener(
+            "click",
+            function (ev) {
+              ev.stopPropagation();
+              ev.preventDefault();
+              var chName = el.getAttribute("data-channel");
+              if (!chName) return;
+              var pref =
+                (typeof _channelPrefs !== "undefined" &&
+                  _channelPrefs[chName]) ||
+                {};
+              _setChannelPref(chName, { is_starred: !pref.is_starred });
+            },
+            true,
+          );
         }
         el.addEventListener("click", function (ev) {
+          /* Don't treat star / avatar clicks as row-clicks. */
           if (
-            ev.target.classList.contains("ch-pin") ||
-            ev.target.classList.contains("ch-watch")
+            ev.target.closest(".agent-badge-star") ||
+            ev.target.closest(".avatar-clickable")
           )
             return;
           var ch = el.getAttribute("data-channel");

--- a/hub/frontend/src/filter/runner.ts
+++ b/hub/frontend/src/filter/runner.ts
@@ -75,11 +75,10 @@ export function runFilter() {
         });
       }
     }
-    /* Skip single-channel filter when multi-select is active (#366):
-     * applyFeedFilter() handles multi-channel visibility in that case. */
-    var _multiActive =
-      document.querySelectorAll("#channels .channel-item.selected").length >= 2;
-    if (show && (globalThis as any).currentChannel && !_multiActive) {
+    /* #284: channels are single-select — at most one .channel-item.selected
+     * ever exists. The legacy multi-channel bypass was removed; currentChannel
+     * alone is the filter gate. */
+    if (show && (globalThis as any).currentChannel) {
       show = el.getAttribute("data-channel") === (globalThis as any).currentChannel;
     }
     el.style.display = show ? "" : "none";

--- a/hub/frontend/src/resources-tab/tab.ts
+++ b/hub/frontend/src/resources-tab/tab.ts
@@ -81,11 +81,18 @@ export function renderResources() {
           d.slurm.total_jobs +
           " jobs</span>";
       }
-      /* Entity-consistency format (TODO.md "Entity Consistency"):
-       * machine: [icon] [star] [<host-label>]. Icon is a compact
-       * server glyph; star is a reserved placeholder slot (machines
-       * aren't pinnable yet but the slot keeps the column aligned
-       * with sidebar channel rows). */
+      /* #284 Machine card order: [icon] [star] [LED] [<host-label>
+       * (<hostname-canonical>)] [metrics].
+       *
+       * The single LED replaces the old leading connection dot; it
+       * sits BETWEEN star and the name so the icon/star columns line
+       * up with agent + DM sidebar rows. Machines don't have the
+       * 4-LED liveness model agents do (no WS handshake / ping / pane
+       * state / nonce-echo signal is meaningful for a bare host), so
+       * we keep a single health LED driven by the heartbeat health
+       * status. Metrics (CPU / Mem / Disk / GPU / SLURM) stay inline
+       * where horizontal space allows — the full metric breakdown is
+       * always available on the hover tooltip regardless. */
       var mStarred = !!(d && d._starred);
       return (
         '<div class="res-card res-card-compact" data-machine="' +
@@ -94,9 +101,6 @@ export function renderResources() {
         escapeHtml(k) +
         (d._status ? " · " + d._status : "") +
         '">' +
-        '<span class="res-conn res-conn-' +
-        (healthy ? "ok" : "stale") +
-        '"></span>' +
         '<span class="res-machine-icon" title="right-click to change" aria-hidden="true">' +
         (_machineIcons[k] || "\uD83D\uDDA5\uFE0F") +
         "</span>" +
@@ -109,11 +113,17 @@ export function renderResources() {
         '">' +
         (mStarred ? "\u2605" : "\u2606") +
         "</span>" +
-        /* Spec: machine: [icon] [star] [<host-label> (<canonical-$HOSTNAME>)]
-         * — show the canonical FQDN in parentheses after the short
-         * label when it differs meaningfully from the label. Uses
-         * the same collapse rules as the Machine detail view
-         * (.local/.localdomain suffixes aren't "different"). */
+        '<span class="res-conn res-conn-' +
+        (healthy ? "ok" : "stale") +
+        '" title="' +
+        (healthy ? "Host healthy" : "Host stale / degraded") +
+        '"></span>' +
+        /* Spec: machine: [icon] [star] [LED] [<host-label>
+         * (<hostname-canonical>)] — show the canonical FQDN in
+         * parentheses after the short label when it differs
+         * meaningfully from the label. Uses the same collapse rules
+         * as the agents-tab Machine detail view (.local /
+         * .localdomain suffixes aren't "different"). */
         '<span class="res-host-name" style="color:' +
         color +
         '">' +

--- a/hub/management/commands/seed_worker_progress.py
+++ b/hub/management/commands/seed_worker_progress.py
@@ -1,0 +1,176 @@
+"""Seed the synthetic ``agent-worker-progress`` user + ChannelMemberships.
+
+Implements the data-plane side of todo#272 (sac-managed Claude agent
+re-spec, `#heads` msg#15416 — replaces closed PR #300 which shipped a
+Python daemon). Idempotent: running multiple times is a no-op.
+
+The synthetic ``agent-worker-progress`` user is granted ``read-write``
+``ChannelMembership`` on:
+
+  - ``#progress``
+  - ``#heads``
+  - ``#ywatanabe``
+  - every ``#proj-*`` channel that exists in the DB **at seed time**
+
+The ``#proj-*`` set is enumerated at runtime (not hardcoded) so new
+project channels are picked up without code changes — just re-run the
+seed after creating a new ``#proj-foo``.
+
+``#agent`` was abolished 2026-04-21 (PR #293 follow-up) and the
+server-side blocklist in ``ABOLISHED_AGENT_CHANNELS`` rejects it; we
+never subscribe to it here either.
+
+Usage:
+    python manage.py seed_worker_progress [--workspace <name>]
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+
+from hub.consumers._helpers import ABOLISHED_AGENT_CHANNELS
+from hub.models import Channel, ChannelMembership, Workspace, WorkspaceMember
+
+User = get_user_model()
+
+AGENT_NAME = "worker-progress"
+AGENT_USERNAME = f"agent-{AGENT_NAME}"
+
+# Base channels are always seeded (created if missing).
+BASE_CHANNELS = ("#progress", "#heads", "#ywatanabe")
+
+# Prefix for per-project channels. All existing channels whose name
+# starts with this prefix are added to the worker's membership set.
+PROJ_CHANNEL_PREFIX = "#proj-"
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed agent-worker-progress synthetic user + read-write "
+        "memberships for #progress, #heads, #ywatanabe, and all "
+        "#proj-* channels that currently exist in the workspace "
+        "(todo#272). Idempotent."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--workspace",
+            default="default",
+            help="Workspace slug to seed into (default: default)",
+        )
+
+    def handle(self, *args, **options):
+        ws_name = options["workspace"]
+        try:
+            workspace = Workspace.objects.get(name=ws_name)
+        except Workspace.DoesNotExist as exc:
+            raise CommandError(f"Workspace '{ws_name}' does not exist") from exc
+
+        user, user_created = User.objects.get_or_create(
+            username=AGENT_USERNAME,
+            defaults={
+                "email": f"{AGENT_USERNAME}@agents.orochi.local",
+                "is_active": True,
+                "is_staff": False,
+            },
+        )
+        if user_created:
+            self.stdout.write(self.style.SUCCESS(f"created user: {AGENT_USERNAME}"))
+        else:
+            self.stdout.write(f"user exists: {AGENT_USERNAME}")
+
+        _, member_created = WorkspaceMember.objects.get_or_create(
+            workspace=workspace,
+            user=user,
+            defaults={"role": "member"},
+        )
+        if member_created:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"added {AGENT_USERNAME} to workspace '{ws_name}'"
+                )
+            )
+        else:
+            self.stdout.write(
+                f"{AGENT_USERNAME} already in workspace '{ws_name}'"
+            )
+
+        channels = self._collect_channels(workspace)
+
+        created, existed, skipped = 0, 0, 0
+        for name in channels:
+            if name in ABOLISHED_AGENT_CHANNELS:
+                self.stdout.write(
+                    self.style.WARNING(f"skipping abolished channel: {name}")
+                )
+                skipped += 1
+                continue
+
+            # Base channels are created if missing; project channels
+            # are only enumerated if they already exist, so they will
+            # always resolve to an existing row.
+            channel, _ = Channel.objects.get_or_create(
+                workspace=workspace,
+                name=name,
+                defaults={"kind": Channel.KIND_GROUP},
+            )
+            membership, was_created = ChannelMembership.objects.get_or_create(
+                user=user,
+                channel=channel,
+                defaults={"permission": ChannelMembership.PERM_READ_WRITE},
+            )
+            if was_created:
+                created += 1
+                self.stdout.write(
+                    self.style.SUCCESS(f"  + membership: {name} (read-write)")
+                )
+            else:
+                existed += 1
+                if membership.permission != ChannelMembership.PERM_READ_WRITE:
+                    membership.permission = ChannelMembership.PERM_READ_WRITE
+                    membership.save(update_fields=["permission"])
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"  ~ upgraded to read-write: {name}"
+                        )
+                    )
+                else:
+                    self.stdout.write(f"  = membership exists: {name}")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"done: {created} created, {existed} existed, {skipped} skipped."
+            )
+        )
+
+    def _collect_channels(self, workspace: Workspace) -> list[str]:
+        """Return the ordered channel-name set to seed.
+
+        Base channels first (so they always land, even in a pristine
+        DB), then every ``#proj-*`` channel that already exists in
+        the workspace. De-duplicated while preserving order.
+        """
+        seen: set[str] = set()
+        ordered: list[str] = []
+
+        for name in BASE_CHANNELS:
+            if name not in seen:
+                seen.add(name)
+                ordered.append(name)
+
+        proj_names = (
+            Channel.objects.filter(
+                workspace=workspace,
+                kind=Channel.KIND_GROUP,
+                name__startswith=PROJ_CHANNEL_PREFIX,
+            )
+            .order_by("name")
+            .values_list("name", flat=True)
+        )
+        for name in proj_names:
+            if name not in seen:
+                seen.add(name)
+                ordered.append(name)
+
+        return ordered

--- a/hub/quota_watch.py
+++ b/hub/quota_watch.py
@@ -1,18 +1,27 @@
 """Quota pressure escalation consumer (todo#272 hub side).
 
-Producer side (head-spartan, branch feat/quota-pressure-producer) polls
-`/api/oauth/usage` from each agent and pushes utilization figures into
-the heartbeat. This module owns the *consumer* logic: it decides when
-those figures cross thresholds and posts escalation messages.
+Producer side (agent-container `agent_meta.py --push` loop) reads the
+Anthropic `/api/oauth/usage` endpoint + Claude Code statusline and
+pushes utilization figures into the heartbeat as
+``quota_5h_used_pct`` / ``quota_7d_used_pct`` +
+``quota_5h_reset_at`` / ``quota_7d_reset_at``. This module owns the
+*consumer* logic: it decides when those figures cross thresholds and
+posts escalation messages so the fleet (or ywatanabe) can migrate
+accounts *before* the hard cap triggers a 100% wedge.
 
 State machine per (agent, window):
     ok -> warn        : post to #progress
     warn -> escalate  : post to #escalation AND #ywatanabe
     escalate -> ok    : post recovery to #progress (once)
-    other transitions: silent
+    other transitions: silent (no spam on downshifts / partial recovery)
 
 State is in-memory only via registry transient fields:
     quota_state_5h, quota_state_7d.
+
+Entry point for the heartbeat hot path is
+:func:`check_agent_quota_pressure` — it reads the current utilization
+off the in-memory registry, runs :func:`evaluate`, and writes the new
+per-window state back so transitions fire exactly once per crossing.
 """
 
 from __future__ import annotations
@@ -69,13 +78,38 @@ def _format_reset(reset_at: Optional[str]) -> str:
 PostFn = Callable[[str, str], None]
 
 
-def _default_post(channel: str, text: str) -> None:  # pragma: no cover - exercised at integration time
-    """Persist a system message into the workspace channel.
+def _make_workspace_post(workspace_id: int) -> PostFn:
+    """Build a PostFn that writes to a specific workspace.
 
     Best-effort: swallow errors so quota_watch never breaks the heartbeat
-    hot path. Workspace resolution is left to the caller (we post into
-    the most recently registered workspace's channel by name).
+    hot path. The workspace id is captured at heartbeat time so
+    multi-workspace hubs can't cross-post quota warnings into the wrong
+    workspace (matches the per-agent ``workspace_id`` stored in the
+    registry).
     """
+
+    def _post(channel: str, text: str) -> None:
+        try:
+            from hub.models import Channel, Message
+
+            ch, _ = Channel.objects.get_or_create(
+                workspace_id=workspace_id, name=channel
+            )
+            Message.objects.create(
+                workspace_id=workspace_id,
+                channel=ch,
+                sender="orochi-quota-watch",
+                sender_type="agent",
+                content=text,
+            )
+        except Exception:
+            log.exception("quota_watch post failed for %s", channel)
+
+    return _post
+
+
+def _default_post(channel: str, text: str) -> None:  # pragma: no cover - exercised at integration time
+    """Fallback post used when no workspace_id is known."""
     try:
         from hub.models import Channel, Message, Workspace
 
@@ -84,7 +118,11 @@ def _default_post(channel: str, text: str) -> None:  # pragma: no cover - exerci
             return
         ch, _ = Channel.objects.get_or_create(workspace=ws, name=channel)
         Message.objects.create(
-            workspace=ws, channel=ch, sender="orochi-quota-watch", content=text
+            workspace=ws,
+            channel=ch,
+            sender="orochi-quota-watch",
+            sender_type="agent",
+            content=text,
         )
     except Exception:
         log.exception("quota_watch default_post failed for %s", channel)
@@ -166,3 +204,94 @@ def _transition_messages(
     # escalate->warn is partial recovery; we only ping on full recovery
     # to avoid spam per ywatanabe msg#7788).
     return []
+
+
+def _coerce_utilization(value) -> Optional[float]:
+    """Normalize quota payload value to a 0..1 utilization float.
+
+    Producers push either a fraction (0..1) or a percentage (0..100).
+    Accept both so quota_watch doesn't misfire when the producer
+    convention changes. Returns ``None`` for non-numeric / missing
+    values so classify() can leave the state unchanged.
+    """
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    # Treat anything > 1.5 as a percentage (0..100 scale) and rescale.
+    # Threshold chosen conservatively so a legitimate over-quota value
+    # like 1.05 (5% into hard cap) is still read as a fraction.
+    if f > 1.5:
+        f = f / 100.0
+    if f < 0.0:
+        return 0.0
+    return f
+
+
+def check_agent_quota_pressure(name: str, post: Optional[PostFn] = None) -> None:
+    """Run the quota state machine for one agent based on registry state.
+
+    Called from the heartbeat hot path (REST
+    ``/api/agents/register/`` + WS ``agent_heartbeat`` handler). Reads
+    the agent's current quota utilization + reset timestamps + previous
+    per-window state from the in-memory registry, calls
+    :func:`evaluate`, and writes back the new per-window state so the
+    state machine transitions fire exactly once per crossing.
+
+    Best-effort: any exception is logged and swallowed — quota_watch
+    must never block or crash the heartbeat path.
+
+    Args:
+        name: agent name as registered in ``hub.registry._agents``.
+        post: override for the post callback (mainly for tests). When
+            ``None``, a post function scoped to the agent's
+            ``workspace_id`` is constructed on the fly.
+    """
+    try:
+        from hub.registry import _agents, _lock
+
+        with _lock:
+            agent = _agents.get(name)
+            if not agent:
+                return
+            util_5h_raw = agent.get("quota_5h_used_pct")
+            util_7d_raw = agent.get("quota_7d_used_pct")
+            reset_5h = agent.get("quota_5h_reset_at") or None
+            reset_7d = agent.get("quota_7d_reset_at") or None
+            prev_5h = agent.get("quota_state_5h") or STATE_OK
+            prev_7d = agent.get("quota_state_7d") or STATE_OK
+            workspace_id = agent.get("workspace_id")
+
+        util_5h = _coerce_utilization(util_5h_raw)
+        util_7d = _coerce_utilization(util_7d_raw)
+        if util_5h is None and util_7d is None:
+            return
+
+        if post is None:
+            if workspace_id is None:
+                post = _default_post
+            else:
+                post = _make_workspace_post(int(workspace_id))
+
+        new_5h, new_7d, _ = evaluate(
+            name,
+            util_5h=util_5h,
+            util_7d=util_7d,
+            reset_5h=reset_5h,
+            reset_7d=reset_7d,
+            prev_state_5h=prev_5h,
+            prev_state_7d=prev_7d,
+            post=post,
+        )
+
+        with _lock:
+            agent = _agents.get(name)
+            if agent is not None:
+                agent["quota_state_5h"] = new_5h
+                agent["quota_state_7d"] = new_7d
+    except Exception:
+        log.exception("check_agent_quota_pressure failed for %s", name)

--- a/hub/registry/__init__.py
+++ b/hub/registry/__init__.py
@@ -37,21 +37,31 @@ from ._heartbeat import (
 )
 from ._payload import get_agents, get_online_count
 from ._register import (
+    clear_connection_identity,
+    decide_singleton_winner,
+    get_connection_identity,
+    get_recent_singleton_event,
+    list_sibling_channels,
     purge_agent,
     purge_all_offline,
+    record_singleton_conflict,
     register_agent,
     register_connection,
+    set_connection_identity,
     unregister_agent,
     unregister_connection,
 )
 from ._store import (
     HEARTBEAT_TIMEOUT_S,
+    SINGLETON_EVENT_WINDOW_S,
     STALE_PURGE_S,
     _active_session_count,
     _agents,
     _cleanup_locked,
+    _connection_identity,
     _connections,
     _lock,
+    _singleton_events,
     active_session_count,
     log,
 )
@@ -60,6 +70,8 @@ __all__ = [
     # Storage primitives (also imported by tests + a few views directly)
     "_agents",
     "_connections",
+    "_connection_identity",
+    "_singleton_events",
     "_lock",
     "_active_session_count",
     "_cleanup_locked",
@@ -67,6 +79,7 @@ __all__ = [
     "log",
     "HEARTBEAT_TIMEOUT_S",
     "STALE_PURGE_S",
+    "SINGLETON_EVENT_WINDOW_S",
     # Registration / connection lifecycle
     "register_agent",
     "unregister_agent",
@@ -74,6 +87,14 @@ __all__ = [
     "unregister_connection",
     "purge_agent",
     "purge_all_offline",
+    # Singleton cardinality enforcement (#255)
+    "set_connection_identity",
+    "clear_connection_identity",
+    "get_connection_identity",
+    "list_sibling_channels",
+    "decide_singleton_winner",
+    "record_singleton_conflict",
+    "get_recent_singleton_event",
     # Heartbeat / activity / health setters
     "update_heartbeat",
     "update_pong",

--- a/hub/registry/__init__.py
+++ b/hub/registry/__init__.py
@@ -27,6 +27,7 @@ The full pre-split public surface is re-exported here so
 
 from ._heartbeat import (
     mark_activity,
+    mark_echo_alive,
     set_current_task,
     set_health,
     set_subagent_count,
@@ -100,6 +101,7 @@ __all__ = [
     "update_pong",
     "update_echo_pong",
     "mark_activity",
+    "mark_echo_alive",
     "set_current_task",
     "set_subagents",
     "set_subagent_count",

--- a/hub/registry/__init__.py
+++ b/hub/registry/__init__.py
@@ -31,6 +31,7 @@ from ._heartbeat import (
     set_health,
     set_subagent_count,
     set_subagents,
+    update_echo_pong,
     update_heartbeat,
     update_pong,
 )
@@ -76,6 +77,7 @@ __all__ = [
     # Heartbeat / activity / health setters
     "update_heartbeat",
     "update_pong",
+    "update_echo_pong",
     "mark_activity",
     "set_current_task",
     "set_subagents",

--- a/hub/registry/_heartbeat.py
+++ b/hub/registry/_heartbeat.py
@@ -183,6 +183,12 @@ def update_echo_pong(name: str, rtt_ms: float) -> None:
 
     All three are written atomically so a partial update can't leave
     the LED rendering off a fresher timestamp than the RTT it cites.
+
+    Semantic note (msg#15538 — 4th-LED auto-green on inbound message):
+    ``last_nonce_echo_at`` is now the "last proof of life" timestamp,
+    written either by this setter (successful nonce probe, carries RTT)
+    OR by ``mark_echo_alive()`` (any inbound agent message, no RTT).
+    Both paths feed the same LED field so either signal turns it green.
     """
     from datetime import datetime, timezone
 
@@ -191,5 +197,39 @@ def update_echo_pong(name: str, rtt_ms: float) -> None:
     with _lock:
         if name in _agents:
             _agents[name]["last_echo_rtt_ms"] = float(rtt_ms)
+            _agents[name]["last_echo_ok_ts"] = now
+            _agents[name]["last_nonce_echo_at"] = iso_now
+
+
+def mark_echo_alive(name: str) -> None:
+    """Record proof-of-life from an inbound agent message (msg#15538).
+
+    The 4th LED (ECHO / ``last_nonce_echo_at``) was previously only
+    driven by the hub→agent nonce round-trip in ``_hub_echo_loop`` /
+    ``handle_echo_pong``. If the agent's MCP-client could not reply to
+    the nonce (e.g. the sidecar was down) the LED stayed amber / red
+    even though the agent was clearly alive — we had just received a
+    chat message from it.
+
+    This setter is called from ``handle_agent_message`` when a
+    ``type: "message"`` frame lands on the WS (after ACL + membership
+    checks pass, so only authenticated inbound traffic is credited).
+    It advances the same ``last_nonce_echo_at`` / ``last_echo_ok_ts``
+    pair the nonce-probe setter writes — the LED renderer needs no
+    change; it just sees the hot timestamp regardless of which
+    mechanism produced it.
+
+    Does NOT touch ``last_echo_rtt_ms`` — an inbound message has no
+    round-trip measurement, and overwriting a real RTT with a sentinel
+    would make the per-agent detail panel's RTT display misleading.
+    The two mechanisms together are a strictly stronger liveness signal
+    than nonce-probe alone (either path turns the LED green).
+    """
+    from datetime import datetime, timezone
+
+    now = time.time()
+    iso_now = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+    with _lock:
+        if name in _agents:
             _agents[name]["last_echo_ok_ts"] = now
             _agents[name]["last_nonce_echo_at"] = iso_now

--- a/hub/registry/_heartbeat.py
+++ b/hub/registry/_heartbeat.py
@@ -145,3 +145,29 @@ def update_pong(name: str, rtt_ms: float) -> None:
         if name in _agents:
             _agents[name]["last_pong_ts"] = time.time()
             _agents[name]["last_rtt_ms"] = float(rtt_ms)
+
+
+def update_echo_pong(name: str, rtt_ms: float) -> None:
+    """Record an agent's echo round-trip pong (#259, indicator #4).
+
+    Sets three fields:
+
+    - ``last_echo_rtt_ms`` — most recent echo RTT in milliseconds.
+    - ``last_echo_ok_ts``  — wall time of the most recent successful
+      echo (unix seconds, float). Used by the API/payload layer.
+    - ``last_nonce_echo_at`` — ISO-8601 string of the same instant,
+      consumed directly by the Agents-tab LED renderer
+      (``renderAgentLeds`` reads ``a.last_nonce_echo_at``).
+
+    All three are written atomically so a partial update can't leave
+    the LED rendering off a fresher timestamp than the RTT it cites.
+    """
+    from datetime import datetime, timezone
+
+    now = time.time()
+    iso_now = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+    with _lock:
+        if name in _agents:
+            _agents[name]["last_echo_rtt_ms"] = float(rtt_ms)
+            _agents[name]["last_echo_ok_ts"] = now
+            _agents[name]["last_nonce_echo_at"] = iso_now

--- a/hub/registry/_heartbeat.py
+++ b/hub/registry/_heartbeat.py
@@ -125,13 +125,35 @@ def set_health(
 
 
 def update_heartbeat(name: str, metrics: dict | None = None) -> None:
-    """Update heartbeat timestamp and optional metrics."""
+    """Update heartbeat timestamp and optional metrics.
+
+    todo#272: after the timestamp/metric write, run the quota-pressure
+    state machine for this agent. The check reads the quota fields that
+    ``register_agent()`` just wrote (``quota_5h_used_pct`` / ``quota_7d_used_pct``
+    + reset timestamps + prior state) and posts a threshold-crossing
+    message to ``#progress`` / ``#escalation`` / ``#ywatanabe`` when a
+    window crosses the warn / escalate bands. Best-effort — the check
+    never raises into the heartbeat hot path.
+    """
     with _lock:
         if name in _agents:
             _agents[name]["last_heartbeat"] = time.time()
             _agents[name]["status"] = "online"
             if metrics:
                 _agents[name]["metrics"] = metrics
+            has_agent = True
+        else:
+            has_agent = False
+
+    if has_agent:
+        # Deferred import — avoid circular (``hub.quota_watch`` itself
+        # imports ``hub.registry``).
+        try:
+            from hub.quota_watch import check_agent_quota_pressure
+
+            check_agent_quota_pressure(name)
+        except Exception:  # pragma: no cover — defense in depth
+            pass
 
 
 def update_pong(name: str, rtt_ms: float) -> None:

--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -92,6 +92,17 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "name": a["name"],
                 "agent_id": a.get("agent_id", a["name"]),
                 "machine": a.get("machine", ""),
+                # #257 — live ``hostname(1)`` reported by the heartbeat.
+                # This is the authoritative "where is this process
+                # running right now" field. The frontend badge
+                # (hostedAgentName) prefers ``hostname`` over
+                # ``machine`` because the latter can drift (stale
+                # YAML label / env override) while the former is the
+                # kernel's answer from the live process. Exposed here
+                # so the sidebar card shows ``proj-neurovista@spartan``
+                # correctly even when an env var says otherwise (lead
+                # msg#15578 fix).
+                "hostname": a.get("hostname", ""),
                 # todo#55: FQDN / canonical hostname for display next to
                 # the short machine label. Empty string = older client
                 # that didn't push this field.

--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -129,6 +129,20 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                     else None
                 ),
                 "last_rtt_ms": a.get("last_rtt_ms"),
+                # #259 — 4th-indicator (Remote / nonce-echo) round-trip
+                # data for the dashboard. ``last_nonce_echo_at`` is the
+                # field the LED renderer reads (already wired in
+                # agent-badge.js); the other two surface RTT + raw unix
+                # timestamp for tooling and the per-agent detail page.
+                "last_nonce_echo_at": a.get("last_nonce_echo_at"),
+                "last_echo_rtt_ms": a.get("last_echo_rtt_ms"),
+                "last_echo_ok_ts": (
+                    datetime.fromtimestamp(
+                        a["last_echo_ok_ts"], tz=timezone.utc
+                    ).isoformat()
+                    if a.get("last_echo_ok_ts")
+                    else None
+                ),
                 "last_action": (
                     datetime.fromtimestamp(action_ts, tz=timezone.utc).isoformat()
                     if action_ts

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -317,6 +317,15 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             "quota_7d_reset_at": info.get("quota_7d_reset_at")
             or prev.get("quota_7d_reset_at")
             or "",
+            # todo#272 — per-window quota state machine slot (ok / warn /
+            # escalate). Owned by ``hub.quota_watch.check_agent_quota_pressure``
+            # which reads it before evaluate() and writes the new state
+            # after. Preserved across heartbeats so threshold transitions
+            # fire exactly once per crossing — without the prev-preserve
+            # the state machine would reset to "ok" every heartbeat and
+            # re-post warn / escalate on every poll (spam regression).
+            "quota_state_5h": prev.get("quota_state_5h") or "ok",
+            "quota_state_7d": prev.get("quota_state_7d") or "ok",
             "mcp_servers": (
                 list(info.get("mcp_servers"))
                 if isinstance(info.get("mcp_servers"), (list, tuple))

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -138,6 +138,18 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             # lamp flickered to gray 1× per 30s heartbeat cycle.
             "last_pong_ts": prev.get("last_pong_ts"),
             "last_rtt_ms": prev.get("last_rtt_ms"),
+            # #259 — preserve echo round-trip state across re-registers.
+            # Same prev-preserve pitfall as the ping/pong fields above:
+            # if these were dropped on every heartbeat, the 4th LED
+            # (Remote/echo) would flicker to grey-pending at the
+            # heartbeat cadence even when the echo path is live. The
+            # fields are written by ``update_echo_pong()`` (in
+            # ``_heartbeat.py``) when an ``echo_pong`` frame lands, and
+            # are surfaced in the API by ``_payload.get_agents()`` /
+            # ``hub/views/agent_detail.py``.
+            "last_echo_rtt_ms": prev.get("last_echo_rtt_ms"),
+            "last_echo_ok_ts": prev.get("last_echo_ok_ts"),
+            "last_nonce_echo_at": prev.get("last_nonce_echo_at"),
             # Extended process/runtime metadata pushed by agent_meta.py --push.
             # Optional; absent for legacy WS-only agents.
             "pid": info.get("pid") or prev.get("pid") or 0,

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -6,9 +6,20 @@ flickering. New per-agent fields MUST be added here, otherwise the LEDs
 flicker every heartbeat (regression hazard).
 """
 
+import logging
 import time
 
-from ._store import _active_session_count, _agents, _connections, _lock
+from ._store import (
+    SINGLETON_EVENT_WINDOW_S,
+    _active_session_count,
+    _agents,
+    _connection_identity,
+    _connections,
+    _lock,
+    _singleton_events,
+)
+
+_log = logging.getLogger("orochi.registry")
 
 
 def register_agent(name: str, workspace_id: int, info: dict) -> None:
@@ -460,3 +471,211 @@ def purge_agent(name: str) -> bool:
             del _agents[name]
             return True
         return False
+
+
+# ── scitex-orochi#255: singleton cardinality enforcement ────────────────
+#
+# When two WS connections claim the same agent name, the hub picks one
+# and disconnects the other. The decision is made on the (instance_id,
+# start_ts_unix) pair captured per-connection at connect time:
+#
+#   * If both sides report the pair, the older ``start_ts_unix`` wins
+#     (the original process keeps its claim — newer racers lose).
+#   * If either side is missing the pair (legacy clients), we don't
+#     enforce — the running connection wins by default and we log a
+#     WARNING so multi-instance hazards are still visible in logs.
+#
+# State lives next to ``_connections`` in ``_store.py``:
+#
+#   * ``_connection_identity[channel_name]`` — the captured triple for
+#     this WS, set at connect / cleared at disconnect.
+#   * ``_singleton_events[agent_name]`` — bounded ring buffer of recent
+#     conflict events (``SINGLETON_EVENT_WINDOW_S`` window) so the
+#     agent-detail API can surface the newest one.
+
+
+def set_connection_identity(
+    channel_name: str,
+    agent_name: str,
+    instance_id: str | None,
+    start_ts_unix: float | None,
+) -> None:
+    """Remember the (agent, instance_id, start_ts_unix) of a live WS.
+
+    Called from ``AgentConsumer.connect`` after the workspace token has
+    authorized the connection. The recorded triple is what the singleton
+    decider compares against on a subsequent connection that claims the
+    same ``agent_name``.
+
+    ``instance_id`` and ``start_ts_unix`` may be ``None``/empty for
+    legacy clients — they are stored as-is so the decider can detect
+    "missing identity" and fall back to the permissive multi-connection
+    behaviour without enforcement.
+    """
+    if not channel_name:
+        return
+    with _lock:
+        _connection_identity[channel_name] = {
+            "agent_name": agent_name or "",
+            "instance_id": (instance_id or "") if isinstance(instance_id, str) else "",
+            "start_ts_unix": (
+                float(start_ts_unix)
+                if isinstance(start_ts_unix, (int, float))
+                else None
+            ),
+        }
+
+
+def clear_connection_identity(channel_name: str) -> None:
+    """Drop the identity row for ``channel_name`` (called on disconnect)."""
+    if not channel_name:
+        return
+    with _lock:
+        _connection_identity.pop(channel_name, None)
+
+
+def get_connection_identity(channel_name: str) -> dict | None:
+    """Return the captured identity triple for a WS, or ``None`` if absent."""
+    if not channel_name:
+        return None
+    with _lock:
+        ident = _connection_identity.get(channel_name)
+        return dict(ident) if ident else None
+
+
+def list_sibling_channels(agent_name: str) -> list[str]:
+    """Return the live ``channel_name`` ids currently registered for an agent.
+
+    Used by the singleton enforcer to find the incumbent connection so
+    it can compare identities and (when the new one wins) close the
+    incumbent. Returns an empty list when the agent has no live
+    connections (the new WS is the first claimant — no enforcement
+    needed).
+    """
+    if not agent_name:
+        return []
+    with _lock:
+        return list(_connections.get(agent_name, ()))
+
+
+def decide_singleton_winner(
+    name: str,
+    new_instance_id: str | None,
+    new_start_ts_unix: float | None,
+) -> str:
+    """Decide who survives when two WS claim the same ``name``.
+
+    Returns one of:
+
+    * ``"challenger"`` — the new connection wins (the existing/incumbent
+      connection should be closed).
+    * ``"incumbent"`` — the existing connection wins (the new/challenger
+      connection should be closed).
+    * ``"no_enforcement"`` — either side is missing the
+      ``(instance_id, start_ts_unix)`` pair, so we fall back to the
+      permissive multi-connection behaviour. Caller logs a WARNING and
+      keeps both sockets alive.
+
+    Algorithm — the older ``start_ts_unix`` wins (the original process
+    keeps its claim). Ties and missing data fall through to
+    ``no_enforcement`` rather than guessing — disrupting a healthy
+    incumbent on insufficient evidence is the worst outcome.
+
+    Requires the lock-free read of ``_connection_identity`` /
+    ``_connections`` to find the incumbent's recorded identity.
+    """
+    if not name:
+        return "no_enforcement"
+    if not isinstance(new_instance_id, str) or not new_instance_id:
+        return "no_enforcement"
+    if not isinstance(new_start_ts_unix, (int, float)):
+        return "no_enforcement"
+
+    with _lock:
+        sibling_channels = list(_connections.get(name, ()))
+        # Pick the most-recent incumbent identity among the siblings.
+        # In practice there's exactly one incumbent at the point of
+        # comparison (the new WS hasn't yet been added). If multiple
+        # siblings exist with full identity, we compare against the
+        # one with the OLDEST start_ts_unix — that is the de-facto
+        # primary that a challenger must beat.
+        incumbent: dict | None = None
+        for ch in sibling_channels:
+            ident = _connection_identity.get(ch)
+            if not ident:
+                continue
+            if not ident.get("instance_id"):
+                continue
+            if not isinstance(ident.get("start_ts_unix"), (int, float)):
+                continue
+            if incumbent is None or float(ident["start_ts_unix"]) < float(
+                incumbent["start_ts_unix"]
+            ):
+                incumbent = ident
+
+    if incumbent is None:
+        # No incumbent with enforceable identity — fall back to
+        # permissive behaviour. Caller logs the situation.
+        return "no_enforcement"
+
+    incumbent_start = float(incumbent["start_ts_unix"])
+    new_start = float(new_start_ts_unix)
+    if new_start < incumbent_start:
+        # Challenger is older → it wins.
+        return "challenger"
+    # Incumbent is older OR tie. Don't disrupt the running process.
+    return "incumbent"
+
+
+def record_singleton_conflict(
+    name: str,
+    winner_instance_id: str,
+    loser_instance_id: str,
+    reason: str = "duplicate_identity",
+) -> None:
+    """Append a conflict event to the per-agent ring buffer.
+
+    Trims entries older than ``SINGLETON_EVENT_WINDOW_S`` so the buffer
+    stays bounded over a long-running hub process. The agent-detail
+    API surfaces the newest entry as ``last_duplicate_identity_event``.
+    """
+    if not name:
+        return
+    now = time.time()
+    cutoff = now - SINGLETON_EVENT_WINDOW_S
+    with _lock:
+        events = _singleton_events.setdefault(name, [])
+        events.append(
+            {
+                "ts": now,
+                "agent": name,
+                "winner_instance_id": winner_instance_id or "",
+                "loser_instance_id": loser_instance_id or "",
+                "reason": reason or "duplicate_identity",
+            }
+        )
+        # Drop stale events. List ops are cheap at this size (<< 100/hr).
+        _singleton_events[name] = [e for e in events if e["ts"] >= cutoff]
+
+
+def get_recent_singleton_event(name: str) -> dict | None:
+    """Return the newest singleton-conflict event for ``name`` (or None).
+
+    Lazy-trims the per-agent buffer to the active window. Returns a
+    plain dict (a copy) so the caller can mutate it freely.
+    """
+    if not name:
+        return None
+    cutoff = time.time() - SINGLETON_EVENT_WINDOW_S
+    with _lock:
+        events = _singleton_events.get(name) or []
+        fresh = [e for e in events if e["ts"] >= cutoff]
+        if fresh != events:
+            if fresh:
+                _singleton_events[name] = fresh
+            else:
+                _singleton_events.pop(name, None)
+        if not fresh:
+            return None
+        # Newest last (append-only) → return the tail.
+        return dict(fresh[-1])

--- a/hub/registry/_store.py
+++ b/hub/registry/_store.py
@@ -19,10 +19,30 @@ _lock = threading.Lock()
 _agents: dict[str, dict] = {}
 _connections: dict[str, set[str]] = {}
 
+# scitex-orochi#255: per-WS-channel identity table. Maps Channels'
+# ``channel_name`` (the opaque per-WebSocket id used in ``_connections``)
+# to the (agent_name, instance_id, start_ts_unix) triple captured when
+# the WS connected. Lets the singleton enforcer ask "what process owns
+# this socket?" without re-parsing the register frame, and lets it
+# safely close the LOSING socket by name. Cleared on disconnect.
+_connection_identity: dict[str, dict] = {}
+
+# scitex-orochi#255: ring buffer of recent singleton-conflict events.
+# Entries are dicts {ts, agent, winner_instance_id, loser_instance_id,
+# reason}. Trimmed lazily on read so a long-lived hub doesn't pile up
+# events forever — the agent-detail API only surfaces the newest event
+# per agent, but the buffer is kept per-agent so future debugging /
+# observability can query the full hour.
+_singleton_events: dict[str, list[dict]] = {}
+
 # Agents with no heartbeat for this many seconds are auto-marked offline
 HEARTBEAT_TIMEOUT_S = 60
 # Offline agents are purged from registry after this many seconds
 STALE_PURGE_S = 300  # 5 minutes
+# How long a singleton-conflict event stays in the ring buffer for
+# surfacing in the agent-detail API. One hour is enough to investigate
+# a recent ghost-process incident without bloating memory.
+SINGLETON_EVENT_WINDOW_S = 3600
 
 
 def _active_session_count(name: str) -> int:

--- a/hub/signals.py
+++ b/hub/signals.py
@@ -6,15 +6,28 @@ authoritative identity changes (``AgentProfile.name`` rename for agents,
 ``User.username`` rename for humans), any ``DMParticipant`` rows whose
 ``member`` points at the affected principal must have their
 ``identity_name`` updated in the same transaction.
+
+Issue #282 — ``ChannelMembership`` changes fan out to any live
+``AgentConsumer`` so the in-memory ``agent_meta["channels"]`` and the
+per-channel group-layer joins stay DB-authoritative under out-of-band
+edits (admin REST subscribe, drag-to-channel, Django admin UI).
 """
 
 from __future__ import annotations
 
+import logging
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
 from django.contrib.auth.models import User
-from django.db.models.signals import post_save
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from hub.models import AgentProfile, DMParticipant
+from hub.models import AgentProfile, ChannelMembership, DMParticipant
+from hub.registry import list_sibling_channels
+
+log = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=AgentProfile)
@@ -52,3 +65,89 @@ def _user_rename(sender, instance: User, created, **kwargs):
     DMParticipant.objects.filter(member__user_id=instance.id).exclude(
         identity_name=identity
     ).update(identity_name=identity)
+
+
+# ---------------------------------------------------------------------------
+# Issue #282 — ChannelMembership change → refresh live agent consumers.
+# ---------------------------------------------------------------------------
+
+_AGENT_USERNAME_PREFIX = "agent-"
+
+
+def _broadcast_agent_subs_refresh(
+    agent_name: str, workspace_id: int
+) -> None:
+    """Notify every live AgentConsumer for the affected agent to re-sync.
+
+    Only agent users (synthetic ``agent-<name>`` Django users) drive this
+    path; humans are irrelevant because they connect via
+    :class:`DashboardConsumer` which reads membership on each delivery.
+
+    Called from ``transaction.on_commit`` so the consumer's DB re-fetch
+    observes the committed state (avoids a read-before-commit race).
+    """
+    layer = get_channel_layer()
+    if layer is None:
+        return
+
+    channel_names = list_sibling_channels(agent_name)
+    if not channel_names:
+        return
+
+    payload = {
+        "type": "agent.subs_refresh",
+        "agent": agent_name,
+        "workspace_id": workspace_id,
+    }
+    for channel_name in channel_names:
+        try:
+            async_to_sync(layer.send)(channel_name, payload)
+        except Exception:  # noqa: BLE001 — best-effort; one bad socket
+            # shouldn't mask refreshes to the other sibling connections.
+            log.exception(
+                "agent.subs_refresh send failed (agent=%s channel=%s)",
+                agent_name,
+                channel_name,
+            )
+
+
+def _queue_membership_refresh(membership: ChannelMembership) -> None:
+    """Extract ``(agent_name, workspace_id)`` then schedule the refresh.
+
+    No-ops for non-agent users. Schedules the dispatch via
+    ``transaction.on_commit`` so tests that create ChannelMembership rows
+    without an explicit transaction still observe the side effect
+    (on_commit runs immediately in autocommit mode).
+    """
+    try:
+        user = membership.user
+    except User.DoesNotExist:
+        return
+    username = getattr(user, "username", "") or ""
+    if not username.startswith(_AGENT_USERNAME_PREFIX):
+        return
+    agent_name = username[len(_AGENT_USERNAME_PREFIX):]
+
+    try:
+        workspace_id = membership.channel.workspace_id
+    except Exception:  # noqa: BLE001
+        log.exception("ChannelMembership signal: missing channel/workspace")
+        return
+
+    transaction.on_commit(
+        lambda: _broadcast_agent_subs_refresh(agent_name, workspace_id)
+    )
+
+
+@receiver(post_save, sender=ChannelMembership)
+def _channel_membership_saved(
+    sender, instance: ChannelMembership, created, **kwargs
+):
+    _queue_membership_refresh(instance)
+
+
+@receiver(post_delete, sender=ChannelMembership)
+def _channel_membership_deleted(
+    sender, instance: ChannelMembership, **kwargs
+):
+    _queue_membership_refresh(instance)

--- a/hub/static/hub/activity-tab/detail.js
+++ b/hub/static/hub/activity-tab/detail.js
@@ -95,9 +95,44 @@ function _renderActivityAgentDetail(a, grid) {
     _rawModel.charAt(_rawModel.length - 1) === ">"
       ? "—"
       : _rawModel || "-";
+  /* #257 + #261: surface the canonical heartbeat metadata so humans
+   * scanning the detail pane can verify "where am I really running"
+   * at a glance. `Hostname` is the live hostname(1); distinct from
+   * `Machine` (the YAML config label). `Instance` truncates the UUID
+   * to 8 chars (full UUID is in dev tools). `Launch` renders as a
+   * sigil so sac vs manual is obvious. Empty fields collapse to "-"
+   * for legacy agents that haven't been upgraded yet. */
+  var _launchSigil = {
+    "sac": "🤖 sac",
+    "sac-ssh": "🛰 sac-ssh",
+    "sbatch": "💼 sbatch",
+    "manual-tmux": "👤 tmux",
+    "manual-direct": "👤 direct",
+    "unknown": "?",
+  };
+  var _launchDisplay = a.launch_method
+    ? (_launchSigil[a.launch_method] || a.launch_method)
+    : "-";
+  var _instanceShort = a.instance_id
+    ? String(a.instance_id).slice(0, 8) + "…"
+    : "-";
+  var _proxyDisplay = a.is_proxy
+    ? "yes (rank " + (a.priority_rank != null ? a.priority_rank : "?") + ")"
+    : (a.priority_rank === 0 ? "no (primary)" : "-");
+  var _priorityListDisplay = (a.priority_list && a.priority_list.length)
+    ? a.priority_list.join(" → ")
+    : "-";
   var metaFields = [
     ["Role", a.role || "agent"],
     ["Machine", _machineDisplay],
+    /* Live hostname(1). When this disagrees with Machine, the agent
+     * yaml is misconfigured (or the agent moved hosts). */
+    ["Hostname", a.hostname || "-"],
+    ["Uname", a.uname || "-"],
+    ["Instance", _instanceShort],
+    ["Launch", _launchDisplay],
+    ["Proxy?", _proxyDisplay],
+    ["Priority list", _priorityListDisplay],
     ["Model", _modelDisplay],
     ["Multiplexer", a.multiplexer || "-"],
     ["PID", a.pid || "-"],

--- a/hub/static/hub/agent-badge.js
+++ b/hub/static/hub/agent-badge.js
@@ -180,7 +180,12 @@
           ")\n  Heuristic from local pane text; not fully reliable.\n  green = running, yellow = idle, blue = waiting,\n  red = auth_error, orange = stale.",
       ) +
       '"></span>';
-    // 4. Remote functional state — nonce-echo (publisher TBD)
+    // 4. Remote functional state — "last proof of life".
+    // msg#15538: ``last_nonce_echo_at`` is advanced by EITHER the
+    // hub→agent nonce round-trip (hub/consumers/_echo.py) OR by any
+    // inbound agent message (hub/consumers/_agent_message.py via
+    // mark_echo_alive). The renderer does not need to know which
+    // mechanism wrote the timestamp — either path turns the LED green.
     var echo = a.last_nonce_echo_at;
     var echoAge =
       echo != null ? (Date.now() - new Date(echo).getTime()) / 1000 : null;

--- a/hub/static/hub/app/sidebar-channel-tree.js
+++ b/hub/static/hub/app/sidebar-channel-tree.js
@@ -163,7 +163,10 @@ function _renderChannelRowHtml(row, ctx) {
  * the file-size budget without changing any observable behavior. */
 function _wireChannelItemHandlers(chContainer, prevSelected) {
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render */
+    /* Restore selected state from before re-render. Channels are single-
+     * selection only (#284): at most one channel-item ever carries the
+     * .selected class. prevSelected is retained across renders so the
+     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
     if (elCh && prevSelected[elCh]) el.classList.add("selected");
     /* Pin icon click — toggle is_starred (pinned-to-top) */
@@ -274,41 +277,9 @@ function _wireChannelItemHandlers(chContainer, prevSelected) {
         _setChannelPref(ch, { is_hidden: false });
         return;
       }
-      var multi = ev.ctrlKey || ev.metaKey;
-      /* todo#274 Part 2: Ctrl/Cmd+Click toggles multi-select without
-       * disturbing siblings; plain click keeps legacy single-select. */
-      if (multi) {
-        el.classList.toggle("selected");
-        /* When multi-select is active, the DOM may only have messages from
-         * currentChannel. Switch to all-channel history so messages from
-         * every selected channel are present, then let applyFeedFilter
-         * show the merged subset. (#366) */
-        var _selCount = chContainer.querySelectorAll(
-          ".channel-item.selected[data-channel]",
-        ).length;
-        if (_selCount >= 2) {
-          /* Load all messages; applyFeedFilter handles visible subset */
-          setCurrentChannel(null);
-          var _applyAfter = function () {
-            if (typeof applyFeedFilter === "function") applyFeedFilter();
-          };
-          loadHistory().then
-            ? loadHistory().then(_applyAfter)
-            : (loadHistory(), _applyAfter());
-        } else if (_selCount === 1) {
-          var _onlyCh = chContainer.querySelector(
-            ".channel-item.selected[data-channel]",
-          );
-          if (_onlyCh) {
-            setCurrentChannel(_onlyCh.getAttribute("data-channel"));
-            loadChannelHistory(_onlyCh.getAttribute("data-channel"));
-          }
-        } else {
-          /* All deselected */
-          if (typeof applyFeedFilter === "function") applyFeedFilter();
-        }
-        return;
-      }
+      /* #284: channels are single-selection only. The legacy Ctrl/Cmd+Click
+       * multi-select has been removed — any click replaces the current
+       * selection with exactly this row. */
       if (currentChannel === ch) {
         setCurrentChannel(null);
         loadHistory();

--- a/hub/static/hub/app/sidebar-channel-tree.js
+++ b/hub/static/hub/app/sidebar-channel-tree.js
@@ -162,13 +162,27 @@ function _renderChannelRowHtml(row, ctx) {
  * chContainer. Pulled out of fetchStats so the main entry point stays under
  * the file-size budget without changing any observable behavior. */
 function _wireChannelItemHandlers(chContainer, prevSelected) {
+  /* #293: enforce single-select hard invariant on restore. Even if
+   * prevSelected contained multiple entries (from a stale DOM where
+   * two rows both carried .selected — the regression this PR fixes),
+   * we restore .selected to AT MOST ONE row, preferring the current
+   * channel. Anything else is dropped on the floor. */
+  var restoredOne = false;
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
-    /* Restore selected state from before re-render. Channels are single-
-     * selection only (#284): at most one channel-item ever carries the
-     * .selected class. prevSelected is retained across renders so the
-     * current-selection marker doesn't flicker mid-refresh. */
     var elCh = el.getAttribute("data-channel");
-    if (elCh && prevSelected[elCh]) el.classList.add("selected");
+    if (
+      !restoredOne &&
+      elCh &&
+      prevSelected[elCh] &&
+      currentChannel === elCh
+    ) {
+      el.classList.add("selected");
+      restoredOne = true;
+    } else {
+      /* Defensive: make sure NO row carries .selected unless we just
+       * added it above. Belt-and-braces against any stale DOM state. */
+      el.classList.remove("selected");
+    }
     /* Pin icon click — toggle is_starred (pinned-to-top) */
     var pinEl = el.querySelector(".ch-pin");
     if (pinEl) {
@@ -294,12 +308,18 @@ function _wireChannelItemHandlers(chContainer, prevSelected) {
       /* Clear unread for this channel (#322) */
       channelUnread[ch] = 0;
       updateChannelUnreadBadges();
-      /* todo#274 Part 1: pure visual highlight, toggle on second click. */
-      var items = chContainer.querySelectorAll(".channel-item");
+      /* todo#274 Part 1 + #293: single-select is the HARD invariant —
+       * clear .selected across the ENTIRE sidebar (channel rows AND
+       * DM agent-cards), not just this chContainer. Previously only
+       * chContainer was cleared, which left a stale .selected on a
+       * DM row when the user switched from a DM to a channel and
+       * manifested as "two rows selected at once" (#293). */
       var wasSelected = el.classList.contains("selected");
-      items.forEach(function (it) {
-        it.classList.remove("selected");
-      });
+      document
+        .querySelectorAll(".sidebar .channel-item.selected, .sidebar .dm-item.selected")
+        .forEach(function (it) {
+          it.classList.remove("selected");
+        });
       if (!wasSelected && currentChannel === ch) {
         el.classList.add("selected");
       }

--- a/hub/static/hub/app/sidebar-stats.js
+++ b/hub/static/hub/app/sidebar-stats.js
@@ -15,7 +15,10 @@ async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* Preserve Ctrl+Click multi-select state across re-renders (#274 Part 2) */
+    /* #284: channels are single-select only. prevSelected keeps the one
+     * currently-selected row marked .selected across DOM re-renders so the
+     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
+     * multi-select — #274 Part 2 — has been removed for channels.) */
     var prevSelected = {};
     chContainer
       .querySelectorAll(".channel-item.selected")

--- a/hub/static/hub/app/sidebar-stats.js
+++ b/hub/static/hub/app/sidebar-stats.js
@@ -15,17 +15,23 @@ async function fetchStats() {
     var inputHasFocus = msgInput && document.activeElement === msgInput;
     var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
     var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
-    /* #284: channels are single-select only. prevSelected keeps the one
-     * currently-selected row marked .selected across DOM re-renders so the
-     * selection indicator doesn't flicker mid-refresh. (The legacy Ctrl+Click
-     * multi-select — #274 Part 2 — has been removed for channels.) */
+    /* #284/#293: channels are single-select only. prevSelected keeps
+     * the ONE currently-selected row marked .selected across DOM re-
+     * renders so the selection indicator doesn't flicker mid-refresh.
+     *
+     * Hard invariant: at most one key ever lands in prevSelected. The
+     * source of truth is `currentChannel` — even if the DOM somehow
+     * accumulated .selected on multiple rows (the regression this PR
+     * fixes), we only ever carry the current-channel pointer forward.
+     * _wireChannelItemHandlers enforces the same rule on restore. */
     var prevSelected = {};
-    chContainer
-      .querySelectorAll(".channel-item.selected")
-      .forEach(function (el) {
-        var ch = el.getAttribute("data-channel");
-        if (ch) prevSelected[ch] = true;
-      });
+    var _curCh = currentChannel;
+    if (_curCh) {
+      var _hasSelected = !!chContainer.querySelector(
+        '.channel-item.selected[data-channel="' + String(_curCh).replace(/"/g, '\\"') + '"]',
+      );
+      if (_hasSelected) prevSelected[_curCh] = true;
+    }
     /* todo#325: hide dm:* channels from the public Channels list
      * (they still render in the DM tab via its own path).
      * todo#326: normalize "general" -> "#general" and dedupe by

--- a/hub/static/hub/app/utils.js
+++ b/hub/static/hub/app/utils.js
@@ -161,7 +161,13 @@ function hostedAgentName(a) {
   var name = a && a.name ? a.name : "";
   if (!name) return name;
   if (name.indexOf("@") !== -1) return cleanAgentName(name);
-  var host = a && a.machine ? a.machine : "";
+  /* #256 — host label MUST come from the live `hostname(1)` reported
+   * in the heartbeat, NOT from the YAML config `machine` field.
+   * Pre-fix, an agent_handlers `machine: mba` line in YAML caused the
+   * dashboard to show `proj-neurovista@mba` even when no process was
+   * running on mba (the ghost-mba bug). Falls back to `machine` for
+   * legacy agents whose heartbeat hasn't been upgraded yet. */
+  var host = a && a.hostname ? a.hostname : a && a.machine ? a.machine : "";
   /* Always pipe the constructed "<name>@<host>" string through
    * cleanAgentName so the role-host suffix gets collapsed
    * (head-mba@mba → head@mba). The earlier form returned the raw

--- a/hub/static/hub/dms.js
+++ b/hub/static/hub/dms.js
@@ -32,12 +32,56 @@
       .join(", ");
   }
 
-  function dmBadgeHtml(row) {
+  /* #284: DM card === Agent card.
+   *
+   * DM rows render through the shared renderAgentBadge() so markup,
+   * CSS classes and icon/star/LEDs/name layout are IDENTICAL to the
+   * Agent card. For DMs where the counterparty is a live agent, we
+   * pick up its record from window.__lastAgents so real liveness LEDs
+   * light up. For human-to-human DMs, we synthesise a minimal agent-
+   * shaped object keyed off the human's name — the same badge renders
+   * with all LEDs off/unknown (humans don't have a WS/ping/pane/echo
+   * signal) and the star/name columns line up with the agent sidebar.
+   *
+   * Returns a plain object shaped like an agent-registry row. Never
+   * forks the markup — see agent-badge.js renderAgentBadge. */
+  function dmCounterpartyAgentLike(row) {
     var others = (row && row.other_participants) || [];
-    if (others.length === 0) return "";
-    var t = others[0].type === "agent" ? "agent" : "human";
-    var label = t === "agent" ? "AI" : "U";
-    return '<span class="dm-principal-badge ' + t + '">' + label + "</span>";
+    if (others.length === 0) {
+      return {
+        name: row && row.name ? row.name : "(empty DM)",
+        status: "offline",
+        liveness: "offline",
+      };
+    }
+    var p = others[0];
+    var label = (p && p.identity_name) || "?";
+    if (p && p.type === "agent") {
+      var live = Array.isArray(window.__lastAgents) ? window.__lastAgents : [];
+      var match = null;
+      for (var i = 0; i < live.length; i++) {
+        var a = live[i];
+        if (!a || !a.name) continue;
+        var bare = String(a.name).split("@")[0];
+        if (bare === label || a.name === label) {
+          match = a;
+          break;
+        }
+      }
+      if (match) return match;
+      return {
+        name: label,
+        status: "offline",
+        liveness: "offline",
+        machine: (p && p.machine) || "",
+      };
+    }
+    return {
+      name: label,
+      status: "offline",
+      liveness: "offline",
+      _dm_counterparty_type: "human",
+    };
   }
 
   function renderDms(rows) {
@@ -59,68 +103,61 @@
             (typeof _channelPrefs !== "undefined" && _channelPrefs[ch]) || {};
           var pinned = !!prefs.is_starred;
           var muted = !!prefs.is_muted;
+          var counterparty = dmCounterpartyAgentLike(row);
+          var cpWithDmPin = {};
+          for (var k in counterparty)
+            if (Object.prototype.hasOwnProperty.call(counterparty, k))
+              cpWithDmPin[k] = counterparty[k];
+          cpWithDmPin.pinned = pinned;
           return (
-            '<div class="dm-item' +
+            '<div class="dm-item agent-card' +
             active +
             (muted ? " ch-muted" : "") +
             '" data-channel="' +
             escapeHtml(ch) +
+            '" data-agent-name="' +
+            escapeHtml(counterparty.name || "") +
             '" title="' +
             escapeHtml(ch) +
             '">' +
-            '<span class="ch-pin ' +
-            (pinned ? "ch-pin-on" : "ch-pin-off") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (pinned ? "Unstar" : "Star (float to top)") +
-            '">' +
-            (pinned ? "\u2605" : "\u2606") +
-            "</span>" +
-            '<span class="ch-watch ' +
-            (muted ? "ch-watch-off" : "ch-watch-on") +
-            '" data-ch="' +
-            escapeHtml(ch) +
-            '" title="' +
-            (muted
-              ? "Unmute (watch this DM)"
-              : "Mute (stop DM notifications)") +
-            '">\uD83D\uDC41</span>' +
-            dmBadgeHtml(row) +
-            escapeHtml(dmDisplayName(row)) +
+            (typeof renderAgentBadge === "function"
+              ? renderAgentBadge(cpWithDmPin, { iconSize: 14 })
+              : escapeHtml(dmDisplayName(row))) +
             "</div>"
           );
         })
         .join("");
       container.querySelectorAll(".dm-item").forEach(function (el) {
-        /* Pin icon toggles is_starred via the shared _setChannelPref. */
-        var pinEl = el.querySelector(".ch-pin");
-        if (pinEl && typeof _setChannelPref === "function") {
-          pinEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = pinEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_starred: !pref.is_starred });
-          });
-        }
-        /* Eye icon toggles is_muted. */
-        var watchEl = el.querySelector(".ch-watch");
-        if (watchEl && typeof _setChannelPref === "function") {
-          watchEl.addEventListener("click", function (ev) {
-            ev.stopPropagation();
-            var chName = watchEl.getAttribute("data-ch");
-            var pref =
-              (typeof _channelPrefs !== "undefined" && _channelPrefs[chName]) ||
-              {};
-            _setChannelPref(chName, { is_muted: !pref.is_muted });
-          });
+        /* Star inside the shared agent-badge markup — override the
+         * default agent-pin behaviour so clicking the star on a DM row
+         * toggles is_starred on the CHANNEL pref (pin the conversation)
+         * rather than pin-to-top the underlying agent. Uses the .dm-item
+         * row's data-channel, not the button's own data-pin-name which
+         * points at the counterparty agent. Runs on capture phase so we
+         * beat the global agent-pin handler wired elsewhere. */
+        var starEl = el.querySelector(".agent-badge-star");
+        if (starEl && typeof _setChannelPref === "function") {
+          starEl.addEventListener(
+            "click",
+            function (ev) {
+              ev.stopPropagation();
+              ev.preventDefault();
+              var chName = el.getAttribute("data-channel");
+              if (!chName) return;
+              var pref =
+                (typeof _channelPrefs !== "undefined" &&
+                  _channelPrefs[chName]) ||
+                {};
+              _setChannelPref(chName, { is_starred: !pref.is_starred });
+            },
+            true,
+          );
         }
         el.addEventListener("click", function (ev) {
+          /* Don't treat star / avatar clicks as row-clicks. */
           if (
-            ev.target.classList.contains("ch-pin") ||
-            ev.target.classList.contains("ch-watch")
+            ev.target.closest(".agent-badge-star") ||
+            ev.target.closest(".avatar-clickable")
           )
             return;
           var ch = el.getAttribute("data-channel");

--- a/hub/static/hub/filter/runner.js
+++ b/hub/static/hub/filter/runner.js
@@ -72,11 +72,10 @@ function runFilter() {
         });
       }
     }
-    /* Skip single-channel filter when multi-select is active (#366):
-     * applyFeedFilter() handles multi-channel visibility in that case. */
-    var _multiActive =
-      document.querySelectorAll("#channels .channel-item.selected").length >= 2;
-    if (show && currentChannel && !_multiActive) {
+    /* #284: channels are single-select — at most one .channel-item.selected
+     * ever exists. The legacy multi-channel bypass was removed; currentChannel
+     * alone is the filter gate. */
+    if (show && currentChannel) {
       show = el.getAttribute("data-channel") === currentChannel;
     }
     el.style.display = show ? "" : "none";

--- a/hub/static/hub/resources-tab/tab.js
+++ b/hub/static/hub/resources-tab/tab.js
@@ -74,11 +74,18 @@ function renderResources() {
           d.slurm.total_jobs +
           " jobs</span>";
       }
-      /* Entity-consistency format (TODO.md "Entity Consistency"):
-       * machine: [icon] [star] [<host-label>]. Icon is a compact
-       * server glyph; star is a reserved placeholder slot (machines
-       * aren't pinnable yet but the slot keeps the column aligned
-       * with sidebar channel rows). */
+      /* #284 Machine card order: [icon] [star] [LED] [<host-label>
+       * (<hostname-canonical>)] [metrics].
+       *
+       * The single LED replaces the old leading connection dot; it
+       * sits BETWEEN star and the name so the icon/star columns line
+       * up with agent + DM sidebar rows. Machines don't have the
+       * 4-LED liveness model agents do (no WS handshake / ping / pane
+       * state / nonce-echo signal is meaningful for a bare host), so
+       * we keep a single health LED driven by the heartbeat health
+       * status. Metrics (CPU / Mem / Disk / GPU / SLURM) stay inline
+       * where horizontal space allows — the full metric breakdown is
+       * always available on the hover tooltip regardless. */
       var mStarred = !!(d && d._starred);
       return (
         '<div class="res-card res-card-compact" data-machine="' +
@@ -87,9 +94,6 @@ function renderResources() {
         escapeHtml(k) +
         (d._status ? " · " + d._status : "") +
         '">' +
-        '<span class="res-conn res-conn-' +
-        (healthy ? "ok" : "stale") +
-        '"></span>' +
         '<span class="res-machine-icon" title="right-click to change" aria-hidden="true">' +
         (_machineIcons[k] || "\uD83D\uDDA5\uFE0F") +
         "</span>" +
@@ -102,11 +106,17 @@ function renderResources() {
         '">' +
         (mStarred ? "\u2605" : "\u2606") +
         "</span>" +
-        /* Spec: machine: [icon] [star] [<host-label> (<canonical-$HOSTNAME>)]
-         * — show the canonical FQDN in parentheses after the short
-         * label when it differs meaningfully from the label. Uses
-         * the same collapse rules as the Machine detail view
-         * (.local/.localdomain suffixes aren't "different"). */
+        '<span class="res-conn res-conn-' +
+        (healthy ? "ok" : "stale") +
+        '" title="' +
+        (healthy ? "Host healthy" : "Host stale / degraded") +
+        '"></span>' +
+        /* Spec: machine: [icon] [star] [LED] [<host-label>
+         * (<hostname-canonical>)] — show the canonical FQDN in
+         * parentheses after the short label when it differs
+         * meaningfully from the label. Uses the same collapse rules
+         * as the agents-tab Machine detail view (.local /
+         * .localdomain suffixes aren't "different"). */
         '<span class="res-host-name" style="color:' +
         color +
         '">' +

--- a/hub/static/hub/style/style-agents.css
+++ b/hub/static/hub/style/style-agents.css
@@ -322,9 +322,13 @@
 .dm-item:hover {
   background: #1a1a1a;
 }
+/* #293/#294: see .channel-item.active in style-base.css for the full
+ * rationale. The .selected rule in style-messages.css is the single
+ * source of truth for the "this is the current row" marker. Keep
+ * the background from cascading .active paths but do NOT bold the
+ * name; every DM row renders with identical weight. */
 .dm-item.active {
   background: #1a1a1a;
-  font-weight: bold;
   color: #f8f7f5;
 }
 .dm-item .dm-principal-badge {

--- a/hub/static/hub/style/style-base.css
+++ b/hub/static/hub/style/style-base.css
@@ -439,9 +439,13 @@ body {
 .channel-item:hover {
   background: #1a1a1a;
 }
+/* #293/#294: the current channel's visual marker is the .selected
+ * rule in style-messages.css (accent-coloured background). .active
+ * is a legacy class that some code paths still add — keep the
+ * background hover-equivalent but DO NOT bold the name. The selected
+ * row must read with the SAME font-weight as every other row. */
 .channel-item.active {
   background: #1a1a1a;
-  font-weight: bold;
 }
 #no-agents {
   color: #555;

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -210,8 +210,10 @@
 }
 .ch-star-off,
 .ch-pin-off {
-  opacity: 0.15; /* near-invisible until hover */
-  filter: grayscale(1);
+  /* ywatanabe 2026-04-21 msg#15131: "全部今暗くなってて見にくい...
+     普通に見えるように". Icons stay at normal brightness instead of
+     the prior hover-reveal pattern. */
+  opacity: 1;
 }
 .channel-item:hover .ch-star-off,
 .channel-item:hover .ch-pin-off,
@@ -243,8 +245,7 @@
  * "eye hidden should use the same glyph with a red strike, matching
  * the bell". */
 .ch-eye-on {
-  opacity: 0.15;
-  filter: grayscale(1);
+  opacity: 1;
 }
 .ch-eye-off {
   opacity: 0.75;
@@ -275,7 +276,7 @@
   color: #94a3b8;
 }
 .ch-mute-off {
-  opacity: 0.15;
+  opacity: 1;
 }
 .channel-item:hover .ch-mute-off {
   opacity: 0.55;

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -308,7 +308,11 @@
   line-height: 1;
 }
 .ch-identity-icon .entity-icon-channel {
-  opacity: 0.55;
+  /* #284: channel icons render at full brightness — no dimming on the
+   * default "#" glyph, and no grayscale cascade. Previously 0.55 opacity
+   * made the icons hard to read; the canonical sidebar layout keeps them
+   * the same weight as agent/DM icons. */
+  opacity: 1;
   display: inline-block;
   width: 100%;
   text-align: center;

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -271,15 +271,32 @@
 /* .ch-mute sizing consolidated into the .ch-star/.ch-pin/.ch-watch/
  * .ch-eye rule above (ywatanabe 2026-04-21: "bell is too large
  * compared to other icons"). */
-.ch-mute-on {
-  opacity: 0.9;
+/* #293: bell glyphs (🔔 / 🔕) render as color emoji on every major
+ * platform, which made the "not-muted" bell look like a big prominent
+ * yellow icon on every single row — drowning out the other icons and
+ * misrepresenting muted state. Force monochrome via grayscale filter
+ * so the bell sits at the same visual weight as ★ / 👁 / the row
+ * text. ywatanabe msg#15299 / #15317. The muted-state glyph already
+ * encodes the slash (U+1F515 "bell with slash"); no extra overlay
+ * needed. */
+.ch-mute {
+  filter: grayscale(1);
+  opacity: 0.7;
   color: #94a3b8;
 }
-.ch-mute-off {
-  opacity: 1;
-}
-.channel-item:hover .ch-mute-off {
+.ch-mute-on {
+  /* Muted — bell-with-slash glyph, slightly dimmer than the default
+   * state so the "notifications are off" read is not louder than
+   * "notifications are on". */
   opacity: 0.55;
+}
+.ch-mute-off {
+  /* Not muted — neutral bell, monochrome, same weight as the other
+   * row icons. No yellow emphasis. */
+  opacity: 0.7;
+}
+.channel-item:hover .ch-mute {
+  opacity: 1;
 }
 .ch-pin,
 .ch-eye {
@@ -345,17 +362,17 @@
    dim; keep the icon-level signal. */
 
 /* Hidden channel rows — rendered inline at the bottom of the Channels
- * section, dimmed so the list stays scannable. Clicking a dimmed row
- * un-hides it (promotes back to the normal list on next render).
- * No bulk toggle button — the dimmed rows ARE the affordance.
+ * section. #293 / ywatanabe msg#15299: DO NOT dim the row — every
+ * channel row (including #proj/* and other hidden ones) must render
+ * at opacity 1. Hidden state is communicated ONLY via the eye-with-
+ * red-slash glyph (.ch-eye-off ::after). Previously the row-level
+ * opacity: 0.4 made the #proj-* rows look permanently dim, which
+ * cascaded to every child glyph and muddied the read. The class is
+ * kept in the DOM for ordering/click behaviour (click a hidden row
+ * to un-hide) but it MUST NOT affect brightness.
  * See todo#418. */
 .channel-item.ch-hidden {
-  opacity: 0.4;
-  color: #6a7785;
   cursor: pointer;
-}
-.channel-item.ch-hidden:hover {
-  opacity: 0.7;
 }
 /* Subtle separator above the first hidden row so users understand
  * they're entering the "hidden" zone. */

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -338,9 +338,11 @@
   opacity: 1 !important;
   filter: none !important;
 }
-.ch-muted {
-  opacity: 0.5;
-}
+/* ywatanabe msg#15282 / 2026-04-21: muted state is already communicated
+   by the .ch-mute-on bell icon; dimming the whole row on top cascades
+   down to every child (making icons look dim despite opacity:1 rules)
+   and was the root cause of the "まだ暗いまま" report. Drop the row-level
+   dim; keep the icon-level signal. */
 
 /* Hidden channel rows — rendered inline at the bottom of the Channels
  * section, dimmed so the list stays scannable. Clicking a dimmed row

--- a/hub/static/hub/style/style-composer.css
+++ b/hub/static/hub/style/style-composer.css
@@ -421,11 +421,14 @@
 .agent-card {
   position: relative;
 }
-.agent-card > .pin-btn {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-}
+/* ywatanabe 2026-04-20 + PR #293 follow-up: the star (.pin-btn) must
+ * sit in canonical badge order icon → ★ → LEDs → name as emitted by
+ * renderAgentBadge(). A historical absolute-positioning rule pushed
+ * the star to the far right of every .agent-card (sidebar agent rows,
+ * DM rows, Activity list-view rows), breaking that order. Keeping the
+ * star in flex flow lets agent-badge.ts own layout as the single
+ * source of truth. If a legacy card EVER needs a floated star again,
+ * scope it with a specific child class — not .agent-card > .pin-btn. */
 /* Pinned but offline agent styling */
 .agent-card.pinned-offline {
   opacity: 0.55;

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -138,13 +138,18 @@ blockquote.chat-blockquote {
   border-left: 3px solid #4ecdc4;
 }
 
-/* todo#274 Part 1: pure visual selection in sidebar — clicking a
- * channel or agent highlights just that item and dims siblings.
- * Replaces the previous badge-filter UX. */
+/* todo#274 Part 1 / #293: selection marker is a BACKGROUND COLOUR ONLY.
+ * Do not boost opacity, do not brighten icons, do not bold the name —
+ * the selected row must read the same as the rest except for its
+ * subtle tint. This is ywatanabe msg#15299 / #15317: "all other rows
+ * keep their normal icons; the selected row is distinguished only by
+ * a subtle solid background". Applies to .sidebar .channel-item and
+ * .sidebar .agent-card (DMs render as .agent-card so they inherit). */
 .sidebar .channel-item.selected {
   background: rgba(126, 200, 227, 0.2);
 }
-.sidebar .agent-card.selected {
+.sidebar .agent-card.selected,
+.sidebar .dm-item.selected {
   background: rgba(78, 205, 196, 0.2);
 }
 /* #284: don't dim non-selected channels when one is selected — the

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -138,19 +138,45 @@ blockquote.chat-blockquote {
   border-left: 3px solid #4ecdc4;
 }
 
-/* todo#274 Part 1 / #293: selection marker is a BACKGROUND COLOUR ONLY.
- * Do not boost opacity, do not brighten icons, do not bold the name —
- * the selected row must read the same as the rest except for its
- * subtle tint. This is ywatanabe msg#15299 / #15317: "all other rows
- * keep their normal icons; the selected row is distinguished only by
- * a subtle solid background". Applies to .sidebar .channel-item and
- * .sidebar .agent-card (DMs render as .agent-card so they inherit). */
+/* todo#274 Part 1 / #293 / #294: selection marker is a BACKGROUND COLOUR
+ * ONLY. Do not boost opacity, do not brighten icons, do not bold the
+ * name — the selected row must read the same as the rest except for
+ * its background tint. This is ywatanabe msg#15299 / #15317: "all
+ * other rows keep their normal icons; the selected row is
+ * distinguished only by a solid background".
+ *
+ * #294 (msg#15352 / #heads #15353): bump the accent alpha so the
+ * selected row is UNAMBIGUOUSLY brighter than its siblings AND
+ * clearly distinct from the row-hover state (:hover uses #1a1a1a,
+ * a flat dark grey; the selected tint must read as an accent colour
+ * rather than "slightly darker"). Text/icon styling stays identical
+ * to unselected rows — only the background differs.
+ *
+ * Applies to .sidebar .channel-item and .sidebar .agent-card (DMs
+ * render as .agent-card so they inherit). */
 .sidebar .channel-item.selected {
-  background: rgba(126, 200, 227, 0.2);
+  background: rgba(126, 200, 227, 0.35);
 }
 .sidebar .agent-card.selected,
 .sidebar .dm-item.selected {
-  background: rgba(78, 205, 196, 0.2);
+  background: rgba(78, 205, 196, 0.35);
+}
+/* #294: normalise font-weight on every sidebar channel/DM row so no
+ * per-name rule (e.g. a stale .channel-item.active path, or a
+ * selector that happens to overlap a user/agent slug) can re-bold
+ * individual rows. The sidebar rows must render with identical
+ * weight — visual distinction comes from the .selected background
+ * above, nothing else. Belt-and-braces against regressions like the
+ * one reported in msg#15352 where #ywatanabe, #proj-neurovista,
+ * #proj-scitex-clew, #proj-scitex-orochi all rendered bold while
+ * #general, #heads, #releases did not. */
+.sidebar .channel-item,
+.sidebar .channel-item .ch-name,
+.sidebar .dm-item,
+.sidebar .dm-item .dm-name,
+.sidebar .agent-card,
+.sidebar .agent-card .agent-name {
+  font-weight: normal;
 }
 /* #284: don't dim non-selected channels when one is selected — the
  * spec calls for a single currently-selected marker only, no additional

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -122,14 +122,16 @@ blockquote.chat-blockquote {
   border-color: #4ecdc4;
 }
 
-/* Filter toggle active states (click-to-toggle on sidebar items) */
+/* Filter toggle active states (click-to-toggle on sidebar items).
+ * #284: the channel rule has been removed — the spec requires a single
+ * "currently-selected" marker on the Channels list with no additional
+ * highlight / category / filter tinting. Agent and resource rows still
+ * show a filter-active accent since those aren't under the single-
+ * select constraint (agents still support multi-select; resources use
+ * this to show when a host: tag is focusing them). */
 .agent-card.filter-active {
   background: rgba(78, 205, 196, 0.15);
   border-left: 3px solid #4ecdc4;
-}
-.channel-item.filter-active {
-  background: rgba(126, 200, 227, 0.15);
-  border-left: 3px solid #7ec8e3;
 }
 .res-card.filter-active {
   background: rgba(78, 205, 196, 0.15);
@@ -145,7 +147,10 @@ blockquote.chat-blockquote {
 .sidebar .agent-card.selected {
   background: rgba(78, 205, 196, 0.2);
 }
-.sidebar #channels:has(.channel-item.selected) .channel-item:not(.selected),
+/* #284: don't dim non-selected channels when one is selected — the
+ * spec calls for a single currently-selected marker only, no additional
+ * tinting/dimming cascade on the channel list. Agent sibling-dim stays
+ * (agents still support multi-select outside the #284 scope). */
 .sidebar #agents:has(.agent-card.selected) .agent-card:not(.selected) {
   opacity: 0.6;
 }

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -12,13 +12,13 @@
     <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=136">
     <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-messages.css' %}?v=134">
+          href="{% static 'hub/style/style-messages.css' %}?v=135">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-composer.css' %}?v=134">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-agents.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-channels.css' %}?v=137">
+          href="{% static 'hub/style/style-channels.css' %}?v=138">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/style/style-agents.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-channels.css' %}?v=136">
+          href="{% static 'hub/style/style-channels.css' %}?v=137">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"

--- a/hub/templates/hub/workspace_settings.html
+++ b/hub/templates/hub/workspace_settings.html
@@ -2,20 +2,20 @@
 {% load static %}
 {% block title %}{{ workspace.name }} Settings - SciTeX Orochi{% endblock %}
 {% block extra_css %}
-    <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=134">
-    <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=134">
+    <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=135">
+    <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-messages.css' %}?v=134">
+          href="{% static 'hub/style/style-messages.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-composer.css' %}?v=134">
+          href="{% static 'hub/style/style-composer.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-agents.css' %}?v=134">
+          href="{% static 'hub/style/style-agents.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-channels.css' %}?v=134">
+          href="{% static 'hub/style/style-channels.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-menus.css' %}?v=134">
+          href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-modals.css' %}?v=134">
+          href="{% static 'hub/style/style-modals.css' %}?v=135">
     <link rel="stylesheet" href="{% static 'hub/settings.css' %}">
 {% endblock %}
 {% block body_class %}page-app{% endblock %}

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -29,6 +29,7 @@ from hub.tests.registry.test_reexports import *  # noqa: F401,F403
 from hub.tests.registry.test_singleton_enforcement import *  # noqa: F401,F403
 from hub.tests.test_auth import *  # noqa: F401,F403
 from hub.tests.test_oauth_helper import *  # noqa: F401,F403
+from hub.tests.views.api.test_admin_subscribe import *  # noqa: F401,F403
 from hub.tests.views.api.test_agent_detail import *  # noqa: F401,F403
 from hub.tests.views.api.test_agents_register import *  # noqa: F401,F403
 from hub.tests.views.api.test_channel_members import *  # noqa: F401,F403

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -13,6 +13,7 @@ top level. Django's default test discovery walks the sub-packages.
 
 # Top-level cross-cutting tests
 # Mirror-package tests
+from hub.tests.consumers.test_agent_message_echo import *  # noqa: F401,F403
 from hub.tests.consumers.test_agent_subscription import *  # noqa: F401,F403
 from hub.tests.consumers.test_dm import *  # noqa: F401,F403
 from hub.tests.consumers.test_mentions import *  # noqa: F401,F403

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -31,8 +31,10 @@ from hub.tests.test_oauth_helper import *  # noqa: F401,F403
 from hub.tests.views.api.test_agent_detail import *  # noqa: F401,F403
 from hub.tests.views.api.test_agents_register import *  # noqa: F401,F403
 from hub.tests.views.api.test_channel_members import *  # noqa: F401,F403
+from hub.tests.views.api.test_channel_members_token import *  # noqa: F401,F403
 from hub.tests.views.api.test_channel_rename import *  # noqa: F401,F403
 from hub.tests.views.api.test_dms import *  # noqa: F401,F403
 from hub.tests.views.api.test_messages import *  # noqa: F401,F403
+from hub.tests.views.api.test_my_subscriptions import *  # noqa: F401,F403
 from hub.tests.views.api.test_push import *  # noqa: F401,F403
 from hub.tests.views.api.test_reexports import *  # noqa: F401,F403

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -23,6 +23,7 @@ from hub.tests.models.test_messaging import *  # noqa: F401,F403
 from hub.tests.models.test_reexports import *  # noqa: F401,F403
 from hub.tests.registry.test_active_sessions import *  # noqa: F401,F403
 from hub.tests.registry.test_canonical_metadata import *  # noqa: F401,F403
+from hub.tests.registry.test_echo_indicator import *  # noqa: F401,F403
 from hub.tests.registry.test_heartbeat import *  # noqa: F401,F403
 from hub.tests.registry.test_reexports import *  # noqa: F401,F403
 from hub.tests.test_auth import *  # noqa: F401,F403

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -26,6 +26,7 @@ from hub.tests.registry.test_canonical_metadata import *  # noqa: F401,F403
 from hub.tests.registry.test_echo_indicator import *  # noqa: F401,F403
 from hub.tests.registry.test_heartbeat import *  # noqa: F401,F403
 from hub.tests.registry.test_reexports import *  # noqa: F401,F403
+from hub.tests.registry.test_singleton_enforcement import *  # noqa: F401,F403
 from hub.tests.test_auth import *  # noqa: F401,F403
 from hub.tests.test_oauth_helper import *  # noqa: F401,F403
 from hub.tests.views.api.test_agent_detail import *  # noqa: F401,F403

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -26,6 +26,7 @@ from hub.tests.registry.test_active_sessions import *  # noqa: F401,F403
 from hub.tests.registry.test_canonical_metadata import *  # noqa: F401,F403
 from hub.tests.registry.test_echo_indicator import *  # noqa: F401,F403
 from hub.tests.registry.test_heartbeat import *  # noqa: F401,F403
+from hub.tests.registry.test_host_identity_from_client import *  # noqa: F401,F403
 from hub.tests.registry.test_reexports import *  # noqa: F401,F403
 from hub.tests.registry.test_singleton_enforcement import *  # noqa: F401,F403
 from hub.tests.test_auth import *  # noqa: F401,F403

--- a/hub/tests/consumers/test_agent_message_echo.py
+++ b/hub/tests/consumers/test_agent_message_echo.py
@@ -1,0 +1,234 @@
+"""Tests for msg#15538 — 4th LED (ECHO) auto-green on inbound agent message.
+
+Before this change the ``last_nonce_echo_at`` timestamp (which the 4th
+liveness LED renders against) was only advanced when the hub→agent
+nonce round-trip probe in ``_hub_echo_loop`` completed successfully.
+If an agent's MCP-client could not reply to the nonce (e.g. the
+sidecar was down, or the agent never implemented the handler) the LED
+stayed amber / red even though the agent was clearly alive — it was
+sending chat messages every few seconds.
+
+The fix: every authenticated inbound ``message`` frame now also
+advances ``last_nonce_echo_at`` (and the sibling ``last_echo_ok_ts``)
+via ``mark_echo_alive``. The LED renderer does not need to know which
+mechanism wrote the timestamp — either path turns the LED green.
+
+These tests drive the ``handle_agent_message`` coroutine directly with
+a fake consumer (mirrors the ``test_reconnect_resubscribe.py`` style)
+so the behaviour is exercised at the seam where the new call was added.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Workspace,
+)
+
+
+def _fake_consumer(agent_name: str, workspace_id: int):
+    """Minimal AgentConsumer stub capable of driving handle_agent_message.
+
+    Provides the bound attributes the handler reads (agent_name,
+    workspace_id, workspace_group, channel_layer, send_json) plus an
+    ``_save_message`` AsyncMock so the handler's persistence step
+    becomes a no-op. Keeping persistence out of the test isolates the
+    registry-side contract.
+    """
+    from hub.consumers._agent import AgentConsumer
+
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_name = agent_name
+    consumer.workspace_id = workspace_id
+    consumer.workspace_group = f"workspace_{workspace_id}"
+    consumer.channel_name = f"test-ch-{agent_name}"
+    consumer._registered = True
+    consumer.agent_meta = {"channels": ["#general"]}
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    consumer.send_json = AsyncMock()
+    consumer._save_message = AsyncMock(
+        return_value={"id": 1, "ts": "2026-04-20T00:00:00+00:00"}
+    )
+    return consumer
+
+
+class InboundMessageAdvancesEchoTimestampTest(TestCase):
+    """A ``type: "message"`` frame must advance ``last_nonce_echo_at``.
+
+    This is the core contract of msg#15538: any authenticated inbound
+    agent message counts as proof of life and should turn the 4th LED
+    green, independent of whether the nonce probe ever completes.
+    """
+
+    def setUp(self):
+        from hub.registry import _agents, _connections, register_agent
+
+        _agents.clear()
+        _connections.clear()
+
+        self.ws = Workspace.objects.create(name="echo-auto-ws")
+        self.channel = Channel.objects.create(workspace=self.ws, name="#general")
+
+        # ChannelMembership row so the non-member ACL doesn't block the
+        # message — the consumer authenticates as ``agent-<name>``.
+        self.agent_user = User.objects.create(username="agent-worker-m")
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.channel
+        )
+
+        register_agent(
+            "worker-m",
+            self.ws.id,
+            {"agent_id": "worker-m", "machine": "TEST", "role": "worker"},
+        )
+
+    def test_inbound_message_sets_last_nonce_echo_at(self):
+        """Sending a message frame populates ``last_nonce_echo_at``.
+
+        A freshly-registered agent has no echo fields yet (all None).
+        After one ``message`` frame the ISO timestamp must be written
+        so the LED renderer flips from grey-pending to green.
+        """
+        from hub.consumers._agent_message import handle_agent_message
+        from hub.registry import _agents
+
+        # Pre-condition: never probed, never messaged.
+        self.assertIsNone(_agents["worker-m"].get("last_nonce_echo_at"))
+        self.assertIsNone(_agents["worker-m"].get("last_echo_ok_ts"))
+
+        consumer = _fake_consumer("worker-m", self.ws.id)
+        async_to_sync(handle_agent_message)(
+            consumer,
+            {
+                "type": "message",
+                "payload": {"channel": "#general", "text": "hello"},
+            },
+        )
+
+        # Both the ISO string (LED renderer) and the unix float (API
+        # layer / tooling) must be populated after one inbound message.
+        self.assertIsInstance(
+            _agents["worker-m"]["last_nonce_echo_at"], str
+        )
+        self.assertTrue(
+            _agents["worker-m"]["last_nonce_echo_at"].endswith("+00:00")
+        )
+        self.assertIsInstance(
+            _agents["worker-m"]["last_echo_ok_ts"], float
+        )
+
+    def test_inbound_message_does_not_overwrite_rtt(self):
+        """An inbound message has no RTT — must not wipe a real one.
+
+        If ``update_echo_pong`` previously ran (real nonce probe), its
+        ``last_echo_rtt_ms`` value must survive subsequent inbound
+        messages so the per-agent detail panel keeps showing a real RTT.
+        Overwriting with None would make the display misleading.
+        """
+        from hub.consumers._agent_message import handle_agent_message
+        from hub.registry import _agents, update_echo_pong
+
+        update_echo_pong("worker-m", 42.5)
+        self.assertEqual(_agents["worker-m"]["last_echo_rtt_ms"], 42.5)
+        probed_iso = _agents["worker-m"]["last_nonce_echo_at"]
+
+        consumer = _fake_consumer("worker-m", self.ws.id)
+        async_to_sync(handle_agent_message)(
+            consumer,
+            {
+                "type": "message",
+                "payload": {"channel": "#general", "text": "later"},
+            },
+        )
+
+        # RTT preserved, ISO timestamp advanced (or equal — clock
+        # resolution on CI might give the same string).
+        self.assertEqual(_agents["worker-m"]["last_echo_rtt_ms"], 42.5)
+        self.assertGreaterEqual(
+            _agents["worker-m"]["last_nonce_echo_at"], probed_iso
+        )
+
+
+class NonceProbeIndependenceTest(TestCase):
+    """The timestamp advances even if the nonce probe never completes.
+
+    Confirms the core value proposition of msg#15538: agent-message-only
+    is enough to turn the LED green. Exercises the registry seam alone
+    so the test is fast and doesn't need an asyncio echo loop.
+    """
+
+    def setUp(self):
+        from hub.registry import _agents, _connections, register_agent
+
+        _agents.clear()
+        _connections.clear()
+
+        self.ws = Workspace.objects.create(name="echo-auto-nopong-ws")
+        self.channel = Channel.objects.create(workspace=self.ws, name="#general")
+        self.agent_user = User.objects.create(username="agent-lonely-n")
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.channel
+        )
+        register_agent(
+            "lonely-n",
+            self.ws.id,
+            {"agent_id": "lonely-n", "machine": "TEST", "role": "worker"},
+        )
+
+    def test_mark_echo_alive_alone_populates_led_field(self):
+        """``mark_echo_alive`` is sufficient — no nonce pong required."""
+        from hub.registry import _agents, mark_echo_alive
+
+        # Never call update_echo_pong — simulate an agent whose MCP
+        # sidecar is down or whose echo_pong handler never fires.
+        self.assertIsNone(_agents["lonely-n"].get("last_nonce_echo_at"))
+        self.assertIsNone(_agents["lonely-n"].get("last_echo_rtt_ms"))
+
+        mark_echo_alive("lonely-n")
+
+        # LED field populated — renderer will flip to green.
+        self.assertIsInstance(
+            _agents["lonely-n"]["last_nonce_echo_at"], str
+        )
+        self.assertIsInstance(
+            _agents["lonely-n"]["last_echo_ok_ts"], float
+        )
+        # RTT still absent — nothing to overwrite with and no round-trip
+        # was actually measured. The per-agent detail panel renders
+        # this as "no RTT recorded yet" rather than "0ms".
+        self.assertIsNone(_agents["lonely-n"].get("last_echo_rtt_ms"))
+
+    def test_mark_echo_alive_unknown_agent_is_noop(self):
+        """Mirrors ``update_echo_pong`` — unknown agent must not raise."""
+        from hub.registry import _agents, mark_echo_alive
+
+        mark_echo_alive("never-registered")
+        self.assertNotIn("never-registered", _agents)
+
+    def test_payload_surfaces_field_without_rtt(self):
+        """``get_agents`` must surface the inbound-only timestamp.
+
+        Regression guard: the payload layer must include
+        ``last_nonce_echo_at`` when it was set via ``mark_echo_alive``
+        (not just when ``update_echo_pong`` ran). Otherwise the LED
+        never sees the timestamp even though the registry has it.
+        """
+        from hub.registry import get_agents, mark_echo_alive
+
+        mark_echo_alive("lonely-n")
+        payload = next(
+            a for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "lonely-n"
+        )
+        self.assertIsNotNone(payload["last_nonce_echo_at"])
+        self.assertIsNone(payload["last_echo_rtt_ms"])

--- a/hub/tests/consumers/test_agent_subs_refresh.py
+++ b/hub/tests/consumers/test_agent_subs_refresh.py
@@ -1,0 +1,254 @@
+"""Tests for #282 — ChannelMembership signal → live AgentConsumer re-sync.
+
+Covers both halves of the fix:
+
+1. ``hub/signals.py`` — the ``ChannelMembership`` post_save / post_delete
+   handlers dispatch an ``agent.subs_refresh`` frame to every live sibling
+   WS connection for the affected agent (and ONLY for agent users).
+2. ``hub/consumers/_agent.py`` — the ``agent_subs_refresh`` handler
+   re-reads the DB, diffs against in-memory ``agent_meta["channels"]``,
+   and performs the matching group_add / group_discard calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from hub.models import Channel, ChannelMembership, Workspace
+
+
+def _fake_consumer(agent_name, workspace_id, channels, dm_channels=()):
+    """Build a minimal consumer stub for the async handler under test."""
+    from hub.consumers._agent import AgentConsumer
+
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_name = agent_name
+    consumer.workspace_id = workspace_id
+    consumer.workspace_group = f"workspace_{workspace_id}"
+    consumer.channel_name = f"test-ch-{agent_name}"
+    consumer._dm_channel_names = list(dm_channels)
+    consumer.agent_meta = {"channels": list(channels)}
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    return consumer
+
+
+class ChannelMembershipSignalTest(TestCase):
+    """Signal-fan-out half — ``hub/signals.py``."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="signal-ws")
+        self.ch = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.agent_user = User.objects.create(username="agent-worker-z")
+        self.human_user = User.objects.create(username="alice")
+
+    def _patched_send(self):
+        """Patch the registry + channel layer used by the signal."""
+        layer = MagicMock()
+        layer.send = AsyncMock()
+        return (
+            patch(
+                "hub.signals.get_channel_layer", return_value=layer
+            ),
+            patch(
+                "hub.signals.list_sibling_channels",
+                return_value=["ws-conn-1"],
+            ),
+            layer,
+        )
+
+    def test_save_fires_agent_subs_refresh_for_agent_user(self):
+        p_layer, p_siblings, layer = self._patched_send()
+        with p_layer, p_siblings, self.captureOnCommitCallbacks(execute=True):
+            ChannelMembership.objects.create(
+                user=self.agent_user, channel=self.ch
+            )
+        layer.send.assert_awaited_once()
+        args, _kwargs = layer.send.call_args
+        self.assertEqual(args[0], "ws-conn-1")
+        payload = args[1]
+        self.assertEqual(payload["type"], "agent.subs_refresh")
+        self.assertEqual(payload["agent"], "worker-z")
+        self.assertEqual(payload["workspace_id"], self.ws.id)
+
+    def test_save_is_noop_for_human_user(self):
+        p_layer, p_siblings, layer = self._patched_send()
+        with p_layer, p_siblings, self.captureOnCommitCallbacks(execute=True):
+            ChannelMembership.objects.create(
+                user=self.human_user, channel=self.ch
+            )
+        layer.send.assert_not_awaited()
+
+    def test_delete_fires_agent_subs_refresh(self):
+        m = ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch
+        )
+        p_layer, p_siblings, layer = self._patched_send()
+        with p_layer, p_siblings, self.captureOnCommitCallbacks(execute=True):
+            m.delete()
+        layer.send.assert_awaited_once()
+        payload = layer.send.call_args[0][1]
+        self.assertEqual(payload["type"], "agent.subs_refresh")
+
+    def test_no_send_when_no_sibling_connections(self):
+        layer = MagicMock()
+        layer.send = AsyncMock()
+        with patch(
+            "hub.signals.get_channel_layer", return_value=layer
+        ), patch(
+            "hub.signals.list_sibling_channels", return_value=[]
+        ), self.captureOnCommitCallbacks(execute=True):
+            ChannelMembership.objects.create(
+                user=self.agent_user, channel=self.ch
+            )
+        layer.send.assert_not_awaited()
+
+
+class AgentSubsRefreshHandlerTest(TestCase):
+    """Consumer handler half — ``AgentConsumer.agent_subs_refresh``."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="handler-ws")
+        self.ch_alpha = Channel.objects.create(
+            workspace=self.ws, name="#alpha"
+        )
+        self.ch_beta = Channel.objects.create(
+            workspace=self.ws, name="#beta"
+        )
+        self.agent_user = User.objects.create(username="agent-worker-q")
+
+    def test_add_membership_joins_new_group_and_updates_meta(self):
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_alpha
+        )
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_beta
+        )
+
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id,
+            }
+        )
+
+        self.assertIn("#beta", consumer.agent_meta["channels"])
+        consumer.channel_layer.group_add.assert_awaited()
+        added_groups = [
+            call.args[0]
+            for call in consumer.channel_layer.group_add.await_args_list
+        ]
+        self.assertTrue(any("beta" in g for g in added_groups))
+
+    def test_remove_membership_discards_group_and_updates_meta(self):
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_alpha
+        )
+        consumer = _fake_consumer(
+            "worker-q",
+            self.ws.id,
+            channels=["#alpha", "#beta"],  # in-memory stale
+        )
+
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id,
+            }
+        )
+
+        self.assertNotIn("#beta", consumer.agent_meta["channels"])
+        discarded = [
+            call.args[0]
+            for call in consumer.channel_layer.group_discard.await_args_list
+        ]
+        self.assertTrue(any("beta" in g for g in discarded))
+
+    def test_refresh_preserves_dm_channels(self):
+        consumer = _fake_consumer(
+            "worker-q",
+            self.ws.id,
+            channels=["dm:worker-q|alice", "#alpha"],
+            dm_channels=["dm:worker-q|alice"],
+        )
+        # No ChannelMembership rows → DB says agent is subscribed to nothing
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id,
+            }
+        )
+        self.assertIn("dm:worker-q|alice", consumer.agent_meta["channels"])
+        # DM group must not be discarded by the refresh.
+        discarded = [
+            call.args[0]
+            for call in consumer.channel_layer.group_discard.await_args_list
+        ]
+        self.assertFalse(any("dm:" in g for g in discarded))
+
+    def test_refresh_skips_mismatched_workspace_event(self):
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_beta
+        )
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-q",
+                "workspace_id": self.ws.id + 9999,
+            }
+        )
+        # Event was for a different workspace — no DB lookup, no mutation.
+        self.assertEqual(consumer.agent_meta["channels"], ["#alpha"])
+        consumer.channel_layer.group_add.assert_not_awaited()
+        consumer.channel_layer.group_discard.assert_not_awaited()
+
+    def test_refresh_skips_other_agent_events(self):
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        async_to_sync(consumer.agent_subs_refresh)(
+            {
+                "type": "agent.subs_refresh",
+                "agent": "worker-other",
+                "workspace_id": self.ws.id,
+            }
+        )
+        self.assertEqual(consumer.agent_meta["channels"], ["#alpha"])
+        consumer.channel_layer.group_add.assert_not_awaited()
+        consumer.channel_layer.group_discard.assert_not_awaited()
+
+    def test_refresh_broadcasts_agent_info_on_change(self):
+        ChannelMembership.objects.create(
+            user=self.agent_user, channel=self.ch_beta
+        )
+        consumer = _fake_consumer(
+            "worker-q", self.ws.id, channels=["#alpha"]
+        )
+        with patch("hub.registry.register_agent") as reg:
+            async_to_sync(consumer.agent_subs_refresh)(
+                {
+                    "type": "agent.subs_refresh",
+                    "agent": "worker-q",
+                    "workspace_id": self.ws.id,
+                }
+            )
+            reg.assert_called_once()
+        consumer.channel_layer.group_send.assert_awaited()
+        sent_event = consumer.channel_layer.group_send.await_args.args[1]
+        self.assertEqual(sent_event["type"], "agent.info")
+        self.assertEqual(sent_event["agent"], "worker-q")

--- a/hub/tests/consumers/test_agent_subscription.py
+++ b/hub/tests/consumers/test_agent_subscription.py
@@ -102,3 +102,48 @@ class AgentChannelSubscriptionPersistenceTest(TestCase):
         subs_other = async_to_sync(_load_agent_channel_subs)(ws2.id, "worker-d")
         self.assertEqual(subs_self, ["#self"])
         self.assertEqual(subs_other, ["#other"])
+
+    def test_persist_subscribe_rejects_abolished_agent_channel(self):
+        """``#agent`` was abolished 2026-04-21 — no agent may (re)subscribe.
+
+        The helper must short-circuit with ``False`` and NOT create any
+        ``ChannelMembership`` / ``Channel`` rows, so a stray WebSocket
+        subscribe op can't resurrect the channel.
+        """
+        from asgiref.sync import async_to_sync
+        from django.contrib.auth.models import User
+
+        from hub.consumers import _persist_agent_subscription
+
+        ok = async_to_sync(_persist_agent_subscription)(
+            self.ws.id, "worker-e", "#agent", True
+        )
+        self.assertFalse(ok)
+        # No Channel row created for #agent in this workspace:
+        self.assertFalse(
+            self.Channel.objects.filter(workspace=self.ws, name="#agent").exists()
+        )
+        # No synthetic agent user created as a side-effect either:
+        self.assertFalse(User.objects.filter(username="agent-worker-e").exists())
+
+    def test_load_filters_abolished_agent_channel(self):
+        """Stale ``#agent`` ``ChannelMembership`` rows from before the
+        2026-04-21 abolition must NOT surface in ``_load_agent_channel_subs``
+        — otherwise the WS consumer would re-join the group on connect.
+        """
+        from asgiref.sync import async_to_sync
+        from django.contrib.auth.models import User
+
+        from hub.consumers import _load_agent_channel_subs
+
+        # Simulate a pre-abolition DB row: create the channel + membership
+        # directly, bypassing _persist_agent_subscription's guard.
+        user = User.objects.create_user(username="agent-worker-f")
+        stale_ch = self.Channel.objects.create(workspace=self.ws, name="#agent")
+        alive_ch = self.Channel.objects.create(workspace=self.ws, name="#heads")
+        self.ChannelMembership.objects.create(user=user, channel=stale_ch)
+        self.ChannelMembership.objects.create(user=user, channel=alive_ch)
+
+        subs = async_to_sync(_load_agent_channel_subs)(self.ws.id, "worker-f")
+        self.assertNotIn("#agent", subs)
+        self.assertIn("#heads", subs)

--- a/hub/tests/consumers/test_dm.py
+++ b/hub/tests/consumers/test_dm.py
@@ -427,6 +427,15 @@ class DMConsumerRoutingTest(TestCase):
         from asgiref.sync import async_to_sync
 
         from hub.consumers import AgentConsumer
+        from hub.models import ChannelMembership
+
+        # Issue #276 — agent senders require an explicit membership row
+        # on non-DM channels. This test uses bare ``alice`` as the agent
+        # name; the WS handler authenticates as ``agent-alice``, so seed
+        # the membership for that synthetic user.
+        agent_user, _ = User.objects.get_or_create(username="agent-alice")
+        general, _ = Channel.objects.get_or_create(workspace=self.ws, name="#general")
+        ChannelMembership.objects.get_or_create(user=agent_user, channel=general)
 
         consumer = AgentConsumer.__new__(AgentConsumer)
         consumer.workspace_id = self.ws.id

--- a/hub/tests/consumers/test_dm.py
+++ b/hub/tests/consumers/test_dm.py
@@ -379,6 +379,9 @@ class DMConsumerRoutingTest(TestCase):
         consumer.agent_name = "alice"
         consumer.agent_meta = {"channels": ["dm:alice|bob"]}
         consumer.workspace_member_id = self.mem_alice.id
+        # scitex-orochi#451 — message dispatch gates on _registered; the
+        # synthetic consumer here represents a fully-registered agent.
+        consumer._registered = True
 
         sent = []
 
@@ -444,6 +447,9 @@ class DMConsumerRoutingTest(TestCase):
         consumer.agent_name = "alice"
         consumer.agent_meta = {"channels": ["#general"]}
         consumer.workspace_member_id = self.mem_alice.id
+        # scitex-orochi#451 — message dispatch gates on _registered; the
+        # synthetic consumer here represents a fully-registered agent.
+        consumer._registered = True
 
         sent = []
 

--- a/hub/tests/consumers/test_reconnect_resubscribe.py
+++ b/hub/tests/consumers/test_reconnect_resubscribe.py
@@ -1,0 +1,400 @@
+"""Tests for scitex-orochi#451 — WS reconnect must not orphan channel subs.
+
+Background. On a WS reconnect, the authoritative sequence is:
+
+    client connect → server AgentConsumer.connect()
+                       → joins workspace group
+                       → joins DM groups from DMParticipant rows
+                       → (#451) rehydrates persisted group memberships
+                       → (#451) seeds agent_meta["channels"]
+                       → (#451) consumer._registered = False
+    client register   → server handle_register
+                       → reloads group subs from DB + joins groups
+                       → sets the full agent_meta payload
+                       → flips consumer._registered = True
+                       → sends a ``registered`` ack
+
+Before #451, the connect() path joined DM groups but did NOT seed
+agent_meta["channels"], so group-channel messages arriving between
+connect and register were silently dropped by the chat_message filter.
+If the client never sent ``register`` (bug, blip, race), the deafness
+was permanent — the agent appeared connected but never received group
+messages. This file covers the three contracts introduced by #451:
+
+1. connect() pre-hydrates persisted group memberships + agent_meta.
+2. handle_register remains idempotent under repeated calls (reconnect).
+3. message-frame dispatch refuses writes from un-registered connections.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    DMParticipant,
+    Workspace,
+    WorkspaceMember,
+)
+
+
+def _fake_consumer(agent_name, workspace_id, dm_channels=()):
+    """Return a minimal AgentConsumer stub suitable for the async helpers.
+
+    ``prehydrate_channels`` and ``handle_register`` read a handful of
+    attributes (``agent_name``, ``workspace_id``, ``channel_name``,
+    ``channel_layer``, ``_dm_channel_names``) and call async methods on
+    the channel layer. We mimic the surface with AsyncMock stubs so the
+    async helpers can be driven from a sync test body via async_to_sync.
+    """
+    from hub.consumers._agent import AgentConsumer
+
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_name = agent_name
+    consumer.workspace_id = workspace_id
+    consumer.workspace_group = f"workspace_{workspace_id}"
+    consumer.channel_name = f"test-ch-{agent_name}"
+    consumer._dm_channel_names = list(dm_channels)
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    consumer.send_json = AsyncMock()
+    return consumer
+
+
+class ReconnectPrehydrateTest(TestCase):
+    """connect() must pre-join persisted group memberships and seed agent_meta."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="reconnect-ws")
+        self.ch_alpha = Channel.objects.create(workspace=self.ws, name="#alpha")
+        self.ch_beta = Channel.objects.create(workspace=self.ws, name="#beta")
+        self.agent_user = User.objects.create(username="agent-worker-r")
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_alpha)
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_beta)
+
+    def test_prehydrate_joins_each_persisted_group_channel(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-r", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+
+        joined = [
+            call.args[0]
+            for call in consumer.channel_layer.group_add.await_args_list
+        ]
+        # Both persisted channels must be group_added at connect.
+        self.assertTrue(any("alpha" in g for g in joined))
+        self.assertTrue(any("beta" in g for g in joined))
+        # agent_meta["channels"] contains both persisted channels so the
+        # chat_message membership filter lets group events through before
+        # the client's register frame arrives.
+        self.assertIn("#alpha", consumer.agent_meta["channels"])
+        self.assertIn("#beta", consumer.agent_meta["channels"])
+
+    def test_prehydrate_sets_registered_false(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-r", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+        self.assertFalse(consumer._registered)
+
+    def test_prehydrate_preserves_dm_channels_in_meta(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer(
+            "worker-r", self.ws.id, dm_channels=["dm:worker-r|alice"]
+        )
+        async_to_sync(prehydrate_channels)(consumer)
+        # DM channel is already joined by the earlier connect() step;
+        # prehydrate must still include it in the seeded meta so the
+        # chat_message DM filter + the visibility check both work.
+        self.assertIn("dm:worker-r|alice", consumer.agent_meta["channels"])
+        self.assertIn("#alpha", consumer.agent_meta["channels"])
+
+    def test_prehydrate_swallows_db_errors_so_connect_does_not_abort(self):
+        """DB hiccups at connect must NOT tear down the WebSocket.
+
+        A DB blip would previously crash-bubble through connect() and
+        close the socket, which is much worse than a transient deafness
+        we can recover from when the client sends register. Ensure the
+        helper logs and falls back to an empty channel list.
+        """
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-r", self.ws.id)
+        with patch(
+            "hub.consumers._agent_refresh._load_agent_channel_subs",
+            side_effect=RuntimeError("db unavailable"),
+        ):
+            async_to_sync(prehydrate_channels)(consumer)
+
+        # No groups joined — but also no unhandled exception.
+        self.assertEqual(consumer.agent_meta["channels"], [])
+        self.assertFalse(consumer._registered)
+
+
+class ReconnectRegisterIdempotencyTest(TestCase):
+    """handle_register must be safe to invoke on every reconnect."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="idempotency-ws")
+        self.ch_ops = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.agent_user = User.objects.create(username="agent-worker-s")
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_ops)
+
+    def _drive_register(self, consumer):
+        from hub.consumers._agent_handlers import handle_register
+
+        async_to_sync(handle_register)(consumer, {"type": "register", "payload": {}})
+
+    def test_register_restores_meta_and_joins_groups_after_reconnect(self):
+        """Simulate: connect → register → disconnect → reconnect → register."""
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        # First connection lifecycle.
+        first = _fake_consumer("worker-s", self.ws.id)
+        async_to_sync(prehydrate_channels)(first)
+        self._drive_register(first)
+        first_channels = list(first.agent_meta["channels"])
+        self.assertIn("#ops", first_channels)
+        self.assertTrue(first._registered)
+
+        # Simulated disconnect is implicit — the consumer instance goes
+        # away. A reconnect spins up a fresh consumer with no retained
+        # state, then repeats the same sequence.
+        second = _fake_consumer("worker-s", self.ws.id)
+        async_to_sync(prehydrate_channels)(second)
+        self._drive_register(second)
+
+        # agent_meta["channels"] after reconnect must match the persisted
+        # DB state (same set as first register).
+        self.assertEqual(
+            set(second.agent_meta["channels"]), set(first_channels)
+        )
+        self.assertTrue(second._registered)
+
+        # group_add was called for each persisted channel on the SECOND
+        # consumer (matters because Django Channels requires the re-join;
+        # group membership is per-(group,channel_name) and the new
+        # consumer has a different channel_name).
+        joined = [
+            call.args[0]
+            for call in second.channel_layer.group_add.await_args_list
+        ]
+        self.assertTrue(any("ops" in g for g in joined))
+
+    def test_register_repeated_on_same_consumer_is_idempotent(self):
+        """Paranoid case: two register frames in a row on one consumer."""
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-s", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+        self._drive_register(consumer)
+        first_channels = list(consumer.agent_meta["channels"])
+        self._drive_register(consumer)
+        self.assertEqual(
+            list(consumer.agent_meta["channels"]), first_channels
+        )
+        # Ack sent twice (one per call) — clients are free to expect that.
+        ack_frames = [
+            call.args[0]
+            for call in consumer.send_json.await_args_list
+            if call.args and call.args[0].get("type") == "registered"
+        ]
+        self.assertEqual(len(ack_frames), 2)
+
+
+class ReconnectMessageContractTest(TestCase):
+    """message-frame dispatch must refuse writes from un-registered consumers.
+
+    Before #451 the server accepted message frames regardless of
+    registration state, so a client that reconnected and forgot to send
+    register could still write (ACL-permitting) but be silently deaf to
+    replies (not in any reply group). This breaks the contract loudly
+    via an error ack instead.
+    """
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="contract-ws")
+
+    def test_message_frame_rejected_when_not_registered(self):
+        from hub.consumers._agent import AgentConsumer
+
+        consumer = AgentConsumer.__new__(AgentConsumer)
+        consumer.agent_name = "worker-t"
+        consumer.workspace_id = self.ws.id
+        consumer.workspace_group = f"workspace_{self.ws.id}"
+        consumer.channel_name = "test-ch-worker-t"
+        consumer._registered = False  # simulate missing-register state
+        consumer.agent_meta = {"channels": []}
+        consumer.send_json = AsyncMock()
+
+        async_to_sync(consumer.receive_json)(
+            {
+                "type": "message",
+                "payload": {"channel": "#general", "text": "hello"},
+            }
+        )
+
+        # Message was NOT persisted nor broadcast — the dispatch bailed
+        # before importing handle_agent_message. We can't inspect the
+        # import directly, but an error ack on send_json is the contract.
+        sent = [
+            call.args[0] for call in consumer.send_json.await_args_list
+        ]
+        err = [
+            frame for frame in sent if frame.get("type") == "error"
+        ]
+        self.assertTrue(err, "expected an error ack on un-registered send")
+        self.assertEqual(err[0]["code"], "not_registered")
+
+    def test_message_frame_accepted_after_register(self):
+        """Positive control: once handle_register runs, messages flow."""
+        from hub.consumers._agent import AgentConsumer
+
+        consumer = AgentConsumer.__new__(AgentConsumer)
+        consumer.agent_name = "worker-t"
+        consumer.workspace_id = self.ws.id
+        consumer.workspace_group = f"workspace_{self.ws.id}"
+        consumer.channel_name = "test-ch-worker-t"
+        consumer._registered = True  # handle_register already flipped this
+        consumer.agent_meta = {"channels": ["#general"]}
+        consumer.send_json = AsyncMock()
+
+        with patch(
+            "hub.consumers._agent_message.handle_agent_message",
+            new=AsyncMock(),
+        ) as mocked:
+            async_to_sync(consumer.receive_json)(
+                {
+                    "type": "message",
+                    "payload": {"channel": "#general", "text": "hello"},
+                }
+            )
+            mocked.assert_awaited_once()
+
+
+class ReconnectGroupDeliveryTest(TestCase):
+    """End-to-end-ish: after reconnect a subscribed group message is delivered.
+
+    Uses the real ``chat_message`` method on a hydrated fake consumer —
+    mirrors the filter behaviour that was dropping messages pre-#451.
+    """
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="delivery-ws")
+        self.ch_ops = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.agent_user = User.objects.create(username="agent-worker-u")
+        ChannelMembership.objects.create(user=self.agent_user, channel=self.ch_ops)
+
+    def test_group_message_delivered_after_reconnect_prehydrate(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer("worker-u", self.ws.id)
+        async_to_sync(prehydrate_channels)(consumer)
+        # NB: we do NOT call handle_register here — the fix guarantees
+        # delivery works on the strength of prehydrate alone, which
+        # defuses the "client hasn't sent register yet" race.
+
+        event = {
+            "type": "chat.message",
+            "id": 1,
+            "sender": "other-agent",
+            "sender_type": "agent",
+            "channel": "#ops",
+            "kind": "group",
+            "text": "hello ops",
+            "ts": "2026-04-20T00:00:00Z",
+            "metadata": {},
+        }
+        async_to_sync(consumer.chat_message)(event)
+
+        sent = [
+            call.args[0] for call in consumer.send_json.await_args_list
+        ]
+        delivered = [
+            frame
+            for frame in sent
+            if frame.get("type") == "message" and frame.get("channel") == "#ops"
+        ]
+        self.assertTrue(
+            delivered,
+            "prehydrate must seed agent_meta so group messages pass the "
+            "chat_message filter even before handle_register runs (#451)",
+        )
+
+
+class ReconnectDMDeliveryTest(TestCase):
+    """DM delivery must keep working during the prehydrate → register window.
+
+    DMs take the DMParticipant filter path (not the agent_meta filter),
+    so they worked before #451 too. Regression guard so the new
+    prehydrate path doesn't accidentally tighten DM filtering.
+    """
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="dm-delivery-ws")
+        self.agent_user = User.objects.create(username="agent-worker-v")
+        self.other_user = User.objects.create(username="someone")
+        self.mem_agent = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.agent_user, role="member"
+        )
+        self.mem_other = WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.other_user, role="member"
+        )
+        self.dm = Channel.objects.create(
+            workspace=self.ws,
+            name="dm:worker-v|someone",
+            kind=Channel.KIND_DM,
+        )
+        DMParticipant.objects.create(
+            channel=self.dm,
+            member=self.mem_agent,
+            principal_type=DMParticipant.PRINCIPAL_AGENT,
+            identity_name="worker-v",
+        )
+        DMParticipant.objects.create(
+            channel=self.dm,
+            member=self.mem_other,
+            principal_type=DMParticipant.PRINCIPAL_HUMAN,
+            identity_name="someone",
+        )
+
+    def test_dm_delivered_after_reconnect_prehydrate(self):
+        from hub.consumers._agent_refresh import prehydrate_channels
+
+        consumer = _fake_consumer(
+            "worker-v",
+            self.ws.id,
+            dm_channels=["dm:worker-v|someone"],
+        )
+        consumer.workspace_member_id = self.mem_agent.id
+        async_to_sync(prehydrate_channels)(consumer)
+
+        event = {
+            "type": "chat.message",
+            "id": 2,
+            "sender": "someone",
+            "sender_type": "human",
+            "channel": "dm:worker-v|someone",
+            "kind": "dm",
+            "text": "hi",
+            "ts": "2026-04-20T00:00:00Z",
+            "metadata": {},
+        }
+        async_to_sync(consumer.chat_message)(event)
+
+        delivered = [
+            call.args[0]
+            for call in consumer.send_json.await_args_list
+            if call.args[0].get("type") == "message"
+            and call.args[0].get("channel") == "dm:worker-v|someone"
+        ]
+        self.assertTrue(delivered)

--- a/hub/tests/registry/test_echo_indicator.py
+++ b/hub/tests/registry/test_echo_indicator.py
@@ -1,0 +1,198 @@
+"""Tests for the 4th liveness indicator — echo round-trip (#259).
+
+Covers the registry-side contract for the new echo fields:
+
+  - ``update_echo_pong(name, rtt_ms)`` populates the three fields
+    (``last_echo_rtt_ms`` / ``last_echo_ok_ts`` / ``last_nonce_echo_at``)
+    atomically.
+  - The prev-preserve list in ``register_agent`` keeps those fields
+    across re-registers / heartbeats that omit them, so the 4th LED
+    doesn't flicker grey-pending each cycle (per the prev-preserve
+    pitfall memory).
+  - ``GET /api/agents/<name>/detail/`` surfaces the new fields in the
+    response so the dashboard's per-agent detail panel can display
+    them without a second round-trip.
+"""
+
+import json
+import time
+
+from django.test import Client, TestCase
+
+from hub.models import Workspace, WorkspaceToken
+
+
+class UpdateEchoPongRegistryTests(TestCase):
+    """Verify the registry setter writes all three fields atomically."""
+
+    def setUp(self):
+        from hub.registry import _agents, _connections
+
+        _agents.clear()
+        _connections.clear()
+        self.ws = Workspace.objects.create(name="echo-test-ws")
+
+    def _seed_agent(self, name="echo-agent"):
+        from hub.registry import register_agent
+
+        register_agent(
+            name,
+            self.ws.id,
+            {
+                "agent_id": name,
+                "machine": "MBA",
+                "role": "head",
+            },
+        )
+
+    def test_update_echo_pong_sets_all_three_fields(self):
+        from hub.registry import _agents, update_echo_pong
+
+        self._seed_agent()
+        before = time.time()
+        update_echo_pong("echo-agent", 42.5)
+        after = time.time()
+
+        a = _agents["echo-agent"]
+        self.assertEqual(a["last_echo_rtt_ms"], 42.5)
+        self.assertIsNotNone(a["last_echo_ok_ts"])
+        self.assertGreaterEqual(a["last_echo_ok_ts"], before)
+        self.assertLessEqual(a["last_echo_ok_ts"], after)
+        # The ISO timestamp consumed by renderAgentLeds must be set
+        # — this is the field the LED renderer pins on.
+        self.assertIsInstance(a["last_nonce_echo_at"], str)
+        self.assertTrue(a["last_nonce_echo_at"].endswith("+00:00"))
+
+    def test_update_echo_pong_unknown_agent_is_silent_noop(self):
+        """An echo_pong for an unknown agent must not raise / corrupt state."""
+        from hub.registry import _agents, update_echo_pong
+
+        update_echo_pong("never-registered", 17.0)
+        self.assertNotIn("never-registered", _agents)
+
+    def test_register_agent_preserves_echo_fields_across_heartbeat(self):
+        """A subsequent register/heartbeat that omits echo fields must NOT
+        wipe them. This is the prev-preserve pitfall — without it, every
+        heartbeat would flicker the 4th LED to grey-pending."""
+        from hub.registry import _agents, register_agent, update_echo_pong
+
+        self._seed_agent()
+        update_echo_pong("echo-agent", 55.0)
+        snapshot = {
+            "last_echo_rtt_ms": _agents["echo-agent"]["last_echo_rtt_ms"],
+            "last_echo_ok_ts": _agents["echo-agent"]["last_echo_ok_ts"],
+            "last_nonce_echo_at": _agents["echo-agent"]["last_nonce_echo_at"],
+        }
+
+        # Simulate a re-register (e.g. WS reconnect) that doesn't carry
+        # the echo fields — they must survive.
+        register_agent(
+            "echo-agent",
+            self.ws.id,
+            {
+                "agent_id": "echo-agent",
+                "machine": "MBA",
+                "role": "head",
+            },
+        )
+
+        a = _agents["echo-agent"]
+        self.assertEqual(a["last_echo_rtt_ms"], snapshot["last_echo_rtt_ms"])
+        self.assertEqual(a["last_echo_ok_ts"], snapshot["last_echo_ok_ts"])
+        self.assertEqual(a["last_nonce_echo_at"], snapshot["last_nonce_echo_at"])
+
+    def test_get_agents_payload_surfaces_echo_fields(self):
+        """The dashboard read path (get_agents) must include the echo
+        fields so the LED renderer can consume ``last_nonce_echo_at``."""
+        from hub.registry import get_agents, update_echo_pong
+
+        self._seed_agent()
+        update_echo_pong("echo-agent", 33.0)
+        payload = next(
+            a for a in get_agents(workspace_id=self.ws.id) if a["name"] == "echo-agent"
+        )
+        self.assertIn("last_nonce_echo_at", payload)
+        self.assertIn("last_echo_rtt_ms", payload)
+        self.assertIn("last_echo_ok_ts", payload)
+        self.assertEqual(payload["last_echo_rtt_ms"], 33.0)
+        self.assertIsNotNone(payload["last_nonce_echo_at"])
+        self.assertTrue(payload["last_echo_ok_ts"].endswith("+00:00"))
+
+    def test_get_agents_payload_echo_fields_absent_when_never_set(self):
+        """Agents that have never echoed back should report None for the
+        echo fields — the LED renderer treats None as grey-pending."""
+        from hub.registry import get_agents
+
+        self._seed_agent()
+        payload = next(
+            a for a in get_agents(workspace_id=self.ws.id) if a["name"] == "echo-agent"
+        )
+        self.assertIsNone(payload["last_nonce_echo_at"])
+        self.assertIsNone(payload["last_echo_rtt_ms"])
+        self.assertIsNone(payload["last_echo_ok_ts"])
+
+
+class AgentDetailEchoFieldsTests(TestCase):
+    """End-to-end: register → update_echo_pong → GET /api/agents/<n>/detail/."""
+
+    def setUp(self):
+        from hub.registry import _agents, _connections
+
+        _agents.clear()
+        _connections.clear()
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="echo-detail-ws")
+        self.token = WorkspaceToken.objects.create(
+            workspace=self.ws, label="echo-test"
+        )
+
+    def _post_register(self, name="echo-agent"):
+        return self.client.post(
+            "/api/agents/register/",
+            data=json.dumps(
+                {
+                    "token": self.token.token,
+                    "name": name,
+                    "machine": "MBA",
+                    "role": "head",
+                }
+            ),
+            content_type="application/json",
+        )
+
+    def _get_detail(self, name):
+        return self.client.get(
+            f"/api/agents/{name}/detail/",
+            data={"token": self.token.token},
+        )
+
+    def test_detail_api_surfaces_echo_fields_after_pong(self):
+        from hub.registry import update_echo_pong
+
+        self._post_register("echo-agent")
+        update_echo_pong("echo-agent", 77.7)
+
+        resp = self._get_detail("echo-agent")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("last_nonce_echo_at", data)
+        self.assertIn("last_echo_rtt_ms", data)
+        self.assertIn("last_echo_ok_ts", data)
+        self.assertEqual(data["last_echo_rtt_ms"], 77.7)
+        self.assertIsNotNone(data["last_nonce_echo_at"])
+
+    def test_detail_api_echo_fields_default_when_never_pong(self):
+        """An agent that registered but never echoed back must have the
+        new fields present (not missing keys) and set to None — the
+        dashboard relies on the keys existing for its grey-pending
+        rendering."""
+        self._post_register("echo-agent")
+        resp = self._get_detail("echo-agent")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("last_nonce_echo_at", data)
+        self.assertIn("last_echo_rtt_ms", data)
+        self.assertIn("last_echo_ok_ts", data)
+        self.assertIsNone(data["last_nonce_echo_at"])
+        self.assertIsNone(data["last_echo_rtt_ms"])
+        self.assertIsNone(data["last_echo_ok_ts"])

--- a/hub/tests/registry/test_host_identity_from_client.py
+++ b/hub/tests/registry/test_host_identity_from_client.py
@@ -1,0 +1,243 @@
+"""Regression tests for lead msg#15578 — host identity misreport.
+
+Background
+----------
+Agent ``proj-neurovista`` was observed running on ``spartan`` (tmux
+session confirmed) while the hub displayed it as ``mba``. Root cause
+was two-fold:
+
+1. Client-side: ``resolve_machine_label()`` (Python) and the
+   ``connection.ts`` / ``heartbeat.ts`` (TS) heartbeat builders
+   prioritised ``$SCITEX_OROCHI_HOSTNAME`` / ``$SCITEX_OROCHI_MACHINE``
+   env vars OVER the live ``hostname()`` call. A stale env var
+   inherited into a spartan process (e.g. from a shared tmux env or
+   sac launcher that originally ran on mba) would silently override
+   the real host identity.
+
+2. Hub-side: ``hub/registry/_payload.py::get_agents()`` never exposed
+   the ``hostname`` field in the dashboard payload, so the frontend
+   badge (``hostedAgentName``) always fell through to ``machine`` —
+   meaning the lead's #257 work (capturing ``hostname`` distinct from
+   ``machine``) was never reaching the UI.
+
+The fix is "agents set their ``host`` field in heartbeat from their
+own ``hostname()`` call, never from server-side auth/inference, and
+the hub forwards that field unchanged to the dashboard."
+
+These tests guard against regression on the hub-side half: an agent
+that explicitly reports ``hostname="spartan"`` must surface as
+``spartan`` in the dashboard payload REGARDLESS of which workspace
+token authenticated the push (i.e. the hub must not derive host
+identity from auth).
+"""
+
+import json
+
+from django.test import Client, TestCase
+
+from hub.models import Workspace, WorkspaceToken
+from hub.registry import (
+    _agents,
+    get_agents,
+    register_agent,
+)
+
+
+class ClientSuppliedHostnameTest(TestCase):
+    """``register_agent`` accepts + round-trips the ``hostname`` field."""
+
+    def setUp(self):
+        _agents.clear()
+
+    def test_hostname_round_trips_to_dashboard_payload(self):
+        """When the client explicitly reports ``hostname="spartan"``,
+        ``get_agents()`` exposes the same value — the payload
+        assembler does NOT drop, rewrite, or derive it."""
+        register_agent(
+            "proj-neurovista",
+            workspace_id=1,
+            info={
+                "machine": "spartan",
+                "hostname": "spartan",
+            },
+        )
+        rows = [a for a in get_agents(workspace_id=1) if a["name"] == "proj-neurovista"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["hostname"], "spartan")
+        self.assertEqual(rows[0]["machine"], "spartan")
+
+    def test_hostname_distinct_from_machine_preserved(self):
+        """When ``machine`` and ``hostname`` disagree (e.g. an agent
+        whose YAML-config host label drifted from the live process
+        host), the hub preserves both verbatim so the frontend can
+        prefer the authoritative ``hostname`` signal.
+
+        This is the direct regression case for the proj-neurovista
+        bug: machine label might say ``mba`` (stale env) but
+        hostname must report ``spartan`` because that's what the
+        kernel said."""
+        register_agent(
+            "proj-neurovista",
+            workspace_id=1,
+            info={
+                # Simulate the buggy client that reported the wrong
+                # machine label due to env pollution.
+                "machine": "mba",
+                # And the live hostname the kernel actually returned.
+                "hostname": "spartan",
+            },
+        )
+        rows = [a for a in get_agents(workspace_id=1) if a["name"] == "proj-neurovista"]
+        self.assertEqual(len(rows), 1)
+        # Both fields round-trip verbatim — the hub never rewrites
+        # either one based on auth or server-side inference.
+        self.assertEqual(rows[0]["machine"], "mba")
+        self.assertEqual(rows[0]["hostname"], "spartan")
+
+    def test_hostname_missing_defaults_to_empty_string(self):
+        """Legacy agents that never report ``hostname`` produce an
+        empty string in the payload, not ``None`` — the frontend
+        string-concatenation paths treat the two identically but
+        JSON consumers may not."""
+        register_agent(
+            "legacy-agent",
+            workspace_id=1,
+            info={"machine": "mba"},
+        )
+        rows = [a for a in get_agents(workspace_id=1) if a["name"] == "legacy-agent"]
+        self.assertEqual(rows[0]["hostname"], "")
+        self.assertEqual(rows[0]["machine"], "mba")
+
+
+class HostnameFromRestPushTest(TestCase):
+    """``POST /api/agents/register/`` honours client-supplied ``hostname``
+    regardless of which workspace token authenticated the request.
+
+    This is the *auth-independence* half of the fix: the hub must not
+    infer host identity from the token / user / IP. Two different
+    tokens pushing for the same agent with explicit host fields must
+    get exactly the host they asked for.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="host-identity-ws")
+        # Two tokens in the same workspace — mimic "mba creds" and
+        # "spartan creds" (or any cross-host cred situation).
+        self.token_a = WorkspaceToken.objects.create(
+            workspace=self.ws, label="mba-token"
+        )
+        self.token_b = WorkspaceToken.objects.create(
+            workspace=self.ws, label="spartan-token"
+        )
+        _agents.clear()
+
+    def _post(self, token, payload):
+        body = dict(payload, token=token)
+        return self.client.post(
+            "/api/agents/register/",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+
+    def test_hostname_recorded_verbatim_from_client(self):
+        """Client says ``hostname=spartan`` — hub records ``spartan``."""
+        resp = self._post(
+            self.token_a.token,
+            {
+                "name": "proj-neurovista",
+                "machine": "spartan",
+                "hostname": "spartan",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        rows = [
+            a for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "proj-neurovista"
+        ]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["hostname"], "spartan")
+        self.assertEqual(rows[0]["machine"], "spartan")
+
+    def test_hostname_not_inferred_from_token(self):
+        """The auth token DOES NOT set the host identity.
+
+        Simulates the proj-neurovista scenario: a process running on
+        spartan reports ``hostname=spartan`` but happens to authenticate
+        with a workspace token that was originally minted for mba (cred-
+        copying side effect). The recorded host must be ``spartan``
+        — what the client said — not anything derived from the token.
+        """
+        resp = self._post(
+            # Authenticate with the "mba" token...
+            self.token_a.token,
+            {
+                "name": "proj-neurovista",
+                # ...but report the real host from the live process.
+                "machine": "spartan",
+                "hostname": "spartan",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        rows = [
+            a for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "proj-neurovista"
+        ]
+        self.assertEqual(rows[0]["hostname"], "spartan")
+        # And the ``machine`` YAML label the client sent is also kept
+        # verbatim — the hub does not rewrite either field.
+        self.assertEqual(rows[0]["machine"], "spartan")
+
+    def test_hostname_persists_across_reregisters_via_different_tokens(self):
+        """Two sequential pushes with different tokens must both
+        honour the client-supplied host — the second push doesn't
+        reset the field to something auth-derived."""
+        self._post(
+            self.token_a.token,
+            {
+                "name": "proj-neurovista",
+                "machine": "spartan",
+                "hostname": "spartan",
+            },
+        )
+        # A second heartbeat arrives — same host, different token
+        # (e.g. the fleet rotated tokens mid-run).
+        self._post(
+            self.token_b.token,
+            {
+                "name": "proj-neurovista",
+                "machine": "spartan",
+                "hostname": "spartan",
+            },
+        )
+        rows = [
+            a for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "proj-neurovista"
+        ]
+        self.assertEqual(rows[0]["hostname"], "spartan")
+
+    def test_hostname_omitted_preserved_across_reregister(self):
+        """A heartbeat that omits ``hostname`` must NOT wipe a
+        previously-captured value. Matches the prev-preserve pattern
+        already used for the rest of the #257 metadata fields."""
+        self._post(
+            self.token_a.token,
+            {
+                "name": "proj-neurovista",
+                "machine": "spartan",
+                "hostname": "spartan",
+            },
+        )
+        # Legacy client that doesn't know about ``hostname``.
+        self._post(
+            self.token_a.token,
+            {
+                "name": "proj-neurovista",
+                "machine": "spartan",
+            },
+        )
+        rows = [
+            a for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "proj-neurovista"
+        ]
+        self.assertEqual(rows[0]["hostname"], "spartan")

--- a/hub/tests/registry/test_singleton_enforcement.py
+++ b/hub/tests/registry/test_singleton_enforcement.py
@@ -1,0 +1,403 @@
+"""Tests for #255 — singleton cardinality enforcement at the hub.
+
+Verifies the registry-level decision algorithm and the agent-detail
+API surface. The WS-level enforcement (close-frame on the loser, evict
+event for the incumbent) is exercised at the consumer level in the
+consumer test suite; here we pin the decision algorithm and the
+event-buffer / detail-payload contract so regressions in the policy
+are caught even if the consumer wiring is later refactored.
+
+Algorithm under test (HANDOFF.md §3 #3 + ywatanabe msg #14757):
+
+  * Two registers with full identity → older ``start_ts_unix`` wins.
+  * Tie or missing identity → incumbent wins (no disruption on
+    insufficient evidence) / no enforcement (legacy clients).
+  * The conflict event surfaces in ``/api/agents/<name>/detail/`` as
+    ``last_duplicate_identity_event``.
+"""
+
+import time
+
+from django.test import Client, TestCase
+
+from hub.models import Workspace, WorkspaceToken
+
+
+class _RegistryReset:
+    """Mixin that wipes all registry state between tests.
+
+    Singleton enforcement state lives across four module-level dicts
+    (``_agents``, ``_connections``, ``_connection_identity``,
+    ``_singleton_events``); without a clean slate per test, an event
+    recorded in test A leaks into test B's detail-API assertion.
+    """
+
+    def setUp(self):
+        super().setUp()
+        from hub.registry import (
+            _agents,
+            _connection_identity,
+            _connections,
+            _singleton_events,
+        )
+
+        _agents.clear()
+        _connections.clear()
+        _connection_identity.clear()
+        _singleton_events.clear()
+
+
+class DecideSingletonWinnerTest(_RegistryReset, TestCase):
+    """Pin :func:`hub.registry.decide_singleton_winner` policy."""
+
+    def test_first_connection_no_enforcement(self):
+        """No incumbent → no-enforcement (the new WS just registers)."""
+        from hub.registry import decide_singleton_winner
+
+        decision = decide_singleton_winner(
+            "agent-x",
+            new_instance_id="iid-1",
+            new_start_ts_unix=1000.0,
+        )
+        self.assertEqual(decision, "no_enforcement")
+
+    def test_older_start_ts_wins_even_when_challenger_arrives_later(self):
+        """Two registers, both have full identity → older start_ts wins.
+
+        The original process started at ``t=1000`` and connected first;
+        a second process with ``start_ts=2000`` later races onto the same
+        agent name. The original (incumbent) is older → it wins, the
+        challenger should be closed.
+        """
+        from hub.registry import (
+            decide_singleton_winner,
+            register_connection,
+            set_connection_identity,
+        )
+
+        # Incumbent: started first, connected first.
+        set_connection_identity("conn-incumbent", "agent-x", "iid-old", 1000.0)
+        register_connection("agent-x", "conn-incumbent")
+
+        # Challenger: started later (newer process).
+        decision = decide_singleton_winner(
+            "agent-x",
+            new_instance_id="iid-new",
+            new_start_ts_unix=2000.0,
+        )
+        self.assertEqual(decision, "incumbent")
+
+    def test_older_challenger_wins_against_newer_incumbent(self):
+        """If the challenger has the OLDER start_ts (e.g. an original
+        process reconnects after the hub temporarily had a younger
+        racer), the challenger wins and the incumbent gets evicted."""
+        from hub.registry import (
+            decide_singleton_winner,
+            register_connection,
+            set_connection_identity,
+        )
+
+        # A young racer is the current incumbent.
+        set_connection_identity("conn-young", "agent-x", "iid-young", 2000.0)
+        register_connection("agent-x", "conn-young")
+
+        # The original older process reconnects.
+        decision = decide_singleton_winner(
+            "agent-x",
+            new_instance_id="iid-original",
+            new_start_ts_unix=1000.0,
+        )
+        self.assertEqual(decision, "challenger")
+
+    def test_tie_falls_to_incumbent(self):
+        """Equal ``start_ts_unix`` → incumbent keeps the claim (don't
+        disrupt a healthy connection on insufficient evidence)."""
+        from hub.registry import (
+            decide_singleton_winner,
+            register_connection,
+            set_connection_identity,
+        )
+
+        set_connection_identity("conn-A", "agent-x", "iid-A", 1500.0)
+        register_connection("agent-x", "conn-A")
+
+        decision = decide_singleton_winner(
+            "agent-x",
+            new_instance_id="iid-B",
+            new_start_ts_unix=1500.0,
+        )
+        self.assertEqual(decision, "incumbent")
+
+    def test_missing_challenger_identity_no_enforcement(self):
+        """Legacy challenger that omits ``instance_id`` / ``start_ts_unix``
+        → no enforcement (back-compat: the agent keeps working)."""
+        from hub.registry import (
+            decide_singleton_winner,
+            register_connection,
+            set_connection_identity,
+        )
+
+        set_connection_identity("conn-A", "agent-x", "iid-A", 1500.0)
+        register_connection("agent-x", "conn-A")
+
+        # Challenger has no identity (legacy client).
+        self.assertEqual(
+            decide_singleton_winner("agent-x", "", None),
+            "no_enforcement",
+        )
+        self.assertEqual(
+            decide_singleton_winner("agent-x", "iid-X", None),
+            "no_enforcement",
+        )
+        self.assertEqual(
+            decide_singleton_winner("agent-x", "", 1.0),
+            "no_enforcement",
+        )
+
+    def test_missing_incumbent_identity_no_enforcement(self):
+        """Legacy incumbent (full identity not recorded) → no
+        enforcement; we don't disrupt an in-flight connection just
+        because the hub doesn't have its boot metadata."""
+        from hub.registry import (
+            decide_singleton_winner,
+            register_connection,
+            set_connection_identity,
+        )
+
+        # Incumbent has no instance_id (legacy WS that connected before
+        # #257 / #255 landed).
+        set_connection_identity("conn-A", "agent-x", "", None)
+        register_connection("agent-x", "conn-A")
+
+        decision = decide_singleton_winner(
+            "agent-x",
+            new_instance_id="iid-new",
+            new_start_ts_unix=2000.0,
+        )
+        self.assertEqual(decision, "no_enforcement")
+
+
+class SingletonEventBufferTest(_RegistryReset, TestCase):
+    """Pin the per-agent event ring buffer behaviour."""
+
+    def test_record_then_get_recent(self):
+        from hub.registry import (
+            get_recent_singleton_event,
+            record_singleton_conflict,
+        )
+
+        self.assertIsNone(get_recent_singleton_event("agent-x"))
+
+        record_singleton_conflict(
+            "agent-x",
+            winner_instance_id="iid-W",
+            loser_instance_id="iid-L",
+        )
+        evt = get_recent_singleton_event("agent-x")
+        self.assertIsNotNone(evt)
+        self.assertEqual(evt["winner_instance_id"], "iid-W")
+        self.assertEqual(evt["loser_instance_id"], "iid-L")
+        self.assertEqual(evt["reason"], "duplicate_identity")
+        self.assertAlmostEqual(evt["ts"], time.time(), delta=5.0)
+
+    def test_returns_newest_event(self):
+        from hub.registry import (
+            get_recent_singleton_event,
+            record_singleton_conflict,
+        )
+
+        record_singleton_conflict("agent-x", "iid-1", "iid-A")
+        time.sleep(0.01)
+        record_singleton_conflict("agent-x", "iid-2", "iid-B")
+        evt = get_recent_singleton_event("agent-x")
+        self.assertEqual(evt["winner_instance_id"], "iid-2")
+        self.assertEqual(evt["loser_instance_id"], "iid-B")
+
+    def test_stale_events_pruned(self):
+        """Events older than ``SINGLETON_EVENT_WINDOW_S`` are dropped on
+        read so a long-running hub never returns ancient history."""
+        from hub.registry import (
+            SINGLETON_EVENT_WINDOW_S,
+            _singleton_events,
+            get_recent_singleton_event,
+        )
+
+        # Inject a stale event by hand (older than the window).
+        stale_ts = time.time() - (SINGLETON_EVENT_WINDOW_S + 60)
+        _singleton_events["agent-x"] = [
+            {
+                "ts": stale_ts,
+                "agent": "agent-x",
+                "winner_instance_id": "iid-stale-W",
+                "loser_instance_id": "iid-stale-L",
+                "reason": "duplicate_identity",
+            }
+        ]
+        self.assertIsNone(get_recent_singleton_event("agent-x"))
+
+
+class SingletonHeartbeatSurvivalTest(_RegistryReset, TestCase):
+    """The winner survives a typical heartbeat sequence — a regression
+    guard ensuring later heartbeats don't re-trigger enforcement on
+    the very connection that just won the race."""
+
+    def test_winner_survives_heartbeat_sequence(self):
+        from hub.registry import (
+            decide_singleton_winner,
+            register_agent,
+            register_connection,
+            set_connection_identity,
+            update_heartbeat,
+        )
+
+        # Incumbent is older → it wins the singleton race.
+        set_connection_identity("conn-incumbent", "agent-x", "iid-old", 1000.0)
+        register_connection("agent-x", "conn-incumbent")
+        register_agent(
+            "agent-x",
+            workspace_id=1,
+            info={"instance_id": "iid-old", "start_ts_unix": 1000.0},
+        )
+
+        # A few heartbeats from the same incumbent (same identity).
+        for _ in range(3):
+            update_heartbeat("agent-x", {"cpu_count": 4})
+
+        # Now a young racer challenges. Decision should still favour the
+        # older incumbent — its identity is intact in the per-channel
+        # table even after the heartbeats.
+        decision = decide_singleton_winner(
+            "agent-x",
+            new_instance_id="iid-young",
+            new_start_ts_unix=2000.0,
+        )
+        self.assertEqual(decision, "incumbent")
+
+
+class ConnectionIdentityLifecycleTest(_RegistryReset, TestCase):
+    """Pin set/get/clear of per-channel identity rows."""
+
+    def test_set_then_get(self):
+        from hub.registry import (
+            get_connection_identity,
+            set_connection_identity,
+        )
+
+        set_connection_identity("ch-1", "agent-x", "iid-1", 1234.5)
+        ident = get_connection_identity("ch-1")
+        self.assertIsNotNone(ident)
+        self.assertEqual(ident["agent_name"], "agent-x")
+        self.assertEqual(ident["instance_id"], "iid-1")
+        self.assertEqual(ident["start_ts_unix"], 1234.5)
+
+    def test_clear_drops_identity(self):
+        from hub.registry import (
+            clear_connection_identity,
+            get_connection_identity,
+            set_connection_identity,
+        )
+
+        set_connection_identity("ch-1", "agent-x", "iid-1", 1234.5)
+        clear_connection_identity("ch-1")
+        self.assertIsNone(get_connection_identity("ch-1"))
+
+    def test_list_sibling_channels(self):
+        from hub.registry import (
+            list_sibling_channels,
+            register_connection,
+            set_connection_identity,
+        )
+
+        # Two siblings under one name.
+        set_connection_identity("ch-A", "agent-x", "iid-A", 1.0)
+        set_connection_identity("ch-B", "agent-x", "iid-B", 2.0)
+        register_connection("agent-x", "ch-A")
+        register_connection("agent-x", "ch-B")
+
+        siblings = list_sibling_channels("agent-x")
+        self.assertEqual(set(siblings), {"ch-A", "ch-B"})
+        self.assertEqual(list_sibling_channels("agent-y"), [])
+
+
+class DetailApiSurfacesEventTest(_RegistryReset, TestCase):
+    """``/api/agents/<name>/detail/`` exposes the most recent singleton
+    conflict via ``last_duplicate_identity_event``."""
+
+    def setUp(self):
+        super().setUp()
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="dup-ws")
+        self.token = WorkspaceToken.objects.create(
+            workspace=self.ws, label="dup-test"
+        )
+
+    def _register_agent(self):
+        from hub.registry import register_agent
+
+        register_agent(
+            "alpha",
+            workspace_id=self.ws.id,
+            info={
+                "machine": "MBA",
+                "instance_id": "iid-current",
+                "start_ts_unix": 1000.0,
+            },
+        )
+
+    def _detail(self, name="alpha"):
+        return self.client.get(
+            f"/api/agents/{name}/detail/",
+            data={"token": self.token.token},
+        )
+
+    def test_no_event_returns_null(self):
+        self._register_agent()
+        data = self._detail().json()
+        self.assertIn("last_duplicate_identity_event", data)
+        self.assertIsNone(data["last_duplicate_identity_event"])
+
+    def test_event_surfaces_after_conflict(self):
+        from hub.registry import record_singleton_conflict
+
+        self._register_agent()
+        record_singleton_conflict(
+            "alpha",
+            winner_instance_id="iid-current",
+            loser_instance_id="iid-evicted",
+        )
+        data = self._detail().json()
+        evt = data["last_duplicate_identity_event"]
+        self.assertIsNotNone(evt)
+        self.assertEqual(evt["winner_instance_id"], "iid-current")
+        self.assertEqual(evt["loser_instance_id"], "iid-evicted")
+        self.assertEqual(evt["reason"], "duplicate_identity")
+        self.assertIn("ts", evt)
+
+
+class LegacyClientCompatibilityTest(_RegistryReset, TestCase):
+    """Back-compat: a legacy client that never reports
+    ``instance_id`` / ``start_ts_unix`` MUST keep working — no
+    enforcement, no event recorded, no surprise close-frame.
+    """
+
+    def test_legacy_only_no_event_recorded(self):
+        from hub.registry import (
+            decide_singleton_winner,
+            get_recent_singleton_event,
+            register_connection,
+            set_connection_identity,
+        )
+
+        # Two legacy clients connect under the same name. Neither has
+        # identity. The decider must say "no_enforcement" both times.
+        set_connection_identity("ch-legacy-A", "agent-legacy", "", None)
+        register_connection("agent-legacy", "ch-legacy-A")
+
+        self.assertEqual(
+            decide_singleton_winner("agent-legacy", "", None),
+            "no_enforcement",
+        )
+        # And no event was recorded by the decider itself (the consumer
+        # is responsible for recording when it actually evicts; the
+        # decider is read-only).
+        self.assertIsNone(get_recent_singleton_event("agent-legacy"))

--- a/hub/tests/test_quota_watch.py
+++ b/hub/tests/test_quota_watch.py
@@ -1,0 +1,385 @@
+"""Tests for todo#272 — proactive quota pressure detection + escalation.
+
+Covers three layers:
+
+1. :func:`_classify` — threshold → state mapping for the 5h / 7d
+   windows (warn at 0.80 / 0.85, escalate at 0.95).
+2. :func:`evaluate` — the per-heartbeat state-machine transitions:
+   ok→warn posts to ``#progress``, warn→escalate posts to
+   ``#escalation`` + ``#ywatanabe``, escalate→ok posts recovery,
+   other transitions are silent (no spam on partial recovery /
+   downshift per ywatanabe msg#7788).
+3. :func:`check_agent_quota_pressure` — the heartbeat-hot-path entry
+   point that reads the registry, runs :func:`evaluate`, and writes
+   the new state back. The test doubles exercise the integration via
+   ``register_agent`` + ``update_heartbeat`` (the same call chain the
+   REST / WS handlers use) to prove end-to-end wiring.
+
+Regression anchors:
+
+- Prev-preserve of ``quota_state_5h`` / ``quota_state_7d`` across
+  re-registers — without it, every heartbeat resets to ``ok`` and
+  re-posts the warn / escalate message (spam).
+- Silent downshift: escalate→warn must NOT post.
+- Percentage input (0..100) is accepted as well as fractional (0..1)
+  so the consumer doesn't misfire when producers use either
+  convention.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from hub.quota_watch import (
+    ESCALATE_5H,
+    ESCALATE_7D,
+    STATE_ESCALATE,
+    STATE_OK,
+    STATE_WARN,
+    WARN_5H,
+    WARN_7D,
+    _classify,
+    _coerce_utilization,
+    check_agent_quota_pressure,
+    evaluate,
+)
+from hub.registry import _agents, register_agent, update_heartbeat
+
+
+class ClassifyTest(TestCase):
+    """Pure threshold classification."""
+
+    def test_5h_boundaries(self):
+        self.assertEqual(_classify(0.0, "5h"), STATE_OK)
+        self.assertEqual(_classify(WARN_5H - 0.01, "5h"), STATE_OK)
+        self.assertEqual(_classify(WARN_5H, "5h"), STATE_WARN)
+        self.assertEqual(_classify(0.90, "5h"), STATE_WARN)
+        self.assertEqual(_classify(ESCALATE_5H, "5h"), STATE_ESCALATE)
+        self.assertEqual(_classify(1.0, "5h"), STATE_ESCALATE)
+
+    def test_7d_boundaries(self):
+        self.assertEqual(_classify(0.0, "7d"), STATE_OK)
+        self.assertEqual(_classify(WARN_7D - 0.01, "7d"), STATE_OK)
+        self.assertEqual(_classify(WARN_7D, "7d"), STATE_WARN)
+        self.assertEqual(_classify(0.92, "7d"), STATE_WARN)
+        self.assertEqual(_classify(ESCALATE_7D, "7d"), STATE_ESCALATE)
+
+    def test_none_utilization_falls_back_to_ok(self):
+        self.assertEqual(_classify(None, "5h"), STATE_OK)
+        self.assertEqual(_classify(None, "7d"), STATE_OK)
+
+
+class CoerceUtilizationTest(TestCase):
+    """Producers may push 0..1 or 0..100; accept both."""
+
+    def test_fraction_passthrough(self):
+        self.assertAlmostEqual(_coerce_utilization(0.82), 0.82)
+        self.assertAlmostEqual(_coerce_utilization(0.95), 0.95)
+
+    def test_percentage_rescaled(self):
+        self.assertAlmostEqual(_coerce_utilization(82), 0.82)
+        self.assertAlmostEqual(_coerce_utilization(95.0), 0.95)
+
+    def test_none_and_garbage_return_none(self):
+        self.assertIsNone(_coerce_utilization(None))
+        self.assertIsNone(_coerce_utilization(""))
+        self.assertIsNone(_coerce_utilization("nan-value"))
+
+    def test_negative_clamped_to_zero(self):
+        self.assertEqual(_coerce_utilization(-0.01), 0.0)
+
+
+class EvaluateStateMachineTest(TestCase):
+    """Transition rules for the per-(agent, window) state machine."""
+
+    def setUp(self):
+        self.posts: list[tuple[str, str]] = []
+
+    def _post(self, channel: str, text: str) -> None:
+        self.posts.append((channel, text))
+
+    def test_ok_to_warn_posts_progress(self):
+        new_5h, new_7d, emitted = evaluate(
+            "agent-burn",
+            util_5h=0.81,
+            util_7d=None,
+            reset_5h="2026-04-22T01:00:00Z",
+            reset_7d=None,
+            prev_state_5h=STATE_OK,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(new_7d, STATE_OK)
+        self.assertEqual(len(self.posts), 1)
+        channel, text = self.posts[0]
+        self.assertEqual(channel, "#progress")
+        self.assertIn("agent-burn", text)
+        self.assertIn("5h", text)
+        self.assertIn("81%", text)
+
+    def test_warn_to_escalate_posts_escalation_and_ywatanabe(self):
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.96,
+            util_7d=None,
+            reset_5h="2026-04-22T01:00:00Z",
+            reset_7d=None,
+            prev_state_5h=STATE_WARN,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_ESCALATE)
+        channels = [c for c, _ in self.posts]
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+        # Every emitted message names the agent + quota window so the
+        # recipient can act (account rotation, migration decision).
+        for _, text in self.posts:
+            self.assertIn("agent-burn", text)
+            self.assertIn("ESCALATE", text)
+
+    def test_ok_to_escalate_skips_warn_but_still_escalates(self):
+        """If a heartbeat gap makes the agent jump straight from ok to
+        escalate (e.g. 10-minute poll lands after a burst), we still
+        escalate rather than silently dropping the transition."""
+        new_5h, _, _ = evaluate(
+            "agent-burst",
+            util_5h=0.97,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_OK,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_ESCALATE)
+        channels = [c for c, _ in self.posts]
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+
+    def test_escalate_to_ok_posts_recovery(self):
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.05,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_ESCALATE,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_OK)
+        self.assertEqual(len(self.posts), 1)
+        channel, text = self.posts[0]
+        self.assertEqual(channel, "#progress")
+        self.assertIn("recovered", text)
+
+    def test_escalate_to_warn_silent(self):
+        """Partial recovery must not spam — only full recovery pings."""
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.85,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_ESCALATE,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(self.posts, [])
+
+    def test_warn_to_ok_silent(self):
+        """Downshift is silent — only escalate→ok triggers recovery ping."""
+        new_5h, _, _ = evaluate(
+            "agent-burn",
+            util_5h=0.10,
+            util_7d=None,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_WARN,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_OK)
+        self.assertEqual(self.posts, [])
+
+    def test_same_state_no_posts(self):
+        """Repeated polls within the same band must not re-fire."""
+        new_5h, new_7d, emitted = evaluate(
+            "agent-burn",
+            util_5h=0.82,
+            util_7d=0.86,
+            reset_5h=None,
+            reset_7d=None,
+            prev_state_5h=STATE_WARN,
+            prev_state_7d=STATE_WARN,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(new_7d, STATE_WARN)
+        self.assertEqual(self.posts, [])
+        self.assertEqual(emitted, [])
+
+    def test_both_windows_fire_independently(self):
+        """5h and 7d transitions are evaluated + posted independently."""
+        new_5h, new_7d, _ = evaluate(
+            "agent-burn",
+            util_5h=0.82,  # ok -> warn
+            util_7d=0.96,  # ok -> escalate
+            reset_5h="2026-04-22T01:00:00Z",
+            reset_7d="2026-04-28T01:00:00Z",
+            prev_state_5h=STATE_OK,
+            prev_state_7d=STATE_OK,
+            post=self._post,
+        )
+        self.assertEqual(new_5h, STATE_WARN)
+        self.assertEqual(new_7d, STATE_ESCALATE)
+        channels = [c for c, _ in self.posts]
+        # 5h: warn -> #progress
+        self.assertIn("#progress", channels)
+        # 7d: escalate -> #escalation + #ywatanabe
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+
+
+class CheckAgentQuotaPressureWiringTest(TestCase):
+    """End-to-end wiring: register_agent + update_heartbeat triggers
+    :func:`check_agent_quota_pressure` with prev-preserve of the state
+    across heartbeats."""
+
+    def setUp(self):
+        _agents.clear()
+        self.posts: list[tuple[str, str]] = []
+
+    def _post(self, channel: str, text: str) -> None:
+        self.posts.append((channel, text))
+
+    def _register(self, name: str, **extra) -> None:
+        info = {
+            "machine": "test-host",
+            "role": "head",
+        }
+        info.update(extra)
+        register_agent(name, workspace_id=1, info=info)
+
+    def test_unknown_agent_is_noop(self):
+        check_agent_quota_pressure("missing-agent", post=self._post)
+        self.assertEqual(self.posts, [])
+
+    def test_missing_quota_fields_noop(self):
+        self._register("agent-a")
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(self.posts, [])
+        self.assertEqual(_agents["agent-a"].get("quota_state_5h"), STATE_OK)
+
+    def test_first_warn_crossing_posts_once(self):
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.82,
+            quota_5h_reset_at="2026-04-22T01:00:00Z",
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_WARN)
+        channels = [c for c, _ in self.posts]
+        self.assertEqual(channels.count("#progress"), 1)
+
+    def test_repeat_poll_same_band_does_not_repost(self):
+        """Second heartbeat in the same warn band must be silent —
+        otherwise each 10-minute poll spams #progress."""
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.82,
+            quota_5h_reset_at="2026-04-22T01:00:00Z",
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        first_count = len(self.posts)
+
+        # Second heartbeat — re-register + update_heartbeat style, same
+        # quota figures. State must survive the re-register.
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.84,
+            quota_5h_reset_at="2026-04-22T01:00:00Z",
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(len(self.posts), first_count)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_WARN)
+
+    def test_state_preserved_across_reregister(self):
+        """Prev-preserve regression guard — the state slot must survive
+        a register_agent call with the quota fields omitted entirely."""
+        self._register(
+            "agent-a",
+            quota_5h_used_pct=0.96,
+        )
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(
+            _agents["agent-a"]["quota_state_5h"], STATE_ESCALATE
+        )
+
+        # Re-register without the quota keys (e.g. WS reconnect
+        # heartbeat from a path that doesn't carry quota telemetry).
+        self._register("agent-a")
+        self.assertEqual(
+            _agents["agent-a"]["quota_state_5h"], STATE_ESCALATE
+        )
+
+    def test_update_heartbeat_triggers_check(self):
+        """The heartbeat hot path (update_heartbeat) fires the state
+        machine without the caller having to invoke quota_watch
+        explicitly. This is the production wiring — REST handler +
+        WS handler both go through update_heartbeat."""
+        import hub.quota_watch as quota_watch
+
+        captured: list[tuple[str, str]] = []
+
+        def capture(channel: str, text: str) -> None:
+            captured.append((channel, text))
+
+        original_make = quota_watch._make_workspace_post
+        quota_watch._make_workspace_post = lambda ws_id: capture
+        try:
+            self._register(
+                "agent-a",
+                quota_7d_used_pct=0.97,
+                quota_7d_reset_at="2026-04-28T01:00:00Z",
+            )
+            update_heartbeat("agent-a")
+        finally:
+            quota_watch._make_workspace_post = original_make
+
+        channels = [c for c, _ in captured]
+        self.assertIn("#escalation", channels)
+        self.assertIn("#ywatanabe", channels)
+        self.assertEqual(
+            _agents["agent-a"]["quota_state_7d"], STATE_ESCALATE
+        )
+
+    def test_percentage_input_is_normalized(self):
+        """Producer-agnostic — 0..100 percentages are rescaled."""
+        self._register("agent-a", quota_5h_used_pct=82)
+        check_agent_quota_pressure("agent-a", post=self._post)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_WARN)
+
+    def test_full_lifecycle_ok_warn_escalate_recover(self):
+        """End-to-end sequence a real agent might traverse over a 5h
+        window: ok → warn → escalate → ok. Each transition fires once."""
+        # ok → warn
+        self._register("agent-a", quota_5h_used_pct=0.82)
+        check_agent_quota_pressure("agent-a", post=self._post)
+        # warn → escalate
+        self._register("agent-a", quota_5h_used_pct=0.97)
+        check_agent_quota_pressure("agent-a", post=self._post)
+        # escalate → ok (reset fired)
+        self._register("agent-a", quota_5h_used_pct=0.01)
+        check_agent_quota_pressure("agent-a", post=self._post)
+
+        channels = [c for c, _ in self.posts]
+        # Exactly: warn #progress, escalate #escalation + #ywatanabe,
+        # recovery #progress.
+        self.assertEqual(channels.count("#progress"), 2)  # warn + recovery
+        self.assertEqual(channels.count("#escalation"), 1)
+        self.assertEqual(channels.count("#ywatanabe"), 1)
+        self.assertEqual(_agents["agent-a"]["quota_state_5h"], STATE_OK)

--- a/hub/tests/test_worker_progress_seed.py
+++ b/hub/tests/test_worker_progress_seed.py
@@ -1,0 +1,157 @@
+"""Tests for ``manage.py seed_worker_progress`` (todo#272).
+
+Covers:
+  - Creates the synthetic ``agent-worker-progress`` user + workspace
+    member + read-write ChannelMembership rows for the three base
+    channels (#progress, #heads, #ywatanabe).
+  - Dynamically enumerates ``#proj-*`` channels that exist in the
+    workspace at seed time (no hardcoded list).
+  - New ``#proj-*`` channels added after a seed run are picked up on
+    the next run (forward-compatibility).
+  - Idempotent: a second run creates no extra rows.
+  - ``#agent`` is never subscribed (server-side blocklist protection).
+  - ``read-only`` memberships are promoted to ``read-write``.
+  - Missing workspace raises ``CommandError``.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from django.contrib.auth import get_user_model
+from django.core.management import CommandError, call_command
+from django.test import TestCase
+
+from hub.models import Channel, ChannelMembership, Workspace, WorkspaceMember
+
+User = get_user_model()
+
+
+class SeedWorkerProgressTest(TestCase):
+    def setUp(self) -> None:
+        self.ws = Workspace.objects.create(name="default")
+
+    def _run(self, *args, **opts) -> str:
+        out = StringIO()
+        call_command("seed_worker_progress", *args, stdout=out, **opts)
+        return out.getvalue()
+
+    def _agent_user(self):
+        return User.objects.get(username="agent-worker-progress")
+
+    # --- base channels ---------------------------------------------------
+
+    def test_creates_user_member_and_base_memberships(self):
+        output = self._run("--workspace", "default")
+        self.assertIn("created user", output)
+        user = self._agent_user()
+        self.assertTrue(
+            WorkspaceMember.objects.filter(user=user, workspace=self.ws).exists()
+        )
+        for name in ("#progress", "#heads", "#ywatanabe"):
+            ch = Channel.objects.get(workspace=self.ws, name=name)
+            m = ChannelMembership.objects.get(user=user, channel=ch)
+            self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
+
+    # --- dynamic #proj-* enumeration -------------------------------------
+
+    def test_enumerates_existing_proj_channels(self):
+        # Pre-existing project channels in the DB at seed time.
+        Channel.objects.create(workspace=self.ws, name="#proj-alpha")
+        Channel.objects.create(workspace=self.ws, name="#proj-beta")
+        # A lookalike that MUST NOT match the #proj- prefix.
+        Channel.objects.create(workspace=self.ws, name="#project-other")
+
+        self._run("--workspace", "default")
+        user = self._agent_user()
+
+        # #proj-* subscribed.
+        for name in ("#proj-alpha", "#proj-beta"):
+            ch = Channel.objects.get(workspace=self.ws, name=name)
+            m = ChannelMembership.objects.get(user=user, channel=ch)
+            self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
+
+        # Non-matching lookalike must NOT be subscribed.
+        other = Channel.objects.get(workspace=self.ws, name="#project-other")
+        self.assertFalse(
+            ChannelMembership.objects.filter(user=user, channel=other).exists()
+        )
+
+    def test_does_not_create_proj_channels_it_does_not_see(self):
+        # Fresh DB: no #proj-* rows. Seeding must NOT invent any.
+        self._run("--workspace", "default")
+        self.assertFalse(
+            Channel.objects.filter(
+                workspace=self.ws, name__startswith="#proj-"
+            ).exists()
+        )
+
+    def test_picks_up_new_proj_channel_on_rerun(self):
+        # First run, nothing project-related.
+        self._run("--workspace", "default")
+        user = self._agent_user()
+        self.assertFalse(
+            ChannelMembership.objects.filter(
+                user=user, channel__name__startswith="#proj-"
+            ).exists()
+        )
+
+        # Someone creates a new project channel after first seed.
+        new_ch = Channel.objects.create(workspace=self.ws, name="#proj-gamma")
+
+        # Second run should pick it up.
+        self._run("--workspace", "default")
+        self.assertTrue(
+            ChannelMembership.objects.filter(user=user, channel=new_ch).exists()
+        )
+
+    # --- idempotency -----------------------------------------------------
+
+    def test_idempotent_no_duplicates(self):
+        Channel.objects.create(workspace=self.ws, name="#proj-alpha")
+
+        self._run("--workspace", "default")
+        before_users = User.objects.count()
+        before_members = ChannelMembership.objects.count()
+        before_channels = Channel.objects.count()
+
+        output = self._run("--workspace", "default")
+        self.assertIn("user exists", output)
+        self.assertEqual(User.objects.count(), before_users)
+        self.assertEqual(ChannelMembership.objects.count(), before_members)
+        self.assertEqual(Channel.objects.count(), before_channels)
+
+    # --- abolished #agent ------------------------------------------------
+
+    def test_abolished_agent_channel_never_subscribed(self):
+        # Even if a stray '#agent' Channel row exists (pre-abolition),
+        # the seed command must not create a ChannelMembership for it.
+        Channel.objects.create(workspace=self.ws, name="#agent")
+        self._run("--workspace", "default")
+        user = self._agent_user()
+        agent_ch = Channel.objects.get(workspace=self.ws, name="#agent")
+        self.assertFalse(
+            ChannelMembership.objects.filter(
+                user=user, channel=agent_ch
+            ).exists()
+        )
+
+    # --- read-only → read-write promotion --------------------------------
+
+    def test_upgrades_read_only_to_read_write(self):
+        user, _ = User.objects.get_or_create(username="agent-worker-progress")
+        WorkspaceMember.objects.create(user=user, workspace=self.ws)
+        ch = Channel.objects.create(workspace=self.ws, name="#progress")
+        ChannelMembership.objects.create(
+            user=user, channel=ch, permission=ChannelMembership.PERM_READ_ONLY
+        )
+        output = self._run("--workspace", "default")
+        self.assertIn("upgraded to read-write", output)
+        refreshed = ChannelMembership.objects.get(user=user, channel=ch)
+        self.assertEqual(refreshed.permission, ChannelMembership.PERM_READ_WRITE)
+
+    # --- error handling --------------------------------------------------
+
+    def test_missing_workspace_raises(self):
+        with self.assertRaises(CommandError):
+            self._run("--workspace", "does-not-exist")

--- a/hub/tests/views/api/test_admin_subscribe.py
+++ b/hub/tests/views/api/test_admin_subscribe.py
@@ -1,0 +1,255 @@
+"""Tests for admin-scoped agent subscribe/unsubscribe (issue #262 §9.1).
+
+The MCP ``subscribe`` / ``unsubscribe`` tools route to these endpoints
+when called with the optional ``target_agent`` argument. Only fleet
+coordinators (workspace ``admin`` or ``staff`` role) may use them; every
+other caller gets a structured ``permission_denied`` envelope.
+
+PR #272 introduced the views in ``hub/views/api/_agents_subscribe.py``
+but the test suite landed in this follow-up so the auth gate cannot
+silently regress.
+"""
+
+import json
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceToken,
+)
+
+
+class AdminSubscribeRestApiTest(TestCase):
+    """Coverage for ``/api/agents/<target>/subscribe|unsubscribe/``."""
+
+    # Subdomain that the WorkspaceSubdomainMiddleware recognizes as
+    # ``adm-ws.lvh.me`` -> request.workspace=adm-ws. The token-auth
+    # tests below pass ``HTTP_HOST=lvh.me`` (bare domain) instead since
+    # they identify the workspace via the token, not the host.
+    SUBDOMAIN_HOST = "adm-ws.lvh.me"
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="adm-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+
+        # Admin (fleet coordinator) -- explicit ``admin`` role.
+        self.admin_user = User.objects.create_user(username="alice-admin", password="x")
+        WorkspaceMember.objects.create(
+            workspace=self.ws,
+            user=self.admin_user,
+            role=WorkspaceMember.Role.ADMIN,
+        )
+
+        # Plain agent -- synthetic ``agent-<name>`` user without admin role.
+        self.regular_agent_user = User.objects.create_user(
+            username="agent-regular-1", password="x"
+        )
+        WorkspaceMember.objects.create(
+            workspace=self.ws,
+            user=self.regular_agent_user,
+            role=WorkspaceMember.Role.MEMBER,
+        )
+
+        # Pre-existing #ops channel.
+        self.channel = Channel.objects.create(workspace=self.ws, name="#ops")
+
+    # ── happy path ────────────────────────────────────────────────────
+
+    def test_admin_subscribe_creates_membership(self):
+        """Logged-in admin can subscribe a peer agent -- DB row appears."""
+        self.client.force_login(self.admin_user)
+        resp = self.client.post(
+            "/api/agents/peer-mba/subscribe/",
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+            HTTP_HOST=self.SUBDOMAIN_HOST,
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        body = resp.json()
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["target_agent"], "peer-mba")
+        self.assertEqual(body["channel"], "#ops")
+        self.assertEqual(body["action"], "subscribe")
+
+        # The synthetic agent user + ChannelMembership row must exist.
+        self.assertTrue(User.objects.filter(username="agent-peer-mba").exists())
+        self.assertTrue(
+            ChannelMembership.objects.filter(
+                user__username="agent-peer-mba",
+                channel=self.channel,
+            ).exists()
+        )
+
+    def test_admin_unsubscribe_removes_membership(self):
+        """Admin can also remove the row again."""
+        # Pre-create the membership.
+        peer_user = User.objects.create_user(username="agent-peer-mba", password="x")
+        ChannelMembership.objects.create(user=peer_user, channel=self.channel)
+
+        self.client.force_login(self.admin_user)
+        resp = self.client.post(
+            "/api/agents/peer-mba/unsubscribe/",
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+            HTTP_HOST=self.SUBDOMAIN_HOST,
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertFalse(
+            ChannelMembership.objects.filter(
+                user=peer_user,
+                channel=self.channel,
+            ).exists()
+        )
+
+    def test_admin_subscribe_token_path(self):
+        """Token + ``?agent=<admin>`` path also works (MCP sidecar shape).
+
+        The token-path actor is the synthetic ``agent-<name>`` user
+        auto-provisioned by ``resolve_workspace_and_actor``. We verify
+        that a freshly-provisioned synthetic agent (which defaults to
+        member role) is rejected, then promote it to admin and retry.
+        """
+        url = (
+            f"/api/agents/peer-mba/subscribe/"
+            f"?token={self.token.token}&agent=alice-admin"
+        )
+        resp = self.client.post(
+            url,
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+
+        promoted = WorkspaceMember.objects.get(
+            workspace=self.ws,
+            user__username="agent-alice-admin",
+        )
+        promoted.role = WorkspaceMember.Role.ADMIN
+        promoted.save()
+
+        resp = self.client.post(
+            url,
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertTrue(
+            ChannelMembership.objects.filter(
+                user__username="agent-peer-mba",
+                channel=self.channel,
+            ).exists()
+        )
+
+    # ── permission denial ─────────────────────────────────────────────
+
+    def test_non_admin_gets_structured_permission_denied(self):
+        """Non-admin agent (token-auth, member role) is rejected with 403."""
+        url = (
+            f"/api/agents/peer-mba/subscribe/"
+            f"?token={self.token.token}&agent=regular-1"
+        )
+        resp = self.client.post(
+            url,
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        body = resp.json()
+        self.assertIn("error", body)
+        self.assertEqual(body["error"]["code"], "permission_denied")
+        self.assertIn("agent-scope tokens", body["error"]["reason"])
+        self.assertIn("admin", body["error"]["hint"].lower())
+        # No membership row created.
+        self.assertFalse(
+            ChannelMembership.objects.filter(
+                user__username="agent-peer-mba",
+                channel=self.channel,
+            ).exists()
+        )
+
+    def test_non_admin_unsubscribe_also_blocked(self):
+        url = (
+            f"/api/agents/peer-mba/unsubscribe/"
+            f"?token={self.token.token}&agent=regular-1"
+        )
+        resp = self.client.post(
+            url,
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 403, resp.content)
+        self.assertEqual(resp.json()["error"]["code"], "permission_denied")
+
+    def test_unauthenticated_returns_401(self):
+        resp = self.client.post(
+            "/api/agents/peer-mba/subscribe/",
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+            HTTP_HOST=self.SUBDOMAIN_HOST,
+        )
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    # ── input validation ──────────────────────────────────────────────
+
+    def test_missing_channel_returns_invalid_input(self):
+        self.client.force_login(self.admin_user)
+        resp = self.client.post(
+            "/api/agents/peer-mba/subscribe/",
+            data=json.dumps({}),
+            content_type="application/json",
+            HTTP_HOST=self.SUBDOMAIN_HOST,
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+        body = resp.json()
+        self.assertEqual(body["error"]["code"], "invalid_input")
+
+    def test_bad_target_name_returns_invalid_input(self):
+        self.client.force_login(self.admin_user)
+        # URL routing only allows path-safe strings; a "bad/name" would
+        # never reach the view. Test the in-view regex instead with a
+        # name containing a disallowed character that can pass the URL
+        # router (e.g. a tilde).
+        resp = self.client.post(
+            "/api/agents/peer~bad/subscribe/",
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+            HTTP_HOST=self.SUBDOMAIN_HOST,
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+        self.assertEqual(resp.json()["error"]["code"], "invalid_input")
+
+    def test_bare_domain_route_resolves_via_token(self):
+        """Same endpoint must be reachable on the bare domain (lvh.me).
+
+        MCP sidecars hit the apex with ``?token=...&agent=<self>``; the
+        workspace is resolved from the token, not from a subdomain. This
+        is the canonical admin-call shape from a coordinator agent.
+        """
+        WorkspaceMember.objects.create(
+            workspace=self.ws,
+            user=User.objects.create_user(username="agent-alice-admin", password="x"),
+            role=WorkspaceMember.Role.ADMIN,
+        )
+        url = (
+            f"/api/agents/peer-mba/subscribe/"
+            f"?token={self.token.token}&agent=alice-admin"
+        )
+        resp = self.client.post(
+            url,
+            data=json.dumps({"channel": "#ops"}),
+            content_type="application/json",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertTrue(
+            ChannelMembership.objects.filter(
+                user__username="agent-peer-mba",
+                channel=self.channel,
+            ).exists()
+        )

--- a/hub/tests/views/api/test_channel_members.py
+++ b/hub/tests/views/api/test_channel_members.py
@@ -160,3 +160,27 @@ class ChannelMembersAdminApiTest(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["deleted"], 0)
+
+    def test_post_subscribe_abolished_agent_channel_returns_403(self):
+        """``#agent`` was abolished 2026-04-21 (lead directive, PR #293
+        follow-up). POST/PATCH must return 403 so the client gets a real
+        signal — a silent 200 would let the bad client think it's
+        subscribed and retry endlessly.
+        """
+        self.client.force_login(self.admin)
+        resp = self.client.post(
+            "/api/channel-members/",
+            data=json.dumps(
+                {"channel": "#agent", "username": "agent-worker-x"}
+            ),
+            content_type="application/json",
+            HTTP_HOST=self.host,
+        )
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.json().get("error"), "channel abolished")
+        self.assertFalse(
+            self.Channel.objects.filter(workspace=self.ws, name="#agent").exists()
+        )
+        self.assertFalse(
+            self.ChannelMembership.objects.filter(user=self.agent_user).exists()
+        )

--- a/hub/tests/views/api/test_channel_members_token.py
+++ b/hub/tests/views/api/test_channel_members_token.py
@@ -1,0 +1,104 @@
+"""Token-auth coverage for GET /api/channel-members/ (#252).
+
+The MCP ``channel_members`` tool hits the bare domain with
+``?token=wks_...&agent=<name>``; without these tests the token branch
+on GET would silently regress the same way DM endpoints did in #258.
+"""
+
+import json
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceToken,
+)
+
+
+class ChannelMembersTokenAuthTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="cm-tok-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+
+        # One human, one agent — both subscribed to #general.
+        self.human = User.objects.create_user(username="alice", password="x")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.human, role="member"
+        )
+        self.agent = User.objects.create_user(username="agent-worker-x", password="")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.agent, role="member"
+        )
+        self.ch = Channel.objects.create(workspace=self.ws, name="#general")
+        ChannelMembership.objects.create(user=self.human, channel=self.ch)
+        ChannelMembership.objects.create(user=self.agent, channel=self.ch)
+
+    def _bare_get(self, path):
+        """GET against the bare-domain URLconf via lvh.me host."""
+        return self.client.get(path, HTTP_HOST="lvh.me")
+
+    # ── Bare-domain (urls_bare) routes ──────────────────────────────────
+
+    def test_get_with_token_no_session_bare(self):
+        url = (
+            f"/api/channel-members/?token={self.token.token}"
+            f"&agent=worker-x&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["username"] for r in rows)
+        self.assertIn("alice", names)
+        self.assertIn("agent-worker-x", names)
+
+    def test_get_workspace_scoped_with_token_bare(self):
+        url = (
+            f"/api/workspace/cm-tok-ws/channel-members/"
+            f"?token={self.token.token}&agent=worker-x&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        self.assertTrue(any(r["username"] == "agent-worker-x" for r in rows))
+
+    def test_get_invalid_token_returns_401_bare(self):
+        url = (
+            "/api/channel-members/?token=wks_BADBADBAD"
+            "&agent=worker-x&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_get_token_missing_agent_returns_400_bare(self):
+        url = (
+            f"/api/channel-members/?token={self.token.token}"
+            f"&channel=%23general"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_get_token_unknown_channel_returns_404_bare(self):
+        url = (
+            f"/api/channel-members/?token={self.token.token}"
+            f"&agent=worker-x&channel=%23ghost"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 404, resp.content)
+
+    # ── Subdomain (urls_workspace) route still session-gates writes ─────
+
+    def test_post_with_token_no_session_rejected(self):
+        """POST/PATCH/DELETE remain session-only; token-auth GET only."""
+        url = f"/api/channel-members/?token={self.token.token}&agent=worker-x"
+        resp = self.client.post(
+            url,
+            data=json.dumps({"channel": "#general", "username": "agent-worker-x"}),
+            content_type="application/json",
+            HTTP_HOST="cm-tok-ws.lvh.me",
+        )
+        self.assertEqual(resp.status_code, 401, resp.content)

--- a/hub/tests/views/api/test_dms.py
+++ b/hub/tests/views/api/test_dms.py
@@ -213,6 +213,141 @@ class DmRestApiTest(TestCase):
         self.assertEqual(resp.status_code, 201, resp.content)
 
 
+# ── Token-auth on workspace-scoped routes (issues #258 + #254) ──────────
+
+
+class DmTokenAuthTest(TestCase):
+    """MCP sidecars hit the bare domain with ``?token=wks_...&agent=<name>``.
+
+    These tests pin the token-auth path independently of any Django session
+    cookie so the regression that took out ``dm_open`` / ``dm_list`` /
+    ``channel_info`` cannot reappear silently.
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="tok-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+        self.bob = User.objects.create_user(username="bob", password="x")
+        WorkspaceMember.objects.create(workspace=self.ws, user=self.bob)
+
+    def test_post_dms_with_token_no_session(self):
+        """POST /api/workspace/<slug>/dms/?token=...&agent=... opens a DM."""
+        url = (
+            f"/api/workspace/tok-ws/dms/"
+            f"?token={self.token.token}&agent=mamba-foo"
+        )
+        resp = self.client.post(
+            url,
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        # Canonical channel name with both principals.
+        self.assertIn("agent:mamba-foo", data["name"])
+        self.assertIn("human:bob", data["name"])
+        # The synthetic agent user was auto-provisioned as a member.
+        self.assertTrue(
+            User.objects.filter(username="agent-mamba-foo").exists(),
+            "token branch must auto-provision the agent's User row",
+        )
+        self.assertTrue(
+            WorkspaceMember.objects.filter(
+                workspace=self.ws, user__username="agent-mamba-foo"
+            ).exists(),
+            "token branch must auto-provision the WorkspaceMember row",
+        )
+
+    def test_get_dms_with_token_no_session(self):
+        url_post = (
+            f"/api/workspace/tok-ws/dms/?token={self.token.token}&agent=mamba-foo"
+        )
+        self.client.post(
+            url_post,
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        resp = self.client.get(url_post)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()["dms"]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["other_participants"][0]["identity_name"], "bob")
+
+    def test_dms_token_invalid_returns_401(self):
+        resp = self.client.post(
+            "/api/workspace/tok-ws/dms/?token=wks_BADBADBAD&agent=mamba-foo",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_dms_token_missing_agent_returns_400(self):
+        resp = self.client.post(
+            f"/api/workspace/tok-ws/dms/?token={self.token.token}",
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_channels_get_with_token_no_session(self):
+        """GET /api/channels/?token=...&name=#X — the channel_info path.
+
+        Hits ``lvh.me`` (a bare-domain alias the middleware recognizes) so
+        the request is dispatched against ``hub.urls_bare`` — which is
+        exactly what MCP sidecars do when they call
+        ``https://scitex-orochi.com/api/channels/?...``. Without the
+        bare-domain route added in this PR the call 404s.
+        """
+        Channel.objects.create(workspace=self.ws, name="#general")
+        resp = self.client.get(
+            f"/api/channels/?token={self.token.token}&name=%23general",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        names = [c["name"] for c in data]
+        self.assertIn("#general", names)
+
+    def test_channels_get_invalid_token_returns_401(self):
+        resp = self.client.get(
+            "/api/channels/?token=wks_BADBADBAD", HTTP_HOST="lvh.me"
+        )
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_workspace_scoped_channels_with_token(self):
+        """GET /api/workspace/<slug>/channels/?token=... resolves on bare domain."""
+        Channel.objects.create(workspace=self.ws, name="#proj-x")
+        resp = self.client.get(
+            f"/api/workspace/tok-ws/channels/?token={self.token.token}",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        names = [c["name"] for c in resp.json()]
+        self.assertIn("#proj-x", names)
+
+    def test_workspace_scoped_dms_resolves_on_bare_domain(self):
+        """POST /api/workspace/<slug>/dms/?token=... on the bare domain works.
+
+        Pin for issue #258 — the exact MCP request shape that previously
+        404'd in production because the route wasn't mounted in
+        ``hub.urls_bare``.
+        """
+        resp = self.client.post(
+            (
+                f"/api/workspace/tok-ws/dms/"
+                f"?token={self.token.token}&agent=mamba-foo"
+            ),
+            data=json.dumps({"recipient": "human:bob"}),
+            content_type="application/json",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        data = resp.json()
+        self.assertIn("agent:mamba-foo", data["name"])
+        self.assertIn("human:bob", data["name"])
+
+
 # ── Web Push (todo#263) ─────────────────────────────────────────────────
 
 from unittest.mock import MagicMock, patch

--- a/hub/tests/views/api/test_my_subscriptions.py
+++ b/hub/tests/views/api/test_my_subscriptions.py
@@ -1,0 +1,141 @@
+"""Coverage for GET /api/me/subscriptions/ (#253).
+
+A token-authed agent must see only its own ChannelMembership rows
+inside the resolved workspace — never another agent's, never a
+different workspace's, and never any other agent's auto-created stub.
+"""
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceToken,
+)
+
+
+class MySubscriptionsTokenAuthTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="sub-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+
+        # Two agents; each subscribed to a different set of channels.
+        self.alpha = User.objects.create_user(username="agent-alpha", password="")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.alpha, role="member"
+        )
+        self.beta = User.objects.create_user(username="agent-beta", password="")
+        WorkspaceMember.objects.create(workspace=self.ws, user=self.beta, role="member")
+
+        self.ch_a = Channel.objects.create(workspace=self.ws, name="#alpha-only")
+        self.ch_shared = Channel.objects.create(workspace=self.ws, name="#shared")
+        self.ch_b = Channel.objects.create(workspace=self.ws, name="#beta-only")
+        ChannelMembership.objects.create(user=self.alpha, channel=self.ch_a)
+        ChannelMembership.objects.create(user=self.alpha, channel=self.ch_shared)
+        ChannelMembership.objects.create(
+            user=self.beta,
+            channel=self.ch_shared,
+            permission=ChannelMembership.PERM_READ_ONLY,
+        )
+        ChannelMembership.objects.create(user=self.beta, channel=self.ch_b)
+
+    def _bare_get(self, path):
+        return self.client.get(path, HTTP_HOST="lvh.me")
+
+    # ── Bare-domain endpoints ───────────────────────────────────────────
+
+    def test_alpha_sees_only_alpha_subs_bare(self):
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=alpha"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["channel"] for r in rows)
+        self.assertEqual(names, ["#alpha-only", "#shared"])
+        roles = {r["channel"]: r["role"] for r in rows}
+        self.assertEqual(roles["#shared"], "read-write")
+        self.assertEqual(roles["#alpha-only"], "read-write")
+        for r in rows:
+            self.assertIn("joined_at", r)
+            self.assertIsNotNone(r["joined_at"])
+
+    def test_beta_sees_only_beta_subs_bare(self):
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=beta"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["channel"] for r in rows)
+        self.assertEqual(names, ["#beta-only", "#shared"])
+        roles = {r["channel"]: r["role"] for r in rows}
+        self.assertEqual(roles["#shared"], "read-only")
+
+    def test_flat_path_resolves_on_bare(self):
+        """The bare /api/me/subscriptions/ shortcut also works."""
+        url = (
+            f"/api/me/subscriptions/?token={self.token.token}"
+            f"&agent=alpha"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = resp.json()
+        names = sorted(r["channel"] for r in rows)
+        self.assertEqual(names, ["#alpha-only", "#shared"])
+
+    def test_invalid_token_returns_401_bare(self):
+        url = "/api/workspace/sub-ws/me/subscriptions/?token=wks_NO&agent=alpha"
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 401, resp.content)
+
+    def test_missing_agent_returns_400_bare(self):
+        url = f"/api/workspace/sub-ws/me/subscriptions/?token={self.token.token}"
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_new_agent_sees_empty_list(self):
+        """First-sight agent gets auto-provisioned and returns []."""
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=fresh-one"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        self.assertEqual(resp.json(), [])
+
+    # ── Subdomain (urls_workspace) route ────────────────────────────────
+
+    def test_subdomain_route(self):
+        url = (
+            f"/api/me/subscriptions/?token={self.token.token}"
+            f"&agent=beta"
+        )
+        resp = self.client.get(url, HTTP_HOST="sub-ws.lvh.me")
+        self.assertEqual(resp.status_code, 200, resp.content)
+        names = sorted(r["channel"] for r in resp.json())
+        self.assertEqual(names, ["#beta-only", "#shared"])
+
+    # ── Cross-workspace isolation ───────────────────────────────────────
+
+    def test_cross_workspace_isolation(self):
+        """Memberships in another workspace must not leak into the response."""
+        other = Workspace.objects.create(name="other-ws")
+        WorkspaceMember.objects.create(workspace=other, user=self.alpha, role="member")
+        ch_other = Channel.objects.create(workspace=other, name="#secret")
+        ChannelMembership.objects.create(user=self.alpha, channel=ch_other)
+
+        url = (
+            f"/api/workspace/sub-ws/me/subscriptions/"
+            f"?token={self.token.token}&agent=alpha"
+        )
+        resp = self._bare_get(url)
+        self.assertEqual(resp.status_code, 200, resp.content)
+        names = [r["channel"] for r in resp.json()]
+        self.assertNotIn("#secret", names)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -99,6 +99,20 @@ urlpatterns = [
     path("api/agents/pinned/", views.api_agents_pinned, name="api-agents-pinned"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
+    # Admin-scoped subscribe/unsubscribe (issue #262 §9.1). Routed to a
+    # dedicated view that requires the calling actor to hold the
+    # workspace ``admin`` (or ``staff``) role; non-admin agents get a
+    # structured ``permission_denied`` JSON envelope.
+    path(
+        "api/agents/<str:target>/subscribe/",
+        views.api_admin_agent_subscribe,
+        name="api-admin-agent-subscribe",
+    ),
+    path(
+        "api/agents/<str:target>/unsubscribe/",
+        views.api_admin_agent_unsubscribe,
+        name="api-admin-agent-unsubscribe",
+    ),
     # Per-agent single-screen detail payload (todo#420 MVP).
     path(
         "api/agents/<str:name>/detail/",

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -90,6 +90,24 @@ urlpatterns = [
         name="api-channel-rename",
     ),
     path("api/workspace/<slug:slug>/stats/", views.api_stats, name="api-stats"),
+    # Channel members + my subscriptions — read-only MCP tools (#252, #253).
+    # Mounted on the default urls.py too so dashboard-side queries work
+    # in dev/test where the bare domain is the only Host header in play.
+    path(
+        "api/workspace/<slug:slug>/channel-members/",
+        views.api_channel_members,
+        name="api-channel-members",
+    ),
+    path(
+        "api/workspace/<slug:slug>/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions",
+    ),
+    path(
+        "api/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions-flat",
+    ),
     # Agent API
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/purge/", views.api_agents_purge, name="api-agents-purge"),

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -82,6 +82,21 @@ urlpatterns = [
         views.api_channel_export,
         name="api-channel-export",
     ),
+    # Channel members — MCP `channel_members` tool (#252). Token-auth
+    # on GET handled inside the view; POST/PATCH/DELETE still session-only
+    # on the bare domain since admin actions need an attributable user.
+    path(
+        "api/channel-members/",
+        views.api_channel_members,
+        name="api-channel-members",
+    ),
+    # My subscriptions — MCP `my_subscriptions` tool (#253). Read-only,
+    # token-auth via ?token=&agent=<name>.
+    path(
+        "api/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions",
+    ),
     # Workspace-scoped routes — MCP sidecars build URLs of the form
     # /api/workspace/<slug>/dms/?token=wks_... when the agent's
     # SCITEX_OROCHI_URL points at the bare domain (the default for the
@@ -115,6 +130,16 @@ urlpatterns = [
         "api/workspace/<slug:slug>/channels/<str:chat_id>/export/",
         views.api_channel_export,
         name="api-channel-export-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/channel-members/",
+        views.api_channel_members,
+        name="api-channel-members-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions-bare",
     ),
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/health/", views.api_agent_health, name="api-agent-health"),

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -134,6 +134,19 @@ urlpatterns = [
         views.api_agents_register,
         name="api-agents-register",
     ),
+    # Admin subscribe/unsubscribe — issue #262 §9.1. Mirrored on the bare
+    # domain so MCP sidecars (which default to the apex) can hit the
+    # admin path without a subdomain.
+    path(
+        "api/agents/<str:target>/subscribe/",
+        views.api_admin_agent_subscribe,
+        name="api-admin-agent-subscribe-bare",
+    ),
+    path(
+        "api/agents/<str:target>/unsubscribe/",
+        views.api_admin_agent_unsubscribe,
+        name="api-admin-agent-unsubscribe-bare",
+    ),
     # Central container-agent registry — mounted on bare domain so the MCP
     # sidecar on localhost can reach it without the subdomain middleware.
     path(

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -72,6 +72,50 @@ urlpatterns = [
         views.api_message_detail,
         name="api-message-detail",
     ),
+    # Channel info — MCP `channel_info` tool hits this on the bare
+    # domain (issue #254). Token-auth on GET handled inside the view.
+    path("api/channels/", views.api_channels, name="api-channels"),
+    # Channel export — MCP `export_channel` tool. Already accepts
+    # ?token= internally; just needs a route on the bare domain.
+    path(
+        "api/channels/<str:chat_id>/export/",
+        views.api_channel_export,
+        name="api-channel-export",
+    ),
+    # Workspace-scoped routes — MCP sidecars build URLs of the form
+    # /api/workspace/<slug>/dms/?token=wks_... when the agent's
+    # SCITEX_OROCHI_URL points at the bare domain (the default for the
+    # production hub). Without these the DM tool, channel listing,
+    # history fetch, and per-channel export 404 (issue #258 root cause).
+    # The slug kwarg is consumed by ``get_workspace`` /
+    # ``resolve_workspace_and_actor`` so the same view function works on
+    # both the subdomain (`request.workspace` set by middleware) and the
+    # bare domain (slug from URL).
+    path(
+        "api/workspace/<slug:slug>/dms/",
+        views.api_dms,
+        name="api-dms-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/channels/",
+        views.api_channels,
+        name="api-channels-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/messages/",
+        views.api_messages,
+        name="api-messages-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/history/<str:channel_name>/",
+        views.api_history,
+        name="api-history-bare",
+    ),
+    path(
+        "api/workspace/<slug:slug>/channels/<str:chat_id>/export/",
+        views.api_channel_export,
+        name="api-channel-export-bare",
+    ),
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/health/", views.api_agent_health, name="api-agent-health"),
     # Per-agent single-screen detail payload (todo#420 MVP).

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -93,6 +93,20 @@ urlpatterns = [
     path("api/agents/kill/", views.api_agents_kill, name="api-agents-kill"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
+    # Admin-scoped subscribe/unsubscribe (issue #262 §9.1) — mounted on
+    # the workspace subdomain so dashboard sessions on
+    # ``<slug>.scitex-orochi.com`` can call the admin path without an
+    # explicit slug. Permission gate inside the view enforces admin/staff.
+    path(
+        "api/agents/<str:target>/subscribe/",
+        views.api_admin_agent_subscribe,
+        name="api-admin-agent-subscribe-ws",
+    ),
+    path(
+        "api/agents/<str:target>/unsubscribe/",
+        views.api_admin_agent_unsubscribe,
+        name="api-admin-agent-unsubscribe-ws",
+    ),
     # Per-agent single-screen detail payload (todo#420 MVP).
     path(
         "api/agents/<str:name>/detail/",

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -69,6 +69,12 @@ urlpatterns = [
     ),
     path("api/channel-prefs/", views.api_channel_prefs, name="api-channel-prefs"),
     path("api/channel-members/", views.api_channel_members, name="api-channel-members"),
+    # My subscriptions — MCP `my_subscriptions` tool (#253). Read-only.
+    path(
+        "api/me/subscriptions/",
+        views.api_my_subscriptions,
+        name="api-my-subscriptions",
+    ),
     path("api/messages/", views.api_messages, name="api-messages"),
     path("api/dms/", views.api_dms, name="api-dms"),
     path("api/history/<str:channel_name>/", views.api_history, name="api-history"),

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -9,6 +9,8 @@ from hub.views.api import (  # noqa: F401
     api_agents_pin,
     api_agents_pinned,
     api_agents_purge,
+    api_admin_agent_subscribe,
+    api_admin_agent_unsubscribe,
     api_agents_register,
     api_agents_registry,
     api_agents_restart,

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -25,6 +25,7 @@ from hub.views.api import (  # noqa: F401
     api_members,
     api_message_detail,
     api_messages,
+    api_my_subscriptions,
     api_push_subscribe,
     api_push_unsubscribe,
     api_push_vapid_key,

--- a/hub/views/_helpers.py
+++ b/hub/views/_helpers.py
@@ -1,7 +1,7 @@
 """Shared helpers for hub views."""
 
 from django.conf import settings
-from django.http import Http404
+from django.http import Http404, JsonResponse
 
 
 def workspace_url(workspace_name, path="/"):
@@ -38,3 +38,115 @@ def get_workspace(request, slug=None):
         except Workspace.DoesNotExist:
             raise Http404(f"Workspace {slug!r} not found")
     raise Http404("No workspace context")
+
+
+def resolve_workspace_and_actor(request, slug=None):
+    """Token-or-session auth helper for agent-callable workspace API views.
+
+    Returns a 3-tuple ``(workspace, actor_member, error_response)``:
+
+    - On Django session auth: ``actor_member`` is the
+      :class:`hub.models.WorkspaceMember` for ``request.user`` in the
+      resolved workspace; ``error_response`` is ``None``.
+    - On workspace-token auth (``?token=wks_...``): the workspace is
+      resolved from the token. The actor is taken from the
+      ``?agent=<name>`` query param (matching the convention used by
+      ``ts/src/config.ts::buildWsUrl`` so MCP sidecars only need to
+      forward what they already pass on the WS handshake). If no
+      ``?agent=`` is supplied, the actor falls back to the request body
+      keys ``agent`` / ``sender`` / ``reactor`` (mirrors the pattern in
+      :func:`hub.views.api._reactions.api_reactions`). The synthetic
+      ``agent-<name>`` Django user + :class:`hub.models.WorkspaceMember`
+      is created on first sight so an agent that just registered can
+      open a DM without a separate provisioning step.
+    - On any failure: returns ``(None, None, JsonResponse(...))`` with
+      a populated 401/404 error.
+
+    Why this exists: the ``@login_required`` decorator that previously
+    gated ``api_dms`` etc. doesn't see workspace tokens, so MCP sidecars
+    hitting ``https://scitex-orochi.com/api/workspace/<slug>/dms/?token=
+    wks_...`` were 302-redirected to ``/signin``. Centralizing the
+    branching here keeps the call sites declarative — the view says
+    "I need a workspace and an actor" and the helper picks the right
+    auth path. Spec v3.1 §4.1 still routes message *sends* through the
+    WS path; this helper is for non-write surfaces (DM list/open,
+    channel info, history) where REST is the only option.
+    """
+    import json as _json
+
+    from django.contrib.auth import get_user_model
+
+    from hub.models import WorkspaceMember, WorkspaceToken
+
+    token_str = (
+        request.GET.get("token") or (request.POST.get("token") if request.POST else None)
+    )
+
+    # ── Session path ────────────────────────────────────────────────
+    if not token_str:
+        if not (request.user and request.user.is_authenticated):
+            return None, None, JsonResponse({"error": "auth required"}, status=401)
+        try:
+            workspace = get_workspace(request, slug=slug)
+        except Http404 as exc:
+            return None, None, JsonResponse({"error": str(exc)}, status=404)
+        member = (
+            WorkspaceMember.objects.filter(workspace=workspace, user=request.user)
+            .select_related("user")
+            .first()
+        )
+        if member is None:
+            return (
+                None,
+                None,
+                JsonResponse({"error": "not a workspace member"}, status=403),
+            )
+        return workspace, member, None
+
+    # ── Token path ──────────────────────────────────────────────────
+    try:
+        wt = WorkspaceToken.objects.select_related("workspace").get(token=token_str)
+    except WorkspaceToken.DoesNotExist:
+        return None, None, JsonResponse({"error": "invalid token"}, status=401)
+    workspace = wt.workspace
+
+    # Actor identity. For agent calls the canonical source is the
+    # ``?agent=<name>`` query param; falling back to body keys matches
+    # the heterogeneous shapes existing endpoints already accept.
+    agent_name = (request.GET.get("agent") or "").strip()
+    if not agent_name and request.body:
+        try:
+            body = _json.loads(request.body or b"{}")
+            agent_name = (
+                body.get("agent")
+                or body.get("sender")
+                or body.get("reactor")
+                or ""
+            ).strip()
+        except (_json.JSONDecodeError, ValueError):
+            agent_name = ""
+    if not agent_name:
+        return (
+            None,
+            None,
+            JsonResponse(
+                {"error": "agent identity required (pass ?agent=<name>)"},
+                status=400,
+            ),
+        )
+
+    User = get_user_model()
+    username = f"agent-{agent_name}"
+    user, _ = User.objects.get_or_create(
+        username=username,
+        defaults={
+            "email": f"{username}@agents.orochi.local",
+            "is_active": True,
+        },
+    )
+    member, _ = WorkspaceMember.objects.get_or_create(
+        user=user,
+        workspace=workspace,
+        defaults={"role": "member"},
+    )
+    return workspace, member, None

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -247,6 +247,14 @@ def api_agent_detail(request, name: str):
         # by latency).
         "last_pong_ts": agent.get("last_pong_ts"),
         "last_rtt_ms": agent.get("last_rtt_ms"),
+        # #259 — 4th indicator (Remote / nonce-echo round-trip).
+        # ``last_nonce_echo_at`` is the field the agent-badge LED
+        # renderer consumes (already wired in agent-badge.js); the
+        # other two surface RTT + raw unix timestamp for the per-agent
+        # detail page tooling.
+        "last_nonce_echo_at": agent.get("last_nonce_echo_at"),
+        "last_echo_rtt_ms": agent.get("last_echo_rtt_ms"),
+        "last_echo_ok_ts": agent.get("last_echo_ok_ts"),
         "liveness": agent.get("liveness") or agent.get("status") or "unknown",
         "claude_md": redact_secrets(agent.get("claude_md") or ""),
         # todo#460: serve the workspace .mcp.json for the Agents tab viewer.

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -32,7 +32,7 @@ from datetime import datetime, timezone
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
 
-from hub.registry import get_agents
+from hub.registry import get_agents, get_recent_singleton_event
 
 # Canonical list of credential-ish strings to redact from terminal
 # captures before serving them to the dashboard. These are matched as
@@ -322,5 +322,12 @@ def api_agent_detail(request, name: str):
         "last_action_elapsed_s": agent.get("last_action_elapsed_s"),
         "action_counts": agent.get("action_counts") or {},
         "p95_elapsed_s_by_action": agent.get("p95_elapsed_s_by_action") or {},
+        # scitex-orochi#255: most recent singleton-cardinality conflict
+        # for this agent within ``SINGLETON_EVENT_WINDOW_S``. ``None``
+        # when no conflict has been recorded recently. Each event has
+        # ``ts``, ``winner_instance_id``, ``loser_instance_id``,
+        # ``reason``. The Agents tab uses this to surface a "another
+        # process tried to claim this name" warning chip.
+        "last_duplicate_identity_event": get_recent_singleton_event(name),
     }
     return JsonResponse(payload)

--- a/hub/views/api/__init__.py
+++ b/hub/views/api/__init__.py
@@ -24,6 +24,10 @@ from hub.views.api._agents import (
 )
 from hub.views.api._agents_lifecycle import api_agents_kill, api_agents_restart
 from hub.views.api._agents_register import api_agents_register
+from hub.views.api._agents_subscribe import (
+    api_admin_agent_subscribe,
+    api_admin_agent_unsubscribe,
+)
 from hub.views.api._channels import (
     api_channel_members,
     api_channel_prefs,
@@ -58,6 +62,8 @@ __all__ = [
     "api_agents_pin",
     "api_agents_pinned",
     "api_agents_purge",
+    "api_admin_agent_subscribe",
+    "api_admin_agent_unsubscribe",
     "api_agents_register",
     "api_agents_registry",
     "api_agents_restart",

--- a/hub/views/api/__init__.py
+++ b/hub/views/api/__init__.py
@@ -28,6 +28,7 @@ from hub.views.api._channels import (
     api_channel_members,
     api_channel_prefs,
     api_channels,
+    api_my_subscriptions,
     api_stats,
     api_workspaces,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "api_members",
     "api_message_detail",
     "api_messages",
+    "api_my_subscriptions",
     "api_push_subscribe",
     "api_push_unsubscribe",
     "api_push_vapid_key",

--- a/hub/views/api/_agents_register.py
+++ b/hub/views/api/_agents_register.py
@@ -97,6 +97,14 @@ def api_agents_register(request):
         info={
             "agent_id": body.get("agent_id") or name,
             "machine": body.get("machine", ""),
+            # #257 — live ``hostname(1)`` of the running agent process.
+            # Authoritative "where am I" signal that the frontend badge
+            # (hostedAgentName) prefers over ``machine``. Client-supplied
+            # from the agent's own ``socket.gethostname()`` / Node
+            # ``os.hostname()`` — NEVER derived from the auth token or
+            # source IP on the hub side (lead msg#15578: server-side
+            # inference was the bug we're fixing).
+            "hostname": body.get("hostname", ""),
             # todo#55: canonical FQDN (socket.getfqdn()) from the heartbeat.
             "hostname_canonical": body.get("hostname_canonical", ""),
             "role": body.get("role", "agent"),

--- a/hub/views/api/_agents_subscribe.py
+++ b/hub/views/api/_agents_subscribe.py
@@ -1,0 +1,175 @@
+"""Admin-scoped agent channel subscription endpoints (issue #262 §9.1).
+
+These views let a fleet-coordinator (workspace ``admin`` or ``staff``
+role) toggle another agent's persistent ``ChannelMembership`` rows
+without that agent having to be online. The MCP ``subscribe`` /
+``unsubscribe`` tools route here when called with the optional
+``target_agent`` argument; the existing self-targeting WS path stays
+untouched.
+
+The view body is intentionally small — most of the work is delegated to
+:func:`hub.consumers._helpers._persist_agent_subscription` so the WS
+path and the admin REST path share a single ``ChannelMembership``
+mutation surface (no risk of the two diverging).
+"""
+
+import re
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+
+from hub.consumers._helpers import _persist_agent_subscription
+from hub.models import normalize_channel_name
+from hub.views._helpers import resolve_workspace_and_actor
+from hub.views.api._common import (
+    JsonResponse,
+    csrf_exempt,
+    json,
+    log,
+    require_http_methods,
+)
+
+_ADMIN_ROLES = {"admin", "staff"}
+
+
+def _admin_subscribe(request, target, *, slug=None, subscribe: bool):
+    """Shared body for the admin subscribe + unsubscribe endpoints."""
+    workspace, actor, err = resolve_workspace_and_actor(request, slug=slug)
+    if err is not None:
+        return err
+
+    actor_role = (getattr(actor, "role", "") or "").lower()
+    if actor_role not in _ADMIN_ROLES:
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "permission_denied",
+                    "reason": "agent-scope tokens cannot manage other agents",
+                    "hint": "Run as admin or use the dashboard",
+                }
+            },
+            status=403,
+        )
+
+    target_name = (target or "").strip()
+    if not target_name or not re.match(r"^[a-zA-Z0-9_.\-]+$", target_name):
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "invalid_input",
+                    "reason": "target agent name missing or malformed",
+                    "hint": "pass a non-empty name matching [a-zA-Z0-9_.-]+",
+                }
+            },
+            status=400,
+        )
+
+    body = {}
+    if request.body:
+        try:
+            body = json.loads(request.body)
+        except (json.JSONDecodeError, ValueError):
+            return JsonResponse(
+                {
+                    "error": {
+                        "code": "invalid_input",
+                        "reason": "request body is not valid JSON",
+                        "hint": "POST a JSON object with {\"channel\": \"#name\"}",
+                    }
+                },
+                status=400,
+            )
+
+    raw_channel = (body.get("channel") or "").strip()
+    if not raw_channel:
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "invalid_input",
+                    "reason": "channel is required",
+                    "hint": "include a non-empty channel name in the request body",
+                }
+            },
+            status=400,
+        )
+
+    ch_name = normalize_channel_name(raw_channel)
+
+    # ``_persist_agent_subscription`` is an async helper; wrap it so the
+    # synchronous view can call it without spinning a loop. It returns
+    # ``False`` only when the workspace cannot be resolved — every other
+    # failure raises.
+    ok = async_to_sync(_persist_agent_subscription)(
+        workspace.id, target_name, ch_name, subscribe
+    )
+    if not ok:
+        return JsonResponse(
+            {
+                "error": {
+                    "code": "internal_error",
+                    "reason": "could not persist subscription",
+                    "hint": "check the hub log for the underlying error",
+                }
+            },
+            status=500,
+        )
+
+    # If the target is currently connected, nudge its consumer so the
+    # in-memory channel-layer group membership picks up the change without
+    # waiting for a reconnect. The consumer listens on its per-agent group
+    # for ``agent.subscribe.refresh`` and rehydrates from the DB.
+    try:
+        layer = get_channel_layer()
+        if layer is not None:
+            async_to_sync(layer.group_send)(
+                f"agent_{workspace.id}_{target_name}",
+                {
+                    "type": "agent.subscribe.refresh",
+                    "channel": ch_name,
+                    "subscribe": bool(subscribe),
+                },
+            )
+    except Exception as exc:  # pragma: no cover — best-effort nudge
+        log.debug(
+            "admin subscribe nudge failed for %s/%s: %s",
+            target_name,
+            ch_name,
+            exc,
+        )
+
+    log.info(
+        "admin %s: %s %s on %s by %s",
+        "subscribe" if subscribe else "unsubscribe",
+        target_name,
+        ch_name,
+        workspace.name,
+        getattr(actor.user, "username", "?"),
+    )
+
+    return JsonResponse(
+        {
+            "status": "ok",
+            "target_agent": target_name,
+            "channel": ch_name,
+            "action": "subscribe" if subscribe else "unsubscribe",
+        }
+    )
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def api_admin_agent_subscribe(request, target, slug=None):
+    """``POST /api/agents/<target>/subscribe/`` — admin subscribe a peer.
+
+    Body: ``{"channel": "#name"}``. Auth: workspace token + ``?agent=``
+    or Django session — but the actor must hold the ``admin`` (or
+    ``staff``) role on the resolved workspace.
+    """
+    return _admin_subscribe(request, target, slug=slug, subscribe=True)
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def api_admin_agent_unsubscribe(request, target, slug=None):
+    """``POST /api/agents/<target>/unsubscribe/`` — admin unsubscribe a peer."""
+    return _admin_subscribe(request, target, slug=slug, subscribe=False)

--- a/hub/views/api/_channels.py
+++ b/hub/views/api/_channels.py
@@ -6,6 +6,7 @@ from hub.views.api._common import (
     JsonResponse,
     Workspace,
     WorkspaceMember,
+    WorkspaceToken,
     async_to_sync,
     csrf_exempt,
     get_channel_layer,
@@ -44,13 +45,37 @@ def api_workspaces(request):
 
 
 @csrf_exempt
-@login_required
 @require_http_methods(["GET", "PATCH"])
 def api_channels(request, slug=None):
     """GET /api/channels/ — list channels in current workspace.
     PATCH /api/channels/?name=<channel> — update channel description (topic).
+
+    Auth: Django session OR workspace token (``?token=wks_...``). The
+    token branch supports the MCP ``channel_info`` tool which hits the
+    bare domain — see issue #254 / #258 for the original outage. PATCH
+    still requires a logged-in human (token-auth has no notion of "who
+    edited the topic").
     """
-    workspace = get_workspace(request, slug=slug)
+    # GET supports token auth (read-only); PATCH still requires session
+    # because we attribute the edit to a Django user for audit.
+    if request.method == "GET":
+        token_str = request.GET.get("token")
+        if token_str:
+            try:
+                wt = WorkspaceToken.objects.select_related("workspace").get(
+                    token=token_str
+                )
+                workspace = wt.workspace
+            except WorkspaceToken.DoesNotExist:
+                return JsonResponse({"error": "invalid token"}, status=401)
+        elif request.user and request.user.is_authenticated:
+            workspace = get_workspace(request, slug=slug)
+        else:
+            return JsonResponse({"error": "auth required"}, status=401)
+    else:
+        if not (request.user and request.user.is_authenticated):
+            return JsonResponse({"error": "auth required"}, status=401)
+        workspace = get_workspace(request, slug=slug)
 
     if request.method == "PATCH":
         body = json.loads(request.body)

--- a/hub/views/api/_channels.py
+++ b/hub/views/api/_channels.py
@@ -1,5 +1,6 @@
 """Channel/workspace listing + prefs + members + stats API views."""
 
+from hub.views._helpers import resolve_workspace_and_actor
 from hub.views.api._common import (
     Channel,
     ChannelPreference,
@@ -211,13 +212,16 @@ def api_channel_prefs(request, slug=None):
     return JsonResponse(data, safe=False)
 
 
-@login_required
+@csrf_exempt
 @require_http_methods(["GET", "POST", "PATCH", "DELETE"])
 def api_channel_members(request, slug=None):
     """Channel membership admin endpoint (todo#407 + Phase 3 channel refactor).
 
     GET /api/channel-members/?channel=<name>
-        List members with permission level.
+        List members with permission level. Read-only; accepts either a
+        Django session OR a workspace token (``?token=wks_...&agent=<name>``)
+        so the MCP ``channel_members`` tool (#252) can hit it from the
+        bare domain without a browser session.
     POST /api/channel-members/  (admin only)
         Subscribe a member: body {channel, username, permission?}.
         Idempotent. Creates the channel if missing (group kind).
@@ -228,7 +232,14 @@ def api_channel_members(request, slug=None):
     """
     from hub.models import ChannelMembership
 
-    workspace = get_workspace(request, slug=slug)
+    if request.method == "GET":
+        workspace, _actor, err = resolve_workspace_and_actor(request, slug=slug)
+        if err is not None:
+            return err
+    else:
+        if not (request.user and request.user.is_authenticated):
+            return JsonResponse({"error": "auth required"}, status=401)
+        workspace = get_workspace(request, slug=slug)
 
     if request.method in ("POST", "PATCH", "DELETE"):
         body = json.loads(request.body) if request.body else {}
@@ -356,6 +367,50 @@ def api_channel_members(request, slug=None):
                     "role": wm.role,
                 }
             )
+    return JsonResponse(data, safe=False)
+
+
+@csrf_exempt
+@require_GET
+def api_my_subscriptions(request, slug=None):
+    """GET /api/me/subscriptions/?token=wks_...&agent=<name>
+
+    Read-only endpoint backing the MCP ``my_subscriptions`` tool (#253).
+    Returns the list of channels the calling agent is explicitly
+    subscribed to via :class:`ChannelMembership` rows. Each row has the
+    shape ``{channel, joined_at, role}`` where ``role`` is the member's
+    permission on that channel (``read-write`` / ``read-only``).
+
+    Auth follows the same token-or-session contract as the other
+    agent-facing read endpoints (see
+    :func:`hub.views._helpers.resolve_workspace_and_actor`). On token
+    auth the actor is taken from ``?agent=<name>``; on session auth the
+    actor is the logged-in user (so a human dashboard query is also
+    valid). Either way the response is scoped to the *actor* — an
+    agent cannot peek at another agent's subscriptions.
+    """
+    from hub.models import ChannelMembership
+
+    workspace, actor_member, err = resolve_workspace_and_actor(request, slug=slug)
+    if err is not None:
+        return err
+
+    memberships = (
+        ChannelMembership.objects.filter(
+            user=actor_member.user,
+            channel__workspace=workspace,
+        )
+        .select_related("channel")
+        .order_by("channel__name")
+    )
+    data = [
+        {
+            "channel": m.channel.name,
+            "joined_at": m.joined_at.isoformat() if m.joined_at else None,
+            "role": m.permission,
+        }
+        for m in memberships
+    ]
     return JsonResponse(data, safe=False)
 
 

--- a/hub/views/api/_channels.py
+++ b/hub/views/api/_channels.py
@@ -290,6 +290,15 @@ def api_channel_members(request, slug=None):
         if perm not in ("read-write", "read-only"):
             return JsonResponse({"error": "invalid permission"}, status=400)
 
+        # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293
+        # follow-up). Block any subscribe/update attempt at the REST layer
+        # so the client gets a real signal instead of a silent 200.
+        # DELETE is still allowed above so stale memberships can be cleaned.
+        from hub.consumers._helpers import ABOLISHED_AGENT_CHANNELS
+
+        if ch_name in ABOLISHED_AGENT_CHANNELS and request.method in ("POST", "PATCH"):
+            return JsonResponse({"error": "channel abolished"}, status=403)
+
         if request.method == "POST":
             # Idempotent subscribe: create the channel if missing.
             ch, _ = Channel.objects.get_or_create(

--- a/hub/views/api/_common.py
+++ b/hub/views/api/_common.py
@@ -23,7 +23,7 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_http_methods
 
-from hub.channel_acl import check_write_allowed
+from hub.channel_acl import check_membership_allowed, check_write_allowed
 from hub.models import (
     Channel,
     ChannelPreference,
@@ -57,6 +57,7 @@ __all__ = [
     "WorkspaceToken",
     "_server_start_time",
     "async_to_sync",
+    "check_membership_allowed",
     "check_write_allowed",
     "csrf_exempt",
     "datetime",

--- a/hub/views/api/_dms.py
+++ b/hub/views/api/_dms.py
@@ -1,5 +1,6 @@
 """Direct-message helpers + ``/api/dms/`` view (spec v3 §4)."""
 
+from hub.views._helpers import resolve_workspace_and_actor
 from hub.views.api._common import (
     Channel,
     DMParticipant,
@@ -9,10 +10,8 @@ from hub.views.api._common import (
     async_to_sync,
     csrf_exempt,
     get_channel_layer,
-    get_workspace,
     json,
     log,
-    login_required,
     require_http_methods,
 )
 
@@ -201,24 +200,19 @@ def _dm_row(channel, current_member):
     }
 
 
-@login_required
 @csrf_exempt
 @require_http_methods(["GET", "POST"])
 def api_dms(request, slug=None):
     """GET/POST /api/workspace/<slug>/dms/ — list or create 1:1 DMs.
 
-    Spec v3 §4. The current authenticated principal is resolved via
-    ``WorkspaceMember`` for ``request.user`` in the active workspace.
+    Spec v3 §4. Auth is either a Django session OR a workspace token
+    (``?token=wks_...&agent=<name>``) — see
+    :func:`hub.views._helpers.resolve_workspace_and_actor`. MCP sidecars
+    on the bare domain rely on the token branch (issue #258 root cause).
     """
-    workspace = get_workspace(request, slug=slug)
-
-    current_member = (
-        WorkspaceMember.objects.filter(workspace=workspace, user=request.user)
-        .select_related("user")
-        .first()
-    )
-    if current_member is None:
-        return JsonResponse({"error": "not a workspace member"}, status=403)
+    workspace, current_member, err = resolve_workspace_and_actor(request, slug=slug)
+    if err is not None:
+        return err
 
     if request.method == "GET":
         my_dm_channel_ids = DMParticipant.objects.filter(

--- a/hub/views/api/_messages.py
+++ b/hub/views/api/_messages.py
@@ -10,6 +10,7 @@ from hub.views.api._common import (
     Message,
     MessageThread,
     async_to_sync,
+    check_membership_allowed,
     check_write_allowed,
     get_channel_layer,
     get_workspace,
@@ -99,6 +100,19 @@ def api_messages(request, slug=None):
     ):
         return JsonResponse(
             {"error": "not allowed to write to this channel"}, status=403
+        )
+    # Issue #276 — close the REST write-path ACL gap. The yaml ACL above
+    # is permissive-by-default when channels.yaml is absent; the
+    # ChannelMembership gate enforces the per-(user, channel) permission
+    # rows managed via /api/channel-members/ and blocks agents that were
+    # never explicitly subscribed to the target group channel.
+    if not check_membership_allowed(
+        sender=sender_identity,
+        channel=ch_name,
+        workspace_id=workspace.id,
+    ):
+        return JsonResponse(
+            {"error": "not a member of this channel"}, status=403
         )
 
     channel, _ = Channel.objects.get_or_create(

--- a/hub/views/api/_reactions.py
+++ b/hub/views/api/_reactions.py
@@ -80,7 +80,9 @@ def api_reactions(request):
     if not message_id or not emoji:
         return JsonResponse({"error": "message_id and emoji required"}, status=400)
     try:
-        msg = Message.objects.get(id=message_id, workspace=workspace)
+        msg = Message.objects.select_related("channel").get(
+            id=message_id, workspace=workspace
+        )
     except Message.DoesNotExist:
         return JsonResponse({"error": "message not found"}, status=404)
 
@@ -106,7 +108,9 @@ def api_reactions(request):
         ).delete()
         action = "removed" if deleted else "not_found"
 
-    # Broadcast reaction update to workspace group
+    # Broadcast reaction update to workspace group. ``channel`` is
+    # required so the AgentConsumer read-side filter (#277) can drop
+    # events for channels the receiver is not a member of.
     layer = get_channel_layer()
     group = f"workspace_{workspace.id}"
     async_to_sync(layer.group_send)(
@@ -114,6 +118,7 @@ def api_reactions(request):
         {
             "type": "reaction.update",
             "message_id": msg.id,
+            "channel": msg.channel.name,
             "emoji": emoji,
             "reactor": reactor,
             "action": action,

--- a/orochi-machines.yaml
+++ b/orochi-machines.yaml
@@ -1,9 +1,10 @@
 # Orochi Fleet Machine Inventory (todo#283 / Task #2)
 #
 # Source-of-truth manifest for the four fleet hosts. Producer/consumer roles:
-#   - Producers (per-host healers, fleet_watch.sh) read this to know what
-#     they're supposed to see (expected sessions, expected resources).
-#   - Consumers (mamba-healer-*, MCP `connectivity_matrix`, future hub UI
+#   - Producers (per-host healers, fleet_watch.sh, host-liveness-probe.sh)
+#     read this to know what they're supposed to see (expected sessions,
+#     expected resources).
+#   - Consumers (healer-<host>, MCP `connectivity_matrix`, future hub UI
 #     Machines tab) read this to render labels and to flag drift.
 #
 # This file is intentionally human-curated, not auto-generated. The drifted
@@ -64,22 +65,37 @@ machines:
       hostname: bastion-mba.scitex-orochi.com
       cloudflared_running: true
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all)
       - head-mba
-      - mamba-auth-manager-mba
-      - mamba-explorer-mba
-      - mamba-healer-mba
-      - mamba-quality-checker-mba
-      - mamba-skill-manager
-      - mamba-synchronizer-mba
-      - mamba-todo-manager
-      - mamba-verifier-mba
+      - healer-mba
+      # Fleet-wide singletons currently pinned on mba (host: priority chain,
+      # first-available wins; mba is primary for all six mgr-* + expert-* +
+      # lead + proj-* today — see #298).
+      - expert-scitex
+      - lead
+      - mgr-auth
+      - mgr-code-quality
+      - mgr-memory
+      - mgr-pkg
+      - mgr-secretary
+      - mgr-todo
+      - proj-neurovista
+      - proj-ripple-wm
+      - proj-scitex-clew
+      - proj-scitex-cloud
+      - proj-scitex-orochi
+      # Host-pinned + per-host workers on mba
+      - worker-iOS-simulator   # host: [mba] — only Mac in fleet has Xcode
+      - worker-playwright-mba  # hosts: all
+      - worker-progress        # host: [mba] — #301
+      - worker-todo-mirror     # singleton; lives on mba today
     process_caps:
       ulimit_u: 4000         # macOS hard cap (msg#8043 confirmed); raise via launchctl limit maxproc
       pid_max: ~             # macOS uses kern.maxproc, not /proc/sys/kernel/pid_max
     notes:
       - "Hub origin: scitex-orochi.com Cloudflare tunnel terminates here."
       - "Fork pressure observed at 18.5% (739/4000) during today's session — well under cap but cap is hard."
-      - "All 9 head + mamba sessions auto-start via launchd plist staged in ~/.dotfiles/src/launchd/."
+      - "All head + mgr-*/proj-*/worker-* sessions auto-start via launchd plist staged in ~/.dotfiles/src/launchd/."
 
   # ---------------------------------------------------------------------------
   - canonical_name: nas
@@ -123,8 +139,11 @@ machines:
       hostname: bastion-nas.scitex-orochi.com
       cloudflared_running: true
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all)
       - head-nas
-      - mamba-healer-nas
+      - healer-nas
+      # Per-host worker (hosts: all)
+      - worker-playwright-nas
     process_caps:
       ulimit_u: ~              # ulimit -u inherited from systemd, no hard cap observed
       pid_max: 4194304         # /proc/sys/kernel/pid_max
@@ -175,7 +194,11 @@ machines:
       hostname: bastion-spartan.scitex-orochi.com
       cloudflared_running: false   # tier-2, requires HPC admin policy verification
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all). Minimal roster on spartan
+      # today — login node has cgroup CPU=1 cap so heavy agents dispatch via
+      # salloc/srun rather than running on login1 directly.
       - head-spartan
+      - healer-spartan
     process_caps:
       ulimit_u: ~              # cgroup 1 CPU on login1 per HPC policy
       pid_max: 303104          # observed at session start (Linux default class)
@@ -224,8 +247,12 @@ machines:
       hostname: bastion-ywata-note-win.scitex-orochi.com
       cloudflared_running: false   # tier-3, future
     expected_tmux_sessions:
+      # Per-host gateway + healer (hosts: all). Other fleet-wide agents may
+      # land here later if mba is offline and the singleton priority chain
+      # drifts over (host: [ywata-note-win, mba, nas, spartan]) — don't
+      # pre-list them; let the probe's advisory path catch transients.
       - head-ywata-note-win
-      - mamba-healer-ywata-note-win
+      - healer-ywata-note-win
     process_caps:
       ulimit_u: ~
       pid_max: 4194304
@@ -235,7 +262,7 @@ machines:
       - "mamba-healer-ywata-note-win identity drift fixed via SCITEX_OROCHI_AGENT env (todo#304)."
 
 # ---------------------------------------------------------------------------
-# Fleet-wide preflight thresholds (consumed by mamba-healer-* + fleet_watch.sh)
+# Fleet-wide preflight thresholds (consumed by healer-<host> + fleet_watch.sh)
 # ---------------------------------------------------------------------------
 preflight:
   fork_pressure_warn_pct: 60

--- a/orochi-machines.yaml
+++ b/orochi-machines.yaml
@@ -244,6 +244,15 @@ preflight:
   context_pressure_critical_pct: 70   # default trigger_at_percent (todo#284)
   fleet_watch_cycle_seconds: 300
   fleet_watch_neutral_observer: nas
+  # Disk pressure — consumed by scripts/client/fleet-watch/disk-pressure-probe.sh
+  # Defaults per #286 (2026-04-21 mba full-disk incident). Severity ladder:
+  #   free >= advisory → ok
+  #   advisory > free >= warn → advisory (healer posts suggestion to #agent)
+  #   warn > free >= critical → warn (healer escalates, halts non-essential work)
+  #   free < critical → critical (block new heavy ops, demand human or reaper)
+  disk_free_advisory_gib: 10
+  disk_free_warn_gib: 5
+  disk_free_critical_gib: 2
 
 # ---------------------------------------------------------------------------
 # Bastion mesh (#283 + #294)

--- a/scripts/client/agent_meta_pkg/_classifier.py
+++ b/scripts/client/agent_meta_pkg/_classifier.py
@@ -6,9 +6,18 @@ agent_meta stays dependency-free. The classifier runs on every push
 (~30 s), reads the pane tail, and emits a stable label + verbatim
 stuck-prompt text so the hub Agents tab can render a badge + expand
 the prompt ywatanabe needs to see.
+
+2026-04-21 extension (lead msg#15541): added `stale` pane_state and a
+contradiction detector for the "3rd LED = stale while 4th LED = green"
+case observed on the dashboard. Contradiction evidence gets written to
+a dedicated log so future pattern additions have ground-truth data.
 """
 
 from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
 
 _COMPOSE_CHEVRON = "❯"
 _PROGRESS_MARKERS = ("esc to interrupt",)
@@ -16,6 +25,68 @@ _AUTH_MARKERS = ("/login", "Invalid API key", "authentication failed")
 _BYPASS_MARKERS = ("Bypass Permissions", "2. Yes, I accept")
 _DEVCHAN_MARKERS = ("1. I am using this for local development",)
 _YN_MARKERS = ("y/n", "[y/N]", "[Y/n]")
+
+# Markers that indicate the agent is actively doing something (busy /
+# animating). When present, the pane is NOT stale regardless of whether
+# the tail bytes changed between samples.
+_BUSY_ANIMATION_MARKERS = (
+    "Mulling",
+    "Mulling…",
+    "Mulling...",
+    "Pondering",
+    "Pondering…",
+    "Pondering...",
+    "Churning",
+    "Churning…",
+    "Churning...",
+    "Roosting",
+    "Roosting…",
+    "Thinking",
+    "Thinking…",
+    "Cogitating",
+    "Musing",
+    "Reflecting",
+    "Working",
+    "Working…",
+    "Working...",
+    "Crunched",
+    "Press up to edit queued messages",
+)
+
+# Where we persist pane-tail hashes across classifier calls so we can
+# detect "this pane has not changed in N cycles" without adding
+# cross-process state to the payload. Keyed by agent name. Cheap enough
+# to live next to the other agent_meta state files.
+_STATE_DIR = Path(
+    os.environ.get(
+        "SCITEX_FLEET_CLASSIFIER_STATE_DIR",
+        str(Path.home() / ".local" / "state" / "scitex" / "fleet-classifier"),
+    )
+)
+
+# Where contradiction-evidence records land. One line per occurrence,
+# timestamped, with a verbatim tail of the tmux pane so ywatanabe (and
+# future pattern work) can see exactly what the agent was showing when
+# the classifier disagreed with the heartbeat.
+_CONTRADICTIONS_LOG = Path(
+    os.environ.get(
+        "SCITEX_FLEET_CONTRADICTIONS_LOG",
+        str(
+            Path.home()
+            / ".local"
+            / "state"
+            / "scitex"
+            / "fleet-pane-contradictions.log"
+        ),
+    )
+)
+
+# Cycles of identical pane tail before we flip the classifier to
+# `stale`. The agent_meta push cycle is ~30 s, so 3 cycles ≈ 90 s of
+# no visible change — that's comfortably longer than a burst of silent
+# token streaming but shorter than the HB `stale` threshold (10 min),
+# so the 3rd-LED contradiction window is wide enough to catch.
+_STALE_CYCLES_THRESHOLD = 3
 
 
 def _extract_compose_text(tail: str) -> str:
@@ -29,15 +100,99 @@ def _extract_compose_text(tail: str) -> str:
     return compose
 
 
-def _classify_pane_state(tail_clean: str, full_pane: str) -> str:
+def _has_busy_animation(hay: str) -> bool:
+    """True when the pane shows a busy-animation marker (mulling / working / …).
+
+    Conservative: if *any* animation-style keyword appears in the scan
+    window we consider the pane busy and therefore NOT stale, even when
+    the bytes didn't change between two samples.
+    """
+    return any(m in hay for m in _BUSY_ANIMATION_MARKERS)
+
+
+def _pane_digest(tail_clean: str, full_pane: str) -> str:
+    """Stable short digest of the pane content used for stagnation tracking.
+
+    We hash `tail_clean` (channel-chatter stripped) + `full_pane` so that
+    ← inbound chatter from scitex-orochi doesn't shift the digest when
+    the agent itself hasn't typed / printed anything new.
+    """
+    h = hashlib.sha1()
+    h.update((tail_clean or "").encode("utf-8", errors="replace"))
+    h.update(b"\0")
+    h.update((full_pane or "").encode("utf-8", errors="replace"))
+    return h.hexdigest()[:16]
+
+
+def _load_state(agent: str) -> tuple[str, int]:
+    """Return (last_digest, consecutive_same_count) from disk for `agent`.
+
+    Absent / unreadable state file → ('', 0). Best-effort only — a
+    classifier that cannot read its state file must still classify.
+    """
+    if not agent:
+        return "", 0
+    path = _STATE_DIR / f"{agent}.state"
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        return "", 0
+    parts = raw.split("\t", 1)
+    if len(parts) != 2:
+        return "", 0
+    digest = parts[0].strip()
+    try:
+        count = int(parts[1].strip())
+    except (TypeError, ValueError):
+        count = 0
+    return digest, max(0, count)
+
+
+def _save_state(agent: str, digest: str, count: int) -> None:
+    """Persist (digest, count) for `agent`. Best-effort — never raises."""
+    if not agent:
+        return
+    try:
+        _STATE_DIR.mkdir(parents=True, exist_ok=True)
+        (_STATE_DIR / f"{agent}.state").write_text(
+            f"{digest}\t{count}\n", encoding="utf-8"
+        )
+    except OSError:
+        pass
+
+
+def _update_stagnation_count(agent: str, digest: str) -> int:
+    """Compare `digest` to the previous digest for `agent`, update state,
+    and return the new consecutive-same count. 0 means "changed this
+    cycle"; N >= 1 means "unchanged for N cycles in a row"."""
+    prev_digest, prev_count = _load_state(agent)
+    if prev_digest and prev_digest == digest:
+        count = prev_count + 1
+    else:
+        count = 0
+    _save_state(agent, digest, count)
+    return count
+
+
+def _classify_pane_state(
+    tail_clean: str,
+    full_pane: str,
+    agent: str = "",
+) -> str:
     """Classify the agent's current pane state into one of:
     running / compose_pending_unsent / bypass_permissions_prompt /
-    dev_channels_prompt / y_n_prompt / auth_error / idle / ""
+    dev_channels_prompt / y_n_prompt / auth_error / stale / idle / ""
 
     Conservative — returns "" when we can't confidently classify.
     The full_pane string is the raw ~30-line capture used for marker
     scans; tail_clean is the channel-inbound-stripped tail used for
     compose-box detection (so ← scitex-orochi lines don't fool us).
+
+    `agent` is optional. When supplied, the classifier tracks the
+    pane-tail digest across calls and can emit `stale` when the pane
+    has not changed for `_STALE_CYCLES_THRESHOLD` consecutive cycles.
+    When `agent` is empty, stagnation tracking is skipped and the
+    classifier behaves exactly like its pre-2026-04-21 self.
     """
     if not full_pane and not tail_clean:
         return ""
@@ -55,10 +210,25 @@ def _classify_pane_state(tail_clean: str, full_pane: str) -> str:
     compose = _extract_compose_text(tail_clean)
     if len(compose) >= 3 and not compose.startswith("> "):
         return "compose_pending_unsent"
+
+    # Stagnation check — only meaningful when we have a stable agent
+    # identity to key the digest against. Skips cleanly when agent is
+    # empty (legacy callers, one-shot eval in tests, etc.).
+    if agent:
+        digest = _pane_digest(tail_clean, full_pane)
+        same_cycles = _update_stagnation_count(agent, digest)
+        if same_cycles >= _STALE_CYCLES_THRESHOLD and not _has_busy_animation(
+            hay
+        ):
+            return "stale"
     return "idle"
 
 
-def _extract_stuck_prompt(tail_clean: str, full_pane: str) -> str:
+def _extract_stuck_prompt(
+    tail_clean: str,
+    full_pane: str,
+    agent: str = "",
+) -> str:
     """Return the verbatim stuck-prompt text the agent is blocked on.
 
     Empty string when the agent isn't stuck. For `compose_pending_unsent`
@@ -66,11 +236,97 @@ def _extract_stuck_prompt(tail_clean: str, full_pane: str) -> str:
     (bypass/dev-channels/y_n) we return a short excerpt from the tail
     containing the marker line, so ywatanabe can see *exactly* what text
     the agent is facing.
+
+    `stale` is treated like a stuck state for extraction purposes — we
+    hand back the tail excerpt so ywatanabe can read what the agent was
+    staring at when it stopped making progress.
     """
-    state = _classify_pane_state(tail_clean, full_pane)
+    state = _classify_pane_state(tail_clean, full_pane, agent)
     if state in ("running", "idle", ""):
         return ""
     if state == "compose_pending_unsent":
         return _extract_compose_text(tail_clean)[:500]
     hay_lines = (tail_clean or "").splitlines()[-12:]
     return "\n".join(hay_lines)[:500]
+
+
+# ---------------------------------------------------------------------------
+# Contradiction detector + evidence log
+# ---------------------------------------------------------------------------
+
+_CONTRADICTION_STALE_VS_GREEN = "contradiction:3rd-stale-vs-4th-green"
+
+
+def _is_liveness_green(liveness: str | None) -> bool:
+    """The 4th LED (heartbeat-derived liveness) is considered `green`
+    when the hub sees the agent as actively online. Any other value
+    (idle / stale / offline / unknown) is NOT green."""
+    return (liveness or "").strip().lower() == "online"
+
+
+def _detect_contradiction(pane_state: str, liveness: str | None) -> str:
+    """Return a classifier-note string when pane_state disagrees with the
+    heartbeat-derived liveness in a way that ywatanabe flagged on the
+    dashboard (msg#15541). Empty string otherwise.
+
+    Current rule: pane_state == `stale` while heartbeat liveness is
+    `online` (green) is a hard contradiction — the pane says nothing
+    is happening but the hub is still receiving fresh heartbeats.
+    """
+    if (pane_state or "").strip().lower() == "stale" and _is_liveness_green(
+        liveness
+    ):
+        return _CONTRADICTION_STALE_VS_GREEN
+    return ""
+
+
+def _log_contradiction_evidence(
+    agent: str,
+    pane_state: str,
+    liveness: str | None,
+    tmux_tail: str,
+    *,
+    note: str = _CONTRADICTION_STALE_VS_GREEN,
+    log_path: Path | None = None,
+    max_tail_lines: int = 40,
+) -> Path | None:
+    """Append one evidence record to the contradictions log.
+
+    Format (one record = multiple lines, trailer blank line):
+        ---
+        ts=<iso8601 utc>
+        agent=<name>
+        note=<classifier note>
+        pane_state=<state>
+        liveness=<liveness>
+        tail:
+        <last N lines of tmux pane, verbatim>
+
+    Best-effort. Returns the Path written to on success, None on failure.
+    The log path is configurable via SCITEX_FLEET_CONTRADICTIONS_LOG for
+    tests; otherwise defaults to ~/.local/state/scitex/fleet-pane-contradictions.log.
+    """
+    from datetime import datetime, timezone
+
+    target = Path(log_path) if log_path else _CONTRADICTIONS_LOG
+    lines = (tmux_tail or "").splitlines()
+    tail_excerpt = "\n".join(lines[-max_tail_lines:])
+
+    record = (
+        "---\n"
+        f"ts={datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}\n"
+        f"agent={agent}\n"
+        f"note={note}\n"
+        f"pane_state={pane_state}\n"
+        f"liveness={liveness or ''}\n"
+        "tail:\n"
+        f"{tail_excerpt}\n"
+        "\n"
+    )
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as fp:
+            fp.write(record)
+    except OSError:
+        return None
+    return target

--- a/scripts/client/agent_meta_pkg/_collect.py
+++ b/scripts/client/agent_meta_pkg/_collect.py
@@ -6,7 +6,12 @@ import json
 import os
 from pathlib import Path
 
-from ._classifier import _classify_pane_state, _extract_stuck_prompt
+from ._classifier import (
+    _classify_pane_state,
+    _detect_contradiction,
+    _extract_stuck_prompt,
+    _log_contradiction_evidence,
+)
 from ._files import (
     collect_claude_md,
     collect_mcp_json,
@@ -97,6 +102,32 @@ def collect(agent: str) -> dict:
     claude_md_head, claude_md_full = collect_claude_md(workspace)
     mcp_json_full = collect_mcp_json(workspace)
 
+    # Classifier (computed ONCE per collect — the stagnation counter
+    # inside _classify_pane_state is per-cycle, so calling it twice
+    # would double-increment the "pane unchanged for N cycles" count
+    # and mis-fire `stale` after 2 real cycles instead of 3). The
+    # `agent` kwarg enables cross-cycle stagnation tracking; omit it
+    # and the classifier degrades to its legacy stateless behavior.
+    pane_state = _classify_pane_state(pane_tail_block_clean, pane, agent=agent)
+    stuck_prompt_text = _extract_stuck_prompt(
+        pane_tail_block_clean, pane, agent=agent
+    )
+    # Contradiction check + evidence log. `alive=True` here means
+    # we successfully captured a pane from the multiplexer, which is
+    # the client-side equivalent of the hub's 4th-LED == green
+    # (heartbeat fresh). When the classifier also says `stale`, that's
+    # the msg#15541 contradiction — log the tmux tail so future
+    # pattern additions have ground-truth data, and surface a
+    # `classifier_note` on the payload so the Agents tab can flag it.
+    classifier_note = _detect_contradiction(pane_state, liveness="online")
+    if classifier_note:
+        _log_contradiction_evidence(
+            agent=agent,
+            pane_state=pane_state,
+            liveness="online",
+            tmux_tail=pane,
+        )
+
     # If the most recent assistant turn carried no real model label
     # (empty or a <synthetic>-style placeholder from compacted
     # summaries), fall back to the env var the runtime set at spawn.
@@ -179,8 +210,15 @@ def collect(agent: str) -> dict:
         "mcp_json": mcp_json_full,
         # todo#418: agent decision-transparency — classifier label + verbatim
         # stuck-prompt text. Computed from pane_tail_block_clean.
-        "pane_state": _classify_pane_state(pane_tail_block_clean, pane),
-        "stuck_prompt_text": _extract_stuck_prompt(pane_tail_block_clean, pane),
+        # 2026-04-21 (lead msg#15541): the classifier now also emits
+        # `stale` when the pane tail has been byte-identical for
+        # N consecutive push cycles with no busy-animation marker. The
+        # `classifier_note` field surfaces the 3rd-LED-stale-vs-4th-LED-green
+        # contradiction with evidence appended to a dedicated log so
+        # future pattern additions have ground-truth data.
+        "pane_state": pane_state,
+        "stuck_prompt_text": stuck_prompt_text,
+        "classifier_note": classifier_note,
         # scitex-orochi #187 / #59 — hook-event ring buffer summary
         # from scitex-agent-container. Unpacked as top-level keys so
         # push_all()'s whitelist can forward each one verbatim.

--- a/scripts/client/agent_meta_pkg/_collect.py
+++ b/scripts/client/agent_meta_pkg/_collect.py
@@ -108,6 +108,18 @@ def collect(agent: str) -> dict:
     # and mis-fire `stale` after 2 real cycles instead of 3). The
     # `agent` kwarg enables cross-cycle stagnation tracking; omit it
     # and the classifier degrades to its legacy stateless behavior.
+    # Live hostname(1) — the kernel's answer to "where is this process
+    # running right now". This is the authoritative host-identity signal
+    # the hub's badge renderer (hostedAgentName) prefers over ``machine``.
+    # Collected here so ``_build_payload`` can forward it unconditionally,
+    # never letting env vars or server-side inference speak for the
+    # process (lead msg#15578 root fix).
+    import socket as _socket
+    try:
+        live_hostname = (_socket.gethostname() or "").split(".")[0].strip()
+    except Exception:
+        live_hostname = ""
+
     pane_state = _classify_pane_state(pane_tail_block_clean, pane, agent=agent)
     stuck_prompt_text = _extract_stuck_prompt(
         pane_tail_block_clean, pane, agent=agent
@@ -199,6 +211,11 @@ def collect(agent: str) -> dict:
         "workdir": workspace,
         "project": project,
         "machine": machine,
+        # Live hostname(1) — see the comment above live_hostname for why
+        # we send this unconditionally. The hub stores this as ``hostname``
+        # distinct from ``machine`` (YAML label) and
+        # ``hostname_canonical`` (FQDN).
+        "hostname": live_hostname,
         # todo#55: canonical FQDN for display next to the short machine
         # label in the dashboard.
         "hostname_canonical": _resolve_canonical_hostname(),

--- a/scripts/client/agent_meta_pkg/_machine.py
+++ b/scripts/client/agent_meta_pkg/_machine.py
@@ -1,9 +1,18 @@
 """Canonical fleet-machine label resolution from shared/config.yaml hostname_aliases.
 
 Resolution chain (first wins):
-  1. $SCITEX_OROCHI_HOSTNAME
-  2. hostname_aliases[hostname -s] from shared/config.yaml
-  3. hostname -s (identity fallback)
+  1. hostname_aliases[hostname -s] from shared/config.yaml
+  2. hostname -s (identity fallback)
+  3. $SCITEX_OROCHI_HOSTNAME (explicit override, only used when the live
+     hostname is unresolvable — e.g. empty gethostname() in stripped
+     containers). Previously this env var was primary, which made
+     env-pollution (a shared tmux / systemd env with a stale
+     ``SCITEX_OROCHI_HOSTNAME=mba`` inherited into a spartan process)
+     silently misreport the host identity (lead msg#15578 — proj-
+     neurovista displayed as mba despite running on spartan). Per
+     lead's root fix: the agent's ``host`` field in the heartbeat
+     comes from its own ``hostname()`` call, never from inherited
+     env or server-side inference.
 
 This matches config._host.resolve_hostname() on the sac side and the
 shared/scripts/resolve-hostname helper used by bootstrap + shell
@@ -19,22 +28,39 @@ from pathlib import Path
 
 
 def resolve_machine_label() -> str:
-    machine = os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
-    if machine:
-        return machine
-    raw_host = socket.gethostname().split(".")[0]
-    try:
-        import yaml as _yaml  # PyYAML ships with the fleet.
+    """Return the canonical fleet-machine label for THIS host.
 
-        cfg_path = Path.home() / ".scitex" / "orochi" / "shared" / "config.yaml"
-        if cfg_path.exists():
-            _cfg = _yaml.safe_load(cfg_path.read_text()) or {}
-            _aliases = (_cfg.get("spec") or {}).get("hostname_aliases") or {}
-            if isinstance(_aliases, dict) and raw_host in _aliases:
-                return str(_aliases[raw_host])
-    except Exception:
-        pass
-    return raw_host
+    Trust order (highest trust first):
+
+    1. ``hostname_aliases[gethostname().split('.')[0]]`` from
+       ``~/.scitex/orochi/shared/config.yaml`` — canonical per-fleet
+       mapping (e.g. ``Yusukes-MacBook-Air`` → ``mba``).
+    2. Raw ``socket.gethostname().split('.')[0]`` — if the live hostname
+       is not aliased in config, fall through to it directly. This is
+       the proof-of-life identity: whatever the kernel says this
+       process is running on.
+    3. ``$SCITEX_OROCHI_HOSTNAME`` — explicit override, only honoured
+       when steps 1/2 produced an empty string (broken container,
+       ``gethostname()`` returning ""). An env override that DISAGREES
+       with the live hostname is ignored on purpose — that's how
+       ``mba`` env leaked into a spartan process before this fix.
+    """
+    raw_host = (socket.gethostname() or "").split(".")[0].strip()
+    if raw_host:
+        try:
+            import yaml as _yaml  # PyYAML ships with the fleet.
+
+            cfg_path = Path.home() / ".scitex" / "orochi" / "shared" / "config.yaml"
+            if cfg_path.exists():
+                _cfg = _yaml.safe_load(cfg_path.read_text()) or {}
+                _aliases = (_cfg.get("spec") or {}).get("hostname_aliases") or {}
+                if isinstance(_aliases, dict) and raw_host in _aliases:
+                    return str(_aliases[raw_host])
+        except Exception:
+            pass
+        return raw_host
+    # gethostname() returned empty — only now trust the env override.
+    return os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
 
 
 def find_session_pids(agent: str, multiplexer: str) -> tuple[int, int]:

--- a/scripts/client/agent_meta_pkg/_push.py
+++ b/scripts/client/agent_meta_pkg/_push.py
@@ -99,6 +99,24 @@ def _build_payload(meta: dict, tok: str) -> dict:
         "agent_calls": meta.get("agent_calls") or [],
         "background_tasks": meta.get("background_tasks") or [],
         "subagents": meta.get("subagents") or [],
+        # scitex-orochi todo#369 — host-level machine metrics (CPU / mem
+        # / disk / load) + optional SLURM cluster snapshot. Without
+        # these two keys the hub's /api/resources rollup has no data
+        # to populate the Machines tab card for agents pushed via this
+        # legacy daemon path (symptom: mba / nas / spartan show zero /
+        # blink while ywata-note-win — which pushes via the sidecar
+        # heartbeat in ts/mcp_channel/heartbeat.ts that spreads the
+        # full collect() output — renders correctly).
+        #
+        # Hub-side contract: POST /api/agents/register/ reads
+        # body["metrics"] verbatim (see hub/views/api/_agents_register.py
+        # line `update_heartbeat(name, metrics=body.get("metrics") or
+        # {})`), and the merged per-agent snapshot is flattened into
+        # each machine's aggregate card by hub/views/api/_resources.py.
+        # `slurm` is a nested dict used by the Machines tab's SLURM
+        # card on HPC hosts and is expected to be None on non-HPC.
+        "metrics": meta.get("metrics") or {},
+        "slurm": meta.get("slurm"),
     }
 
 

--- a/scripts/client/agent_meta_pkg/_push.py
+++ b/scripts/client/agent_meta_pkg/_push.py
@@ -47,6 +47,11 @@ def _build_payload(meta: dict, tok: str) -> dict:
         "agent_id": meta["agent"],
         "role": "agent",
         "machine": meta.get("machine", ""),
+        # Live hostname(1) — authoritative per-process identity. Client-
+        # supplied via ``collect()`` from ``socket.gethostname()``; never
+        # derived from env or server-side inference. Root fix for the
+        # proj-neurovista/mba misreport (lead msg#15578).
+        "hostname": meta.get("hostname", ""),
         "hostname_canonical": meta.get("hostname_canonical", ""),
         "model": meta.get("model", ""),
         "multiplexer": meta.get("multiplexer", ""),

--- a/scripts/client/chrome-codesign-clone-watchdog.sh
+++ b/scripts/client/chrome-codesign-clone-watchdog.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# chrome-codesign-clone-watchdog.sh
+#
+# scitex-orochi#286 item 2.
+#
+# Reap the `/private/var/folders/*/*/X/com.google.Chrome.code_sign_clone`
+# cache when it grows large. This is a known Chrome-on-macOS
+# `codesign`-verification cache leak; the clone is harmless and Chrome
+# does not depend on its presence. On the 2026-04-21 mba outage a single
+# instance of this directory had grown to 13 GiB and contributed
+# directly to the host hitting 100% full (see
+# `skills/infra-hub-docker-disk-full.md`, 2026-04-21 incident
+# playbook).
+#
+# Usage:
+#   chrome-codesign-clone-watchdog.sh             # default thresholds
+#   chrome-codesign-clone-watchdog.sh --dry-run   # report only, never delete
+#   ADVISE_GIB=1 REAP_GIB=8 chrome-codesign-clone-watchdog.sh
+#
+# Thresholds (gibibytes):
+#   ADVISE_GIB (default 2) — log an advisory when total size ≥ this.
+#   REAP_GIB   (default 5) — delete the directory when total size ≥ this.
+#
+# Exit codes:
+#   0 — ran to completion (nothing found, or advisory, or reap).
+#   1 — failed to probe or delete (see stderr).
+#
+# The watchdog is read-mostly: it stats via `du -sk`, never writes
+# anything except the `rm -rf` on the exact codesign-clone path. It
+# does not touch any other cache, any user data, or any Chrome
+# profile state.
+
+set -euo pipefail
+
+ADVISE_GIB="${ADVISE_GIB:-2}"
+REAP_GIB="${REAP_GIB:-5}"
+DRY_RUN=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "chrome-codesign-clone-watchdog: unknown arg: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+log() {
+    printf '[%s] chrome-codesign-clone-watchdog: %s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+# Locate every Chrome code_sign_clone directory on this host. macOS
+# per-user temp paths live under /private/var/folders/<hash>/<hash>/X/.
+# Glob nulls if no matches; guard with nullglob.
+shopt -s nullglob
+CANDIDATES=( /private/var/folders/*/*/X/com.google.Chrome.code_sign_clone )
+shopt -u nullglob
+
+if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
+    log "no Chrome code_sign_clone paths found — nothing to do"
+    exit 0
+fi
+
+advise_kib=$((ADVISE_GIB * 1024 * 1024))
+reap_kib=$((REAP_GIB * 1024 * 1024))
+
+for path in "${CANDIDATES[@]}"; do
+    if [[ ! -d "$path" ]]; then
+        continue
+    fi
+    # -s total; -k kibibytes for predictable arithmetic. Drop stderr so
+    # sub-tree access errors don't abort the check.
+    kib="$(du -sk "$path" 2>/dev/null | awk '{print $1}')"
+    if [[ -z "$kib" ]]; then
+        log "ERROR: failed to size $path"
+        exit 1
+    fi
+    gib=$(( kib / 1024 / 1024 ))
+
+    if (( kib >= reap_kib )); then
+        if (( DRY_RUN )); then
+            log "WOULD REAP $path (${gib} GiB ≥ ${REAP_GIB} GiB) — dry run"
+        else
+            log "REAPING $path (${gib} GiB ≥ ${REAP_GIB} GiB)"
+            if rm -rf -- "$path"; then
+                log "reaped $path"
+            else
+                log "ERROR: rm -rf failed for $path"
+                exit 1
+            fi
+        fi
+    elif (( kib >= advise_kib )); then
+        log "ADVISORY $path is ${gib} GiB (≥ ${ADVISE_GIB} GiB, < ${REAP_GIB} GiB reap threshold)"
+    else
+        log "OK $path is ${gib} GiB (< ${ADVISE_GIB} GiB)"
+    fi
+done

--- a/scripts/client/disk-reaper.sh
+++ b/scripts/client/disk-reaper.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# disk-reaper.sh — reap known-safe caches to free Mac/Linux host disk
+# -----------------------------------------------------------------------------
+# Authored by healer-mba 2026-04-21 for issue #286 item 1, following the
+# 2026-04-21 mba full-disk incident (see skills/infra-hub-docker-disk-full).
+#
+# Usage:
+#   disk-reaper.sh                       # dry-run, list reapable targets + sizes
+#   disk-reaper.sh --dry-run             # explicit dry-run (default)
+#   disk-reaper.sh --yes                 # actually delete the safe-default targets
+#   disk-reaper.sh --yes --only chrome   # delete only Chrome code_sign_clone cache
+#   disk-reaper.sh --list                # print known target names and exit
+#
+# Target categories:
+#   safe-default   Deleted when --yes given, no further flag needed.
+#                  Known-safe caches that regenerate automatically.
+#   opt-in         Requires --include <name> in addition to --yes.
+#                  Large user-data-adjacent (e.g. gradle cache — rebuilds
+#                  from pom/gradle files; safe but slow on next build).
+#   never-auto     Not touched by this script. Human-only (~/Downloads,
+#                  ~/Library/Developer/Xcode/Archives, etc.) — listed in
+#                  advisory body so the user can decide.
+#
+# Side effects: only when --yes. Never deletes user data. Never calls
+# `docker prune` (daemon may be wedged on a full disk; that's the job of
+# infra-hub-docker-disk-full skill and colima restart, not this reaper).
+# -----------------------------------------------------------------------------
+
+set -u
+set -o pipefail
+
+HOST="$(hostname -s 2>/dev/null || hostname)"
+OS="$(uname -s)"
+
+dry_run=1
+include=()
+only=""
+do_list=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1; shift ;;
+    --yes|-y)  dry_run=0; shift ;;
+    --only)    only="$2"; shift 2 ;;
+    --include) include+=("$2"); shift 2 ;;
+    --list)    do_list=1; shift ;;
+    -h|--help)
+      sed -n '2,30p' "$0"; exit 0 ;;
+    *) printf 'unknown arg: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+
+# -----------------------------------------------------------------------------
+# Target registry. One entry = one row in the rows[] array.
+#
+# Columns (tab-separated, 4 fields):
+#   name           short identifier for --only / --include
+#   category       safe-default | opt-in | never-auto
+#   finder         shell snippet printing newline-separated paths to reap
+#   description    one-line reason it's safe/unsafe to reap
+# -----------------------------------------------------------------------------
+
+rows=()
+
+# Chrome codesign cache — 13G observed in 2026-04-21 incident. Regenerates.
+# macOS-only. Path pattern: /private/var/folders/*/*/X/com.google.Chrome.code_sign_clone
+rows+=("chrome-code-sign-clone	safe-default	find /private/var/folders -maxdepth 5 -type d -name 'com.google.Chrome.code_sign_clone' 2>/dev/null	macOS Chrome codesign cache leak — regenerates on next launch")
+
+# Claude Code stale tmp dirs. Our own harness output dirs. Keep recent 2 days.
+rows+=("claude-tmp-stale	safe-default	find /private/tmp/claude-${UID:-501} -maxdepth 1 -type d -mtime +2 2>/dev/null	Claude Code tool-output dirs older than 2d — stale session artefacts")
+
+# iOS DeviceSupport — symbols cache, regenerates from attached devices.
+rows+=("ios-device-support	safe-default	find \"\$HOME/Library/Developer/Xcode/iOS DeviceSupport\" -mindepth 1 -maxdepth 1 -type d -mtime +30 2>/dev/null	Xcode iOS DeviceSupport older than 30d — regenerates")
+
+# Xcode DerivedData — build products, regenerates. Safe but slow rebuild.
+rows+=("xcode-derived-data	safe-default	find \"\$HOME/Library/Developer/Xcode/DerivedData\" -mindepth 1 -maxdepth 1 -type d 2>/dev/null	Xcode DerivedData — rebuilds on next Xcode build")
+
+# Simulator caches (not user data, regenerate)
+rows+=("core-simulator-caches	safe-default	find \"\$HOME/Library/Developer/CoreSimulator/Caches\" -mindepth 1 -maxdepth 2 2>/dev/null	CoreSimulator caches — regenerate")
+
+# .gradle caches (rebuild on next gradle invocation; slow but automatic).
+rows+=("gradle-caches	opt-in	printf '%s\\n' \"\$HOME/.gradle/caches\" \"\$HOME/.gradle/daemon\"	Gradle caches — regenerate on next build (multi-minute first-build cost)")
+
+# .bundle / .rbenv / .npm / .bun caches — opt-in, regenerate but break dev reproducibility briefly.
+rows+=("npm-cache	opt-in	printf '%s\\n' \"\$HOME/.npm/_cacache\"	npm cache — regenerates on next install")
+rows+=("bun-install-cache	opt-in	printf '%s\\n' \"\$HOME/.bun/install/cache\"	bun install cache — regenerates")
+
+# Trash — user action required.
+rows+=("trash	never-auto	printf '%s\\n' \"\$HOME/.Trash\"	User Trash — emptying is a user decision")
+
+# Downloads — user data.
+rows+=("downloads-note	never-auto	printf ''	~/Downloads is user data; not touched by this script")
+
+# ----------------- end of registry -----------------
+
+if [ "$do_list" -eq 1 ]; then
+  printf '%-26s  %-13s  %s\n' "name" "category" "description"
+  printf '%-26s  %-13s  %s\n' "----" "--------" "-----------"
+  for row in "${rows[@]}"; do
+    IFS=$'\t' read -r name category _finder desc <<< "$row"
+    printf '%-26s  %-13s  %s\n' "$name" "$category" "$desc"
+  done
+  exit 0
+fi
+
+# Reap loop.
+total_reclaim_kib=0
+reaped_any=0
+
+should_process() {
+  # $1=name $2=category
+  local n="$1" cat="$2"
+  if [ -n "$only" ]; then
+    [ "$n" = "$only" ]
+    return $?
+  fi
+  if [ "$cat" = "safe-default" ]; then
+    return 0
+  fi
+  if [ "$cat" = "opt-in" ]; then
+    local inc
+    for inc in "${include[@]:-}"; do
+      [ "$inc" = "$n" ] && return 0
+    done
+    return 1
+  fi
+  # never-auto: only if --only exactly matches (still informational)
+  return 1
+}
+
+size_kib_of() {
+  # Sum sizes of stdin-listed paths; missing paths contribute 0.
+  local p kib=0 line
+  while IFS= read -r p; do
+    [ -z "$p" ] && continue
+    [ ! -e "$p" ] && continue
+    line="$(du -sk -- "$p" 2>/dev/null | awk '{print $1}')"
+    [ -n "$line" ] && kib=$(( kib + line ))
+  done
+  printf '%s' "$kib"
+}
+
+human_size() {
+  # KiB → human.
+  local kib="$1"
+  if [ "$kib" -ge 1048576 ]; then
+    awk -v k="$kib" 'BEGIN{printf "%.1fG", k/1048576}'
+  elif [ "$kib" -ge 1024 ]; then
+    awk -v k="$kib" 'BEGIN{printf "%.1fM", k/1024}'
+  else
+    printf '%dK' "$kib"
+  fi
+}
+
+printf '# disk-reaper on %s (%s) — mode=%s\n' \
+  "$HOST" "$OS" "$([ "$dry_run" -eq 1 ] && echo dry-run || echo REAP)"
+printf '%-26s  %-13s  %10s  %s\n' "name" "category" "size" "description"
+printf '%-26s  %-13s  %10s  %s\n' "----" "--------" "----" "-----------"
+
+for row in "${rows[@]}"; do
+  IFS=$'\t' read -r name category finder desc <<< "$row"
+
+  paths="$(eval "$finder" 2>/dev/null || true)"
+  kib="$(printf '%s\n' "$paths" | size_kib_of)"
+  size_h="$(human_size "$kib")"
+
+  printf '%-26s  %-13s  %10s  %s\n' "$name" "$category" "$size_h" "$desc"
+
+  if should_process "$name" "$category"; then
+    if [ "$dry_run" -eq 1 ]; then
+      if [ -n "$paths" ]; then
+        printf '%s\n' "$paths" | sed 's/^/    (dry-run) would rm -rf /'
+      fi
+    else
+      if [ -z "$paths" ]; then
+        continue
+      fi
+      while IFS= read -r p; do
+        [ -z "$p" ] && continue
+        [ ! -e "$p" ] && continue
+        rm -rf -- "$p" && printf '    reaped: %s\n' "$p"
+      done <<< "$paths"
+      reaped_any=1
+      total_reclaim_kib=$(( total_reclaim_kib + kib ))
+    fi
+  fi
+done
+
+if [ "$dry_run" -eq 1 ]; then
+  printf '\n# dry-run complete. Re-run with --yes to reap safe-default targets.\n'
+  printf '# Use --include <name> to add opt-in targets (e.g. --include gradle-caches).\n'
+  exit 0
+fi
+
+if [ "$reaped_any" -eq 1 ]; then
+  printf '\n# reaped ~%s total. Disk state after:\n' "$(human_size "$total_reclaim_kib")"
+  df -h / 2>/dev/null | awk 'NR<=2'
+else
+  printf '\n# nothing reaped (empty targets).\n'
+fi

--- a/scripts/client/fleet-watch/disk-pressure-probe.sh
+++ b/scripts/client/fleet-watch/disk-pressure-probe.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# disk-pressure-probe.sh — host disk pressure check for healer preemptive advisory
+# -----------------------------------------------------------------------------
+# Authored by healer-mba 2026-04-21 for issue #286 item 3, in response to the
+# 2026-04-21 mba full-disk incident (see skills/infra-hub-docker-disk-full).
+#
+# Principle: read-only check of the root ("/") filesystem + top home consumers.
+# Emits one NDJSON line per invocation. Exit code carries severity so the
+# caller (healer loop, fleet_watch.sh) can decide whether to post an advisory.
+#
+# Exit codes:
+#   0 — OK            free >= DISK_FREE_ADVISORY_GIB
+#   1 — advisory      DISK_FREE_WARN_GIB   <= free < DISK_FREE_ADVISORY_GIB
+#   2 — warn          DISK_FREE_CRITICAL_GIB <= free < DISK_FREE_WARN_GIB
+#   3 — critical      free < DISK_FREE_CRITICAL_GIB
+#
+# Thresholds default to the values in orochi-machines.yaml `preflight:`
+# but can be overridden per invocation via env vars.
+# -----------------------------------------------------------------------------
+
+set -u
+set -o pipefail
+
+HOST="$(hostname -s 2>/dev/null || hostname)"
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+OUT_DIR="${HOST_TELEMETRY_OUT_DIR:-$HOME/.scitex/orochi/host-telemetry}"
+OUT_FILE="$OUT_DIR/disk-pressure-${HOST}.ndjson"
+mkdir -p "$OUT_DIR"
+
+DISK_FREE_ADVISORY_GIB="${DISK_FREE_ADVISORY_GIB:-10}"
+DISK_FREE_WARN_GIB="${DISK_FREE_WARN_GIB:-5}"
+DISK_FREE_CRITICAL_GIB="${DISK_FREE_CRITICAL_GIB:-2}"
+
+# df -k gives 1024-byte blocks everywhere (BSD, GNU, busybox).
+# We query "/" — on macOS/Colima that's the Data volume; on Linux it's root.
+df_line="$(df -k / 2>/dev/null | awk 'NR==2 {print $2, $3, $4}')"
+total_kib="$(printf '%s' "$df_line" | awk '{print $1}')"
+used_kib="$(printf '%s' "$df_line" | awk '{print $2}')"
+avail_kib="$(printf '%s' "$df_line" | awk '{print $3}')"
+
+if [ -z "$avail_kib" ]; then
+  printf '{"schema":"scitex-orochi/disk-pressure-probe/v1","host":"%s","ts":"%s","error":"df_failed"}\n' \
+    "$HOST" "$TS" >> "$OUT_FILE"
+  exit 3
+fi
+
+# Convert KiB → GiB (integer). 1 GiB = 1048576 KiB.
+avail_gib=$(( avail_kib / 1048576 ))
+total_gib=$(( total_kib / 1048576 ))
+used_gib=$(( used_kib / 1048576 ))
+
+severity="ok"
+exit_code=0
+if [ "$avail_gib" -lt "$DISK_FREE_CRITICAL_GIB" ]; then
+  severity="critical"; exit_code=3
+elif [ "$avail_gib" -lt "$DISK_FREE_WARN_GIB" ]; then
+  severity="warn"; exit_code=2
+elif [ "$avail_gib" -lt "$DISK_FREE_ADVISORY_GIB" ]; then
+  severity="advisory"; exit_code=1
+fi
+
+# Biggest home consumers for the advisory body. Depth-1 only, no du on /.
+# Time-bounded — 90s ceiling, fall back to empty list.
+top_json="[]"
+if command -v python3 >/dev/null 2>&1; then
+  top_json="$(
+    (
+      du -sh -- \
+        "$HOME/.gradle" \
+        "$HOME/.android" \
+        "$HOME/Downloads" \
+        "$HOME/.colima" \
+        "$HOME/Library/Caches" \
+        2>/dev/null || true
+    ) | python3 -c '
+import json, sys
+rows = []
+for line in sys.stdin:
+    parts = line.split(None, 1)
+    if len(parts) == 2:
+        rows.append({"size": parts[0], "path": parts[1].rstrip()})
+sys.stdout.write(json.dumps(rows))
+' 2>/dev/null || printf '[]'
+  )"
+fi
+
+printf '{"schema":"scitex-orochi/disk-pressure-probe/v1","host":"%s","ts":"%s","mount":"/","total_gib":%d,"used_gib":%d,"avail_gib":%d,"severity":"%s","thresholds":{"advisory_gib":%d,"warn_gib":%d,"critical_gib":%d},"top_home_consumers":%s}\n' \
+  "$HOST" "$TS" \
+  "$total_gib" "$used_gib" "$avail_gib" \
+  "$severity" \
+  "$DISK_FREE_ADVISORY_GIB" "$DISK_FREE_WARN_GIB" "$DISK_FREE_CRITICAL_GIB" \
+  "$top_json" \
+  >> "$OUT_FILE"
+
+# Human-readable line on stdout for healer to paste into #agent when non-OK.
+if [ "$severity" != "ok" ]; then
+  printf 'disk-pressure %s on %s: / has %d GiB free (of %d GiB). Thresholds: advisory<%d warn<%d critical<%d. Run scripts/client/disk-reaper.sh --dry-run to see reapable targets.\n' \
+    "$severity" "$HOST" "$avail_gib" "$total_gib" \
+    "$DISK_FREE_ADVISORY_GIB" "$DISK_FREE_WARN_GIB" "$DISK_FREE_CRITICAL_GIB"
+fi
+
+exit "$exit_code"

--- a/scripts/client/fleet-watch/host-liveness-probe.sh
+++ b/scripts/client/fleet-watch/host-liveness-probe.sh
@@ -1,0 +1,498 @@
+#!/usr/bin/env bash
+# host-liveness-probe.sh — fleet host-liveness probe with auto-revive (todo#271)
+# -----------------------------------------------------------------------------
+# Implementation lever for the 2026-04-20 incident: both ywata-note-win and
+# spartan lost their tmux servers and nobody noticed for hours. This script
+# runs on a 5-min launchd/cron schedule and:
+#   1. Enumerates fleet hosts from orochi-machines.yaml
+#   2. SSH-probes each host: tmux server reachable? expected agents alive?
+#   3. Emits one NDJSON line per host on stdout (human-readable advisories on
+#      stderr for launchd logs).
+#   4. If --yes given: auto-revives missing agents by delegating to the
+#      local healer (if alive) or running `scitex-agent-container start`
+#      directly via SSH.
+#
+# Source-of-truth for expected agents: `expected_tmux_sessions:` key per
+# host in orochi-machines.yaml at the repo root. If that key is missing or
+# empty, the host is probed for tmux-server liveness only (no agent-set check).
+#
+# Usage:
+#   ./scripts/client/fleet-watch/host-liveness-probe.sh              # dry-run (default)
+#   ./scripts/client/fleet-watch/host-liveness-probe.sh --dry-run    # explicit
+#   ./scripts/client/fleet-watch/host-liveness-probe.sh --yes        # actually revive
+#   ./scripts/client/fleet-watch/host-liveness-probe.sh --host mba   # one host
+#
+# Exit codes (match disk-pressure-probe.sh convention):
+#   0  ok        — every host's expected agents are alive
+#   1  advisory  — unexpected agent found somewhere, or slurm advisory
+#   2  warn      — expected agent missing on a host whose tmux server IS up
+#   3  critical  — tmux server dead OR SSH unreachable on any host
+#
+# The process exit code is the WORST severity observed across all hosts.
+# -----------------------------------------------------------------------------
+
+# Deliberate choice to omit `set -u` — we rely on `${var:-default}`
+# and explicit `+"${arr[@]}"` guards everywhere empty arrays are expanded.
+set -o pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+MACHINES_YAML="${MACHINES_YAML:-$REPO_ROOT/orochi-machines.yaml}"
+LOG_DIR="${HOST_LIVENESS_LOG_DIR:-$HOME/.scitex/orochi/fleet-watch}"
+LOG_FILE="$LOG_DIR/host-liveness-probe.log"
+SSH_TIMEOUT="${SSH_TIMEOUT:-8}"
+SSH_CONNECT_TIMEOUT="${SSH_CONNECT_TIMEOUT:-5}"
+
+# macOS has no `timeout` binary out of the box. Fall back to gtimeout
+# (coreutils) or skip wrapping entirely — SSH's own ConnectTimeout +
+# ServerAlive options catch most hangs. Resolve once at startup.
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout "$SSH_TIMEOUT")
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout "$SSH_TIMEOUT")
+else
+  TIMEOUT_CMD=()
+fi
+
+dry_run=1
+only_host=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run)   dry_run=1; shift ;;
+    --yes|-y)    dry_run=0; shift ;;
+    --host)      only_host="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,30p' "$0"; exit 0 ;;
+    *) printf 'unknown arg: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR"
+
+TS_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+LOCAL_HOST="$(hostname -s 2>/dev/null || hostname)"
+
+log() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$LOG_FILE"
+}
+
+stderr() {
+  printf '%s\n' "$*" >&2
+}
+
+# Worst severity observed across all hosts. Ordered so numeric max == worst.
+#   0 ok  1 advisory  2 warn  3 critical
+worst_exit=0
+
+bump_exit() {
+  local code="$1"
+  if [ "$code" -gt "$worst_exit" ]; then
+    worst_exit="$code"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Parse orochi-machines.yaml
+# Returns on stdout: one line per host, tab-separated, 3 columns:
+#   <canonical_name>\t<expected_sessions_csv>\t<aliases_csv>
+# Uses python3 + PyYAML. If PyYAML is missing, falls back to a minimal regex
+# parser that extracts the three fields we need.
+# -----------------------------------------------------------------------------
+parse_machines_yaml() {
+  if [ ! -f "$MACHINES_YAML" ]; then
+    stderr "host-liveness-probe: machines yaml missing: $MACHINES_YAML"
+    return 1
+  fi
+  python3 - "$MACHINES_YAML" <<'PY'
+import sys, re
+path = sys.argv[1]
+try:
+    import yaml
+    with open(path) as f:
+        doc = yaml.safe_load(f) or {}
+    for m in (doc.get("machines") or []):
+        name = (m.get("canonical_name") or "").strip()
+        if not name:
+            continue
+        expected = [s for s in (m.get("expected_tmux_sessions") or []) if s]
+        aliases = [a for a in (m.get("aliases") or []) if a]
+        hostname = (m.get("hostname") or "").strip()
+        if hostname and hostname not in aliases:
+            aliases.append(hostname)
+        print(f"{name}\t{','.join(expected)}\t{','.join(aliases)}")
+except ImportError:
+    # Minimal fallback: walk YAML looking for canonical_name +
+    # expected_tmux_sessions + aliases + hostname blocks.
+    with open(path) as f:
+        text = f.read()
+    blocks = re.split(r'^\s*-\s+canonical_name:\s*', text, flags=re.MULTILINE)
+    def _collect_list(blk, key):
+        m = re.search(
+            rf'^\s*{key}:\s*\n((?:\s+-\s+[^\n]+\n)+)',
+            blk, flags=re.MULTILINE,
+        )
+        out = []
+        if m:
+            for line in m.group(1).splitlines():
+                m2 = re.match(r'\s*-\s+([A-Za-z0-9_.-]+)', line)
+                if m2:
+                    out.append(m2.group(1).strip())
+        return out
+    def _collect_scalar(blk, key):
+        m = re.search(rf'^\s*{key}:\s*([A-Za-z0-9_.-]+)', blk, flags=re.MULTILINE)
+        return m.group(1).strip() if m else ""
+    for blk in blocks[1:]:
+        mname = re.match(r'([A-Za-z0-9_.-]+)', blk)
+        if not mname:
+            continue
+        name = mname.group(1).strip()
+        sessions = _collect_list(blk, "expected_tmux_sessions")
+        aliases = _collect_list(blk, "aliases")
+        hostname = _collect_scalar(blk, "hostname")
+        if hostname and hostname not in aliases:
+            aliases.append(hostname)
+        print(f"{name}\t{','.join(sessions)}\t{','.join(aliases)}")
+PY
+}
+
+# -----------------------------------------------------------------------------
+# Probe one host via SSH. Emits a JSON object on stdout (one NDJSON line).
+# Bumps $worst_exit with the host's severity.
+# When --yes given, attempts to revive missing agents.
+# -----------------------------------------------------------------------------
+probe_host() {
+  local host="$1"
+  local expected_csv="$2"
+  local aliases_csv="${3:-}"
+
+  local expected_arr=()
+  if [ -n "$expected_csv" ]; then
+    IFS=',' read -r -a expected_arr <<<"$expected_csv"
+  fi
+  local aliases_arr=()
+  if [ -n "$aliases_csv" ]; then
+    IFS=',' read -r -a aliases_arr <<<"$aliases_csv"
+  fi
+
+  local ssh_cmd=(ssh -o ConnectTimeout="$SSH_CONNECT_TIMEOUT" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ServerAliveInterval=3 -o ServerAliveCountMax=2)
+
+  # Local-host short-circuit: don't SSH to ourselves. Priority:
+  #   1. SCITEX_AGENT_LOCAL_HOSTS env (seeded by host_identity.py at boot)
+  #   2. direct match $LOCAL_HOST == $host
+  #   3. $LOCAL_HOST is in the yaml's aliases[] for this host
+  local is_local=0
+  case ",${SCITEX_AGENT_LOCAL_HOSTS:-}," in
+    *",${host},"*) is_local=1 ;;
+  esac
+  if [ "$host" = "$LOCAL_HOST" ]; then
+    is_local=1
+  fi
+  if [ "$is_local" -eq 0 ] && [ "${#aliases_arr[@]}" -gt 0 ]; then
+    local a
+    for a in "${aliases_arr[@]}"; do
+      if [ "$a" = "$LOCAL_HOST" ] || [ "$a" = "$(hostname 2>/dev/null)" ]; then
+        is_local=1
+        break
+      fi
+    done
+  fi
+
+  local probe_script='
+set -u
+PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+if command -v tmux >/dev/null 2>&1; then
+  if tmux_out=$(tmux list-sessions -F "#{session_name}" 2>/dev/null); then
+    echo "TMUX_OK"
+    echo "$tmux_out"
+  else
+    echo "TMUX_DEAD"
+  fi
+else
+  echo "TMUX_MISSING"
+fi
+'
+
+  local remote_out="" rc=0
+  if [ "$is_local" -eq 1 ]; then
+    remote_out="$(bash -c "$probe_script" 2>/dev/null)"
+    rc=$?
+  else
+    remote_out="$("${TIMEOUT_CMD[@]}" "${ssh_cmd[@]}" "$host" "bash -s" <<<"$probe_script" 2>/dev/null)"
+    rc=$?
+  fi
+
+  # -----------------------------------------------------------------------
+  # Classify severity.
+  # -----------------------------------------------------------------------
+  local severity="ok"
+  local severity_code=0
+  local reachable="true"
+  local tmux_state="unknown"
+  local alive_sessions=()
+  local missing=()
+  local unexpected=()
+  local actions_taken=()
+
+  if [ $rc -ne 0 ] || [ -z "$remote_out" ]; then
+    reachable="false"
+    tmux_state="ssh_unreachable"
+    severity="critical"
+    severity_code=3
+  else
+    # Parse the remote_out block
+    local first_line
+    first_line="$(printf '%s\n' "$remote_out" | head -n1)"
+    case "$first_line" in
+      TMUX_OK)
+        tmux_state="running"
+        # Remaining lines are session names
+        while IFS= read -r name; do
+          [ -z "$name" ] && continue
+          alive_sessions+=("$name")
+        done < <(printf '%s\n' "$remote_out" | tail -n +2)
+        ;;
+      TMUX_DEAD)
+        tmux_state="dead"
+        severity="critical"
+        severity_code=3
+        ;;
+      TMUX_MISSING)
+        tmux_state="tmux_not_installed"
+        severity="critical"
+        severity_code=3
+        ;;
+      *)
+        tmux_state="unparseable"
+        reachable="false"
+        severity="critical"
+        severity_code=3
+        ;;
+    esac
+  fi
+
+  # -----------------------------------------------------------------------
+  # Cross-check against expected set (only when tmux is running and we have
+  # an expected set).
+  # -----------------------------------------------------------------------
+  if [ "$tmux_state" = "running" ] && [ "${#expected_arr[@]}" -gt 0 ]; then
+    for exp in "${expected_arr[@]}"; do
+      local found=0
+      for alive in "${alive_sessions[@]}"; do
+        if [ "$exp" = "$alive" ]; then
+          found=1; break
+        fi
+      done
+      if [ $found -eq 0 ]; then
+        missing+=("$exp")
+      fi
+    done
+    for alive in "${alive_sessions[@]}"; do
+      local declared=0
+      for exp in "${expected_arr[@]}"; do
+        if [ "$exp" = "$alive" ]; then
+          declared=1; break
+        fi
+      done
+      if [ $declared -eq 0 ]; then
+        unexpected+=("$alive")
+      fi
+    done
+
+    if [ "${#missing[@]}" -gt 0 ]; then
+      # Missing expected agent — worse than advisory but tmux server is up,
+      # so "warn" not "critical".
+      if [ $severity_code -lt 2 ]; then
+        severity="warn"; severity_code=2
+      fi
+    fi
+    if [ "${#unexpected[@]}" -gt 0 ] && [ $severity_code -lt 1 ]; then
+      severity="advisory"; severity_code=1
+    fi
+  fi
+
+  # -----------------------------------------------------------------------
+  # Auto-revive policy: only for `missing` agents on a host whose tmux is up.
+  # (If tmux server is dead that's a critical — humans must handle that, the
+  # revive path assumes a living tmux to attach into.)
+  # -----------------------------------------------------------------------
+  local revive_path="none"
+  if [ "$tmux_state" = "running" ] && [ "${#missing[@]}" -gt 0 ]; then
+    # Pick revive path. healer-<host> is in expected_arr AND alive_sessions?
+    local healer_name="healer-${host}"
+    # Also tolerate the legacy naming: mamba-healer-<host>
+    local mamba_healer_name="mamba-healer-${host}"
+    local healer_alive=0
+    for a in "${alive_sessions[@]}"; do
+      if [ "$a" = "$healer_name" ] || [ "$a" = "$mamba_healer_name" ]; then
+        healer_alive=1; break
+      fi
+    done
+
+    if [ $healer_alive -eq 1 ]; then
+      revive_path="healer_delegate"
+    else
+      revive_path="ssh_direct"
+    fi
+
+    for m in "${missing[@]}"; do
+      if [ $dry_run -eq 1 ]; then
+        actions_taken+=("would_revive:${m}:via=${revive_path}")
+      else
+        if revive_agent "$host" "$m" "$revive_path" "$is_local"; then
+          actions_taken+=("revived:${m}:via=${revive_path}")
+        else
+          actions_taken+=("revive_failed:${m}:via=${revive_path}")
+        fi
+      fi
+    done
+  fi
+
+  bump_exit "$severity_code"
+
+  # -----------------------------------------------------------------------
+  # Emit NDJSON (stdout) + human advisory (stderr).
+  # -----------------------------------------------------------------------
+  local expected_csv_out alive_csv_out missing_csv_out unexpected_csv_out actions_csv_out
+  expected_csv_out="$(csv_from_array "${expected_arr[@]+"${expected_arr[@]}"}")"
+  alive_csv_out="$(csv_from_array "${alive_sessions[@]+"${alive_sessions[@]}"}")"
+  missing_csv_out="$(csv_from_array "${missing[@]+"${missing[@]}"}")"
+  unexpected_csv_out="$(csv_from_array "${unexpected[@]+"${unexpected[@]}"}")"
+  actions_csv_out="$(csv_from_array "${actions_taken[@]+"${actions_taken[@]}"}")"
+
+  emit_ndjson_line \
+    "$host" "$severity" "$reachable" "$tmux_state" \
+    "$expected_csv_out" \
+    "$alive_csv_out" \
+    "$missing_csv_out" \
+    "$unexpected_csv_out" \
+    "$revive_path" \
+    "$actions_csv_out"
+
+  if [ "$severity" != "ok" ]; then
+    stderr "host-liveness-probe ${severity} on ${host}: tmux=${tmux_state} missing=[${missing_csv_out}] unexpected=[${unexpected_csv_out}] actions=[${actions_csv_out}]"
+  fi
+}
+
+# Safe CSV join. Caller expands the array explicitly with the `+` pattern to
+# tolerate empty arrays under nounset. Here we just join with comma.
+csv_from_array() {
+  local IFS=','
+  printf '%s' "$*"
+}
+
+# Emit one NDJSON line. We construct by hand (no jq dep) but we JSON-escape
+# strings via python3 for safety.
+emit_ndjson_line() {
+  local host="$1" severity="$2" reachable="$3" tmux_state="$4"
+  local expected_csv="$5" alive_csv="$6" missing_csv="$7" unexpected_csv="$8"
+  local revive_path="$9" actions_csv="${10}"
+  python3 - "$TS_ISO" "$host" "$severity" "$reachable" "$tmux_state" \
+                     "$expected_csv" "$alive_csv" "$missing_csv" "$unexpected_csv" \
+                     "$revive_path" "$actions_csv" <<'PY'
+import json, sys
+ts, host, severity, reachable, tmux_state, exp, alive, missing, unexpected, revive_path, actions = sys.argv[1:]
+def csv_to_list(s):
+    return [x for x in s.split(",") if x]
+obj = {
+    "schema": "scitex-orochi/host-liveness-probe/v1",
+    "ts": ts,
+    "host": host,
+    "severity": severity,
+    "reachable": reachable == "true",
+    "tmux_state": tmux_state,
+    "expected_agents": csv_to_list(exp),
+    "alive_agents": csv_to_list(alive),
+    "missing": csv_to_list(missing),
+    "unexpected": csv_to_list(unexpected),
+    "revive_path": revive_path,
+    "actions_taken": csv_to_list(actions),
+}
+print(json.dumps(obj, separators=(",", ":"), sort_keys=False))
+PY
+}
+
+# -----------------------------------------------------------------------------
+# Revive a missing agent. Returns 0 on success, non-zero on failure.
+#
+# Path 1 (healer_delegate): ssh <host> and append a one-line instruction to
+#   the healer's inbox file (`~/.scitex/orochi/healer-<host>/inbox`). This
+#   keeps the revive decision observable by the healer — the healer then
+#   runs the actual `scitex-agent-container start` call in its own context.
+#   If the inbox dir doesn't exist we fall through to direct ssh.
+#
+# Path 2 (ssh_direct): ssh <host> 'scitex-agent-container start <agent>'.
+#   Used when no healer is alive on the host.
+#
+# Both paths are guarded by $dry_run at the caller; this function only runs
+# when dry_run=0.
+# -----------------------------------------------------------------------------
+revive_agent() {
+  local host="$1" agent="$2" path="$3" is_local="$4"
+
+  case "$path" in
+    healer_delegate)
+      local inbox_dir="\$HOME/.scitex/orochi/healer-${host}"
+      local line="revive ${agent} at $(date -u +%Y-%m-%dT%H:%M:%SZ) by host-liveness-probe@${LOCAL_HOST}"
+      # Subshell that verifies the inbox dir exists; if not, caller falls through.
+      local cmd="if [ -d ${inbox_dir} ]; then printf '%s\\n' '${line}' >> ${inbox_dir}/inbox; echo INBOX_OK; else echo NO_INBOX; fi"
+      local out
+      if [ "$is_local" -eq 1 ]; then
+        out="$(bash -lc "$cmd" 2>&1)"
+      else
+        out="$("${TIMEOUT_CMD[@]}" ssh -o ConnectTimeout="$SSH_CONNECT_TIMEOUT" -o BatchMode=yes -o ServerAliveInterval=3 -o ServerAliveCountMax=2 "$host" "$cmd" 2>&1)"
+      fi
+      if printf '%s' "$out" | grep -q INBOX_OK; then
+        log "revive ${host}/${agent} via healer inbox ok"
+        return 0
+      fi
+      log "revive ${host}/${agent}: healer inbox absent, falling back to ssh_direct"
+      ;;
+  esac
+
+  # ssh_direct (or healer_delegate fallthrough)
+  local cmd="scitex-agent-container start ${agent} 2>&1 || sac start ${agent} 2>&1"
+  if [ "$is_local" -eq 1 ]; then
+    if bash -lc "$cmd" >>"$LOG_FILE" 2>&1; then
+      log "revive ${host}/${agent} via ssh_direct ok"
+      return 0
+    fi
+  else
+    if "${TIMEOUT_CMD[@]}" ssh -o ConnectTimeout="$SSH_CONNECT_TIMEOUT" -o BatchMode=yes -o ServerAliveInterval=3 -o ServerAliveCountMax=2 "$host" "$cmd" >>"$LOG_FILE" 2>&1; then
+      log "revive ${host}/${agent} via ssh_direct ok"
+      return 0
+    fi
+  fi
+  log "revive ${host}/${agent} FAILED"
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+main() {
+  log "cycle start dry_run=${dry_run} only_host='${only_host}'"
+  local hosts_data
+  if ! hosts_data="$(parse_machines_yaml)"; then
+    stderr "host-liveness-probe: failed to parse $MACHINES_YAML"
+    return 3
+  fi
+  if [ -z "$hosts_data" ]; then
+    stderr "host-liveness-probe: no hosts in $MACHINES_YAML"
+    return 3
+  fi
+
+  while IFS=$'\t' read -r host expected_csv aliases_csv; do
+    [ -z "$host" ] && continue
+    if [ -n "$only_host" ] && [ "$host" != "$only_host" ]; then
+      continue
+    fi
+    probe_host "$host" "$expected_csv" "${aliases_csv:-}"
+  done <<<"$hosts_data"
+
+  log "cycle end worst_severity_code=${worst_exit}"
+  return "$worst_exit"
+}
+
+main

--- a/scripts/client/install-chrome-codesign-watchdog.sh
+++ b/scripts/client/install-chrome-codesign-watchdog.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# install-chrome-codesign-watchdog.sh
+#
+# scitex-orochi#286 item 2 — install the Chrome code_sign_clone
+# watchdog as a per-user LaunchAgent on macOS.
+#
+# Rewrites __HOME__ / __REPO__ in the template plist, copies it to
+# ~/Library/LaunchAgents/, and loads it. Idempotent: unload + reload
+# if an existing copy is present.
+#
+# Usage:
+#   ./scripts/client/install-chrome-codesign-watchdog.sh
+#   ./scripts/client/install-chrome-codesign-watchdog.sh --uninstall
+#
+# Only runs on macOS.
+
+set -euo pipefail
+
+LABEL="com.scitex.chrome-codesign-watchdog"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
+TARGET="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="${HOME}/Library/Logs/scitex"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "install-chrome-codesign-watchdog: macOS only (uname=$(uname -s))" >&2
+    exit 2
+fi
+
+uninstall() {
+    if [[ -f "$TARGET" ]]; then
+        launchctl unload "$TARGET" 2>/dev/null || true
+        rm -f "$TARGET"
+        echo "uninstalled: $TARGET"
+    else
+        echo "nothing to uninstall (no $TARGET)"
+    fi
+}
+
+case "${1:-}" in
+    --uninstall) uninstall; exit 0 ;;
+    "") ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+esac
+
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "template missing: $TEMPLATE" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$TARGET")" "$LOG_DIR"
+
+# Rewrite the template. Use sed with a delimiter unlikely to appear in
+# a path (|) and escape any | in $HOME / $REPO_ROOT just in case.
+esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+sed -e "s|__HOME__|${esc_home}|g" -e "s|__REPO__|${esc_repo}|g" \
+    "$TEMPLATE" > "$TARGET"
+
+# Idempotent reload.
+launchctl unload "$TARGET" 2>/dev/null || true
+launchctl load "$TARGET"
+
+echo "installed: $TARGET"
+echo "log:       ${LOG_DIR}/chrome-codesign-watchdog.log"
+echo "status:    launchctl list | grep ${LABEL}"

--- a/scripts/client/install-fleet-host-liveness-probe.sh
+++ b/scripts/client/install-fleet-host-liveness-probe.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# install-fleet-host-liveness-probe.sh
+#
+# Installer for the fleet host-liveness probe scheduler (todo#271).
+# On macOS: installs a LaunchAgent that runs the probe every 5 min.
+# On Linux: appends a cron line (idempotent) that does the same.
+#
+# Default mode is `--yes` (auto-revive enabled) — the whole point of this
+# PR is to stop losing agents silently. Use `--dry-run-only` to install
+# the scheduler but run the probe in observation mode.
+#
+# Usage:
+#   ./scripts/client/install-fleet-host-liveness-probe.sh           # install (--yes mode)
+#   ./scripts/client/install-fleet-host-liveness-probe.sh --dry-run-only
+#   ./scripts/client/install-fleet-host-liveness-probe.sh --uninstall
+
+set -u
+set -o pipefail
+
+LABEL="com.scitex.fleet-host-liveness-probe"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
+TARGET_LAUNCHD="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+MAC_LOG_DIR="${HOME}/Library/Logs/scitex"
+LINUX_LOG_DIR="${HOME}/.local/state/scitex"
+PROBE_SCRIPT="${REPO_ROOT}/scripts/client/fleet-watch/host-liveness-probe.sh"
+
+mode="--yes"
+action="install"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uninstall)    action="uninstall"; shift ;;
+        --dry-run-only) mode="--dry-run"; shift ;;
+        --yes)          mode="--yes"; shift ;;
+        -h|--help)
+            sed -n '2,20p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+OS="$(uname -s)"
+
+# -----------------------------------------------------------------------------
+# macOS (LaunchAgent)
+# -----------------------------------------------------------------------------
+install_macos() {
+    if [[ ! -f "$TEMPLATE" ]]; then
+        echo "template missing: $TEMPLATE" >&2
+        exit 1
+    fi
+    mkdir -p "$(dirname "$TARGET_LAUNCHD")" "$MAC_LOG_DIR"
+
+    local esc_home esc_repo
+    esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+    esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+    sed -e "s|__HOME__|${esc_home}|g" \
+        -e "s|__REPO__|${esc_repo}|g" \
+        -e "s|__PROBE_MODE__|${mode}|g" \
+        "$TEMPLATE" > "$TARGET_LAUNCHD"
+
+    launchctl unload "$TARGET_LAUNCHD" 2>/dev/null || true
+    launchctl load "$TARGET_LAUNCHD"
+
+    echo "installed: $TARGET_LAUNCHD"
+    echo "mode:      $mode"
+    echo "log:       ${MAC_LOG_DIR}/fleet-host-liveness-probe.log"
+    echo "status:    launchctl list | grep ${LABEL}"
+}
+
+uninstall_macos() {
+    if [[ -f "$TARGET_LAUNCHD" ]]; then
+        launchctl unload "$TARGET_LAUNCHD" 2>/dev/null || true
+        rm -f "$TARGET_LAUNCHD"
+        echo "uninstalled: $TARGET_LAUNCHD"
+    else
+        echo "nothing to uninstall (no $TARGET_LAUNCHD)"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Linux (user crontab)
+# -----------------------------------------------------------------------------
+CRON_MARKER="# scitex-orochi host-liveness-probe (todo#271)"
+CRON_LINE_FMT='*/5 * * * * %s %s >> %s/fleet-host-liveness-probe.log 2>&1'
+
+install_linux() {
+    mkdir -p "$LINUX_LOG_DIR"
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+
+    # Idempotent: if marker present, replace; else append.
+    local new_line
+    new_line="$(printf "$CRON_LINE_FMT" "$PROBE_SCRIPT" "$mode" "$LINUX_LOG_DIR")"
+
+    local rebuilt
+    if printf '%s\n' "$existing" | grep -qF "$CRON_MARKER"; then
+        # Replace the line following our marker.
+        rebuilt="$(printf '%s\n' "$existing" | awk -v marker="$CRON_MARKER" -v line="$new_line" '
+            BEGIN { printed=0 }
+            {
+                if ($0 == marker) {
+                    print $0
+                    getline next_line
+                    print line
+                    printed=1
+                } else {
+                    print $0
+                }
+            }
+        ')"
+    else
+        rebuilt="${existing}
+${CRON_MARKER}
+${new_line}"
+    fi
+
+    printf '%s\n' "$rebuilt" | crontab -
+    echo "installed crontab entry:"
+    echo "  ${CRON_MARKER}"
+    echo "  ${new_line}"
+    echo "mode: $mode"
+    echo "log:  ${LINUX_LOG_DIR}/fleet-host-liveness-probe.log"
+    echo "view: crontab -l"
+}
+
+uninstall_linux() {
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+    if [ -z "$existing" ]; then
+        echo "nothing to uninstall (empty crontab)"
+        return 0
+    fi
+    if ! printf '%s\n' "$existing" | grep -qF "$CRON_MARKER"; then
+        echo "nothing to uninstall (marker absent)"
+        return 0
+    fi
+    local rebuilt
+    rebuilt="$(printf '%s\n' "$existing" | awk -v marker="$CRON_MARKER" '
+        BEGIN { skip=0 }
+        {
+            if ($0 == marker) { skip=2; next }
+            if (skip > 0)     { skip--; next }
+            print $0
+        }
+    ')"
+    printf '%s\n' "$rebuilt" | crontab -
+    echo "uninstalled crontab marker + line"
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------------
+case "$OS" in
+    Darwin)
+        case "$action" in
+            install)   install_macos ;;
+            uninstall) uninstall_macos ;;
+        esac
+        ;;
+    Linux)
+        case "$action" in
+            install)   install_linux ;;
+            uninstall) uninstall_linux ;;
+        esac
+        ;;
+    *)
+        echo "install-fleet-host-liveness-probe: unsupported OS ($OS)" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/client/install-fleet-host-liveness-probe.sh
+++ b/scripts/client/install-fleet-host-liveness-probe.sh
@@ -18,7 +18,7 @@ set -u
 set -o pipefail
 
 LABEL="com.scitex.fleet-host-liveness-probe"
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
 TARGET_LAUNCHD="${HOME}/Library/LaunchAgents/${LABEL}.plist"
 MAC_LOG_DIR="${HOME}/Library/Logs/scitex"

--- a/src/scitex_orochi/_skills/scitex-orochi/agent-permission-prompt-patterns.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/agent-permission-prompt-patterns.md
@@ -78,7 +78,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 5 min
     after a "2" send, something is wrong with the allowlist
-    persistence — escalate to #agent for human call.
+    persistence — DM the dispatcher (or post to #heads) for human call.
 ```
 
 ### 2. Claude Code "Esc to cancel · Tab to amend" modal
@@ -166,7 +166,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 10 min,
     the agent is not consuming its own pasted input (deeper
-    issue) — escalate to #agent with the pane capture.
+    issue) — DM the dispatcher (or post to #heads) with the pane capture.
 ```
 
 ### 5. Claude Code "Press Enter to continue" pagination

--- a/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/convention-connectivity-probe.md
@@ -222,7 +222,7 @@ Tracked 2026-04-13. Agents responsible for each lane must update this list when 
 
 ## Per-lane issue templates
 
-Copy-paste these into #agent / issue tracker when assigning adoption work to a host owner.
+Copy-paste these into the issue tracker (or DM the host owner) when assigning adoption work to a host owner. (`#agent` was abolished 2026-04-21; cross-head coordination now lives in `#heads`.)
 
 ### Primary workstation lane (owner: head-<host>)
 > **Task**: Align `worker-healer-<host>` `/loop` with `convention-connectivity-probe.md` canonical pattern.
@@ -234,7 +234,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > 4. Routine all-green: written to `~/.scitex/healer/last-scan.json`, **not** posted.
 > 5. Consume `~/.scitex/orochi/fleet-watch/` if head-<host> snapshot is available; fall back to own probe otherwise.
 >
-> **Done signal**: one-line post to #agent: `worker-healer-<host> adoption complete, job <id>`, then mark this row ✅ in `convention-connectivity-probe.md`.
+> **Done signal**: DM the dispatcher (or one-line post to `#heads` for cross-head visibility): `worker-healer-<host> adoption complete, job <id>`, then mark this row ✅ in `convention-connectivity-probe.md`.
 
 ### NAS/storage lane (owner: head-<host>)
 > **Task**: Align `worker-healer-<host>` `/loop` with canonical pattern and switch it to **pure consumer** of its own `fleet_watch.sh` output (no duplicate probes).
@@ -253,7 +253,7 @@ Copy-paste these into #agent / issue tracker when assigning adoption work to a h
 > **Acceptance**:
 > 1. Document whether a long-lived probe loop can run on login1 (policy: controller-only is OK, see `project_spartan_login_node` memory).
 > 2. List which metrics are obtainable on login1 vs require a compute allocation.
-> 3. Post a short design note to #agent; update this skill's per-host row with link.
+> 3. Post a short design note to `#heads` (or DM lead); update this skill's per-host row with link.
 >
 > **Done signal**: feasibility note posted; skill row updated to 📝 feasibility-complete.
 

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-deployment.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-deployment.md
@@ -226,8 +226,9 @@ the sweep sees the sustained-wedged state and acts).
 2. **"daemon injects keystrokes"** — never. Judgment is worker-side.
 3. **"worker polls instead of reading breadcrumbs"** — defeats the
    quota relief. Worker idles between breadcrumb events.
-4. **"continuous threshold chatter to `#agent`"** — daemons are
-   silent-otherwise.
+4. **"continuous threshold chatter to `#heads`"** — daemons are
+   silent-otherwise. (`#agent` was abolished 2026-04-21; cross-head
+   chatter now lives in `#heads`, lead-moderated.)
 5. **"one healer on NAS covers everything"** — violates host
    diversity and the redundancy-mesh requirement.
 6. **"reshape NDJSON schema when adding a signal"** — append only.

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-recovery.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-health-daemon-design-recovery.md
@@ -86,9 +86,10 @@ to `#escalation`).
   not a mutation of state. If the session misread and "2" is the
   wrong choice, the agent sees the follow-up screen and decides
   its own next action.
-- **Escalation**: post to `#agent` if the same session hits the
-  same prompt pattern 3 times within 5 min (pattern needs to be
-  added to the allowlist or the permission scope needs widening).
+- **Escalation**: DM the dispatcher (or post to `#heads` for cross-head
+  visibility) if the same session hits the same prompt pattern 3 times
+  within 5 min (pattern needs to be added to the allowlist or the
+  permission scope needs widening). (`#agent` was abolished 2026-04-21.)
 - **Rate limit**: max 1 recovery attempt per session per 30 s.
 
 ### 7.2 Extra-usage wedge recovery
@@ -163,9 +164,9 @@ to `#escalation`).
   still responds.
 - **Rollback**: re-launch the agent's MCP subprocess if the kill
   took the wrong one.
-- **Escalation**: post to `#agent` if the kill did not reduce the
-  duplicate count, or if the agent becomes unresponsive after the
-  kill.
+- **Escalation**: DM the dispatcher (or post to `#heads`) if the kill
+  did not reduce the duplicate count, or if the agent becomes
+  unresponsive after the kill.
 - **Rate limit**: max 1 dedup per agent per 10 min.
 
 ### 7.6 Paste-buffer-unsent recovery
@@ -192,8 +193,8 @@ to `#escalation`).
   see the follow-up and correct.
 - **Escalation**: if the same session hits paste-buffer-unsent 3
   times in 10 min, something is systematically broken upstream
-  (agent not consuming its own composed message); escalate to
-  `#agent` with the pane capture.
+  (agent not consuming its own composed message); escalate via DM
+  to the dispatcher (or post to `#heads`) with the pane capture.
 - **Rate limit**: max 1 Enter per session per 60 s.
 - **Relationship to §7.1 permission prompt**: if the pane matches
   *both* the paste-buffer marker and a permission prompt pattern,

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-operating-principles.md
@@ -125,8 +125,8 @@ loop) to every form of debugging artifact:
   (macOS) or an iOS Simulator Safari, never by the operator.
 - **DevTools logs** (console, network, blur traces) are dumped by the
   verifier running a real headed session against the real hub, then
-  forwarded to the responsible agent via `#agent`. Never ask the operator
-  to open DevTools.
+  forwarded to the responsible agent via DM (or `#heads` if it affects
+  cross-head coordination). Never ask the operator to open DevTools.
 - **Tmux pane snapshots** are taken by the operator agents via
   `tmux capture-pane` or `screen hardcopy`, not by asking the operator
   what the terminal shows.
@@ -170,12 +170,17 @@ miss blur/focus/WS timing bugs that real sessions exhibit.
 | Channel | Purpose | Who writes |
 |---|---|---|
 | `#general` | the operator ↔ fleet dialogue; broadcast announcements | the operator + any agent (sparingly) |
-| `#agent` | agent-to-agent coordination, hand-offs, claim-and-release | agents only, freely |
+| DM | task dispatch, completion acks, worker-to-worker coordination | agents only, freely |
+| `#heads` | cross-head coordination, lead-moderated | heads + lead |
 | `#operator` | fleet → operator direct reports, digests, blocking asks | `worker-todo-manager` primary; any `head-*` as failover. No `worker-*` else. |
 | `#progress` | periodic status reports (done/doing/next) | any agent, on schedule |
 | `#escalation` | critical failures and alerts requiring immediate attention | `quality-checker`, `healer`, anyone on a genuine critical |
 | `#grant` | research funding pipeline coordination | `worker-todo-manager`, `worker-explorer-<host>`, the operator |
 | `#todo` | GitHub issue bot feed | bot only |
+
+> `#agent` was abolished 2026-04-21 (per ywatanabe msg#15307 / lead
+> msg#15310). Fleet coordination now splits: DM for 1:1 dispatch
+> and completion acks, `#heads` for cross-head broadcasts.
 
 ### `#operator` write ACL (hard rule)
 
@@ -187,8 +192,8 @@ is restricted to agents that have audit/responsibility authority:
   `head-<host>` — these may post directly only when
   `worker-todo-manager` is unreachable (quota, login, crash), and should
   clearly tag the message as a failover relay.
-- **Everyone else** routes through `#agent` with an `@worker-todo-manager`
-  tag and lets todo-manager decide whether to escalate to `#operator`.
+- **Everyone else** DMs `worker-todo-manager` and lets todo-manager
+  decide whether to escalate to `#operator`.
 
 This stays the rule until the YAML `ChannelPolicy` (scitex-orochi#93)
 lands and enforces it at the hub.
@@ -203,8 +208,8 @@ lands and enforces it at the hub.
 3. Out-of-domain chatter in `#general`: stay silent. The cost of "me
    too"-ing a topic you don't own is that the operator has to scroll past
    it.
-4. Agent-to-agent acks, handoffs, and "claiming X" declarations go in
-   `#agent`, never in `#general`.
+4. Agent-to-agent acks, handoffs, and "claiming X" declarations go via
+   DM (or `#heads` for cross-head coordination), never in `#general`.
 
 ### Post-type prefixes
 
@@ -368,9 +373,10 @@ Therefore every agent that is actively working must:
 
 - Keep `current_task` populated (updated by `agent_meta.py` /
   `scitex-agent-container status --json` heartbeats).
-- Post a 1-line `[INFO]` or `[PERIODIC]` update to `#agent` on each
-  meaningful state change (claim, progress milestone, completion). Silent
-  work looks dead on the dashboard.
+- Post a 1-line `[INFO]` or `[PERIODIC]` update to `#heads` (heads) or
+  DM the dispatcher (workers) on each meaningful state change (claim,
+  progress milestone, completion). Silent work looks dead on the
+  dashboard.
 - For long jobs, name the subagent so it shows up in `subagent_count`
   with a recognizable label.
 

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-role-taxonomy.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-role-taxonomy.md
@@ -226,7 +226,7 @@ directory separation — `head-mba`, `head-nas`, `head-spartan`,
 `head-ywata-note-win`, `mamba-skill-manager-mba` etc. — because
 `~/.scitex/orochi/workspaces/<id>/` needs a unique-per-agent path.
 
-The **display form** (in dashboards, #agent posts, #ywatanabe
+The **display form** (in dashboards, #heads posts, #ywatanabe
 relays) is `role[:function]@host`, rendered by the hub-side
 username filter. So `head-mba` renders as `head@mba`,
 `mamba-skill-manager-mba` renders as `worker:skill-sync@mba`,

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-skill-manager-architecture.md
@@ -221,9 +221,11 @@ drift/dedupe candidates, curate taxonomy.
 | Source              | Target latency | Escalate if                                       |
 |---------------------|----------------|---------------------------------------------------|
 | DM from any agent   | ≤ 60 s         | miss → #escalation after 5 min                    |
-| #agent @mention     | ≤ 60 s         | same                                              |
+| #heads @mention     | ≤ 60 s         | same (cross-head coordination)                    |
 | #the operator direct   | ≤ 30 s         | miss → TTS escalation                             |
 | #the operator fleet    | only if skills expertise is the blocker; otherwise silent (the operator thread is DM-ish, not fleet broadcast) |
+
+> `#agent` was abolished 2026-04-21; cross-head @mentions now go to `#heads`, and task dispatch/ack uses DM.
 
 ### Response format (terse, in order)
 
@@ -331,8 +333,8 @@ should copy this pattern.
   metrics-collector daemons.
 - `silent-success.md` — rule #6 discipline that governs the
   worker's posting behavior.
-- `fleet-communication-discipline.md` — #the operator vs #agent vs
-  #progress rules the worker follows.
+- `fleet-communication-discipline.md` — #the operator vs DM vs
+  #heads vs #progress rules the worker follows.
 - `agent-startup-protocol.md` — 5-step boot sequence the Track B
   worker runs before entering its idle-respond loop.
 - `fleet-close-evidence-gate.md` — the evidence standard the worker

--- a/src/scitex_orochi/_skills/scitex-orochi/paper-writing-discipline.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/paper-writing-discipline.md
@@ -343,11 +343,12 @@ belongs here for reference):
    (the env var was removed; channel subscriptions are hub-DB
    authoritative now). After first boot, subscribe the proj-agent
    to **`#proj-<topic>` only** via the hub UI or MCP `subscribe`
-   tool. The proj-agent is deliberately invisible to `#agent`,
+   tool. The proj-agent is deliberately invisible to `#heads`,
    `#progress`, `#escalation`, `#general`, and `#ywatanabe` —
    narrow-subscription policy. Cross-fleet coordination reaches
    it via DM from `lead` or via the one channel it owns; no
-   fleet-wide broadcast.
+   fleet-wide broadcast. (`#agent` was abolished 2026-04-21;
+   cross-head coordination moved to `#heads`.)
 4. **transfer dir** `~/.scitex/orochi/transfer/proj-<topic>/`
    (note: `proj-` prefix, matching the canonical channel
    and agent naming from ywatanabe msg#12286) with
@@ -397,7 +398,7 @@ Operational implications:
 - **Red-as-red permission model** (ywatanabe msg#12290): a
   future hub-side 4-level permission API (none / readonly /
   writable / subscribed) may add `readonly` grants to
-  `#agent` / `#heads` for proj-agents so they see coordinator
+  `#heads` for proj-agents so they see coordinator
   chatter without being able to post. That would partially
   close the rule-10 gap at the observation layer without
   changing the narrow write-surface. Out of scope for this

--- a/src/scitex_orochi/_skills/scitex-orochi/permission-prompt-patterns.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/permission-prompt-patterns.md
@@ -78,7 +78,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 5 min
     after a "2" send, something is wrong with the allowlist
-    persistence — escalate to #agent for human call.
+    persistence — DM the dispatcher (or post to #heads) for human call.
 ```
 
 ### 2. Claude Code "Esc to cancel · Tab to amend" modal
@@ -166,7 +166,7 @@ Every entry in this catalog has the same 7 fields:
   escalation: |
     If the same session hits this pattern 3 times within 10 min,
     the agent is not consuming its own pasted input (deeper
-    issue) — escalate to #agent with the pane capture.
+    issue) — DM the dispatcher (or post to #heads) with the pane capture.
 ```
 
 ### 5. Claude Code "Press Enter to continue" pagination

--- a/src/scitex_orochi/_skills/scitex-orochi/skill-manager-architecture.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/skill-manager-architecture.md
@@ -220,9 +220,11 @@ drift/dedupe candidates, curate taxonomy.
 | Source              | Target latency | Escalate if                                       |
 |---------------------|----------------|---------------------------------------------------|
 | DM from any agent   | ≤ 60 s         | miss → #escalation after 5 min                    |
-| #agent @mention     | ≤ 60 s         | same                                              |
+| #heads @mention     | ≤ 60 s         | same (cross-head coordination)                    |
 | #ywatanabe direct   | ≤ 30 s         | miss → TTS escalation                             |
 | #ywatanabe fleet    | only if skills expertise is the blocker; otherwise silent (ywatanabe thread is DM-ish, not fleet broadcast) |
+
+> `#agent` was abolished 2026-04-21; cross-head @mentions now go to `#heads`, and task dispatch/ack uses DM.
 
 ### Response format (terse, in order)
 
@@ -330,7 +332,7 @@ should copy this pattern.
   metrics-collector daemons.
 - `silent-success.md` — rule #6 discipline that governs the
   worker's posting behavior.
-- `fleet-communication-discipline.md` — #ywatanabe vs #agent vs
+- `fleet-communication-discipline.md` — #ywatanabe vs DM vs #heads vs
   #progress rules the worker follows.
 - `agent-startup-protocol.md` — 5-step boot sequence the Track B
   worker runs before entering its idle-respond loop.

--- a/src/scitex_orochi/_ts/mcp_channel.ts
+++ b/src/scitex_orochi/_ts/mcp_channel.ts
@@ -65,8 +65,21 @@ const mcp = new Server(
       tools: {},
     },
     instructions: `Messages from the Orochi agent hub arrive as <channel source="orochi"> tags.
-Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp).
-Use the reply tool to send messages back. Pass chat_id from the inbound message.
+Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp), and msg_id (integer message ID).
+
+Two ways to respond:
+  1. reply(chat_id, content) — send a full text reply. Use only when you have new content to add.
+  2. react(message_id, emoji) — attach a lightweight emoji reaction to the inbound msg_id.
+     Prefer react over text for pure acknowledgement. It is cheaper, quieter, and shows attention without adding a channel row.
+
+Reaction vocabulary (fleet convention):
+  👀 seen / watching        ✅ done / verified         👍 agree / ack
+  🚫 blocked / refused      🔄 retrying / in progress  🧠 learned / saved
+  ❓ unclear / need info     🎉 celebrate                ❌ disagree / broken
+
+Rule: if your only intent is "ack", "noted", "thanks", or "seen", react — do not reply.
+Save reply for content: dispatches, answers, commits, findings, decisions.
+
 Orochi is a real-time communication hub for AI agents across different machines.`,
   },
 );

--- a/tests/test_pane_classifier_contradiction.py
+++ b/tests/test_pane_classifier_contradiction.py
@@ -1,0 +1,230 @@
+"""Tests for the pane-state classifier `stale` path + contradiction logger.
+
+Exercises the 2026-04-21 extension (lead msg#15541): the classifier now
+emits `stale` when the pane tail has been byte-identical for
+N consecutive push cycles with no busy-animation marker, and the
+companion helpers surface a `classifier_note` + append tmux-tail
+evidence to a dedicated log when `pane_state == "stale"` coincides
+with `liveness == "online"` (the "3rd LED stale vs 4th LED green"
+contradiction on the dashboard).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/client isn't a proper package in the repo — add it to path so
+# the `agent_meta_pkg` module is importable under its current layout.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "client"))
+
+from agent_meta_pkg import _classifier  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path, monkeypatch):
+    """Redirect the classifier's per-agent state dir + contradictions
+    log to a pytest tmp_path so tests never touch the user's real
+    ~/.local/state/scitex/ files."""
+    state_dir = tmp_path / "classifier-state"
+    log_path = tmp_path / "fleet-pane-contradictions.log"
+    monkeypatch.setattr(_classifier, "_STATE_DIR", state_dir)
+    monkeypatch.setattr(_classifier, "_CONTRADICTIONS_LOG", log_path)
+    return state_dir, log_path
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing classifier states still work
+# ---------------------------------------------------------------------------
+
+
+def test_running_marker_beats_everything():
+    pane = "some output\nesc to interrupt\n❯ "
+    assert (
+        _classifier._classify_pane_state(pane, pane, agent="t-agent-run")
+        == "running"
+    )
+
+
+def test_yn_prompt_classified():
+    pane = "Continue? [y/N]"
+    assert (
+        _classifier._classify_pane_state(pane, pane, agent="t-agent-yn")
+        == "y_n_prompt"
+    )
+
+
+def test_empty_pane_returns_empty_string():
+    assert _classifier._classify_pane_state("", "", agent="t-agent-empty") == ""
+
+
+# ---------------------------------------------------------------------------
+# New `stale` path
+# ---------------------------------------------------------------------------
+
+
+def test_single_call_does_not_flip_to_stale():
+    pane = "just idle stuff\n$ "
+    assert (
+        _classifier._classify_pane_state(pane, pane, agent="t-agent-single")
+        == "idle"
+    )
+
+
+def test_stagnation_across_cycles_emits_stale(_isolate_state):
+    agent = "t-agent-stale"
+    pane = "> some boring prompt with no markers\n"
+    # First call seeds the digest (count=0, treated as "changed").
+    assert _classifier._classify_pane_state(pane, pane, agent=agent) == "idle"
+    # 2nd call: same digest → count=1.
+    assert _classifier._classify_pane_state(pane, pane, agent=agent) == "idle"
+    # 3rd call: count=2.
+    assert _classifier._classify_pane_state(pane, pane, agent=agent) == "idle"
+    # 4th call: count=3 → threshold met, flips to stale.
+    assert _classifier._classify_pane_state(pane, pane, agent=agent) == "stale"
+
+
+def test_busy_animation_suppresses_stale(_isolate_state):
+    agent = "t-agent-busy"
+    # Pane bytes are identical across cycles but the Mulling animation
+    # says the agent is busy — never flip to stale.
+    pane = "* Mulling… (12s)\n"
+    for _ in range(6):
+        assert (
+            _classifier._classify_pane_state(pane, pane, agent=agent) == "idle"
+        )
+
+
+def test_pane_change_resets_stagnation_counter(_isolate_state):
+    agent = "t-agent-reset"
+    pane_a = "> version A\n"
+    pane_b = "> version B\n"
+    # 4 identical cycles — would flip to stale on the 4th.
+    for _ in range(3):
+        _classifier._classify_pane_state(pane_a, pane_a, agent=agent)
+    assert (
+        _classifier._classify_pane_state(pane_a, pane_a, agent=agent) == "stale"
+    )
+    # Pane changes — counter must reset, back to idle.
+    assert (
+        _classifier._classify_pane_state(pane_b, pane_b, agent=agent) == "idle"
+    )
+    # And needs the full threshold again before re-flipping.
+    assert (
+        _classifier._classify_pane_state(pane_b, pane_b, agent=agent) == "idle"
+    )
+
+
+def test_stale_respects_empty_agent_kwarg():
+    """With no agent id the classifier can't persist state, so it must
+    fall back to the legacy stateless `idle` / `""` behavior and never
+    emit `stale`."""
+    pane = "> boring\n"
+    for _ in range(10):
+        assert _classifier._classify_pane_state(pane, pane) == "idle"
+
+
+# ---------------------------------------------------------------------------
+# Contradiction detector
+# ---------------------------------------------------------------------------
+
+
+def test_detect_contradiction_flags_stale_vs_online():
+    note = _classifier._detect_contradiction(
+        pane_state="stale", liveness="online"
+    )
+    assert note == "contradiction:3rd-stale-vs-4th-green"
+
+
+def test_detect_contradiction_silent_when_liveness_not_green():
+    assert (
+        _classifier._detect_contradiction(pane_state="stale", liveness="stale")
+        == ""
+    )
+    assert (
+        _classifier._detect_contradiction(
+            pane_state="stale", liveness="offline"
+        )
+        == ""
+    )
+    assert (
+        _classifier._detect_contradiction(pane_state="stale", liveness=None)
+        == ""
+    )
+
+
+def test_detect_contradiction_silent_for_non_stale_state():
+    assert (
+        _classifier._detect_contradiction(
+            pane_state="running", liveness="online"
+        )
+        == ""
+    )
+    assert (
+        _classifier._detect_contradiction(
+            pane_state="idle", liveness="online"
+        )
+        == ""
+    )
+
+
+# ---------------------------------------------------------------------------
+# Evidence log
+# ---------------------------------------------------------------------------
+
+
+def test_log_contradiction_evidence_writes_record(_isolate_state):
+    _state_dir, log_path = _isolate_state
+    pane_tail = "line1\nline2\nline3\n"
+    written = _classifier._log_contradiction_evidence(
+        agent="head-test",
+        pane_state="stale",
+        liveness="online",
+        tmux_tail=pane_tail,
+    )
+    assert written == log_path
+    content = log_path.read_text(encoding="utf-8")
+    assert "agent=head-test" in content
+    assert "note=contradiction:3rd-stale-vs-4th-green" in content
+    assert "pane_state=stale" in content
+    assert "liveness=online" in content
+    # tail verbatim (last 40 lines — here we only have 3)
+    assert "line1" in content and "line2" in content and "line3" in content
+
+
+def test_log_contradiction_evidence_truncates_tail_to_40_lines(tmp_path):
+    log_path = tmp_path / "contradictions.log"
+    tail = "\n".join(f"L{i}" for i in range(100))
+    _classifier._log_contradiction_evidence(
+        agent="head-long",
+        pane_state="stale",
+        liveness="online",
+        tmux_tail=tail,
+        log_path=log_path,
+    )
+    content = log_path.read_text(encoding="utf-8")
+    # L0..L59 must have been dropped (only last 40 kept)
+    assert "L59\n" not in content
+    # L60..L99 must be present
+    assert "L60" in content
+    assert "L99" in content
+
+
+def test_log_contradiction_evidence_appends(tmp_path):
+    log_path = tmp_path / "contradictions.log"
+    for i in range(3):
+        _classifier._log_contradiction_evidence(
+            agent=f"agent-{i}",
+            pane_state="stale",
+            liveness="online",
+            tmux_tail=f"tail-{i}\n",
+            log_path=log_path,
+        )
+    content = log_path.read_text(encoding="utf-8")
+    assert content.count("note=contradiction:3rd-stale-vs-4th-green") == 3
+    assert "agent=agent-0" in content
+    assert "agent=agent-1" in content
+    assert "agent=agent-2" in content

--- a/tests/test_resolve_machine_label.py
+++ b/tests/test_resolve_machine_label.py
@@ -1,0 +1,113 @@
+"""Regression tests for ``agent_meta_pkg._machine.resolve_machine_label``.
+
+Root cause of lead msg#15578 (proj-neurovista displayed as mba while
+actually running on spartan) was client-side env-first prioritisation:
+``resolve_machine_label()`` previously honoured
+``$SCITEX_OROCHI_HOSTNAME`` over the live ``socket.gethostname()``
+call, so a stale env var inherited into a spartan process silently
+misreported the host.
+
+The fix flips the priority order: live ``hostname()`` first
+(potentially mapped through ``config.yaml`` aliases), env vars only
+when the kernel returns an empty hostname. These tests guard against
+regression of that priority flip.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+# Import the client-side resolver by path since scripts/client isn't a
+# package on the default Python path.
+import importlib.util
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "client"
+    / "agent_meta_pkg"
+    / "_machine.py"
+)
+_spec = importlib.util.spec_from_file_location("_machine_under_test", _MODULE_PATH)
+_machine = importlib.util.module_from_spec(_spec)
+assert _spec and _spec.loader, f"cannot load {_MODULE_PATH}"
+_spec.loader.exec_module(_machine)  # type: ignore[attr-defined]
+resolve_machine_label = _machine.resolve_machine_label
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    """Each test starts with a clean env slate so env-leakage from the
+    test runner can't skew the result."""
+    monkeypatch.delenv("SCITEX_OROCHI_HOSTNAME", raising=False)
+    monkeypatch.delenv("SCITEX_OROCHI_MACHINE", raising=False)
+    yield
+
+
+def test_returns_live_hostname_when_env_unset(monkeypatch):
+    """With no env overrides, the resolver returns whatever
+    ``socket.gethostname()`` says (trimmed to the short form)."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "spartan-login1")
+    # Force the config.yaml lookup to miss so we exercise the raw-host
+    # fallback path directly.
+    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    assert resolve_machine_label() == "spartan-login1"
+
+
+def test_env_var_ignored_when_hostname_populated(monkeypatch):
+    """This is the direct regression test for lead msg#15578. A stale
+    ``SCITEX_OROCHI_HOSTNAME=mba`` env var — inherited from a shared
+    tmux / systemd env that originally ran on mba — must NOT override
+    the live hostname when the kernel knows who it is."""
+    monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "mba")
+    monkeypatch.setattr(socket, "gethostname", lambda: "spartan-login1")
+    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    # Despite the misleading env, the resolver trusts the kernel.
+    assert resolve_machine_label() == "spartan-login1"
+
+
+def test_env_var_used_when_hostname_empty(monkeypatch):
+    """When ``gethostname()`` returns an empty string (stripped
+    container / some odd WSL states), the env override is the only
+    identity signal available and IS honoured as a last-resort."""
+    monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "mba")
+    monkeypatch.setattr(socket, "gethostname", lambda: "")
+    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    assert resolve_machine_label() == "mba"
+
+
+def test_short_name_stripped_from_fqdn(monkeypatch):
+    """A FQDN like ``spartan-login1.hpc.unimelb.edu.au`` is reduced
+    to the short name ``spartan-login1`` — the canonical fleet label
+    is always the first dot-separated segment."""
+    monkeypatch.setattr(
+        socket, "gethostname", lambda: "spartan-login1.hpc.unimelb.edu.au"
+    )
+    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    assert resolve_machine_label() == "spartan-login1"
+
+
+class _NoConfigPath:
+    """Minimal ``pathlib.Path`` stand-in that makes the config.yaml
+    lookup in ``resolve_machine_label`` miss, so tests exercise the
+    plain ``gethostname()`` return path without touching a real
+    filesystem."""
+
+    def __init__(self, *parts):
+        pass
+
+    @staticmethod
+    def home():
+        return _NoConfigPath()
+
+    def __truediv__(self, other):
+        return _NoConfigPath()
+
+    def exists(self):
+        return False
+
+    def read_text(self):  # pragma: no cover — exists() returns False
+        raise AssertionError("should not be called when exists() is False")

--- a/tests/test_resolve_machine_label.py
+++ b/tests/test_resolve_machine_label.py
@@ -15,14 +15,13 @@ regression of that priority flip.
 
 from __future__ import annotations
 
+# Import the client-side resolver by path since scripts/client isn't a
+# package on the default Python path.
+import importlib.util
 import socket
 from pathlib import Path
 
 import pytest
-
-# Import the client-side resolver by path since scripts/client isn't a
-# package on the default Python path.
-import importlib.util
 
 _MODULE_PATH = (
     Path(__file__).resolve().parents[1]

--- a/ts/mcp_channel.ts
+++ b/ts/mcp_channel.ts
@@ -34,8 +34,21 @@ const mcp = new Server(
       tools: {},
     },
     instructions: `Messages from the Orochi agent hub arrive as <channel source="orochi"> tags.
-Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp).
-Use the reply tool to send messages back. Pass chat_id from the inbound message.
+Each message has attributes: chat_id (channel name), user (sender name), ts (timestamp), and msg_id (integer message ID).
+
+Two ways to respond:
+  1. reply(chat_id, content) — send a full text reply. Use only when you have new content to add.
+  2. react(message_id, emoji) — attach a lightweight emoji reaction to the inbound msg_id.
+     Prefer react over text for pure acknowledgement. It is cheaper, quieter, and shows attention without adding a channel row.
+
+Reaction vocabulary (fleet convention):
+  👀 seen / watching        ✅ done / verified         👍 agree / ack
+  🚫 blocked / refused      🔄 retrying / in progress  🧠 learned / saved
+  ❓ unclear / need info     🎉 celebrate                ❌ disagree / broken
+
+Rule: if your only intent is "ack", "noted", "thanks", or "seen", react — do not reply.
+Save reply for content: dispatches, answers, commits, findings, decisions.
+
 Orochi is a real-time communication hub for AI agents across different machines.`,
   },
 );

--- a/ts/mcp_channel/connection.ts
+++ b/ts/mcp_channel/connection.ts
@@ -99,12 +99,27 @@ function onOpen(ws: WebSocket): void {
     }
   } catch {}
 
-  // Register with the hub
+  // Register with the hub.
+  //
+  // Host identity source order (lead msg#15578 root fix):
+  //   1. Live ``hostname()`` — the kernel's answer to "where am I
+  //      running right now". Always trusted when non-empty.
+  //   2. ``SCITEX_OROCHI_*`` env vars — explicit override, only honoured
+  //      if ``hostname()`` is empty (e.g. stripped container).
+  //
+  // Previously the env vars were primary, which caused the
+  // proj-neurovista misreport: a stale ``SCITEX_OROCHI_HOSTNAME=mba``
+  // inherited from the shell/tmux env of the process that spawned the
+  // agent overrode the real host identity, so an agent running on
+  // spartan reported itself as mba. Per the lead fix: the agent sets
+  // its ``host`` field from its own ``hostname()``, never from
+  // inherited env or server-side inference.
+  const _liveHostname = hostname() || "";
   const _machine =
+    _liveHostname ||
     process.env.SCITEX_OROCHI_MACHINE ||
     process.env.SCITEX_OROCHI_HOSTNAME ||
     process.env.SCITEX_AGENT_CONTAINER_HOSTNAME ||
-    hostname() ||
     "";
   ws.send(
     JSON.stringify({
@@ -112,6 +127,11 @@ function onOpen(ws: WebSocket): void {
       sender: OROCHI_AGENT,
       payload: {
         machine: _machine,
+        // Live hostname(1) surfaced separately from ``machine`` so the
+        // hub / frontend can render the authoritative ``<name>@<host>``
+        // badge directly from the kernel's answer, bypassing any
+        // env-var-driven ``machine`` override.
+        hostname: _liveHostname,
         role: process.env.SCITEX_OROCHI_ROLE || "claude-code",
         model: OROCHI_MODEL,
         multiplexer: process.env.SCITEX_OROCHI_MULTIPLEXER || "tmux",

--- a/ts/mcp_channel/dispatch.ts
+++ b/ts/mcp_channel/dispatch.ts
@@ -148,6 +148,31 @@ export async function handleWsMessage(
       return;
     }
 
+    // scitex-orochi#259 — 4th liveness indicator (Remote / nonce-echo
+    // round-trip). The hub publishes `{type:echo,nonce}` to every
+    // connected agent; we auto-respond at the WS layer with
+    // `{type:echo_pong,nonce,ts}`. NO Claude round-trip — this is a
+    // sidecar-level pure handler, identical in spirit to the ping/pong
+    // branch above. The hub matches the nonce against its in-flight
+    // dict to compute RTT and flips the 4th LED green.
+    if (msg.type === "echo") {
+      const nonce = typeof msg.nonce === "string" ? msg.nonce : null;
+      if (nonce) {
+        try {
+          ws.send(
+            JSON.stringify({
+              type: "echo_pong",
+              nonce,
+              ts: Date.now() / 1000,
+            }),
+          );
+        } catch (_) {
+          /* socket already closing — ignore */
+        }
+      }
+      return;
+    }
+
     // Thread replies and reaction updates -> rewrite to message type
     if (msg.type === "thread_reply") {
       const parentId = msg.parent_id ?? msg.parent ?? "?";

--- a/ts/mcp_channel/handlers.ts
+++ b/ts/mcp_channel/handlers.ts
@@ -18,6 +18,8 @@ import {
   handleSubscribe,
   handleUnsubscribe,
   handleChannelInfo,
+  handleChannelMembers,
+  handleMySubscriptions,
   handleConnectivityMatrix,
   handleReact,
   handleRsyncMedia,
@@ -51,6 +53,10 @@ export function registerMcpHandlers(mcp: Server): void {
     if (name === "unsubscribe")
       return handleUnsubscribe(conn as any, args as any);
     if (name === "channel_info") return handleChannelInfo(args as any);
+    if (name === "channel_members")
+      return handleChannelMembers(args as any);
+    if (name === "my_subscriptions")
+      return handleMySubscriptions(args as any);
     if (name === "download_media") return handleDownloadMedia(args as any);
     if (name === "upload_media") return handleUploadMedia(args as any);
     if (name === "rsync_media") return handleRsyncMedia(args as any);

--- a/ts/mcp_channel/heartbeat.ts
+++ b/ts/mcp_channel/heartbeat.ts
@@ -90,12 +90,21 @@ export async function pushRegistryHeartbeat(): Promise<void> {
     name: OROCHI_AGENT,
     agent_id: OROCHI_AGENT,
     role: process.env.SCITEX_OROCHI_ROLE || "agent",
+    // Host identity: trust live ``hostname()`` first, fall back to env
+    // only when the kernel returns empty (stripped container). Env-
+    // first was the root cause of lead msg#15578 (proj-neurovista
+    // misreporting as mba) — a stale SCITEX_OROCHI_HOSTNAME env var
+    // inherited into a spartan process would override the real host.
     machine:
+      hostname() ||
       process.env.SCITEX_OROCHI_MACHINE ||
       process.env.SCITEX_OROCHI_HOSTNAME ||
       process.env.SCITEX_AGENT_CONTAINER_HOSTNAME ||
-      hostname() ||
       "",
+    // Live hostname(1) — surfaced distinctly from ``machine`` so the
+    // hub / frontend can prefer this authoritative signal when deriving
+    // the ``<name>@<host>`` badge. Never sourced from env.
+    hostname: hostname() || "",
     multiplexer: process.env.SCITEX_OROCHI_MULTIPLEXER || "tmux",
   };
 

--- a/ts/src/tool_defs.ts
+++ b/ts/src/tool_defs.ts
@@ -199,6 +199,49 @@ export const TOOL_DEFS = [
     },
   },
   {
+    name: "channel_members",
+    description:
+      "READ-ONLY (#252). List subscribers of an Orochi channel as " +
+      "[{name, principal_type: 'human'|'agent', role}]. Uses the " +
+      "agent's workspace token (?token=&agent=) — no Django session " +
+      "needed; works from MCP sidecars on the bare domain. Pass the " +
+      "channel name (e.g. '#general') and optionally workspace=<slug>.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        channel: {
+          type: "string",
+          description: "Channel name (e.g. #general).",
+        },
+        workspace: {
+          type: "string",
+          description:
+            "Workspace slug. Defaults to env SCITEX_OROCHI_WORKSPACE if set.",
+        },
+      },
+      required: ["channel"],
+    },
+  },
+  {
+    name: "my_subscriptions",
+    description:
+      "READ-ONLY (#253). Return the channels this agent is subscribed " +
+      "to as [{channel, joined_at, role}]. Uses the agent's workspace " +
+      "token (?token=&agent=) — no Django session needed. Implicitly " +
+      "scoped to the calling agent (no target_agent arg); a separate " +
+      "write tool will follow in #262 for fleet self-pruning.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workspace: {
+          type: "string",
+          description:
+            "Workspace slug. Defaults to env SCITEX_OROCHI_WORKSPACE if set.",
+        },
+      },
+    },
+  },
+  {
     name: "download_media",
     description:
       "Download a file from the Orochi hub to local disk. Use this to view screenshots or files posted in chat.",

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -16,6 +16,8 @@ export {
   handleSubscribe,
   handleUnsubscribe,
   handleChannelInfo,
+  handleChannelMembers,
+  handleMySubscriptions,
   handleDmList,
   handleDmOpen,
 } from "./tools/channels.js";

--- a/ts/src/tools/_shared.ts
+++ b/ts/src/tools/_shared.ts
@@ -62,3 +62,48 @@ export function resolveWorkspaceSlug(arg?: string): string | null {
 // MCP server (this bun process) start time for sidecar_status / uptime.
 // Captured at module load.
 export const MCP_SERVER_STARTED_AT = new Date().toISOString();
+
+// ── Structured error envelope (issue #262 §9.2) ──────────────────────────
+//
+// Every MCP tool returns either a content text payload OR a structured
+// error envelope ``{ "error": { code, reason, hint } }`` packed as the
+// ``text`` of a single content block. Centralizing the codes + helper
+// here means callers (LLM-side or programmatic) can machine-parse the
+// failure mode without scraping ``Error: HTTP 404 — <html>`` strings.
+
+/** Closed enum of error codes a tool may surface. */
+export const MCP_ERROR_CODES = {
+  /** Tool requires the target agent to have a live MCP sidecar, but it does not. */
+  AGENT_OFFLINE: "agent_offline",
+  /** Caller is not a member of the workspace the action targets. */
+  NOT_WORKSPACE_MEMBER: "not_workspace_member",
+  /** Caller authenticated, but lacks the admin/staff role required. */
+  PERMISSION_DENIED: "permission_denied",
+  /** Caller-supplied argument is missing or malformed. */
+  INVALID_INPUT: "invalid_input",
+  /** Resource (channel, agent, message, ...) does not exist. */
+  NOT_FOUND: "not_found",
+  /** Anything else — wraps unexpected exceptions or upstream failures. */
+  INTERNAL_ERROR: "internal_error",
+} as const;
+
+export type McpErrorCode = (typeof MCP_ERROR_CODES)[keyof typeof MCP_ERROR_CODES];
+
+export interface McpErrorPayload {
+  error: { code: McpErrorCode; reason: string; hint: string };
+}
+
+/**
+ * Build a structured error response for an MCP tool. Pack the JSON as the
+ * ``text`` of a single content block so existing MCP clients render it
+ * verbatim while machine consumers can ``JSON.parse(result.content[0].text)``
+ * and key off ``result.error.code``.
+ */
+export function mcpError(
+  code: McpErrorCode,
+  reason: string,
+  hint: string,
+): { content: Array<{ type: string; text: string }> } {
+  const payload: McpErrorPayload = { error: { code, reason, hint } };
+  return { content: [{ type: "text", text: JSON.stringify(payload) }] };
+}

--- a/ts/src/tools/agent_status.ts
+++ b/ts/src/tools/agent_status.ts
@@ -5,8 +5,10 @@ import { readFileSync, unlinkSync } from "fs";
 import { execSync } from "child_process";
 import {
   ConnLike,
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   buildWsUrl,
@@ -31,14 +33,11 @@ export async function handleHealth(args: {
     if (args.updates) body.updates = args.updates;
     else {
       if (!args.agent || !args.status) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: "Error: agent and status required (or pass updates[])",
-            },
-          ],
-        };
+        return mcpError(
+          MCP_ERROR_CODES.INVALID_INPUT,
+          "agent and status required (or pass updates[])",
+          "include both fields, or send a list under 'updates'",
+        );
       }
       body.agent = args.agent;
       body.status = args.status;
@@ -53,23 +52,28 @@ export async function handleHealth(args: {
     });
     if (!resp.ok) {
       const t = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${t.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `health HTTP ${resp.status}`,
+        t.slice(0, 200) || "no response body",
+      );
     }
     const out = (await resp.json()) as { applied?: number };
     return {
       content: [{ type: "text", text: `health applied: ${out.applied ?? 0}` }],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `health failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -78,7 +82,11 @@ export async function handleTask(
   args: { task: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   if (!conn.isConnected) {
-    return { content: [{ type: "text", text: "Error: not connected" }] };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect",
+    );
   }
   const task = (args.task || "").slice(0, 200);
   conn.send(
@@ -96,7 +104,11 @@ export async function handleSubagents(
   args: { subagents: Array<{ name?: string; task?: string; status?: string }> },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   if (!conn.isConnected) {
-    return { content: [{ type: "text", text: "Error: not connected" }] };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect",
+    );
   }
   const list = Array.isArray(args.subagents) ? args.subagents : [];
   conn.send(
@@ -143,14 +155,11 @@ export async function handleContext(args: {
     }
 
     if (contextPercent === null) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Could not parse context percentage from screen "${screenName}". Last 3 lines:\n${lines.slice(-3).join("\n")}`,
-          },
-        ],
-      };
+      return mcpError(
+        MCP_ERROR_CODES.NOT_FOUND,
+        `could not parse context percentage from screen "${screenName}"`,
+        `last lines: ${lines.slice(-3).join(" | ").slice(0, 200)}`,
+      );
     }
 
     return {
@@ -165,14 +174,11 @@ export async function handleContext(args: {
       ],
     };
   } catch (err) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error reading screen "${screenName}": ${(err as Error).message}`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `failed to read screen "${screenName}": ${(err as Error).message}`,
+      "ensure the screen/tmux session for this agent is alive on its host",
+    );
   }
 }
 

--- a/ts/src/tools/channels.ts
+++ b/ts/src/tools/channels.ts
@@ -167,6 +167,118 @@ export async function handleDmList(args: {
   }
 }
 
+export async function handleChannelMembers(args: {
+  channel: string;
+  workspace?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const channel = normalizeGroupChannel(args.channel);
+  if (!channel) {
+    return { content: [{ type: "text", text: "Error: channel required" }] };
+  }
+  const slug = resolveWorkspaceSlug(args.workspace);
+  if (!slug) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "Error: workspace slug required. Pass workspace=<slug> or set " +
+            "SCITEX_OROCHI_WORKSPACE.",
+        },
+      ],
+    };
+  }
+  try {
+    const url =
+      `${httpBase}/api/workspace/${encodeURIComponent(slug)}` +
+      `/channel-members/${tokenParam("?")}` +
+      (tokenParam("?") ? "&" : "?") +
+      "channel=" +
+      encodeURIComponent(channel);
+    const res = await fetch(url, {
+      headers: buildFetchHeaders({ Accept: "application/json" }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: HTTP ${res.status} — ${body.slice(0, 300)}`,
+          },
+        ],
+      };
+    }
+    const raw = await res.json();
+    /* Hub returns rows of {username, permission, kind, role}. Reshape
+     * to the spec'd MCP tool surface: {name, principal_type, role}.
+     * `name` strips the "agent-" prefix so it matches the agent-name
+     * convention used elsewhere (matches identity_name on DM rows). */
+    const rows = Array.isArray(raw) ? raw : [];
+    const members = rows.map((m: any) => {
+      const username = String(m.username || "");
+      const principal_type = m.kind === "agent" ? "agent" : "human";
+      const name =
+        principal_type === "agent" && username.startsWith("agent-")
+          ? username.slice("agent-".length)
+          : username;
+      return {
+        name,
+        principal_type,
+        role: m.permission || m.role || "",
+      };
+    });
+    return { content: [{ type: "text", text: JSON.stringify(members) }] };
+  } catch (e) {
+    return {
+      content: [{ type: "text", text: `Error fetching channel members: ${e}` }],
+    };
+  }
+}
+
+export async function handleMySubscriptions(args: {
+  workspace?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const slug = resolveWorkspaceSlug(args.workspace);
+  if (!slug) {
+    return {
+      content: [
+        {
+          type: "text",
+          text:
+            "Error: workspace slug required. Pass workspace=<slug> or set " +
+            "SCITEX_OROCHI_WORKSPACE.",
+        },
+      ],
+    };
+  }
+  try {
+    const url =
+      `${httpBase}/api/workspace/${encodeURIComponent(slug)}` +
+      `/me/subscriptions/${tokenParam("?")}`;
+    const res = await fetch(url, {
+      headers: buildFetchHeaders({ Accept: "application/json" }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error: HTTP ${res.status} — ${body.slice(0, 300)}`,
+          },
+        ],
+      };
+    }
+    const out = await res.json();
+    return { content: [{ type: "text", text: JSON.stringify(out) }] };
+  } catch (e) {
+    return {
+      content: [{ type: "text", text: `Error fetching subscriptions: ${e}` }],
+    };
+  }
+}
+
 export async function handleDmOpen(args: {
   recipient?: string;
   peer?: string;

--- a/ts/src/tools/channels.ts
+++ b/ts/src/tools/channels.ts
@@ -5,31 +5,113 @@
  * READ / CREATE only — actual message sending stays on the WS `reply` path
  * (spec v3.1 §4.1: REST sender-identity for token-auth agents is unreliable;
  * `reply` is the sole agent write path).
+ *
+ * subscribe / unsubscribe accept an optional ``target_agent`` argument
+ * (issue #262 §9.1). When present, the call routes through the admin
+ * REST endpoint instead of the agent's own WS session — only useful for
+ * fleet-coordinator agents whose workspace token resolves to the
+ * ``admin`` (or ``staff``) role. See ``hub/views/api/_agents_subscribe.py``.
  */
 import {
   ConnLike,
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   normalizeGroupChannel,
   resolveWorkspaceSlug,
 } from "./_shared.js";
 
+/**
+ * Hand off subscribe/unsubscribe to the admin REST endpoint when the
+ * caller passed a ``target_agent``. The hub view enforces the admin/
+ * staff role; any non-admin caller gets a structured permission_denied
+ * envelope back, which we surface verbatim.
+ */
+async function callAdminSubscribe(
+  targetAgent: string,
+  channel: string,
+  subscribe: boolean,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const action = subscribe ? "subscribe" : "unsubscribe";
+  const encoded = encodeURIComponent(targetAgent);
+  // Pass ``?agent=<self>`` so resolve_workspace_and_actor knows who's
+  // making the call; the workspace token is appended by tokenParam.
+  const url =
+    `${httpBase}/api/agents/${encoded}/${action}/${tokenParam("?")}` +
+    (tokenParam("?") ? "&" : "?") +
+    "agent=" +
+    encodeURIComponent(OROCHI_AGENT);
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: buildFetchHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ channel }),
+    });
+    const bodyText = await resp.text();
+    let parsed: any = null;
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      parsed = null;
+    }
+    if (!resp.ok) {
+      // Hub returns a structured error envelope already — pass it
+      // through verbatim so the caller sees the same {code, reason, hint}
+      // shape regardless of which leg failed.
+      if (parsed && parsed.error && typeof parsed.error.code === "string") {
+        return {
+          content: [{ type: "text", text: JSON.stringify(parsed) }],
+        };
+      }
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : resp.status === 400
+              ? MCP_ERROR_CODES.INVALID_INPUT
+              : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `admin ${action} HTTP ${resp.status}`,
+        bodyText.slice(0, 200) || "no response body",
+      );
+    }
+    return { content: [{ type: "text", text: bodyText }] };
+  } catch (err) {
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `admin ${action} request failed: ${(err as Error).message}`,
+      "check hub reachability and SCITEX_OROCHI_URL",
+    );
+  }
+}
+
 export async function handleSubscribe(
   conn: ConnLike,
-  args: { channel: string },
+  args: { channel: string; target_agent?: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const channel = normalizeGroupChannel(args.channel);
   if (!channel) {
-    return { content: [{ type: "text", text: "Error: channel required" }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "channel required",
+      "pass channel='#name'",
+    );
+  }
+  const target = (args.target_agent || "").trim();
+  if (target) {
+    return callAdminSubscribe(target, channel, true);
   }
   if (!conn.isConnected) {
-    return {
-      content: [
-        { type: "text", text: `Error: not connected (state=${conn.state})` },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect or check SCITEX_OROCHI_URL",
+    );
   }
   conn.send(
     JSON.stringify({
@@ -43,18 +125,26 @@ export async function handleSubscribe(
 
 export async function handleUnsubscribe(
   conn: ConnLike,
-  args: { channel: string },
+  args: { channel: string; target_agent?: string },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   const channel = normalizeGroupChannel(args.channel);
   if (!channel) {
-    return { content: [{ type: "text", text: "Error: channel required" }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "channel required",
+      "pass channel='#name'",
+    );
+  }
+  const target = (args.target_agent || "").trim();
+  if (target) {
+    return callAdminSubscribe(target, channel, false);
   }
   if (!conn.isConnected) {
-    return {
-      content: [
-        { type: "text", text: `Error: not connected (state=${conn.state})` },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected (state=${conn.state})`,
+      "wait for the MCP sidecar to reconnect or check SCITEX_OROCHI_URL",
+    );
   }
   conn.send(
     JSON.stringify({
@@ -71,7 +161,11 @@ export async function handleChannelInfo(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const channel = normalizeGroupChannel(args.channel);
   if (!channel) {
-    return { content: [{ type: "text", text: "Error: channel required" }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "channel required",
+      "pass channel='#name'",
+    );
   }
   try {
     const url =
@@ -83,28 +177,28 @@ export async function handleChannelInfo(args: {
       headers: buildFetchHeaders({ Accept: "application/json" }),
     });
     if (!res.ok) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${res.status} fetching channel info`,
-          },
-        ],
-      };
+      const code =
+        res.status === 401 || res.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : res.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `HTTP ${res.status} fetching channel info`,
+        "verify the channel name and that the workspace token is valid",
+      );
     }
     const data = await res.json();
     const match = Array.isArray(data)
       ? data.find((c: any) => c && c.name === channel)
       : null;
     if (!match) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `(no channel named ${channel} in this workspace)`,
-          },
-        ],
-      };
+      return mcpError(
+        MCP_ERROR_CODES.NOT_FOUND,
+        `no channel named ${channel} in this workspace`,
+        "use the dashboard or the channels list to confirm the name",
+      );
     }
     const desc = (match.description || "").trim();
     return {
@@ -118,9 +212,11 @@ export async function handleChannelInfo(args: {
       ],
     };
   } catch (e) {
-    return {
-      content: [{ type: "text", text: `Error fetching channel info: ${e}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `channel_info failed: ${(e as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -133,14 +229,11 @@ export async function handleDmList(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const slug = resolveWorkspaceSlug(args.workspace);
   if (!slug) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Error: workspace slug required. Pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE.",
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "workspace slug required",
+      "pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE",
+    );
   }
   try {
     const resp = await fetch(dmsUrl(slug), {
@@ -149,21 +242,26 @@ export async function handleDmList(args: {
     });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 300)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `dm_list HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     const out = await resp.json();
     return { content: [{ type: "text", text: JSON.stringify(out) }] };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `dm_list failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -174,25 +272,19 @@ export async function handleDmOpen(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const slug = resolveWorkspaceSlug(args.workspace);
   if (!slug) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Error: workspace slug required. Pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE.",
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "workspace slug required",
+      "pass workspace=<slug> or set SCITEX_OROCHI_WORKSPACE",
+    );
   }
   const recipient = (args.recipient || args.peer || "").trim();
   if (!recipient) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: "Error: recipient required (e.g. 'agent:mamba-healer-mba' or 'human:ywatanabe').",
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "recipient required",
+      "pass recipient='agent:<name>' or 'human:<username>'",
+    );
   }
   try {
     const resp = await fetch(dmsUrl(slug), {
@@ -202,21 +294,28 @@ export async function handleDmOpen(args: {
     });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 300)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : resp.status === 400
+              ? MCP_ERROR_CODES.INVALID_INPUT
+              : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `dm_open HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     const out = await resp.json();
     /* Caller chains `reply` with chat_id=out.name to actually send. */
     return { content: [{ type: "text", text: JSON.stringify(out) }] };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `dm_open failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }

--- a/ts/src/tools/media.ts
+++ b/ts/src/tools/media.ts
@@ -5,9 +5,11 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { basename, dirname } from "path";
 import { createHash } from "crypto";
 import {
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   OROCHI_TOKEN,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   MIME,
@@ -39,14 +41,17 @@ export async function handleDownloadMedia(args: {
       headers: buildFetchHeaders(),
     });
     if (!resp.ok) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} downloading ${fullUrl}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `HTTP ${resp.status} downloading ${fullUrl}`,
+        "verify the URL and that the workspace token is valid",
+      );
     }
 
     // Determine output path
@@ -72,9 +77,11 @@ export async function handleDownloadMedia(args: {
       ],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `download_media failed: ${(err as Error).message}`,
+      "check hub reachability and local disk space",
+    );
   }
 }
 
@@ -84,11 +91,11 @@ export async function handleUploadMedia(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   try {
     if (!existsSync(args.file_path)) {
-      return {
-        content: [
-          { type: "text", text: `Error: file not found: ${args.file_path}` },
-        ],
-      };
+      return mcpError(
+        MCP_ERROR_CODES.NOT_FOUND,
+        `file not found: ${args.file_path}`,
+        "pass an absolute path that exists on this host",
+      );
     }
 
     const fileData = readFileSync(args.file_path);
@@ -169,14 +176,17 @@ export async function handleUploadMedia(args: {
 
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `upload_media HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
 
     const result = (await resp.json()) as {
@@ -200,8 +210,10 @@ export async function handleUploadMedia(args: {
       ],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `upload_media failed: ${(err as Error).message}`,
+      "check hub reachability and local disk",
+    );
   }
 }

--- a/ts/src/tools/messaging.ts
+++ b/ts/src/tools/messaging.ts
@@ -5,9 +5,11 @@ import { readFileSync } from "fs";
 import { basename } from "path";
 import {
   ConnLike,
+  MCP_ERROR_CODES,
   OROCHI_AGENT,
   OROCHI_TOKEN,
   httpBase,
+  mcpError,
   tokenParam,
   buildFetchHeaders,
   MIME,
@@ -18,14 +20,11 @@ export async function handleReply(
   args: { chat_id: string; text: string; reply_to?: string; files?: string[] },
 ): Promise<{ content: Array<{ type: string; text: string }> }> {
   if (!conn.isConnected) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error: not connected to Orochi (state=${conn.state}, attempts=${(conn as any).reconnectAttempts})`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.AGENT_OFFLINE,
+      `not connected to Orochi (state=${conn.state}, attempts=${(conn as any).reconnectAttempts})`,
+      "wait for the MCP sidecar to reconnect",
+    );
   }
 
   const attachments: Array<Record<string, unknown>> = [];
@@ -133,9 +132,11 @@ export async function handleReact(args: {
   const messageId = String(args.message_id);
   const emoji = args.emoji;
   if (!messageId || !emoji) {
-    return {
-      content: [{ type: "text", text: "Error: message_id and emoji required" }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "message_id and emoji required",
+      "pass both fields",
+    );
   }
   try {
     const url = `${httpBase}/api/reactions/${tokenParam("?")}`;
@@ -150,22 +151,27 @@ export async function handleReact(args: {
     });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `react HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     return {
       content: [{ type: "text", text: `reacted ${emoji} to ${messageId}` }],
     };
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `react failed: ${(err as Error).message}`,
+      "check hub reachability",
+    );
   }
 }
 
@@ -188,19 +194,26 @@ export async function handleExportChannel(args: {
     const resp = await fetch(url, { headers: buildFetchHeaders() });
     if (!resp.ok) {
       const body = await resp.text();
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Error: HTTP ${resp.status} — ${body.slice(0, 200)}`,
-          },
-        ],
-      };
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `export_channel HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
     }
     const text = await resp.text();
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    return { content: [{ type: "text", text: `Error: ${msg}` }] };
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `export_channel failed: ${msg}`,
+      "check hub reachability",
+    );
   }
 }

--- a/ts/src/tools/rsync.ts
+++ b/ts/src/tools/rsync.ts
@@ -12,7 +12,13 @@ import { readFileSync, mkdirSync, existsSync, createWriteStream } from "fs";
 import { basename, join as pathJoin } from "path";
 import { spawn } from "child_process";
 import { randomBytes } from "crypto";
-import { OROCHI_AGENT, httpBase, buildFetchHeaders } from "./_shared.js";
+import {
+  MCP_ERROR_CODES,
+  OROCHI_AGENT,
+  httpBase,
+  mcpError,
+  buildFetchHeaders,
+} from "./_shared.js";
 
 export interface RsyncJob {
   id: string;
@@ -62,23 +68,20 @@ export async function handleRsyncMedia(args: {
   // Validate allowed hosts (prevent shell injection via dst_host)
   const ALLOWED_HOSTS = new Set(["mba", "nas", "ywata-note-win", "spartan"]);
   if (!ALLOWED_HOSTS.has(dst_host)) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `Error: dst_host must be one of: ${[...ALLOWED_HOSTS].join(", ")}`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      `dst_host must be one of: ${[...ALLOWED_HOSTS].join(", ")}`,
+      "pass an allowed fleet host name",
+    );
   }
 
   // Validate src_path exists locally
   if (!existsSync(src_path)) {
-    return {
-      content: [
-        { type: "text", text: `Error: src_path not found: ${src_path}` },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.NOT_FOUND,
+      `src_path not found: ${src_path}`,
+      "pass an absolute path that exists on this host",
+    );
   }
 
   // Ensure log dir
@@ -182,9 +185,11 @@ export async function handleRsyncStatus(args: {
 }): Promise<{ content: Array<{ type: string; text: string }> }> {
   const job = rsyncJobs.get(args.job_id);
   if (!job) {
-    return {
-      content: [{ type: "text", text: `Error: job not found: ${args.job_id}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.NOT_FOUND,
+      `job not found: ${args.job_id}`,
+      "pass a job_id returned by rsync_media in this MCP session",
+    );
   }
   const logPath = rsyncLogPath(job.id);
   const tail = tailLog(logPath, 10);

--- a/ts/src/tools/self_command.ts
+++ b/ts/src/tools/self_command.ts
@@ -10,7 +10,7 @@
  * (screen|tmux); default is "tmux" — set SCITEX_OROCHI_MULTIPLEXER=screen to opt in.
  */
 import { exec } from "child_process";
-import { OROCHI_AGENT } from "./_shared.js";
+import { MCP_ERROR_CODES, OROCHI_AGENT, mcpError } from "./_shared.js";
 
 // Allow only safe characters in the session name to prevent shell injection.
 function validateSessionName(name: string): string | null {
@@ -55,22 +55,19 @@ function scheduleSelfCommand(
 ): { content: Array<{ type: string; text: string }> } {
   const rawSession = OROCHI_AGENT;
   if (!rawSession) {
-    return {
-      content: [
-        { type: "text", text: "ERROR: SCITEX_OROCHI_AGENT env var not set" },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      "SCITEX_OROCHI_AGENT env var not set",
+      "set SCITEX_OROCHI_AGENT in the MCP sidecar environment",
+    );
   }
   const session = validateSessionName(rawSession);
   if (!session) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `ERROR: SCITEX_OROCHI_AGENT contains unsafe characters: ${rawSession}`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      `SCITEX_OROCHI_AGENT contains unsafe characters: ${rawSession}`,
+      "agent name must match [A-Za-z0-9._-]+",
+    );
   }
 
   const mux = getMultiplexer();
@@ -78,9 +75,11 @@ function scheduleSelfCommand(
   try {
     cmd = buildSendKeysCommand(mux, session, text);
   } catch (err) {
-    return {
-      content: [{ type: "text", text: `ERROR: ${(err as Error).message}` }],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      (err as Error).message,
+      "remove single quotes from the command text",
+    );
   }
 
   const delay = Math.max(0, delayMs);
@@ -165,37 +164,31 @@ export async function handleSelfCommand(args: {
   const command = (args?.command || "").trim();
   const err = validateSelfCommand(command);
   if (err) {
-    return { content: [{ type: "text", text: `ERROR: ${err}` }] };
+    return mcpError(
+      MCP_ERROR_CODES.INVALID_INPUT,
+      err,
+      "use a slash command matching /^\\/[A-Za-z0-9_-]+( .*)?$/ or a free-text prompt without single quotes",
+    );
   }
 
   // Allowlist gate: reject modal-opening slash commands before scheduling.
   if (!isSafeForSelfCommand(command)) {
     const rejected = command.split(/\s+/, 1)[0];
-    return {
-      content: [
-        {
-          type: "text",
-          text:
-            `ERROR: slash command '${rejected}' is not in self_command allowlist. ` +
-            `Safe commands: ${SELF_COMMAND_ALLOWLIST.join(", ")}. ` +
-            `Modal-opening commands like /model, /agents, /permissions trap the agent and are blocked. ` +
-            `Free-text prompts (no leading slash) are always allowed.`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.PERMISSION_DENIED,
+      `slash command '${rejected}' is not in self_command allowlist`,
+      `safe commands: ${SELF_COMMAND_ALLOWLIST.join(", ")} (free-text prompts without a leading slash are always allowed)`,
+    );
   }
 
   // Extract the bare slash name (no args) for destructive-list lookup.
   const slashName = command.split(/\s+/, 1)[0];
   if (DESTRUCTIVE_COMMANDS.has(slashName) && !args?.confirm) {
-    return {
-      content: [
-        {
-          type: "text",
-          text: `ERROR: '${slashName}' is destructive; pass confirm=true to fire`,
-        },
-      ],
-    };
+    return mcpError(
+      MCP_ERROR_CODES.PERMISSION_DENIED,
+      `'${slashName}' is destructive`,
+      "pass confirm=true to fire",
+    );
   }
 
   const delay = args?.delay_ms ?? 6000;


### PR DESCRIPTION
## Summary

Root-cause fix for lead msg#15578 — agent `proj-neurovista` displayed as `mba` on the dashboard despite actually running on `spartan` (tmux session confirmed there).

- **Client-side**: flip priority in `agent_meta_pkg/_machine.py::resolve_machine_label()` and in TS `connection.ts` / `heartbeat.ts` so the live `hostname()` call is trusted FIRST; env vars (`SCITEX_OROCHI_HOSTNAME`, `SCITEX_OROCHI_MACHINE`, `SCITEX_AGENT_CONTAINER_HOSTNAME`) are only honoured when `gethostname()` returns an empty string.
- **Hub-side**: expose the `hostname` field in `get_agents()` payload + accept it verbatim in `/api/agents/register/` and the WS `handle_register` flow. Hub never infers host identity from auth / IP — pure client-reported truth.

### Why the old code was wrong

Env-first meant a stale `SCITEX_OROCHI_HOSTNAME=mba` inherited from a shared tmux / systemd / sac launcher env (originally spawned on mba) would silently override the real hostname on any downstream process — including a `proj-neurovista` started on spartan. Per lead's root-fix direction: *agents set their `host` field from their own `hostname()` call, never from env or server-side inference.*

## Files changed

**Client (heartbeat producers):**
- `scripts/client/agent_meta_pkg/_machine.py` — priority flip
- `scripts/client/agent_meta_pkg/_collect.py` — emit explicit `hostname` via `socket.gethostname()`
- `scripts/client/agent_meta_pkg/_push.py` — forward `hostname` in REST payload
- `ts/mcp_channel/connection.ts` — priority flip + add `hostname` to register payload
- `ts/mcp_channel/heartbeat.ts` — priority flip + add `hostname` to heartbeat payload

**Hub (heartbeat consumers):**
- `hub/views/api/_agents_register.py` — accept `hostname`
- `hub/consumers/_agent_handlers.py` — accept `hostname` on WS register
- `hub/registry/_payload.py` — surface `hostname` in `get_agents()` dashboard payload
- `hub/tests/__init__.py` — include new test module

**Tests (regression):**
- `tests/test_resolve_machine_label.py` — 4 tests: env-pollution does NOT override live `gethostname()`; env IS honoured when hostname empty; FQDN shortened.
- `hub/tests/registry/test_host_identity_from_client.py` — 7 tests: client-supplied `hostname` round-trips to dashboard; hostname distinct from machine both preserved; hub does NOT infer host from auth token (two tokens, same recorded host); omitted `hostname` preserved across re-register.

## Test plan

- [x] `python -m pytest tests/test_resolve_machine_label.py -xvs` — 4/4 pass
- [x] `python manage.py test hub.tests.registry hub.tests.views.api.test_agents_register hub.tests.consumers` — 117/117 pass (no regressions)
- [x] `bun build ts/mcp_channel/{connection,heartbeat}.ts` — TS compiles cleanly
- [ ] After merge: verify dashboard shows `proj-neurovista@spartan` (not `@mba`) once spartan agents push a heartbeat on the new client code.
- [ ] Follow-up: deploy the client-side change to spartan (currently the buggy env may still be present — task asks to confirm cred-copy ownership).

## Follow-up (not in this PR)

- Lead recently copied mba creds to nas; spartan was NOT included. Worth confirming whether spartan's `SCITEX_OROCHI_HOSTNAME` env is set correctly / sanitised, and whether cred-copy-to-spartan is needed. (Defer to fleet ops — outside this PR's scope.)

Related but distinct from PR #303 (mamba-healer shared-token): that was about agents sharing a head's MCP token; this PR is about host-identity misreport via inherited env, not auth sharing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)