### PR TITLE
fix(ui/sidebar,graph): align Agents↔Channels columns, row-wide channel color, graph channel card parity (msg#15599)

### DIFF
--- a/hub/frontend/src/channel-badge.ts
+++ b/hub/frontend/src/channel-badge.ts
@@ -198,13 +198,27 @@ import { escapeHtml } from "./app/utils";
   }
 
   // ── SVG renderer: topology canvas ──────────────────────────────────
-  // Emits a <g class="topo-channel" data-channel="..."> group with:
-  //   diamond polygon + icon + star + eye + mute + label rect + label.
-  // Canonical element order: icon + star + eye + mute + name — IDENTICAL
-  // to renderChannelBadgeHtml above, so sidebar / pool / canvas all read
-  // left-to-right the same way. ywatanabe 2026-04-20: "ALL channel badge
-  // MUST have the SAME UI and functionalities".
-  // pos = {x, y, r}; r optional (default 12).
+  // Emits a <g class="topo-channel" data-channel="..."> group as a
+  // horizontal pill laid out icon + star + eye + mute + name —
+  // geometrically IDENTICAL to renderAgentBadgeSvg (agent-badge-svg.ts)
+  // so sidebar, pool chip and topology-canvas channel nodes all share
+  // the same visual + functional vocabulary (msg#15599 Task C, "lead:
+  // channels は visual + functional (star / eye / notification)
+  // 完全一致"). Click behaviour is wired through body-level
+  // delegation in attachChannelBadgeHandlers below — the glyphs carry
+  // `.ch-star` / `.ch-eye` / `.ch-mute` / `.ch-icon` with
+  // `data-channel`, so a click on the canvas triggers the same
+  // `_setChannelPref` path as a click on the sidebar row.
+  //
+  // Prior implementation rendered a rotated-square diamond with
+  // glyphs scattered at the four quadrants; this departed from the
+  // sidebar card and gave the channel nodes a second-class feel
+  // (msg#15599 "channel nodes render different visual than sidebar").
+  //
+  // pos = {x, y, r}; r is the legacy "diamond radius" input, here
+  // mapped to per-node sizing via the background pill stroke — we
+  // keep the param for call-site compatibility (topology-nodes.ts
+  // passes a per-channel r derived from subscriber count).
   function renderChannelBadgeSvg(name, pos, opts) {
     opts = opts || {};
     var m = channelBadgeModel(name);
@@ -212,27 +226,9 @@ import { escapeHtml } from "./app/utils";
     var showUnread = !!opts.showUnread;
     var x = pos.x;
     var y = pos.y;
-    var r = pos.r || 12;
     var count = opts.count != null ? opts.count : null;
     var labelText = count != null ? m.norm + " (" + count + ")" : m.norm;
     var extraClass = opts.extraClass || "";
-
-    var pts =
-      x +
-      "," +
-      (y - r) +
-      " " +
-      (x + r) +
-      "," +
-      y +
-      " " +
-      x +
-      "," +
-      (y + r) +
-      " " +
-      (x - r) +
-      "," +
-      y;
 
     var chCls = "topo-node topo-channel";
     if (m.isStarred) chCls += " topo-channel-starred";
@@ -240,150 +236,199 @@ import { escapeHtml } from "./app/utils";
     if (m.isHidden) chCls += " topo-channel-hidden";
     if (extraClass) chCls += " " + extraClass;
 
-    // Icon: URL → <image>, emoji → <text>, else no glyph.
+    // Slot geometry — mirrors renderAgentBadgeSvg (icon + star + eye
+    // + <agents have 4 LEDs here> + name). Channels skip the LED
+    // block (they don't carry liveness); the mute bell takes the
+    // same visual weight slot so the row still reads as a full pill.
+    var iconSize = opts.iconSize || 14;
+    var iconHalf = iconSize / 2;
+    var GAP = 6; // between-slot gap, same constant as agent badge
+    var slotW = 14; // star / eye / mute slot width, matches agent badge
+    var textW = Math.max(40, labelText.length * 6.5);
+    var total =
+      iconSize +
+      GAP +
+      slotW + // star
+      GAP +
+      (showEye ? slotW + GAP : 0) + // eye
+      slotW + // mute
+      GAP +
+      textW;
+    var clusterLeft = x - total / 2;
+    var glyphX = clusterLeft + iconHalf;
+    var starX = glyphX + iconHalf + GAP + slotW / 2;
+    var eyeX = showEye ? starX + slotW / 2 + GAP + slotW / 2 : starX;
+    var muteX =
+      (showEye ? eyeX : starX) + slotW / 2 + GAP + slotW / 2;
+    var nameX = muteX + slotW / 2 + GAP;
+
+    // Background pill — IDENTICAL rect shape and stroke classes as
+    // renderAgentBadgeSvg (.topo-channel-bg already styled in
+    // activity-tab-compose-edges.css to match .topo-agent-bg).
+    var badgeLeft = clusterLeft - 4;
+    var badgeWidth = total + 8;
+    var badgeY = y - 11;
+    var bg =
+      '<rect class="topo-channel-bg" x="' +
+      badgeLeft.toFixed(1) +
+      '" y="' +
+      badgeY.toFixed(1) +
+      '" width="' +
+      badgeWidth.toFixed(1) +
+      '" height="22" rx="11" ry="11"/>';
+
+    // Icon: URL → <image>, emoji → <text>, else fallback "#" text.
+    // Uses the same `.ch-icon` + `data-channel` contract as the HTML
+    // badge so the body-level `ch-icon` click delegate (emoji picker)
+    // catches canvas clicks unchanged.
     var iconGlyph = "";
     if (m.iconIsUrl) {
-      var imgSize = Math.max(14, Math.round(r * 1.6));
       iconGlyph =
         '<image class="topo-ch-icon-img ch-icon" data-channel="' +
         _escape(m.norm) +
         '" href="' +
         _escape(m.iconGlyph) +
         '" x="' +
-        (x - imgSize / 2).toFixed(1) +
+        (glyphX - iconHalf).toFixed(1) +
         '" y="' +
-        (y - imgSize / 2).toFixed(1) +
+        (y - iconHalf).toFixed(1) +
         '" width="' +
-        imgSize +
+        iconSize +
         '" height="' +
-        imgSize +
-        '" preserveAspectRatio="xMidYMid slice"/>';
+        iconSize +
+        '" preserveAspectRatio="xMidYMid slice" style="cursor:pointer"/>';
     } else if (m.iconGlyph) {
       iconGlyph =
         '<text class="topo-ch-emoji ch-icon" data-channel="' +
         _escape(m.norm) +
         '" x="' +
-        x.toFixed(1) +
+        glyphX.toFixed(1) +
         '" y="' +
         (y + 4).toFixed(1) +
         '" font-size="' +
-        Math.max(11, Math.round(r * 1.2)) +
-        '" text-anchor="middle" dominant-baseline="middle">' +
+        Math.max(11, iconSize - 2) +
+        '" text-anchor="middle" dominant-baseline="middle" style="cursor:pointer">' +
         _escape(m.iconGlyph) +
         "</text>";
+    } else {
+      // Fallback "#" placeholder — keeps the icon column populated so
+      // every channel node reads with the same 4-slot rhythm as the
+      // sidebar even when no emoji/avatar is set.
+      iconGlyph =
+        '<text class="topo-ch-emoji ch-icon" data-channel="' +
+        _escape(m.norm) +
+        '" x="' +
+        glyphX.toFixed(1) +
+        '" y="' +
+        (y + 4).toFixed(1) +
+        '" font-size="12" text-anchor="middle" dominant-baseline="middle" fill="' +
+        (m.color || "#94a3b8") +
+        '" style="cursor:pointer">#</text>';
     }
 
-    // Star — always rendered; filled gold when starred, dim outline when not.
+    // Star — always rendered (placeholder-empty when not starred) so
+    // the slot geometry stays constant across nodes, matching agent
+    // behaviour.
     var starFill = m.isStarred ? "#fbbf24" : "#3a3a3a";
     var starGlyph =
       '<text class="topo-ch-star ch-star" data-channel="' +
       _escape(m.norm) +
       '" x="' +
-      (x + r + 2).toFixed(1) +
+      starX.toFixed(1) +
       '" y="' +
-      (y - r + 4).toFixed(1) +
-      '" font-size="11" fill="' +
+      (y + 4).toFixed(1) +
+      '" font-size="13" fill="' +
       starFill +
-      '" style="cursor:pointer" title="' +
+      '" text-anchor="middle" style="cursor:pointer"><title>' +
       (m.isStarred ? "Unstar" : "Star") +
-      '">' +
+      "</title>" +
       (m.isStarred ? "\u2605" : "\u2606") +
       "</text>";
 
-    // Eye — optional. Mirrors the bell pattern: same 👁 glyph in both
-    // states, with a red diagonal stroke overlaid when hidden (no
-    // Unicode crossed-eye exists, so we draw a <line> across the text
-    // bbox). Glyph is wrapped in a <g class="topo-ch-eye"> so the
-    // stroke shares the click target.
+    // Eye — always rendered when showEye, with the SAME 👁 glyph in
+    // both states and a red strike when hidden. Wrapped in a <g> so
+    // the strike shares the click target (mirrors agent eye SVG).
     var eyeGlyph = "";
     if (showEye) {
-      var eyeX = (x - r - 12).toFixed(1);
-      var eyeY = (y + r + 8).toFixed(1);
       var eyeText =
         '<text x="' +
-        eyeX +
+        eyeX.toFixed(1) +
         '" y="' +
-        eyeY +
-        '" font-size="9" fill="#94a3b8">\uD83D\uDC41</text>';
+        (y + 4).toFixed(1) +
+        '" font-size="11" text-anchor="middle" fill="#94a3b8" style="cursor:pointer">\uD83D\uDC41</text>';
       var eyeStrike = "";
       if (m.isHidden) {
-        // Diagonal red strike across the glyph's bbox. Glyph is ~9px
-        // tall + ~10px wide at font-size=9; strike goes from top-left
-        // to bottom-right of that bbox.
-        var sx1 = (x - r - 15).toFixed(1);
-        var sy1 = (parseFloat(eyeY) - 7).toFixed(1);
-        var sx2 = (x - r - 5).toFixed(1);
-        var sy2 = (parseFloat(eyeY) + 2).toFixed(1);
         eyeStrike =
           '<line x1="' +
-          sx1 +
+          (eyeX - 5).toFixed(1) +
           '" y1="' +
-          sy1 +
+          (y + 3).toFixed(1) +
           '" x2="' +
-          sx2 +
+          (eyeX + 5).toFixed(1) +
           '" y2="' +
-          sy2 +
-          '" stroke="#ef4444" stroke-width="2" stroke-linecap="round" pointer-events="none"/>';
+          (y - 3).toFixed(1) +
+          '" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round" pointer-events="none"/>';
       }
       eyeGlyph =
         '<g class="topo-ch-eye ch-eye' +
         (m.isHidden ? " ch-eye-off" : " ch-eye-on") +
         '" data-channel="' +
         _escape(m.norm) +
-        '" style="cursor:pointer">' +
+        '" style="cursor:pointer"><title>' +
+        (m.isHidden ? "Show channel (un-hide)" : "Hide channel") +
+        "</title>" +
         eyeText +
         eyeStrike +
         "</g>";
     }
 
-    // Mute — only rendered when muted (keeps diamond uncluttered).
+    // Mute bell — always rendered (placeholder when not muted) so the
+    // column geometry is stable; matches the sidebar pattern where
+    // .ch-mute is a reserved slot regardless of state.
+    var muteFill = m.isMuted ? "#94a3b8" : "#3a3a3a";
     var muteGlyph =
       '<text class="topo-ch-mute ch-mute" data-channel="' +
       _escape(m.norm) +
       '" x="' +
-      (x - r - 12).toFixed(1) +
+      muteX.toFixed(1) +
       '" y="' +
-      (y - r + 4).toFixed(1) +
-      '" font-size="9" fill="' +
-      (m.isMuted ? "#94a3b8" : "#3a3a3a") +
-      '" style="cursor:pointer">' +
+      (y + 4).toFixed(1) +
+      '" font-size="11" fill="' +
+      muteFill +
+      '" text-anchor="middle" style="cursor:pointer"><title>' +
+      (m.isMuted ? "Unmute" : "Mute") +
+      "</title>" +
       (m.isMuted ? "\uD83D\uDD15" : "\uD83D\uDD14") +
       "</text>";
 
-    // Label rect + text (channel label above diamond).
-    var labelW = Math.max(40, labelText.length * 6.5);
-    var labelX = x - labelW / 2 - 6;
-    var labelY = y - r - 18;
-    var labelRect =
-      '<rect class="topo-channel-bg" x="' +
-      labelX.toFixed(1) +
-      '" y="' +
-      labelY.toFixed(1) +
-      '" width="' +
-      (labelW + 12).toFixed(1) +
-      '" height="20" rx="10" ry="10"/>';
-    var labelTextSvg =
+    // Name label — uses the per-channel accent colour so canvas text
+    // matches the sidebar row's new row-wide colorization (Task B).
+    var nameColor = m.color || "#eaf1fb";
+    var nameSvg =
       '<text class="topo-label topo-label-ch" x="' +
-      x +
+      nameX.toFixed(1) +
       '" y="' +
-      (y - r - 4).toFixed(1) +
-      '" text-anchor="middle">' +
+      (y + 4).toFixed(1) +
+      '" fill="' +
+      _escape(nameColor) +
+      '">' +
       _escape(labelText) +
       "</text>";
 
-    // Optional unread bubble (not used on canvas today, but available).
+    // Optional unread bubble (not used on canvas today, kept for
+    // surface parity with the HTML renderer).
     var unreadSvg = "";
     if (showUnread && m.unread > 0) {
       unreadSvg =
         '<circle class="topo-ch-unread" cx="' +
-        (x + r + 6).toFixed(1) +
+        (badgeLeft + badgeWidth - 4).toFixed(1) +
         '" cy="' +
-        (y + r).toFixed(1) +
+        (y - 10).toFixed(1) +
         '" r="7" fill="#ef4444"/>' +
         '<text class="topo-ch-unread-text" x="' +
-        (x + r + 6).toFixed(1) +
+        (badgeLeft + badgeWidth - 4).toFixed(1) +
         '" y="' +
-        (y + r + 3).toFixed(1) +
+        (y - 7).toFixed(1) +
         '" font-size="9" fill="#fff" text-anchor="middle">' +
         (m.unread > 9 ? "9+" : m.unread) +
         "</text>";
@@ -399,15 +444,15 @@ import { escapeHtml } from "./app/utils";
       (count != null ? ' data-agent-count="' + count + '"' : "") +
       (attrs ? " " + attrs : "") +
       ">" +
-      '<polygon points="' +
-      pts +
-      '" fill="#1a1a1a" stroke="#444" stroke-width="1"/>' +
+      "<title>" +
+      _escape(m.tooltip || m.norm) +
+      "</title>" +
+      bg +
       iconGlyph +
       starGlyph +
       eyeGlyph +
       muteGlyph +
-      labelRect +
-      labelTextSvg +
+      nameSvg +
       unreadSvg +
       "</g>"
     );

--- a/hub/static/hub/activity-tab/activity-tab-detail-pane.css
+++ b/hub/static/hub/activity-tab/activity-tab-detail-pane.css
@@ -18,7 +18,11 @@
 .activity-grid.activity-view-topology .topo-agent.topo-drop-target text {
   filter: drop-shadow(0 0 4px #4ecdc4);
 }
-.activity-grid.activity-view-topology .topo-channel.topo-drop-target polygon {
+/* msg#15599 Task C: channel nodes now use a .topo-channel-bg rect
+ * pill (not a diamond <polygon>); drop-target highlight targets the
+ * shared background class — same selector shape as the agent rule
+ * above. */
+.activity-grid.activity-view-topology .topo-channel.topo-drop-target .topo-channel-bg {
   stroke: #4ecdc4 !important;
   stroke-width: 3 !important;
   fill: rgba(78, 205, 196, 0.18) !important;

--- a/hub/static/hub/activity-tab/activity-tab-list.css
+++ b/hub/static/hub/activity-tab/activity-tab-list.css
@@ -198,7 +198,17 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  /* ywatanabe 2026-04-21: tighter row height so more agents fit. */
+  /* ywatanabe 2026-04-21: tighter row height so more agents fit.
+   * msg#15599 Task A: border-left widened to 2px (vs the 1px all-
+   * around border) so the agent row's content-start sits at the SAME
+   * x as the Channels section (.sidebar .channel-item in
+   * style-channels.css carries a 2px left accent stripe). The border
+   * stays transparent on agents — accent colour is applied to the
+   * NAME text (via inline color in agent-badge.ts renderAgentName),
+   * mirroring how Channels now colorize the name (style-channels.css
+   * .sidebar .channel-item .ch-name rule). Top/right/bottom borders
+   * held at 1px so the hover outline (border-color #2a2a2a below)
+   * still draws a visible frame on three sides. */
   padding: 1px 6px;
   margin-bottom: 1px;
   border-radius: 3px;
@@ -207,6 +217,7 @@
   font-size: 11px;
   background: transparent;
   border: 1px solid transparent;
+  border-left-width: 2px;
   transition:
     background 0.15s,
     border-color 0.15s;

--- a/hub/static/hub/activity-tab/activity-tab-topology-nodes.css
+++ b/hub/static/hub/activity-tab/activity-tab-topology-nodes.css
@@ -173,12 +173,18 @@
 .activity-grid.activity-view-topology .topo-agent:hover text {
   filter: brightness(1.25);
 }
+/* msg#15599 Task C: channel topology nodes now render as horizontal
+ * pills (same shape as agent nodes) instead of diamonds. Hover /
+ * starred / muted styling targets the new .topo-channel-bg rect
+ * (same SSoT class as .topo-agent-bg) rather than the removed
+ * <polygon>. Glyph rules still target `text` since the inner
+ * star/eye/mute/name are all SVG text elements. */
 .activity-grid.activity-view-topology .topo-channel,
-.activity-grid.activity-view-topology .topo-channel polygon,
+.activity-grid.activity-view-topology .topo-channel rect,
 .activity-grid.activity-view-topology .topo-channel text {
   cursor: pointer;
 }
-.activity-grid.activity-view-topology .topo-channel:hover polygon {
+.activity-grid.activity-view-topology .topo-channel:hover .topo-channel-bg {
   stroke: #4ecdc4;
   stroke-width: 2;
   filter: drop-shadow(0 0 3px #4ecdc4);
@@ -188,7 +194,7 @@
  * or starred without cross-referencing the sidebar. ywatanabe
  * 2026-04-19: "mute channel does not change visual" / "star channel
  * as well". */
-.activity-grid.activity-view-topology .topo-channel-starred polygon {
+.activity-grid.activity-view-topology .topo-channel-starred .topo-channel-bg {
   stroke: #fbbf24;
   stroke-width: 1.8;
 }
@@ -198,7 +204,7 @@
 .activity-grid.activity-view-topology .topo-channel-muted {
   opacity: 0.4;
 }
-.activity-grid.activity-view-topology .topo-channel-muted polygon {
+.activity-grid.activity-view-topology .topo-channel-muted .topo-channel-bg {
   fill: #111 !important;
   stroke: #333;
 }

--- a/hub/static/hub/channel-badge.js
+++ b/hub/static/hub/channel-badge.js
@@ -193,13 +193,14 @@
   }
 
   // ── SVG renderer: topology canvas ──────────────────────────────────
-  // Emits a <g class="topo-channel" data-channel="..."> group with:
-  //   diamond polygon + icon + star + eye + mute + label rect + label.
-  // Canonical element order: icon + star + eye + mute + name — IDENTICAL
-  // to renderChannelBadgeHtml above, so sidebar / pool / canvas all read
-  // left-to-right the same way. ywatanabe 2026-04-20: "ALL channel badge
-  // MUST have the SAME UI and functionalities".
-  // pos = {x, y, r}; r optional (default 12).
+  // msg#15599 Task C — horizontal-pill layout (icon + star + eye +
+  // mute + name) that mirrors renderAgentBadgeSvg so canvas channel
+  // nodes match the sidebar channel rows visually AND functionally.
+  // Glyphs carry the same .ch-* classes + data-channel as the HTML
+  // badge, so body-level delegation in attachChannelBadgeHandlers
+  // below catches clicks from any surface. Prior diamond+scattered-
+  // glyphs layout removed in favour of this SSoT-with-agent-node
+  // geometry.
   function renderChannelBadgeSvg(name, pos, opts) {
     opts = opts || {};
     var m = channelBadgeModel(name);
@@ -207,27 +208,9 @@
     var showUnread = !!opts.showUnread;
     var x = pos.x;
     var y = pos.y;
-    var r = pos.r || 12;
     var count = opts.count != null ? opts.count : null;
     var labelText = count != null ? m.norm + " (" + count + ")" : m.norm;
     var extraClass = opts.extraClass || "";
-
-    var pts =
-      x +
-      "," +
-      (y - r) +
-      " " +
-      (x + r) +
-      "," +
-      y +
-      " " +
-      x +
-      "," +
-      (y + r) +
-      " " +
-      (x - r) +
-      "," +
-      y;
 
     var chCls = "topo-node topo-channel";
     if (m.isStarred) chCls += " topo-channel-starred";
@@ -235,150 +218,173 @@
     if (m.isHidden) chCls += " topo-channel-hidden";
     if (extraClass) chCls += " " + extraClass;
 
-    // Icon: URL → <image>, emoji → <text>, else no glyph.
+    // Slot geometry — mirrors renderAgentBadgeSvg.
+    var iconSize = opts.iconSize || 14;
+    var iconHalf = iconSize / 2;
+    var GAP = 6;
+    var slotW = 14;
+    var textW = Math.max(40, labelText.length * 6.5);
+    var total =
+      iconSize +
+      GAP +
+      slotW +
+      GAP +
+      (showEye ? slotW + GAP : 0) +
+      slotW +
+      GAP +
+      textW;
+    var clusterLeft = x - total / 2;
+    var glyphX = clusterLeft + iconHalf;
+    var starX = glyphX + iconHalf + GAP + slotW / 2;
+    var eyeX = showEye ? starX + slotW / 2 + GAP + slotW / 2 : starX;
+    var muteX =
+      (showEye ? eyeX : starX) + slotW / 2 + GAP + slotW / 2;
+    var nameX = muteX + slotW / 2 + GAP;
+
+    var badgeLeft = clusterLeft - 4;
+    var badgeWidth = total + 8;
+    var badgeY = y - 11;
+    var bg =
+      '<rect class="topo-channel-bg" x="' +
+      badgeLeft.toFixed(1) +
+      '" y="' +
+      badgeY.toFixed(1) +
+      '" width="' +
+      badgeWidth.toFixed(1) +
+      '" height="22" rx="11" ry="11"/>';
+
     var iconGlyph = "";
     if (m.iconIsUrl) {
-      var imgSize = Math.max(14, Math.round(r * 1.6));
       iconGlyph =
         '<image class="topo-ch-icon-img ch-icon" data-channel="' +
         _escape(m.norm) +
         '" href="' +
         _escape(m.iconGlyph) +
         '" x="' +
-        (x - imgSize / 2).toFixed(1) +
+        (glyphX - iconHalf).toFixed(1) +
         '" y="' +
-        (y - imgSize / 2).toFixed(1) +
+        (y - iconHalf).toFixed(1) +
         '" width="' +
-        imgSize +
+        iconSize +
         '" height="' +
-        imgSize +
-        '" preserveAspectRatio="xMidYMid slice"/>';
+        iconSize +
+        '" preserveAspectRatio="xMidYMid slice" style="cursor:pointer"/>';
     } else if (m.iconGlyph) {
       iconGlyph =
         '<text class="topo-ch-emoji ch-icon" data-channel="' +
         _escape(m.norm) +
         '" x="' +
-        x.toFixed(1) +
+        glyphX.toFixed(1) +
         '" y="' +
         (y + 4).toFixed(1) +
         '" font-size="' +
-        Math.max(11, Math.round(r * 1.2)) +
-        '" text-anchor="middle" dominant-baseline="middle">' +
+        Math.max(11, iconSize - 2) +
+        '" text-anchor="middle" dominant-baseline="middle" style="cursor:pointer">' +
         _escape(m.iconGlyph) +
         "</text>";
+    } else {
+      iconGlyph =
+        '<text class="topo-ch-emoji ch-icon" data-channel="' +
+        _escape(m.norm) +
+        '" x="' +
+        glyphX.toFixed(1) +
+        '" y="' +
+        (y + 4).toFixed(1) +
+        '" font-size="12" text-anchor="middle" dominant-baseline="middle" fill="' +
+        (m.color || "#94a3b8") +
+        '" style="cursor:pointer">#</text>';
     }
 
-    // Star — always rendered; filled gold when starred, dim outline when not.
     var starFill = m.isStarred ? "#fbbf24" : "#3a3a3a";
     var starGlyph =
       '<text class="topo-ch-star ch-star" data-channel="' +
       _escape(m.norm) +
       '" x="' +
-      (x + r + 2).toFixed(1) +
+      starX.toFixed(1) +
       '" y="' +
-      (y - r + 4).toFixed(1) +
-      '" font-size="11" fill="' +
+      (y + 4).toFixed(1) +
+      '" font-size="13" fill="' +
       starFill +
-      '" style="cursor:pointer" title="' +
+      '" text-anchor="middle" style="cursor:pointer"><title>' +
       (m.isStarred ? "Unstar" : "Star") +
-      '">' +
+      "</title>" +
       (m.isStarred ? "\u2605" : "\u2606") +
       "</text>";
 
-    // Eye — optional. Mirrors the bell pattern: same 👁 glyph in both
-    // states, with a red diagonal stroke overlaid when hidden (no
-    // Unicode crossed-eye exists, so we draw a <line> across the text
-    // bbox). Glyph is wrapped in a <g class="topo-ch-eye"> so the
-    // stroke shares the click target.
     var eyeGlyph = "";
     if (showEye) {
-      var eyeX = (x - r - 12).toFixed(1);
-      var eyeY = (y + r + 8).toFixed(1);
       var eyeText =
         '<text x="' +
-        eyeX +
+        eyeX.toFixed(1) +
         '" y="' +
-        eyeY +
-        '" font-size="9" fill="#94a3b8">\uD83D\uDC41</text>';
+        (y + 4).toFixed(1) +
+        '" font-size="11" text-anchor="middle" fill="#94a3b8" style="cursor:pointer">\uD83D\uDC41</text>';
       var eyeStrike = "";
       if (m.isHidden) {
-        // Diagonal red strike across the glyph's bbox. Glyph is ~9px
-        // tall + ~10px wide at font-size=9; strike goes from top-left
-        // to bottom-right of that bbox.
-        var sx1 = (x - r - 15).toFixed(1);
-        var sy1 = (parseFloat(eyeY) - 7).toFixed(1);
-        var sx2 = (x - r - 5).toFixed(1);
-        var sy2 = (parseFloat(eyeY) + 2).toFixed(1);
         eyeStrike =
           '<line x1="' +
-          sx1 +
+          (eyeX - 5).toFixed(1) +
           '" y1="' +
-          sy1 +
+          (y + 3).toFixed(1) +
           '" x2="' +
-          sx2 +
+          (eyeX + 5).toFixed(1) +
           '" y2="' +
-          sy2 +
-          '" stroke="#ef4444" stroke-width="2" stroke-linecap="round" pointer-events="none"/>';
+          (y - 3).toFixed(1) +
+          '" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round" pointer-events="none"/>';
       }
       eyeGlyph =
         '<g class="topo-ch-eye ch-eye' +
         (m.isHidden ? " ch-eye-off" : " ch-eye-on") +
         '" data-channel="' +
         _escape(m.norm) +
-        '" style="cursor:pointer">' +
+        '" style="cursor:pointer"><title>' +
+        (m.isHidden ? "Show channel (un-hide)" : "Hide channel") +
+        "</title>" +
         eyeText +
         eyeStrike +
         "</g>";
     }
 
-    // Mute — only rendered when muted (keeps diamond uncluttered).
+    var muteFill = m.isMuted ? "#94a3b8" : "#3a3a3a";
     var muteGlyph =
       '<text class="topo-ch-mute ch-mute" data-channel="' +
       _escape(m.norm) +
       '" x="' +
-      (x - r - 12).toFixed(1) +
+      muteX.toFixed(1) +
       '" y="' +
-      (y - r + 4).toFixed(1) +
-      '" font-size="9" fill="' +
-      (m.isMuted ? "#94a3b8" : "#3a3a3a") +
-      '" style="cursor:pointer">' +
+      (y + 4).toFixed(1) +
+      '" font-size="11" fill="' +
+      muteFill +
+      '" text-anchor="middle" style="cursor:pointer"><title>' +
+      (m.isMuted ? "Unmute" : "Mute") +
+      "</title>" +
       (m.isMuted ? "\uD83D\uDD15" : "\uD83D\uDD14") +
       "</text>";
 
-    // Label rect + text (channel label above diamond).
-    var labelW = Math.max(40, labelText.length * 6.5);
-    var labelX = x - labelW / 2 - 6;
-    var labelY = y - r - 18;
-    var labelRect =
-      '<rect class="topo-channel-bg" x="' +
-      labelX.toFixed(1) +
-      '" y="' +
-      labelY.toFixed(1) +
-      '" width="' +
-      (labelW + 12).toFixed(1) +
-      '" height="20" rx="10" ry="10"/>';
-    var labelTextSvg =
+    var nameColor = m.color || "#eaf1fb";
+    var nameSvg =
       '<text class="topo-label topo-label-ch" x="' +
-      x +
+      nameX.toFixed(1) +
       '" y="' +
-      (y - r - 4).toFixed(1) +
-      '" text-anchor="middle">' +
+      (y + 4).toFixed(1) +
+      '" fill="' +
+      _escape(nameColor) +
+      '">' +
       _escape(labelText) +
       "</text>";
 
-    // Optional unread bubble (not used on canvas today, but available).
     var unreadSvg = "";
     if (showUnread && m.unread > 0) {
       unreadSvg =
         '<circle class="topo-ch-unread" cx="' +
-        (x + r + 6).toFixed(1) +
+        (badgeLeft + badgeWidth - 4).toFixed(1) +
         '" cy="' +
-        (y + r).toFixed(1) +
+        (y - 10).toFixed(1) +
         '" r="7" fill="#ef4444"/>' +
         '<text class="topo-ch-unread-text" x="' +
-        (x + r + 6).toFixed(1) +
+        (badgeLeft + badgeWidth - 4).toFixed(1) +
         '" y="' +
-        (y + r + 3).toFixed(1) +
+        (y - 7).toFixed(1) +
         '" font-size="9" fill="#fff" text-anchor="middle">' +
         (m.unread > 9 ? "9+" : m.unread) +
         "</text>";
@@ -394,15 +400,15 @@
       (count != null ? ' data-agent-count="' + count + '"' : "") +
       (attrs ? " " + attrs : "") +
       ">" +
-      '<polygon points="' +
-      pts +
-      '" fill="#1a1a1a" stroke="#444" stroke-width="1"/>' +
+      "<title>" +
+      _escape(m.tooltip || m.norm) +
+      "</title>" +
+      bg +
       iconGlyph +
       starGlyph +
       eyeGlyph +
       muteGlyph +
-      labelRect +
-      labelTextSvg +
+      nameSvg +
       unreadSvg +
       "</g>"
     );

--- a/hub/static/hub/style/style-base.css
+++ b/hub/static/hub/style/style-base.css
@@ -400,17 +400,25 @@ body {
    * sidebar card metrics (.sidebar .agent-card.sidebar-compact in
    * style-messages.css) so Channels and Agents lists read at the same
    * row height. font-size + min-height already matched; only padding
-   * + margin needed nudging. Icons (icon→★→👁→🔔→name) are still
-   * specific to channels — only container metrics align. */
+   * + margin needed nudging.
+   *
+   * msg#15599: padding + gap unified pixel-for-pixel with
+   * .sidebar-agent-row (activity-tab-list.css) so the icon and ★
+   * columns land at the SAME x from the row's left edge in both
+   * sections. The 2px left border (transparent fallback, tinted via
+   * --channel-accent when set; see style-channels.css) accounts for
+   * the accent stripe from PR #306 task 4. Agent rows carry a
+   * matching transparent border-left so both content boxes start
+   * 2+6=8px from the outer edge. */
   margin-bottom: 2px;
-  padding: 4px 8px;
+  padding: 1px 6px;
   border-radius: 4px;
   transition: background 0.15s;
   cursor: pointer;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   min-height: 20px;
 }
 .unread-badge {

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -388,6 +388,18 @@
 .sidebar .channel-item .ch-identity-icon {
   color: var(--channel-accent, inherit);
 }
+/* msg#15599 Task B: row-wide colorization — the channel NAME text
+ * picks up the per-channel accent colour too, mirroring how agent
+ * cards tint the agent name via inline `color:` in agent-badge.ts.
+ * Previously only the icon + 2px stripe carried colour (PR #306 task
+ * 4); lead wanted the name to read coloured as well. The 👁/🔔 glyphs
+ * stay monochrome (they encode state, not identity), and the bell /
+ * eye grayscale filters in the rules above are untouched. Row
+ * background and opacity remain PR #293/#295 invariants (opacity 1,
+ * no per-row font-weight). */
+.sidebar .channel-item .ch-name {
+  color: var(--channel-accent, inherit);
+}
 .ch-pin:hover,
 .ch-watch:hover,
 .ch-eye:hover {

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -202,7 +202,11 @@
   flex: 0 0 14px;
   font-size: 11px;
   line-height: 1;
-  margin-right: 2px;
+  /* msg#15599 Task A: drop per-slot margin-right — the sidebar row's
+   * flex `gap` (now unified at 4px with .sidebar-agent-row) handles
+   * inter-slot spacing, so each slot has the IDENTICAL width to the
+   * Agents section. Previous 2px margin-right added 2×4 = 8px of drift
+   * between the Agents and Channels icon columns. */
   cursor: pointer;
   transition:
     color 0.15s,
@@ -298,30 +302,28 @@
 .channel-item:hover .ch-mute {
   opacity: 1;
 }
-.ch-pin,
-.ch-eye {
+/* .ch-pin and .ch-eye sizing is consolidated into the first
+ * .ch-star/.ch-pin/.ch-watch/.ch-eye/.ch-mute rule above (msg#15599
+ * Task A cleanup — the duplicate block here re-declared the same
+ * width/flex and served no purpose). */
+
+/* Custom channel icon slot in the sidebar (todo#101). Fixed-width
+ * wrapper — MUST clamp both width and flex-basis so rows with an
+ * emoji glyph, an image avatar, or the default '#' placeholder all
+ * line up the channel-name column. Without the flex-basis clamp, a
+ * wide emoji pushes the name right and column alignment breaks.
+ * msg#15599 Task A: slot width dropped from 18px to 14px and
+ * margin-right removed so the channel icon column is geometrically
+ * identical to the agent icon slot (.agent-badge-icon width:14px in
+ * agent-badge.ts, no margin — inter-slot spacing handled by the
+ * row's flex gap). */
+.ch-identity-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 14px;
   height: 14px;
   flex: 0 0 14px;
-  line-height: 1;
-}
-
-/* Custom channel icon slot in the sidebar (todo#101). Fixed-width
- * wrapper — MUST clamp both width and flex-basis so rows with an
- * emoji glyph, an image avatar, or the default '#' placeholder all
- * line up the channel-name column. Without the flex-basis clamp, a
- * wide emoji pushes the name right and column alignment breaks. */
-.ch-identity-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  flex: 0 0 18px;
-  margin-right: 4px;
   overflow: hidden;
   line-height: 1;
 }
@@ -344,8 +346,8 @@
   line-height: 1;
 }
 .ch-identity-icon img.agent-avatar {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   border-radius: 3px;
   object-fit: cover;
 }
@@ -375,9 +377,13 @@
   /* Fallback to the existing muted text colour when no accent is set
    * (e.g. renderChannelBadgeHtml called with no channelBadgeModel). */
   border-left: 2px solid var(--channel-accent, transparent);
-  /* Nudge padding-left to keep the icon column aligned when the stripe
-   * lands (2px stripe + 6px inner pad → matches original 8px left pad). */
-  padding-left: 6px;
+  /* .channel-item in style-base.css already carries padding: 1px 6px
+   * (unified with .sidebar-agent-row per msg#15599 column-align spec).
+   * The 2px border-left above stacks on top of that 6px, giving a
+   * content start of 8px from the outer edge — matched by the
+   * transparent border-left applied to .sidebar-agent-row in
+   * activity-tab-list.css, so the icon / ★ columns line up across
+   * the Agents and Channels sidebar sections. */
 }
 .sidebar .channel-item .ch-identity-icon {
   color: var(--channel-accent, inherit);


### PR DESCRIPTION
## Summary

Three focused fixes to the sidebar + topology-canvas channel UI,
triggered by ywatanabe msg#15599 and lead msg#15601 on #heads.
Each task lands in its own commit so review can be incremental.

### Task A — Agents / Channels column alignment
Icon and star columns now sit at the SAME x from the row's left edge
across the Agents and Channels sidebar sections. Unified container
padding + gap + left-border geometry so content starts 8px from the
outer edge in both sections; dropped the 18px + 4px
`.ch-identity-icon` to 14px to match `.agent-badge-icon`; removed
2px margin-right on `.ch-star/.ch-pin/.ch-watch/.ch-eye/.ch-mute`
(the row's flex gap handles inter-slot spacing) and cleaned up a
duplicate `.ch-pin/.ch-eye` size re-declaration.

Files: `hub/static/hub/style/style-base.css`,
`hub/static/hub/style/style-channels.css`,
`hub/static/hub/activity-tab/activity-tab-list.css` (commit `ebc1d23`).

### Task B — Row-wide channel color
Channel NAME text picks up `--channel-accent` the way agent cards
colorize the agent-name, extending PR #306 task 4's icon-tint +
2px-stripe to cover the name too. Eye / bell stay monochrome (state
signals), row opacity stays 1, per-row font-weight stays normal
(PR #293/#295 invariants).

Files: `hub/static/hub/style/style-channels.css` (commit `84db7e1`).

### Task C — Graph channel cards match sidebar channel cards
`renderChannelBadgeSvg` rewritten to emit a horizontal pill
(icon + star + eye + mute + name) with the SAME cluster geometry
as `renderAgentBadgeSvg`, replacing the rotated-square diamond with
scattered glyphs. Migrated hover / starred / muted / drop-target
CSS selectors from `.topo-channel polygon` to
`.topo-channel .topo-channel-bg` (same SSoT class as
`.topo-agent-bg`). Functional parity (star / eye / notification)
was already wired via the capture-phase body-level delegation in
`attachChannelBadgeHandlers` — the new SVG glyphs carry the same
`.ch-*` classes + `data-channel`, so canvas clicks route through
the exact same `_setChannelPref` call the sidebar click does.

Files: `hub/frontend/src/channel-badge.ts` +
`hub/static/hub/channel-badge.js` (JS mirror),
`hub/static/hub/activity-tab/activity-tab-topology-nodes.css`,
`hub/static/hub/activity-tab/activity-tab-detail-pane.css`
(commit `f671fe6`).

## Build / typecheck

```
npm run typecheck   # pass
npm run build       # pass
```

## Test plan

- [ ] Sidebar: open the Agents + Channels sections side by side —
      icon column and star column must align horizontally across
      both.
- [ ] Sidebar Channels: the channel NAME text reads in the per-
      channel accent colour (matches the icon tint); eye and bell
      stay grey.
- [ ] Agents tab > Topology view: channel nodes render as
      horizontal pills with `#channel` icon, star, eye, bell, name,
      visually identical to the sidebar row.
- [ ] Click star on a topology channel node → row toggles starred
      without opening the channel compose popup. Same for eye and
      bell.
- [ ] Hover a topology channel node → teal glow on the pill
      (`.topo-channel-bg` stroke).
- [ ] Starred channel on canvas → amber stroke on the pill; muted
      channel → opacity 0.4 + grey pill.

## Screenshots

The `prod-screenshot` Makefile target takes a cookie-authed shot of
live `scitex-orochi.com`, which has not yet deployed this branch,
so a pre-merge candidate.png would just re-show
`candidate-post-306.png`. Visual verification should happen after
merge + prod rebuild. `candidate-post-306.png` remains the current
reference at `.playwright-cli/candidate-post-306.png` and is what
the changes are measured against.

## References

- ywatanabe msg#15599 (task spec)
- lead msg#15601 (channels visual + functional parity)
- PR #306 — prior topology auto-layout + channel accent stripe work
  this builds on
- PR #293 / PR #295 — row opacity + font-weight invariants preserved
