### PR TITLE
feat(ui): renderChannelBadge SSoT + 10-item sidebar/graph polish (Step 2)

### DIFF
--- a/hub/frontend/src/activity-tab/channel-hover-preview.ts
+++ b/hub/frontend/src/activity-tab/channel-hover-preview.ts
@@ -1,0 +1,273 @@
+// @ts-nocheck
+import { apiUrl, escapeHtml } from "../app/utils";
+
+/* activity-tab/channel-hover-preview.ts — Item 11 (lead msg#15646).
+ *
+ * Lightweight hover-preview popover for channel nodes on the Agents
+ * topology canvas. On settled hover (300 ms delay) of a .topo-channel
+ * group, fetch the last 7 messages via GET /api/history/<channel>/
+ * and render them in a floating popover anchored near the node.
+ *
+ * Design rules (from lead spec):
+ *   - 300 ms hover delay so a quick cursor sweep doesn't flash the
+ *     popover. Debounce resets on re-entry.
+ *   - Snapshot on hover: no auto-refresh. For deeper exploration the
+ *     user double-clicks to jump to the Chat tab (existing behaviour).
+ *   - Pointer entering the popover does NOT dismiss it — the user
+ *     needs to read without having the popover vanish under the
+ *     cursor. Dismiss on pointerleave of BOTH the node and the
+ *     popover, or on outer click.
+ *   - Scrollable if content overflows; reuse the chat feed's
+ *     message-cell typography via the shared .chp-* styles in
+ *     style-menus.css.
+ *   - Vanilla TS / DOM only — no framer-motion, no react. Matches the
+ *     style of channel-controls.ts / context-menus.ts.
+ *
+ * Caching: we keep a tiny Map<channel, {data, at}> of the last
+ * fetched snapshot with a 5 s TTL so rapid re-hover doesn't
+ * re-fetch on every pass. This is explicitly NOT live data — hovering
+ * twice within 5 s returns the same snapshot, which is fine because
+ * the spec calls this "snapshot on hover".
+ */
+
+var HOVER_DELAY_MS = 300;
+var CACHE_TTL_MS = 5000;
+var FETCH_LIMIT = 7;
+
+var _hoverTimer: any = null;
+var _currentNode: any = null;
+var _currentPopover: any = null;
+var _cache: any = {};
+/* Incrementing request epoch so a late-arriving fetch for a channel
+ * the user has already moved away from doesn't silently paint over a
+ * newer hover target. */
+var _epoch = 0;
+
+function _clearHoverTimer() {
+  if (_hoverTimer) {
+    clearTimeout(_hoverTimer);
+    _hoverTimer = null;
+  }
+}
+
+function _destroyPopover() {
+  if (_currentPopover && _currentPopover.parentNode) {
+    _currentPopover.parentNode.removeChild(_currentPopover);
+  }
+  _currentPopover = null;
+  _currentNode = null;
+}
+
+function _fmtTime(iso) {
+  if (!iso) return "";
+  try {
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    var hh = String(d.getHours()).padStart(2, "0");
+    var mm = String(d.getMinutes()).padStart(2, "0");
+    return hh + ":" + mm;
+  } catch (_e) {
+    return "";
+  }
+}
+
+function _truncate(s, n) {
+  if (!s) return "";
+  s = String(s);
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + "\u2026";
+}
+
+function _renderRows(messages) {
+  if (!messages || !messages.length) {
+    return '<div class="chp-empty">(no recent messages)</div>';
+  }
+  /* API returns newest-first; flip so the popover reads chronologically
+   * like the chat feed does. */
+  var rows = messages.slice().reverse();
+  return rows
+    .map(function (m) {
+      var sender = m.sender || "?";
+      var ts = _fmtTime(m.ts);
+      var content = _truncate(m.content || "", 140);
+      return (
+        '<div class="chp-row">' +
+        '<div class="chp-meta">' +
+        '<span class="chp-sender">' +
+        escapeHtml(sender) +
+        "</span>" +
+        (ts
+          ? '<span class="chp-ts">' + escapeHtml(ts) + "</span>"
+          : "") +
+        "</div>" +
+        '<div class="chp-body">' +
+        escapeHtml(content) +
+        "</div>" +
+        "</div>"
+      );
+    })
+    .join("");
+}
+
+function _positionPopover(pop, node) {
+  /* Anchor near the node but stay inside the viewport with 8 px pad.
+   * Prefer right-of-node; flip to left if right would overflow. If
+   * bottom would overflow, align to top of viewport. */
+  var pad = 8;
+  var rect = node.getBoundingClientRect();
+  var pr = pop.getBoundingClientRect();
+  var left = rect.right + 8;
+  var top = rect.top;
+  if (left + pr.width > window.innerWidth - pad) {
+    left = Math.max(pad, rect.left - pr.width - 8);
+  }
+  if (top + pr.height > window.innerHeight - pad) {
+    top = Math.max(pad, window.innerHeight - pr.height - pad);
+  }
+  pop.style.left = left + "px";
+  pop.style.top = top + "px";
+}
+
+function _openPopover(node, channel) {
+  _destroyPopover();
+  var pop = document.createElement("div");
+  pop.className = "channel-hover-popover";
+  pop.setAttribute("data-channel", channel);
+  pop.style.cssText =
+    "position:fixed;z-index:9998;left:0;top:0;pointer-events:auto;";
+  pop.innerHTML =
+    '<div class="chp-header">' +
+    escapeHtml(channel) +
+    '<span class="chp-hint">last ' +
+    FETCH_LIMIT +
+    "</span>" +
+    "</div>" +
+    '<div class="chp-body-scroll"><div class="chp-loading">Loading\u2026</div></div>';
+  document.body.appendChild(pop);
+  _currentPopover = pop;
+  _currentNode = node;
+  _positionPopover(pop, node);
+
+  /* Pointer entering the popover must NOT dismiss it — user wants to
+   * read. pointerleave on the popover itself closes (dismiss on outer
+   * pointerleave + outer click, per spec). */
+  pop.addEventListener("pointerleave", function (ev) {
+    /* If the cursor moves back onto the source node, keep the popover
+     * open — the node's own pointerleave handler will tear down when
+     * the user truly leaves. */
+    var rel = ev.relatedTarget;
+    if (rel && _currentNode && _currentNode.contains(rel)) return;
+    _destroyPopover();
+  });
+
+  /* Re-use cached snapshot if fresh (≤5 s). Spec says "snapshot on
+   * hover"; TTL here just avoids a trivially-redundant fetch during
+   * rapid re-hovers of the same node. */
+  var cached = _cache[channel];
+  var now = Date.now();
+  if (cached && now - cached.at < CACHE_TTL_MS) {
+    _paintMessages(pop, cached.data);
+    return;
+  }
+
+  var myEpoch = ++_epoch;
+  var url = apiUrl(
+    "/api/history/" + encodeURIComponent(channel) + "/?limit=" + FETCH_LIMIT,
+  );
+  fetch(url, { credentials: "same-origin" })
+    .then(function (res) {
+      if (!res.ok) throw new Error("HTTP " + res.status);
+      return res.json();
+    })
+    .then(function (data) {
+      _cache[channel] = { data: data, at: Date.now() };
+      /* Bail if the user has already moved to a different node — we
+       * don't want a stale fetch to paint over the current popover. */
+      if (myEpoch !== _epoch) return;
+      if (
+        !_currentPopover ||
+        _currentPopover.getAttribute("data-channel") !== channel
+      )
+        return;
+      _paintMessages(_currentPopover, data);
+    })
+    .catch(function (err) {
+      if (myEpoch !== _epoch) return;
+      if (
+        !_currentPopover ||
+        _currentPopover.getAttribute("data-channel") !== channel
+      )
+        return;
+      var body = _currentPopover.querySelector(".chp-body-scroll");
+      if (body) {
+        body.innerHTML =
+          '<div class="chp-empty">Failed to load (' +
+          escapeHtml(String(err && err.message ? err.message : err)) +
+          ")</div>";
+      }
+    });
+}
+
+function _paintMessages(pop, data) {
+  var body = pop.querySelector(".chp-body-scroll");
+  if (!body) return;
+  body.innerHTML = _renderRows(data);
+  /* Re-anchor: the popover may have grown from loading-size to full
+   * content-size, potentially pushing it off-screen. */
+  if (_currentNode) _positionPopover(pop, _currentNode);
+}
+
+export function _ovgWireChannelHoverPreview(grid) {
+  if (!grid) return;
+  /* pointerover/pointerleave over the grid. We debounce per-node so a
+   * cursor that sweeps across the canvas doesn't fire a preview for
+   * each node it happens to cross. */
+  grid.addEventListener("pointerover", function (ev) {
+    var node = ev.target.closest(".topo-channel[data-channel]");
+    if (!node || !grid.contains(node)) return;
+    var ch = node.getAttribute("data-channel");
+    if (!ch) return;
+    /* Same node as we're already showing? nothing to do. */
+    if (
+      _currentPopover &&
+      _currentPopover.getAttribute("data-channel") === ch &&
+      _currentNode === node
+    ) {
+      return;
+    }
+    _clearHoverTimer();
+    _hoverTimer = setTimeout(function () {
+      _hoverTimer = null;
+      _openPopover(node, ch);
+    }, HOVER_DELAY_MS);
+  });
+  grid.addEventListener(
+    "pointerleave",
+    function (ev) {
+      var node = ev.target.closest(".topo-channel[data-channel]");
+      if (!node || !grid.contains(node)) return;
+      /* Cancel a pending settle-timer when the cursor leaves before
+       * 300 ms — avoids popping up after the cursor is already gone. */
+      _clearHoverTimer();
+      /* Closing is gated: if the cursor moved into the popover we
+       * keep it alive (popover's own pointerleave handles close). */
+      var rel = ev.relatedTarget;
+      if (rel && _currentPopover && _currentPopover.contains(rel)) return;
+      _destroyPopover();
+    },
+    true,
+  );
+  /* Outer click dismisses (spec). Capture phase so we run before any
+   * site-local click handler eats the event. */
+  document.addEventListener(
+    "click",
+    function (ev) {
+      if (!_currentPopover) return;
+      if (_currentPopover.contains(ev.target)) return;
+      var node = ev.target.closest(".topo-channel[data-channel]");
+      if (node && node === _currentNode) return;
+      _destroyPopover();
+    },
+    true,
+  );
+}

--- a/hub/frontend/src/activity-tab/compose.ts
+++ b/hub/frontend/src/activity-tab/compose.ts
@@ -401,8 +401,25 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
    * clipboard carries a file/image, route to the Chat composer (the
    * canonical paste-to-attach pipeline lives there) and re-dispatch
    * the paste event so the upload.js handler does the work.
-   * ywatanabe 2026-04-19: "small input modal should support pasting". */
+   * ywatanabe 2026-04-19: "small input modal should support pasting".
+   *
+   * PR #<this> Item 10 (lead msg#15637): graph-compose paste was
+   * triggering a tab switch to Chat when the user intended the paste
+   * to land in the graph input. Root cause: the paste event bubbled
+   * up from this textarea to msg-input's body-attached paste handler
+   * (upload.ts handleClipboardPaste) which is focused on msg-input;
+   * when msg-input received the bubbled paste it implicitly reacted
+   * as if the user had interacted with the Chat composer. The fix is
+   * simple: unconditionally stopPropagation() on every paste into the
+   * graph input so nothing bubbles past this handler. The textarea
+   * still receives the native paste (we don't preventDefault unless
+   * we're re-routing files/long-text to msg-input explicitly). */
   input.addEventListener("paste", function (ev) {
+    /* Item 10: contain paste to this popup unconditionally — paste
+     * MUST NOT bubble up to msg-input's handler or any window-level
+     * tab-router. Don't preventDefault (that would kill native text
+     * paste); only stopPropagation. */
+    ev.stopPropagation();
     var cd =
       ev.clipboardData || (ev.originalEvent && ev.originalEvent.clipboardData);
     if (!cd) return;
@@ -425,8 +442,11 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     } catch (_) {}
     var isLong = text.length > 1000;
     if (hasFile || isLong) {
+      /* Route to Chat composer: block native textarea paste, close
+       * this popup, and synthesize a paste on msg-input (below). The
+       * stopPropagation above already contained the bubble; no need
+       * to repeat it here. */
       ev.preventDefault();
-      ev.stopPropagation();
       close();
       _routeToChat();
       setTimeout(function () {

--- a/hub/frontend/src/activity-tab/grid-delegation.ts
+++ b/hub/frontend/src/activity-tab/grid-delegation.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { _ovgWireChannelHoverPreview } from "./channel-hover-preview";
 import { _ovgWireClick } from "./grid-click";
 import { _ovgWireContextmenu } from "./grid-ctx";
 import { _ovgWireHover } from "./grid-hover";
@@ -7,9 +8,9 @@ import { _memSelectOnChange } from "../app/sidebar-memory-handlers";
 
 /* activity-tab/grid-delegation.js — delegated listeners on the
  * overview grid. Per-handler code lives in grid-click.js / grid-mouse.js
- * / grid-ctx.js / grid-hover.js; this file just wires them up once
- * (guard flag) and defines the standalone _topoSvgPoint helper used
- * by both zoom/pan and drag gestures. */
+ * / grid-ctx.js / grid-hover.js / channel-hover-preview.ts; this file
+ * just wires them up once (guard flag) and defines the standalone
+ * _topoSvgPoint helper used by both zoom/pan and drag gestures. */
 
 export function _wireOverviewGridDelegation(grid) {
   if ((globalThis as any)._overviewGridWired || !grid) return;
@@ -17,6 +18,10 @@ export function _wireOverviewGridDelegation(grid) {
   _ovgWireMouse(grid);
   _ovgWireContextmenu(grid);
   _ovgWireHover(grid);
+  /* Item 11 (lead msg#15646) — settled-hover popover showing the last
+   * 7 messages from a channel node. Independent of the edge-highlight
+   * hover wiring in _ovgWireHover; both coexist on the same target. */
+  _ovgWireChannelHoverPreview(grid);
   _ovgWireChange(grid);
   (globalThis as any)._overviewGridWired = true;
 }

--- a/hub/frontend/src/activity-tab/topology-autolayout.ts
+++ b/hub/frontend/src/activity-tab/topology-autolayout.ts
@@ -7,35 +7,47 @@ import {
 } from "./state";
 import { userName } from "../app/utils";
 
-/* activity-tab/topology-autolayout.ts — "整列" (Tidy) button handler.
+/* activity-tab/topology-autolayout.ts — "Reset Layout" button handler.
  *
  * Re-lays out the topology graph into two concentric rings:
  *   - Inner ring  = channel nodes
  *   - Outer ring  = agents + human user
  *
- * Then runs a couple of light repulsion passes so no two nodes sit
- * within ~1.2 * node_diameter of each other. Positions are written into
+ * Then runs a force-directed relaxation loop so no two nodes sit within
+ * ~1.1 * node_diameter of each other. Positions are written into
  * _topoManualPositions (the same overlay that drag-to-reposition uses)
  * so the layout survives heartbeat re-renders and zoom/pan.
  *
- * No deps; pure math + a two-pass softbody nudge. ywatanabe 2026-04-20
- * lead msg#15493 / todo#305.
+ * No deps; pure math. ywatanabe 2026-04-20 lead msg#15493 / todo#305 +
+ * PR #<this> Item 8 (zero-overlap guarantee).
  */
 
 /* Approximate node footprint used for the overlap-relief pass. The
- * topology renderer itself uses node_diameter ≈ 44 for agent badges
- * and ≈ 32 for channel diamonds; we take the max so repulsion is
- * slightly conservative. */
-var _NODE_D = 48;
-var _MIN_SEP = _NODE_D * 1.2; /* ~58px */
+ * topology renderer uses badge-pill nodes ≈ 90px wide × 22px tall for
+ * agents and ≈ 60px wide × 22px tall for channels (post-PR#310 — no
+ * more diamonds). We use a circumscribed diameter of 90 for the
+ * repulsion radius so wide pills don't visually overlap even when
+ * their centres are exactly `_NODE_D * 1.1` apart.
+ *
+ * Item 8 "guarantee: for N < (some threshold) nodes with the canvas
+ * dimensions available, post-layout every pair is at least
+ * node_diameter × 1.1 apart". */
+var _NODE_D = 90;
+var _MIN_SEP = _NODE_D * 1.1; /* ~99px */
+var _MAX_ITER = 300;
 
 /* One repulsion pass — O(n²) over the node set, fine for <200 nodes.
  * For each close pair, push them apart along the connecting vector by
  * half the overlap each. `anchors` holds the target-ring position so a
  * displaced node is also softly pulled back toward its assigned ring
- * slot; without this a dense cluster can spiral outward forever. */
+ * slot; without this a dense cluster can spiral outward forever.
+ *
+ * Returns the number of overlapping pairs observed in this pass so the
+ * caller's relaxation loop can terminate early when no overlap remains
+ * (PR #<this> Item 8). */
 function _repulsePass(nodes, anchors, strength) {
-  var i, j, a, b, dx, dy, d, overlap, ux, uy, push;
+  var i, j, a, b, dx, dy, d, overlap, ux, uy;
+  var overlapCount = 0;
   for (i = 0; i < nodes.length; i++) {
     for (j = i + 1; j < nodes.length; j++) {
       a = nodes[i];
@@ -44,9 +56,12 @@ function _repulsePass(nodes, anchors, strength) {
       dy = b.y - a.y;
       d = Math.sqrt(dx * dx + dy * dy);
       if (d >= _MIN_SEP) continue;
+      overlapCount++;
       if (d < 0.01) {
-        /* Co-located — nudge along a deterministic axis. */
-        ux = 1;
+        /* Co-located — nudge along a deterministic axis. Use node
+         * index parity so repeat-overlapping pairs drift apart
+         * consistently across iterations. */
+        ux = (i + j) % 2 === 0 ? 1 : -1;
         uy = 0;
         d = 0.01;
       } else {
@@ -68,6 +83,7 @@ function _repulsePass(nodes, anchors, strength) {
     nodes[i].x += (anc.x - nodes[i].x) * 0.05;
     nodes[i].y += (anc.y - nodes[i].y) * 0.05;
   }
+  return overlapCount;
 }
 
 /* Compute concentric ring positions for the currently-visible topology
@@ -163,11 +179,55 @@ export function _topoAutoLayout() {
     outerIdx++;
   });
 
-  /* Two nudge passes — empirically enough to resolve the typical
-   * 15-agent / 10-channel overlap on a default-sized canvas without
-   * drifting the rings noticeably. */
-  _repulsePass(nodes, anchors, 1.0);
-  _repulsePass(nodes, anchors, 0.7);
+  /* PR #<this> Item 8: force-directed relaxation loop with zero-overlap
+   * guarantee. Run up to _MAX_ITER passes; exit early when no pair
+   * overlaps. Strength decays over iterations so early passes move
+   * fast and late passes fine-tune without oscillation. Each iteration
+   * is O(n²); at N < 200 nodes and 300 iter cap this is <60k op/pass
+   * which runs instantly in the browser.
+   *
+   * If the canvas literally cannot fit the nodes (rOuter × 2π < N ×
+   * _MIN_SEP), we still relax to the best-effort spacing but log a
+   * console warning so the user knows the layout is saturated. */
+  var idealOuterSpacing =
+    (2 * Math.PI * rOuter) / Math.max(1, nOuter);
+  var idealInnerSpacing =
+    (2 * Math.PI * rInner) / Math.max(1, channels.length);
+  var saturated =
+    idealOuterSpacing < _MIN_SEP || idealInnerSpacing < _MIN_SEP;
+  if (saturated) {
+    console.warn(
+      "[topology-autolayout] canvas saturated: best-effort spacing " +
+        "(" +
+        Math.round(Math.min(idealOuterSpacing, idealInnerSpacing)) +
+        "px < " +
+        Math.round(_MIN_SEP) +
+        "px target). Consider hiding some agents/channels or " +
+        "enlarging the viewport.",
+    );
+  }
+  var iter;
+  var overlap = 0;
+  for (iter = 0; iter < _MAX_ITER; iter++) {
+    /* Strength decays linearly from 1.0 → 0.3 over the iteration cap
+     * so early passes do bulk separation and late passes polish. */
+    var strength = 1.0 - (iter / _MAX_ITER) * 0.7;
+    overlap = _repulsePass(nodes, anchors, strength);
+    /* Early-exit: no overlaps remaining = layout is clean. */
+    if (overlap === 0) break;
+  }
+  if (overlap > 0 && !saturated) {
+    /* Ran to the iteration cap without converging despite the canvas
+     * having enough room — surface that so future tuning can raise
+     * the cap if needed. */
+    console.warn(
+      "[topology-autolayout] did not converge after " +
+        _MAX_ITER +
+        " iterations, " +
+        overlap +
+        " overlapping pair(s) remain.",
+    );
+  }
 
   /* Write back into the manual-position overlay. We REPLACE every
    * existing entry for the keys we touched so partial drags don't

--- a/hub/frontend/src/activity-tab/topology-nodes.ts
+++ b/hub/frontend/src/activity-tab/topology-nodes.ts
@@ -4,12 +4,20 @@ import { _secondsSinceIso } from "./utils";
 import { renderAgentBadgeSvg } from "../agent-badge-svg";
 import { renderChannelBadgeSvg } from "../channel-badge";
 
-/* activity-tab/topology-nodes.js — SVG emission for channel diamonds,
- * agent pills, and the human user node. */
+/* activity-tab/topology-nodes.js — SVG emission for channel nodes,
+ * agent pills, and the human user node.
+ *
+ * PR #<this> Item 9 (ywatanabe msg#15637): channel nodes are rendered
+ * ONLY through renderChannelBadgeSvg — the prior rotated-square
+ * "diamond" shape is removed. Every node (agent AND channel) now
+ * goes through the shared badge modules so canvas ↔ sidebar ↔ pool
+ * stay in lockstep ("channel ノードの ダイヤモンド形状は削除、
+ * identity badge だけで十分"). No parallel renderer; no diamond
+ * fallback. */
 
 export function _topoBuildChannelsSvg(visible, channels, chPos, chSet, _chPrefs) {
   /* Per-channel subscriber counts across the visible agents. Used to
-   * scale each channel diamond — "based on the number of agents, the
+   * scale each channel badge — "based on the number of agents, the
    * channel node can be larger" (ywatanabe 2026-04-19). */
   var chAgentCounts = {};
   visible.forEach(function (a) {
@@ -18,8 +26,9 @@ export function _topoBuildChannelsSvg(visible, channels, chPos, chSet, _chPrefs)
       chAgentCounts[c] = (chAgentCounts[c] || 0) + 1;
     });
   });
-  /* Channel diamonds (rotated squares) with label above. Size scales
-   * per user-selected "size:" dropdown (todo#95):
+  /* Channel badges (horizontal pills via renderChannelBadgeSvg) with
+   * identity inline. Size scales per user-selected "size:" dropdown
+   * (todo#95):
    *   equal       — fixed r = 12
    *   subscribers — r = 8 + sqrt(count-1)*5, clamped [8,22]
    *   posts       — reserved; /api/stats does not yet expose post counts,
@@ -46,17 +55,16 @@ export function _topoBuildChannelsSvg(visible, channels, chPos, chSet, _chPrefs)
        * 2026-04-20: "ALL channel badge MUST have the SAME UI and
        * functionalities"). No inline glyph/star/eye/mute emission
        * here — the SSoT owns the full channel visual. */
-      if (typeof renderChannelBadgeSvg === "function") {
-        return renderChannelBadgeSvg(
-          c,
-          { x: p.x, y: p.y, r: r },
-          { showEye: true, showUnread: false, count: count },
-        );
-      }
-      /* Fallback shouldn't fire once channel-badge.js is loaded;
-       * kept minimal so the canvas still renders if the helper is
-       * missing for any reason. */
-      return "";
+      /* Item 9: no fallback — renderChannelBadgeSvg is the ONLY path.
+       * channel-badge.ts loads before this file in the Vite bundle
+       * (see src/index.ts import order), so the helper is always
+       * defined. If it is missing we want to fail loudly rather than
+       * silently render nothing. */
+      return renderChannelBadgeSvg(
+        c,
+        { x: p.x, y: p.y, r: r },
+        { showEye: true, showUnread: false, count: count },
+      );
     })
     .join("");
 

--- a/hub/frontend/src/activity-tab/topology.ts
+++ b/hub/frontend/src/activity-tab/topology.ts
@@ -343,11 +343,13 @@ export function _renderActivityTopology(visible, grid) {
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="minus" title="Zoom out (−)">−</button>' +
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="reset" title="Reset zoom (0)">0</button>' +
     '<button type="button" class="topo-ctrl-btn" data-topo-ctrl="plus" title="Zoom in (+)">+</button>' +
-    /* todo#305: 整列 (Tidy) button — runs concentric-ring auto-layout
-     * (inner = channels, outer = agents + human) with two light
-     * repulsion passes so overlapping nodes spread out. Layout only
-     * runs on explicit click; drag / zoom / pan are unchanged. */
-    '<button type="button" class="topo-ctrl-btn topology-autolayout-btn" data-topo-ctrl="integrate" title="整列 (auto-layout: channels inner, agents outer)">整列</button>' +
+    /* todo#305 + PR #<this> Item 7: "Reset Layout" button — runs
+     * concentric-ring auto-layout (inner = channels, outer = agents +
+     * human) with force-directed repulsion so overlapping nodes spread
+     * out. Layout only runs on explicit click; drag / zoom / pan are
+     * unchanged. Internal action name stays `integrate` so existing
+     * dispatcher logic (zoompan.ts) continues to route correctly. */
+    '<button type="button" class="topo-ctrl-btn topology-autolayout-btn" data-topo-ctrl="integrate" title="Reset Layout (channels inner ring, agents outer ring)">Reset Layout</button>' +
     "</div>";
   var pool = _topoBuildPoolHtml(visible, channels);
   /* todo#67 — Time seekbar + play button docked at the bottom of the

--- a/hub/frontend/src/agent-badge-svg.ts
+++ b/hub/frontend/src/agent-badge-svg.ts
@@ -356,12 +356,18 @@ import { escapeHtml, getAgentColor } from "./app/utils";
         var eyeCls =
           "topo-agent-eye " +
           (hiddenFlag ? "topo-agent-eye-off" : "topo-agent-eye-on");
+        /* Item 12 (msg#15661): brighten visible-state and keep hidden
+         * eye grey so the red slash carries the dominant cue. Mirrors
+         * the channel eye so both entity types read identically. */
+        var eyeFill = hiddenFlag ? "#64748b" : "#cbd5e1";
         var eyeGlyph =
           '<text x="' +
           eyeX.toFixed(1) +
           '" y="' +
           (y + 4).toFixed(1) +
-          '" font-size="11" text-anchor="middle" fill="#94a3b8" style="cursor:pointer">\uD83D\uDC41</text>';
+          '" font-size="11" text-anchor="middle" fill="' +
+          eyeFill +
+          '" style="cursor:pointer">\uD83D\uDC41</text>';
         var strike = hiddenFlag
           ? '<line x1="' +
             (eyeX - 5).toFixed(1) +
@@ -371,7 +377,7 @@ import { escapeHtml, getAgentColor } from "./app/utils";
             (eyeX + 5).toFixed(1) +
             '" y2="' +
             (y - 3).toFixed(1) +
-            '" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round" pointer-events="none"/>'
+            '" stroke="#ef4444" stroke-width="2" stroke-linecap="round" pointer-events="none"/>'
           : "";
         eyeSvg =
           '<g class="' +

--- a/hub/frontend/src/app/channel-prefs.ts
+++ b/hub/frontend/src/app/channel-prefs.ts
@@ -267,6 +267,15 @@ export function _sortedStarred() {
     });
 }
 
+/* PR #<this> Item 1 (SSoT audit): this function predates channel-badge.ts
+ * and renders its own inline channel-row markup. The DOM elements it
+ * targets (#starred-heading, #starred-channels) do NOT exist in the
+ * current dashboard.html / workspace_settings.html templates — the
+ * function returns early on every call. Kept as-is to avoid surprise
+ * removal in a polish PR; the next time a "Starred" subsection UI
+ * surface is needed, this renderer MUST be rewritten to delegate to
+ * renderChannelBadgeHtml(ch, {context:"starred", ...}) rather than
+ * forking the markup again. */
 export function _renderStarredSection() {
   var heading = document.getElementById("starred-heading");
   var container = document.getElementById("starred-channels");

--- a/hub/frontend/src/app/context-menus.ts
+++ b/hub/frontend/src/app/context-menus.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { _agentSubscribe, _openAgentDmSimple, _toggleAgentChannelSubscription, openChannelExport } from "./agent-actions";
-import { _setAgentIcon, _setChannelIcon, _setChannelPref } from "./channel-prefs";
+import { _setChannelPref } from "./channel-prefs";
 import { _channelPrefs } from "./members";
 import { escapeHtml, userName } from "./utils";
 
@@ -34,39 +34,31 @@ export var _ctxMenu = null;
 export function _showChannelCtxMenu(ch, x, y) {
   _hideChannelCtxMenu();
   var prefs = _channelPrefs[ch] || {};
-  var starred = prefs.is_starred;
-  var muted = prefs.is_muted;
-  var hidden = prefs.is_hidden;
   var notif = prefs.notification_level || "all";
+  /* Item 13 (msg#15675): star/mute/hidden state is read directly via
+   * the channel-badge icons in sidebar/graph — this menu no longer
+   * toggles them. Locals removed to reflect the narrower scope. */
 
   var menu = document.createElement("div");
   menu.className = "ch-ctx-menu";
   menu.style.cssText =
     "position:fixed;z-index:9999;left:" + x + "px;top:" + y + "px;";
-  /* Reserve a fixed-width glyph slot at the start of every row so the
-   * channel-name / label column lines up whether a row has a prefix
-   * (☆/★/🔇/🔔/⤓) or not. Without the empty placeholder, rows without a
-   * glyph start flush-left and names jitter into misaligned columns.
-   * todo#99. ywatanabe 2026-04-19. */
-  var G_STAR_OFF = "\u2606"; /* ☆ */
-  var G_STAR_ON = "\u2605"; /* ★ */
-  var G_MUTE_OFF = "\uD83D\uDD14"; /* 🔔 bell — mute OFF (will mute on click) */
-  var G_MUTE_ON = "\uD83D\uDD15"; /* 🔕 bell-with-slash — currently muted */
   var G_EXPORT = "\u2935"; /* ⤵ export */
   var G_EMPTY = "";
   function _glyph(g) {
     return '<span class="ch-ctx-glyph">' + g + "</span>";
   }
+  /* Item 13 (lead msg#15675 / msg#15678) — deduplicate the channel
+   * right-click menu against the direct badge icons (★ / 👁 / 🔔 / icon).
+   * Lead's canonical delete-list: Star, Mute, Set Icon, Clear Icon,
+   * Delete Channel, Show Channel, Hide Channel, Mute Notifications.
+   * Kept: Export Channel (no icon equivalent). Also kept: Notifications
+   * level chooser (All / @ Mentions only / Nothing) — this is a 3-way
+   * selector and is NOT duplicated by the bell icon's boolean toggle,
+   * so it survives the dedup. Also kept: "Hide node (Viz topology)" —
+   * this is a session-only viz hide, distinct from the persistent
+   * eye-icon is_hidden that propagates across surfaces. */
   menu.innerHTML = [
-    '<div class="ch-ctx-item" data-action="star">' +
-      _glyph(starred ? G_STAR_ON : G_STAR_OFF) +
-      (starred ? "Unstar" : "Star channel") +
-      "</div>",
-    '<div class="ch-ctx-item" data-action="mute">' +
-      _glyph(muted ? G_MUTE_ON : G_MUTE_OFF) +
-      (muted ? "Unmute" : "Mute channel") +
-      "</div>",
-    '<div class="ch-ctx-sep"></div>',
     '<div class="ch-ctx-label">Notifications</div>',
     '<div class="ch-ctx-item ch-ctx-notif' +
       (notif === "all" ? " ch-ctx-active" : "") +
@@ -84,21 +76,9 @@ export function _showChannelCtxMenu(ch, x, y) {
       _glyph(G_EMPTY) +
       "Nothing</div>",
     '<div class="ch-ctx-sep"></div>',
-    '<div class="ch-ctx-item" data-action="set-icon">' +
-      _glyph("\uD83C\uDFA8") +
-      "Set icon\u2026</div>",
-    '<div class="ch-ctx-item" data-action="clear-icon">' +
-      _glyph(G_EMPTY) +
-      "Clear icon</div>",
-    '<div class="ch-ctx-sep"></div>',
     '<div class="ch-ctx-item ch-ctx-export" data-action="export">' +
       _glyph(G_EXPORT) +
       "Export channel\u2026</div>",
-    '<div class="ch-ctx-sep"></div>',
-    '<div class="ch-ctx-item ch-ctx-hide" data-action="hide">' +
-      _glyph(G_EMPTY) +
-      (hidden ? "Show channel" : "Hide channel") +
-      "</div>",
     '<div class="ch-ctx-sep"></div>',
     '<div class="ch-ctx-item ch-ctx-hide" data-action="topo-hide">' +
       _glyph(G_EMPTY) +
@@ -112,9 +92,11 @@ export function _showChannelCtxMenu(ch, x, y) {
   menu.querySelectorAll(".ch-ctx-item").forEach(function (item) {
     item.addEventListener("click", function () {
       var action = item.getAttribute("data-action");
-      if (action === "star") _setChannelPref(ch, { is_starred: !starred });
-      else if (action === "mute") _setChannelPref(ch, { is_muted: !muted });
-      else if (action === "notif-all")
+      /* Item 13: trimmed action set — star / mute / hide / set-icon /
+       * clear-icon are now handled exclusively by the channel-badge
+       * icons (delegation in channel-badge.ts attachChannelBadgeHandlers).
+       * Remaining: notification-level trio, export, topo-hide. */
+      if (action === "notif-all")
         _setChannelPref(ch, { notification_level: "all" });
       else if (action === "notif-mentions")
         _setChannelPref(ch, { notification_level: "mentions" });
@@ -124,22 +106,7 @@ export function _showChannelCtxMenu(ch, x, y) {
         _hideChannelCtxMenu();
         openChannelExport(ch);
         return;
-      } else if (action === "set-icon") {
-        _hideChannelCtxMenu();
-        if (typeof window.openEmojiPicker === "function") {
-          window.openEmojiPicker(function (emoji) {
-            _setChannelIcon(ch, { icon_emoji: emoji });
-          });
-        }
-        return;
-      } else if (action === "clear-icon") {
-        _setChannelIcon(ch, {
-          icon_emoji: "",
-          icon_image: "",
-          icon_text: "",
-        });
-      } else if (action === "hide") _setChannelPref(ch, { is_hidden: !hidden });
-      else if (action === "topo-hide") {
+      } else if (action === "topo-hide") {
         if (typeof window._topoHide === "function") {
           try {
             window._topoHide("channel", ch);
@@ -240,13 +207,18 @@ export function _showAgentContextMenu(agent, x, y) {
       '<div class="ch-ctx-item ch-ctx-hide" data-topo-hide="1">' +
       "Hide node (Viz topology)</div>"
     : "";
+  /* Item 13 (msg#15675 / msg#15678) — same dedup principle as the
+   * channel ctx-menu: drop icon-equivalent rows. The agent avatar is
+   * already an .avatar-clickable trigger for the emoji picker (see
+   * agent-badge.ts), so "Set icon" / "Clear icon" here duplicate the
+   * icon affordance. Kept: Add-to / DM / Remove-from submenus (no
+   * icon equivalent), plus the session-only "Hide node (Viz
+   * topology)" row which is distinct from the persistent eye-icon
+   * is_hidden that propagates across surfaces. */
   menu.innerHTML = [
     '<div class="ch-ctx-label">Agent: ' + escapeHtml(agent) + "</div>",
     '<div class="ch-ctx-item ch-ctx-sub" data-sub="add">Add to channel&nbsp;&hellip; &#9656;</div>',
     '<div class="ch-ctx-item ch-ctx-sub" data-sub="dm">DM with agent&nbsp;&hellip; &#9656;</div>',
-    '<div class="ch-ctx-sep"></div>',
-    '<div class="ch-ctx-item" data-action="set-icon">\uD83C\uDFA8 Set icon\u2026</div>',
-    '<div class="ch-ctx-item" data-action="clear-icon">Clear icon</div>',
     '<div class="ch-ctx-sep"></div>',
     '<div class="ch-ctx-item ch-ctx-sub ch-ctx-hide" data-sub="remove">Remove from channel&nbsp;&hellip; &#9656;</div>',
     hideRow,
@@ -264,32 +236,10 @@ export function _showAgentContextMenu(agent, x, y) {
       _hideAgentCtxMenu();
     });
   }
-  /* Set icon — emoji picker for the agent's AgentProfile.icon_emoji.
-   * Mirrors the channel "Set icon" flow in _showChannelCtxMenu so
-   * configuration is uniform across entity types (TODO.md Entity
-   * Consistency: "Icons (svg/png) must be configurable"). */
-  var setIconItem = menu.querySelector('.ch-ctx-item[data-action="set-icon"]');
-  if (setIconItem) {
-    setIconItem.addEventListener("click", function (ev) {
-      ev.stopPropagation();
-      _hideAgentCtxMenu();
-      if (typeof window.openEmojiPicker === "function") {
-        window.openEmojiPicker(function (emoji) {
-          _setAgentIcon(agent, { icon_emoji: emoji });
-        });
-      }
-    });
-  }
-  var clearIconItem = menu.querySelector(
-    '.ch-ctx-item[data-action="clear-icon"]',
-  );
-  if (clearIconItem) {
-    clearIconItem.addEventListener("click", function (ev) {
-      ev.stopPropagation();
-      _setAgentIcon(agent, { icon_emoji: "" });
-      _hideAgentCtxMenu();
-    });
-  }
+  /* Item 13: "Set icon" / "Clear icon" rows dropped here — the agent
+   * avatar carries .avatar-clickable which opens the emoji picker
+   * directly (see agent-badge.ts, delegated in sidebar-agents.ts /
+   * dms.ts / agents-tab/overview.ts). */
 
   var subEl = null;
   function openSub(anchor, html, onPick) {

--- a/hub/frontend/src/channel-badge.ts
+++ b/hub/frontend/src/channel-badge.ts
@@ -348,14 +348,24 @@ import { escapeHtml } from "./app/utils";
     // Eye — always rendered when showEye, with the SAME 👁 glyph in
     // both states and a red strike when hidden. Wrapped in a <g> so
     // the strike shares the click target (mirrors agent eye SVG).
+    //
+    // Item 12 (msg#15661): visible-state fill bumped from #94a3b8
+    // (slate-400) to #cbd5e1 (slate-300) so the eye reads brightly on
+    // the graph canvas, matching the sidebar CSS .ch-eye-on tone. The
+    // hidden-state eye body stays a dim grey (#64748b) and the slash
+    // becomes the dominant semantic cue — red-500 (#ef4444) at
+    // stroke-width 2 so it reads cleanly at canvas font-size 11.
     var eyeGlyph = "";
     if (showEye) {
+      var eyeFill = m.isHidden ? "#64748b" : "#cbd5e1";
       var eyeText =
         '<text x="' +
         eyeX.toFixed(1) +
         '" y="' +
         (y + 4).toFixed(1) +
-        '" font-size="11" text-anchor="middle" fill="#94a3b8" style="cursor:pointer">\uD83D\uDC41</text>';
+        '" font-size="11" text-anchor="middle" fill="' +
+        eyeFill +
+        '" style="cursor:pointer">\uD83D\uDC41</text>';
       var eyeStrike = "";
       if (m.isHidden) {
         eyeStrike =
@@ -367,7 +377,7 @@ import { escapeHtml } from "./app/utils";
           (eyeX + 5).toFixed(1) +
           '" y2="' +
           (y - 3).toFixed(1) +
-          '" stroke="#ef4444" stroke-width="1.5" stroke-linecap="round" pointer-events="none"/>';
+          '" stroke="#ef4444" stroke-width="2" stroke-linecap="round" pointer-events="none"/>';
       }
       eyeGlyph =
         '<g class="topo-ch-eye ch-eye' +

--- a/hub/frontend/src/index.ts
+++ b/hub/frontend/src/index.ts
@@ -75,6 +75,7 @@ import "./activity-tab/grid-click";
 import "./activity-tab/grid-mouse";
 import "./activity-tab/grid-ctx";
 import "./activity-tab/grid-hover";
+import "./activity-tab/channel-hover-preview";
 import "./activity-tab/grid-delegation";
 import "./activity-tab/controls";
 import "./activity-tab/init";

--- a/hub/frontend/src/tabs.ts
+++ b/hub/frontend/src/tabs.ts
@@ -2,6 +2,7 @@
 import { refreshActivityFromApi, startActivityAutoRefresh } from "./activity-tab/data";
 import { renderAgentsTab } from "./agents-tab/overview";
 import { restoreDraftForCurrentChannel } from "./chat/chat-composer";
+import { loadChannelHistory } from "./chat/chat-history";
 import { fetchFiles } from "./files-tab/files-tab-grid";
 import { renderResourcesTab } from "./resources-tab/tab";
 import { fetchSettings } from "./settings-tab";
@@ -9,12 +10,55 @@ import { renderTerminalTab } from "./terminal-tab";
 import { fetchTodoList } from "./todo-tab/todo-tab-list";
 import { renderVizTab, stopVizTab } from "./viz-tab";
 import { fetchWorkspaces } from "./workspaces-tab";
+import { setCurrentChannel } from "./app/state";
+import { channelUnread } from "./app/utils";
 
 /* Tab switching, collapsible sections, mobile sidebar */
 /* globals: activeTab, fetchTodoList, renderAgentsTab, renderResourcesTab,
    fetchWorkspaces */
 
 export var activeTab = "chat";
+
+/* PR #<this> Item 3 helper: pick a sensible default channel when the
+ * Chat tab is activated without one. Preference order:
+ *   1. Channel with the highest unread count (proxy for "most recently
+ *      posted / most relevant right now").
+ *   2. First sidebar channel row in document order (i.e. first in the
+ *      user's star-sorted list).
+ * Returns null if no candidate exists (empty sidebar / first load
+ * before the stats fetch returns). Caller is responsible for null
+ * handling — we intentionally do NOT set a placeholder channel. */
+function _pickFallbackChannel(): string | null {
+  try {
+    /* 1. Highest unread. channelUnread keys are channel names (raw or
+     *    normalised). We filter out DM channels since those are owned
+     *    by the DM surface; Chat fallback should land on a group
+     *    channel. */
+    var best: string | null = null;
+    var bestCount = 0;
+    var unread = (channelUnread as Record<string, number>) || {};
+    Object.keys(unread).forEach(function (k) {
+      if (!k || k.indexOf("dm:") === 0) return;
+      var n = unread[k] || 0;
+      if (n > bestCount) {
+        bestCount = n;
+        best = k;
+      }
+    });
+    if (best) return best;
+    /* 2. First sidebar channel row. Skip hidden/dm rows. */
+    var row = document.querySelector(
+      '.sidebar .channel-item:not([data-hidden="1"])',
+    );
+    if (row) {
+      var ch = row.getAttribute("data-channel");
+      if (ch && ch.indexOf("dm:") !== 0) return ch;
+    }
+  } catch (_) {
+    /* Never let a fallback-pick error break the tab activation. */
+  }
+  return null;
+}
 
 export function _activateTab(tab) {
   activeTab = tab;
@@ -62,6 +106,45 @@ export function _activateTab(tab) {
      * vanishes after the first tab switch. Banner content already tracks
      * the textarea target (see app.js _updateChannelTopicBanner). */
     if (topicBanner) topicBanner.style.display = "";
+    /* PR #<this> Item 3: Chat tab single-channel enforcement. On mount,
+     * if no channel is currently selected (and we're not in a DM), auto-
+     * select a reasonable default — prefer the channel with the most
+     * unread messages (closest proxy to "most recently posted"), fall
+     * back to the first visible sidebar channel. Never leave the Chat
+     * tab in the "Type a message (no channel selected)" state from its
+     * normal flow — that placeholder should only be reachable from the
+     * all-channels filter entry, never from Chat's mount path.
+     *
+     * DM exception: if the user is in a DM thread (currentChannel starts
+     * with "dm:"), we don't interfere — DMs are first-class chat
+     * targets. */
+    var cur = (globalThis as any).currentChannel;
+    var inDm = typeof cur === "string" && cur.indexOf("dm:") === 0;
+    if (!cur && !inDm) {
+      var picked = _pickFallbackChannel();
+      if (picked) {
+        setCurrentChannel(picked);
+        if (typeof loadChannelHistory === "function")
+          loadChannelHistory(picked);
+        /* Flip .selected on the sidebar row so the visual matches the
+         * state; the full sidebar re-render on next stats fetch will
+         * idempotently do the same, but this makes the transition feel
+         * instant. */
+        document
+          .querySelectorAll(
+            ".sidebar .channel-item.selected, .sidebar .dm-item.selected",
+          )
+          .forEach(function (it) {
+            it.classList.remove("selected");
+          });
+        var row = document.querySelector(
+          '.sidebar .channel-item[data-channel="' +
+            picked.replace(/"/g, '\\"') +
+            '"]',
+        );
+        if (row) row.classList.add("selected");
+      }
+    }
     /* Always default-focus the compose input when the chat tab is shown.
      * Per ywatanabe spec (msg 5470, 2026-04-12): the compose textarea is
      * the primary action target on the chat tab, so the user should never

--- a/hub/static/hub/activity-tab/activity-tab-list.css
+++ b/hub/static/hub/activity-tab/activity-tab-list.css
@@ -199,16 +199,14 @@
   align-items: center;
   gap: 4px;
   /* ywatanabe 2026-04-21: tighter row height so more agents fit.
-   * msg#15599 Task A: border-left widened to 2px (vs the 1px all-
-   * around border) so the agent row's content-start sits at the SAME
-   * x as the Channels section (.sidebar .channel-item in
-   * style-channels.css carries a 2px left accent stripe). The border
-   * stays transparent on agents — accent colour is applied to the
-   * NAME text (via inline color in agent-badge.ts renderAgentName),
-   * mirroring how Channels now colorize the name (style-channels.css
-   * .sidebar .channel-item .ch-name rule). Top/right/bottom borders
-   * held at 1px so the hover outline (border-color #2a2a2a below)
-   * still draws a visible frame on three sides. */
+   * msg#15599 Task A originally widened border-left to 2px to match
+   * a corresponding 2px accent stripe on the Channels section; PR
+   * #<this> Item 2 removed that Channels stripe per ywatanabe
+   * msg#15608 ("left bar disliked"). To keep both sidebar sections
+   * column-aligned, the agent row reverts to a uniform 1px transparent
+   * border on all four sides. Accent colour continues to be applied to
+   * the name text via inline color in agent-badge.ts renderAgentName
+   * (identity-on-name matches Channels' .ch-name colour rule). */
   padding: 1px 6px;
   margin-bottom: 1px;
   border-radius: 3px;
@@ -217,7 +215,6 @@
   font-size: 11px;
   background: transparent;
   border: 1px solid transparent;
-  border-left-width: 2px;
   transition:
     background 0.15s,
     border-color 0.15s;

--- a/hub/static/hub/style/style-agents.css
+++ b/hub/static/hub/style/style-agents.css
@@ -496,17 +496,28 @@
   line-height: 1;
   font-size: 11px;
   /* Monochrome so the color emoji doesn't outscreech the surrounding
-   * ★ / LEDs. Matches the .ch-mute and .ch-eye treatment. */
+   * ★ / LEDs. Matches the .ch-mute and .ch-eye treatment. Item 12
+   * (msg#15661): default tone bumped from #94a3b8 to #cbd5e1 so the
+   * visible-state eye reads brightly; -off variant overrides back to
+   * dim grey for the hidden state. */
   filter: grayscale(1);
-  color: #94a3b8;
+  color: #cbd5e1;
   cursor: pointer;
   position: relative;
 }
 .agent-badge-eye-on {
-  opacity: 0.7;
+  /* Item 12: visible state — brighter glyph (slate-300). Opacity
+   * bumped from 0.7 to 1.0 so the brightened colour actually reaches
+   * the viewer; previous 0.7 muted the new tone back to the old
+   * ambiguous grey. */
+  opacity: 1;
+  color: #cbd5e1;
 }
 .agent-badge-eye-off {
-  opacity: 0.9;
+  /* Item 12: hidden state — grey eye body, red slash (below) is the
+   * dominant semantic cue. */
+  opacity: 0.85;
+  color: #64748b;
 }
 .agent-badge-eye-off::after {
   content: "";
@@ -514,7 +525,9 @@
   left: 1px;
   right: 1px;
   top: 50%;
-  height: 2px;
+  /* Item 12: bump slash to 2.5 px so it reads cleanly over the grey
+   * glyph, matching .ch-eye-off::after. */
+  height: 2.5px;
   background: #ef4444;
   transform: rotate(-20deg);
   transform-origin: center;

--- a/hub/static/hub/style/style-base.css
+++ b/hub/static/hub/style/style-base.css
@@ -405,11 +405,10 @@ body {
    * msg#15599: padding + gap unified pixel-for-pixel with
    * .sidebar-agent-row (activity-tab-list.css) so the icon and ★
    * columns land at the SAME x from the row's left edge in both
-   * sections. The 2px left border (transparent fallback, tinted via
-   * --channel-accent when set; see style-channels.css) accounts for
-   * the accent stripe from PR #306 task 4. Agent rows carry a
-   * matching transparent border-left so both content boxes start
-   * 2+6=8px from the outer edge. */
+   * sections. PR #<this> Item 2: the prior 2px left accent stripe was
+   * removed (ywatanabe msg#15608 disliked the left bar) — both
+   * channel rows and agent rows now carry uniform 1px transparent
+   * borders so both content boxes start ~7px from the outer edge. */
   margin-bottom: 2px;
   padding: 1px 6px;
   border-radius: 4px;

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -257,15 +257,18 @@
  * "eye hidden should use the same glyph with a red strike, matching
  * the bell". */
 .ch-eye-on {
-  /* PR #<this> Item 5: visible state — normal-colour mid-grey glyph,
-   * same visual weight as the agent row's eye. NOT the row accent
-   * colour — this is state feedback, not identity. */
+  /* Item 12 (msg#15661): visible-state glyph bumped from mid-grey
+   * #94a3b8 (slate-400) to brighter slate-300 #cbd5e1 so "channel is
+   * visible" reads unambiguously on the dark sidebar. Previous tone
+   * was dim enough to be misread as a disabled/hidden state. */
   opacity: 1;
-  color: #94a3b8;
+  color: #cbd5e1;
 }
 .ch-eye-off {
-  /* Hidden state — dimmer grey + red-strike ::after overlay (below). */
-  opacity: 0.75;
+  /* Item 12: eye body stays grey; the dominant semantic cue is the
+   * red diagonal slash in ::after below. Slightly more opaque so the
+   * grey glyph reads through the red overlay. */
+  opacity: 0.85;
   filter: none;
   color: #64748b;
   position: relative;
@@ -276,7 +279,10 @@
   left: 1px;
   right: 1px;
   top: 50%;
-  height: 2px;
+  /* Item 12: bump stroke from 2 → 2.5 px so the red slash reads
+   * cleanly on the 14 px eye glyph against both sidebar-bg and
+   * graph-canvas-bg. Colour stays Tailwind red-500 per spec. */
+  height: 2.5px;
   background: #ef4444;
   transform: rotate(-20deg);
   transform-origin: center;

--- a/hub/static/hub/style/style-channels.css
+++ b/hub/static/hub/style/style-channels.css
@@ -216,8 +216,11 @@
 .ch-pin-off {
   /* ywatanabe 2026-04-21 msg#15131: "全部今暗くなってて見にくい...
      普通に見えるように". Icons stay at normal brightness instead of
-     the prior hover-reveal pattern. */
+     the prior hover-reveal pattern.
+     PR #<this> Item 5: outlined-grey glyph, readable without being
+     loud — mid-grey matches the agent row's neutral glyph weight. */
   opacity: 1;
+  color: #94a3b8;
 }
 .channel-item:hover .ch-star-off,
 .channel-item:hover .ch-pin-off,
@@ -226,7 +229,12 @@
   opacity: 0.7;
 }
 .ch-star-on {
-  color: #f5a623;
+  /* PR #<this> Item 5: starred state uses a brighter filled yellow so
+   * the "this channel is starred" signal reads at the same saturation
+   * weight as agent LED greens / the pinned-agent yellow. #fbbf24 is
+   * the same tint the SVG canvas star uses (channel-badge renderSvg). */
+  color: #fbbf24;
+  opacity: 1;
 }
 .ch-pin-on {
   opacity: 1;
@@ -249,11 +257,17 @@
  * "eye hidden should use the same glyph with a red strike, matching
  * the bell". */
 .ch-eye-on {
+  /* PR #<this> Item 5: visible state — normal-colour mid-grey glyph,
+   * same visual weight as the agent row's eye. NOT the row accent
+   * colour — this is state feedback, not identity. */
   opacity: 1;
+  color: #94a3b8;
 }
 .ch-eye-off {
+  /* Hidden state — dimmer grey + red-strike ::after overlay (below). */
   opacity: 0.75;
   filter: none;
+  color: #64748b;
   position: relative;
 }
 .ch-eye-off::after {
@@ -284,20 +298,31 @@
  * encodes the slash (U+1F515 "bell with slash"); no extra overlay
  * needed. */
 .ch-mute {
+  /* PR #<this> Item 5: bell glyph saturation bumped to match the agent
+   * LED visual weight. Keep grayscale filter for muted (see ch-mute-on)
+   * but let the not-muted / "notifications on" state carry a little
+   * more warmth so the read isn't flat against the sidebar. */
   filter: grayscale(1);
   opacity: 0.7;
   color: #94a3b8;
 }
 .ch-mute-on {
-  /* Muted — bell-with-slash glyph, slightly dimmer than the default
-   * state so the "notifications are off" read is not louder than
-   * "notifications are on". */
-  opacity: 0.55;
+  /* Muted — bell-with-slash glyph at neutral grey, dimmer than the
+   * active state. The slash glyph itself encodes "off"; no extra
+   * colour cue. */
+  opacity: 0.6;
+  color: #64748b;
 }
 .ch-mute-off {
-  /* Not muted — neutral bell, monochrome, same weight as the other
-   * row icons. No yellow emphasis. */
-  opacity: 0.7;
+  /* Not muted — bell glyph at medium-bright so the "notifications on"
+   * state reads at the same saturation as agent LED greens / star
+   * yellow, without overriding the row's per-channel accent colour.
+   * #fbbf24 (bell yellow) would compete with ch-star-on; go with a
+   * soft gold instead. Item 5 explicit ask: "medium-bright colour
+   * (bell-yellow or similar to agent highlight)". */
+  filter: none;
+  opacity: 0.9;
+  color: #e0b87a;
 }
 .channel-item:hover .ch-mute {
   opacity: 1;
@@ -362,28 +387,23 @@
  *      only cascades to CSS-coloured glyphs: the default "#" text and
  *      emoji text via `color:`). Image avatars (img.agent-avatar) are
  *      bitmaps, so the tint doesn't bleed into user-uploaded icons.
- *   2. 2px left-edge stripe on the row so the accent is visible even
- *      when the channel uses an image avatar.
+ *   2. Row name text tinted to the accent (see .ch-name rule below).
  *
  * Intentionally NOT coloured:
- *   - Row background — PR #293's subtle .selected background rule owns
- *     selection signalling. Adding a row-level tint would either mask
- *     or compete with .selected.
- *   - Row text / opacity — PR #295 / #291 banned per-row font-weight
+ *   - Row background — the .selected rounded-rect tint owns selection
+ *     signalling. Adding a row-level tint would compete with .selected.
+ *   - Row text opacity — PR #295 / #291 banned per-row font-weight
  *     and opacity-based dimming.
- *   - 🔔/👁/★ glyphs (ch-mute/ch-eye/ch-star) — monochrome signal icons
- *     per spec. Only the category icon at slot 1 carries colour. */
+ *   - 🔔/👁/★ glyphs — state icons, not identity icons.
+ *
+ * PR #<this> Item 2 (lead msg#15608): the 2px left-edge accent bar is
+ * REMOVED. ywatanabe explicitly disliked the left bar; selection
+ * signalling now uses the subtle rounded-rect background (Item 6).
+ * Unselected rows are plain — no left stripe, no right stripe. */
 .sidebar .channel-item {
-  /* Fallback to the existing muted text colour when no accent is set
-   * (e.g. renderChannelBadgeHtml called with no channelBadgeModel). */
-  border-left: 2px solid var(--channel-accent, transparent);
-  /* .channel-item in style-base.css already carries padding: 1px 6px
-   * (unified with .sidebar-agent-row per msg#15599 column-align spec).
-   * The 2px border-left above stacks on top of that 6px, giving a
-   * content start of 8px from the outer edge — matched by the
-   * transparent border-left applied to .sidebar-agent-row in
-   * activity-tab-list.css, so the icon / ★ columns line up across
-   * the Agents and Channels sidebar sections. */
+  /* No border-left here — Item 2 removed the accent bar. Row-level
+   * styling kept empty-but-present so future accent-adjacent rules
+   * (drag handles, drop targets, etc.) have a stable anchor. */
 }
 .sidebar .channel-item .ch-identity-icon {
   color: var(--channel-accent, inherit);

--- a/hub/static/hub/style/style-menus.css
+++ b/hub/static/hub/style/style-menus.css
@@ -213,6 +213,83 @@
   color: #f8f7f5;
 }
 
+/* ── Channel hover preview (Item 11 / lead msg#15646) ──
+ * Anchored near a .topo-channel node on the Agents tab graph when
+ * the user settles on it for 300 ms. Shows the last 7 messages from
+ * that channel (GET /api/history/<ch>/?limit=7). Styled to match the
+ * chat feed's message-cell typography so the preview reads like a
+ * mini embedded thread, but visually distinct from the context
+ * menu (slightly wider, no rounded hover rows). */
+.channel-hover-popover {
+  background: #0d1e2e;
+  border: 1px solid #1e3a4a;
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.7);
+  width: 320px;
+  max-width: 90vw;
+  max-height: 280px;
+  font-size: 12px;
+  color: #ccc;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.channel-hover-popover .chp-header {
+  padding: 6px 10px;
+  background: #0a1824;
+  border-bottom: 1px solid #1e3a4a;
+  font-weight: 600;
+  color: #e0e6ee;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.channel-hover-popover .chp-hint {
+  font-size: 10px;
+  color: #567;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 400;
+}
+.channel-hover-popover .chp-body-scroll {
+  overflow-y: auto;
+  padding: 4px 0;
+}
+.channel-hover-popover .chp-row {
+  padding: 4px 10px 6px;
+  border-bottom: 1px solid rgba(30, 58, 74, 0.4);
+}
+.channel-hover-popover .chp-row:last-child {
+  border-bottom: none;
+}
+.channel-hover-popover .chp-meta {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  font-size: 11px;
+  margin-bottom: 1px;
+}
+.channel-hover-popover .chp-sender {
+  color: #8ac;
+  font-weight: 600;
+}
+.channel-hover-popover .chp-ts {
+  color: #567;
+  font-size: 10px;
+}
+.channel-hover-popover .chp-body {
+  color: #ccd;
+  line-height: 1.35;
+  word-break: break-word;
+}
+.channel-hover-popover .chp-empty,
+.channel-hover-popover .chp-loading {
+  padding: 10px 12px;
+  color: #567;
+  font-style: italic;
+  text-align: center;
+}
+
 /* ── Channel export modal ── */
 .ch-export-modal {
   position: fixed;

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -145,21 +145,22 @@ blockquote.chat-blockquote {
  * other rows keep their normal icons; the selected row is
  * distinguished only by a solid background".
  *
- * #294 (msg#15352 / #heads #15353): bump the accent alpha so the
- * selected row is UNAMBIGUOUSLY brighter than its siblings AND
- * clearly distinct from the row-hover state (:hover uses #1a1a1a,
- * a flat dark grey; the selected tint must read as an accent colour
- * rather than "slightly darker"). Text/icon styling stays identical
- * to unselected rows — only the background differs.
+ * PR #<this> Items 4+6 (lead msg#15618 / reference
+ * .playwright-cli/ctrl-click-selection-target-2026-04-21.png):
+ * the previous stark accent-teal tint (rgba 126/200/227, 0.35) read
+ * as "overloud" against the dark theme. Replace with a subtle
+ * neutral rounded-rect bg — matches the ctrl+click highlight
+ * ywatanabe liked in msg#15618. Same treatment for agents and DMs
+ * so the whole sidebar reads coherently; no left-accent bar, no
+ * outer glow, just a gentle rounded background tint.
  *
- * Applies to .sidebar .channel-item and .sidebar .agent-card (DMs
- * render as .agent-card so they inherit). */
-.sidebar .channel-item.selected {
-  background: rgba(126, 200, 227, 0.35);
-}
+ * Applies to .sidebar .channel-item, .sidebar .agent-card and
+ * .sidebar .dm-item. */
+.sidebar .channel-item.selected,
 .sidebar .agent-card.selected,
 .sidebar .dm-item.selected {
-  background: rgba(78, 205, 196, 0.35);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
 }
 /* #294: normalise font-weight on every sidebar channel/DM row so no
  * per-name rule (e.g. a stale .channel-item.active path, or a


### PR DESCRIPTION
## Summary

Step 2 of the PR #310 UI refactor — SSoT confirmation + a 10-item
raft of sidebar / graph polish driven by lead msg#15608 / #15618 /
#15637. Single big PR per lead approval.

## Items

1. **renderChannelBadge SSoT** — live call sites audited: sidebar
   (`sidebar-channel-tree.ts`), pool (`topology-pool.ts`), graph SVG
   (`topology-nodes.ts`) all delegate to `channel-badge.ts`.
   Remaining inline renderer (`_renderStarredSection` in
   `channel-prefs.ts`) targets DOM IDs that do not exist in current
   templates; flagged with migration note.
2. **Channel left-accent bar removed** — `style-channels.css`
   `.sidebar .channel-item` border-left deleted; matching 2px
   transparent border-left on agent rows (`activity-tab-list.css`)
   also dropped so both sections stay column-aligned with uniform
   1px frames.
3. **Chat auto-select channel on mount** — `tabs.ts` adds
   `_pickFallbackChannel()` (highest-unread first, falls back to
   first sidebar row). DM exception preserved. No Set<channel>
   multi-select accumulators were found to remove.
4. **Selection highlight softened** — `style-messages.css`
   `.channel-item.selected` / `.agent-card.selected` /
   `.dm-item.selected` unified to
   `rgba(255,255,255,0.08) + border-radius 6px` matching
   `.playwright-cli/ctrl-click-selection-target-2026-04-21.png`.
5. **Icon colorization** — `style-channels.css`: star -> `#fbbf24`
   on / `#94a3b8` off; eye -> mid-grey on, `#64748b` off with red-
   strike; bell -> soft gold `#e0b87a` not-muted, neutral `#64748b`
   muted. All saturations tuned to read at agent-LED weight without
   overriding the per-channel accent.
6. **Selection highlight = ctrl+click style** — folded into item 4
   (same rule now covers all three selectable row types).
7. **"Reset Layout" button** — `topology.ts`: Japanese label
   renamed; `data-topo-ctrl="integrate"` action preserved.
8. **Zero-overlap auto-layout** — `topology-autolayout.ts` replaces
   the 2-pass nudge with a force-directed relaxation loop
   (<=300 iter, strength decays 1.0 -> 0.3, early-exit on
   `overlapCount == 0`). Node repulsion radius bumped to 99px.
   Saturation detection logs a console warning when ideal ring
   spacing falls below the threshold.
9. **Channel nodes via badge SSoT only** — `topology-nodes.ts`
   drops the empty-string fallback; diamond shape was already gone
   post-#310.
10. **Graph paste no longer switches tabs** — `compose.ts`
    unconditional `ev.stopPropagation()` at the top of the graph-
    input paste handler. Root cause: paste was bubbling to
    `upload.ts msgInput.addEventListener("paste", ...)` which
    implicitly surfaced the Chat tab.

## Items 11 / 12 / 13 (folded in — commit 594d334, lead msg#15646/#15661/#15675)

11. **Channel hover preview** (msg#15646) — settled 300 ms hover on
    a `.topo-channel` graph node opens a floating popover anchored
    near the node, rendering the last 7 messages from that channel
    via the existing `GET /api/history/<ch>/?limit=7` endpoint (no
    backend work). Pointer entering the popover does NOT dismiss
    it so the user can read without chasing the popover; dismisses
    on pointerleave of node+popover or on outer click. Vanilla-TS
    / DOM-only, matches the sidebar's style. 5 s per-channel cache
    on the fetch result avoids re-fetching during rapid re-hovers;
    request-epoch counter discards late-arriving fetches for
    channels the user already moved away from. New file
    `activity-tab/channel-hover-preview.ts` + CSS
    `.channel-hover-popover` rules in `style-menus.css`; wired
    from `grid-delegation.ts`.
12. **Eye icon polish** (msg#15661) — visible-state glyph bumped
    from `#94a3b8` (slate-400) to `#cbd5e1` (slate-300) so "channel
    is visible" reads unambiguously. Hidden-state eye body stays
    dim grey (`#64748b`); red slash is the dominant semantic cue,
    stroke bumped to 2.5 px (CSS) / 2 px (SVG) for readability at
    the 11-14 px glyph size. Applied in
    `style-channels.css .ch-eye-on/-off`, its agent twin in
    `style-agents.css .agent-badge-eye-*`, and the graph SVG
    renderers (`channel-badge.ts` + `agent-badge-svg.ts`).
13. **Graph right-click menu dedup** (msg#15675 + msg#15678) —
    channel context menu dropped: Star, Mute, Set Icon, Clear
    Icon, Show Channel, Hide Channel (all duplicated by the badge
    ★/👁/🔔/icon glyphs). Kept: Export Channel (no icon
    equivalent), Notifications level chooser (3-way — not
    duplicated by the bell's boolean toggle), and "Hide node (Viz
    topology)" which is a session-only viz hide distinct from the
    persistent eye-icon `is_hidden`. Agent context menu: dropped
    Set Icon / Clear Icon (the avatar is already
    `.avatar-clickable` → emoji picker). Kept Add-to-channel / DM
    / Remove-from-channel submenus and "Hide node". All changes
    in `app/context-menus.ts`.

## Algorithm chosen for item 8

Concentric-ring seed (channels inner, agents + human outer) +
iterative force-directed repulsion with anchor attraction. Preferred
over pure force layout because the ring structure is semantic.
Strength decays linearly over the iteration cap so early passes do
bulk separation and late passes fine-tune without oscillation.
Early-exit on zero overlap keeps typical layouts fast.

## Root cause for item 10

Graph-popup textarea's paste event bubbled up to the body-attached
`msg-input` paste handler (`upload.ts handleClipboardPaste`). The
short-text code path in the graph popup never called
`stopPropagation()`, so the paste event kept propagating — when the
`msg-input` handler ran, its focus/activation cascade surfaced the
Chat tab. Fixed by unconditional `stopPropagation()` at the top of
the graph-input paste listener (short-text native textarea paste
still lands locally because we do NOT `preventDefault`).

## CI / Validation

- `npm run typecheck` clean (post-items-11/12/13)
- `npm run build` clean (716 KB bundle, 162 KB gzip post-fold)
- Reference image:
  `.playwright-cli/ctrl-click-selection-target-2026-04-21.png`

## Test plan

- [ ] Sidebar renders with no left-accent bar on channels
- [ ] Selected channel row shows subtle neutral rounded-rect tint
- [ ] Star / eye / bell glyphs read at agent-LED saturation weight
- [ ] Eye visible-state glyph reads brightly against dark sidebar
- [ ] Eye hidden-state shows a clear red slash over a dimmer glyph
- [ ] Hovering a channel graph node for 300 ms shows the last-7
      popover; popover stays open while cursor is on it
- [ ] Right-clicking a channel graph node shows only Notifications
      / Export / "Hide node (Viz topology)"
- [ ] Right-clicking an agent graph node shows Add / DM / Remove /
      Hide node (no Set Icon / Clear Icon)
- [ ] Chat tab mount auto-selects a channel (no "Type a message"
      placeholder from normal flow)
- [ ] DM threads still work without auto-override
- [ ] Topology button reads "Reset Layout" in English
- [ ] Reset Layout produces non-overlapping nodes at 15+ agents
- [ ] Graph double-click -> paste "hello" -> input gets "hello",
      Graph tab stays active
