### PR TITLE
fix(classifier): expand busy-marker set to kill false-positive stale flags

### DIFF
--- a/scripts/client/agent_meta_pkg/_classifier.py
+++ b/scripts/client/agent_meta_pkg/_classifier.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 from pathlib import Path
 
 _COMPOSE_CHEVRON = "❯"
@@ -26,30 +27,151 @@ _BYPASS_MARKERS = ("Bypass Permissions", "2. Yes, I accept")
 _DEVCHAN_MARKERS = ("1. I am using this for local development",)
 _YN_MARKERS = ("y/n", "[y/N]", "[Y/n]")
 
-# Markers that indicate the agent is actively doing something (busy /
-# animating). When present, the pane is NOT stale regardless of whether
-# the tail bytes changed between samples.
-_BUSY_ANIMATION_MARKERS = (
+# ---------------------------------------------------------------------------
+# Busy-marker groups (2026-04-21 expansion, fix/classifier-busy-markers-expand)
+#
+# Previously this was one opaque tuple of literal substrings. The
+# contradiction-log evidence from `~/.local/state/scitex/fleet-pane-
+# contradictions.log` (81 KB on head-mba, 480 KB on head-ywata-note-win)
+# showed several false-positive stale classifications where the pane
+# tail was byte-identical across cycles *but the agent was alive and
+# deliberating*. The fix is to split the marker set into documented
+# groups — each rationale-commented — so future additions have a clear
+# home and tests can target one group at a time.
+#
+# Semantics: any match in ANY group => pane is NOT stale.
+# ---------------------------------------------------------------------------
+
+# Group A: Claude Code spinner present-tense gerunds.
+# Rationale: the CC TUI rotates through a fixed set of "‑ing" verbs
+# while the model is streaming tokens. Observed variants include
+# Mulling / Pondering / Churning / Roosting / Thinking / Cogitating /
+# Musing / Reflecting / Working / Contemplating / Deliberating /
+# Considering / Analysing / Brewing / Baking / Cooking / Crunching.
+# We keep the bare form (no ellipsis) because tmux capture sometimes
+# drops the trailing … when wrapping.
+_BUSY_SPINNER_GERUNDS = (
     "Mulling",
-    "Mulling…",
-    "Mulling...",
     "Pondering",
-    "Pondering…",
-    "Pondering...",
     "Churning",
-    "Churning…",
-    "Churning...",
     "Roosting",
-    "Roosting…",
     "Thinking",
-    "Thinking…",
     "Cogitating",
     "Musing",
     "Reflecting",
     "Working",
-    "Working…",
-    "Working...",
+    "Contemplating",
+    "Deliberating",
+    "Considering",
+    "Analysing",
+    "Analyzing",
+    "Brewing",
+    "Baking",
+    "Cooking",
+    "Crunching",
+    "Simmering",
+    "Percolating",
+    "Noodling",
+    "Ruminating",
+)
+
+# Group B: Claude Code spinner past-tense "X for Ns" lines.
+# Rationale: immediately AFTER a streaming burst completes the TUI
+# shows `✻ Baked for 40s`, `✻ Brewed for 35s`, `✻ Cogitated for 39s`,
+# `✻ Cooked for 1m 28s` etc. This line is static (doesn't change until
+# the next turn) but absolutely indicates a live agent that just
+# finished thinking — a prime false-positive source for `stale`.
+# Observed verbatim in log: `Baked for`, `Brewed for`, `Cogitated for`,
+# `Cooked for`. Matched as substrings (no regex) because the duration
+# suffix varies.
+_BUSY_SPINNER_PAST_TENSE = (
+    "Baked for",
+    "Brewed for",
+    "Cogitated for",
+    "Cooked for",
+    "Mulled for",
+    "Pondered for",
+    "Churned for",
+    "Roosted for",
+    "Thought for",
+    "Mused for",
+    "Reflected for",
+    "Worked for",
+    "Contemplated for",
+    "Deliberated for",
+    "Considered for",
+    "Analysed for",
+    "Analyzed for",
+    "Crunched for",
     "Crunched",
+    "Simmered for",
+    "Percolated for",
+    "Noodled for",
+    "Ruminated for",
+)
+
+# Group C: "N local agent(s) still running" — strong liveness signal.
+# Rationale: the CC TUI footer shows this when the user has dispatched
+# `Agent(...)` subagents that are still working. Static text but the
+# main session is very much alive, just waiting on children.
+_BUSY_SUBAGENT_MARKERS = (
+    "local agent still running",
+    "local agents still running",
+    "Backgrounded agent",
+)
+
+# Group D: TodoWrite / task-list static views.
+# Rationale: the #1 false-positive class from the contradiction log.
+# When the agent renders its task list (`TodoWrite` output) the pane
+# looks like:
+#     1 tasks (0 done, 1 in progress, 0 open)
+#     ◼ pane-state classifier: 3rd-stale vs 4th-green contradiction dete…
+# The text is perfectly static between cycles (nothing animates) but
+# the agent is mid-deliberation. We match this via regex — the opaque
+# literal-substring approach can't handle the numeric variance.
+# The `_BUSY_ANIMATION_REGEXES` tuple below holds compiled patterns.
+_BUSY_TASK_LIST_MARKERS = (
+    # "◼" checkbox bullet is the distinctive TodoWrite in-progress glyph.
+    # Its presence anywhere in the scan window means the agent is
+    # tracking work — treat as alive.
+    "◼ ",
+)
+
+# Group E: regex patterns for busy markers that vary numerically /
+# temporally. Each entry: (compiled_pattern, human_rationale).
+_BUSY_ANIMATION_REGEXES: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"\d+\s+tasks?\s+\(\d+\s+done,\s+\d+\s+in\s+progress"),
+        "TodoWrite task-list header: 'N tasks (M done, K in progress...)'",
+    ),
+    (
+        re.compile(r"[✻✽✶✳✢✣]\s+[A-Z][a-z]+(?:ed|ted|ked|wed|ned|med|sed)\s+for\s+\d"),
+        "Claude Code past-tense spinner with star glyph ('✻ Baked for 40s')",
+    ),
+    (
+        re.compile(r"[✻✽✶✳✢✣]\s+[A-Z][a-z]+(?:ing|ling|ning|ming|ting|king)\b"),
+        "Claude Code present-tense spinner with star glyph ('✻ Mulling…')",
+    ),
+    (
+        re.compile(r"\(esc to interrupt\)"),
+        "Streaming-in-progress hint (redundant with _PROGRESS_MARKERS but cheap)",
+    ),
+    (
+        re.compile(r"Press up to edit queued messages?"),
+        "Queued-message hint — implies active session with pending work",
+    ),
+)
+
+# Consolidated literal-substring marker tuple (A + B + C + D + legacy).
+# Kept as a module-level attribute for back-compat with any caller that
+# imports `_BUSY_ANIMATION_MARKERS` directly (e.g. tests).
+_BUSY_ANIMATION_MARKERS: tuple[str, ...] = (
+    *_BUSY_SPINNER_GERUNDS,
+    *(f"{g}…" for g in _BUSY_SPINNER_GERUNDS),
+    *(f"{g}..." for g in _BUSY_SPINNER_GERUNDS),
+    *_BUSY_SPINNER_PAST_TENSE,
+    *_BUSY_SUBAGENT_MARKERS,
+    *_BUSY_TASK_LIST_MARKERS,
     "Press up to edit queued messages",
 )
 
@@ -101,13 +223,29 @@ def _extract_compose_text(tail: str) -> str:
 
 
 def _has_busy_animation(hay: str) -> bool:
-    """True when the pane shows a busy-animation marker (mulling / working / …).
+    """True when the pane shows a busy-animation / known-alive marker.
 
-    Conservative: if *any* animation-style keyword appears in the scan
-    window we consider the pane busy and therefore NOT stale, even when
-    the bytes didn't change between two samples.
+    Checks in this order (cheapest first):
+      1. Literal substrings from `_BUSY_ANIMATION_MARKERS` — the union
+         of groups A (present-tense gerunds), B (past-tense "X for Ns"),
+         C (subagent markers) and D (task-list bullets).
+      2. Compiled regexes from `_BUSY_ANIMATION_REGEXES` — handle the
+         TodoWrite task-list header and star-glyph spinner variants
+         where numerics / verb tense prevent a pure literal match.
+
+    Conservative: if *any* marker matches in the scan window we consider
+    the pane busy and therefore NOT stale, even when the bytes didn't
+    change between two samples. Rationale: false-negative (missing a
+    busy marker) → user sees a spurious `stale` LED; false-positive
+    (over-matching) → user sees a missed stall. The latter is recoverable
+    via the 10-minute heartbeat timeout; the former spams the dashboard.
     """
-    return any(m in hay for m in _BUSY_ANIMATION_MARKERS)
+    if any(m in hay for m in _BUSY_ANIMATION_MARKERS):
+        return True
+    for pattern, _rationale in _BUSY_ANIMATION_REGEXES:
+        if pattern.search(hay):
+            return True
+    return False
 
 
 def _pane_digest(tail_clean: str, full_pane: str) -> str:

--- a/tests/test_pane_classifier_contradiction.py
+++ b/tests/test_pane_classifier_contradiction.py
@@ -228,3 +228,190 @@ def test_log_contradiction_evidence_appends(tmp_path):
     assert "agent=agent-0" in content
     assert "agent=agent-1" in content
     assert "agent=agent-2" in content
+
+
+# ---------------------------------------------------------------------------
+# Expanded busy-marker set (2026-04-21, fix/classifier-busy-markers-expand).
+#
+# Each test drives the classifier across the full `_STALE_CYCLES_THRESHOLD`+1
+# cycles with a byte-identical pane. Without the new markers the classifier
+# would flip to `stale` on the last call; with them it must stay `idle`.
+# ---------------------------------------------------------------------------
+
+
+def _assert_never_stale(pane: str, agent: str, cycles: int = 6) -> None:
+    """Helper: `pane` held constant for many cycles must not go `stale`."""
+    for _ in range(cycles):
+        state = _classifier._classify_pane_state(pane, pane, agent=agent)
+        assert state != "stale", (
+            f"classifier flipped to stale on pane containing marker; "
+            f"pane={pane!r}, agent={agent}"
+        )
+
+
+# --- Group A: present-tense spinner gerunds --------------------------------
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [
+        "Cogitating",
+        "Deliberating",
+        "Contemplating",
+        "Considering",
+        "Analysing",
+        "Analyzing",
+        "Ruminating",
+        "Simmering",
+        "Percolating",
+        "Noodling",
+    ],
+)
+def test_present_tense_spinner_gerund_suppresses_stale(
+    _isolate_state, marker
+):
+    agent = f"t-agent-gerund-{marker.lower()}"
+    pane = f"some boring static output\n* {marker}… (12s)\n"
+    _assert_never_stale(pane, agent)
+
+
+# --- Group B: past-tense "X for Ns" spinner --------------------------------
+
+
+@pytest.mark.parametrize(
+    "marker_line",
+    [
+        "✻ Baked for 1m 42s",
+        "✻ Brewed for 35s",
+        "✻ Cogitated for 39s",
+        "✻ Cooked for 1m 28s",
+        "✻ Thought for 12s",
+        "✻ Pondered for 2m 05s",
+    ],
+)
+def test_past_tense_spinner_suppresses_stale(_isolate_state, marker_line):
+    """Past-tense '✻ Baked for 40s' etc. — the agent just finished a
+    streaming burst and is composing its reply. Pane looks static but
+    the session is alive. This was the #1 false-positive class in the
+    contradiction log on head-ywata-note-win."""
+    agent = f"t-agent-past-{abs(hash(marker_line)) % 1000}"
+    pane = f"some tool output here\n{marker_line}\n"
+    _assert_never_stale(pane, agent)
+
+
+# --- Group C: subagent / background markers --------------------------------
+
+
+def test_local_agent_still_running_suppresses_stale(_isolate_state):
+    """'1 local agent still running' footer means the main session
+    dispatched a subagent and is awaiting results — very much alive."""
+    agent = "t-agent-subagent"
+    pane = (
+        "  Called scitex-orochi (ctrl+o to expand)\n"
+        "✻ Brewed for 35s · 1 local agent still running\n"
+    )
+    _assert_never_stale(pane, agent)
+
+
+def test_local_agents_plural_suppresses_stale(_isolate_state):
+    agent = "t-agent-subagents-plural"
+    pane = "✻ Cooked for 1m 28s · 3 local agents still running\n"
+    _assert_never_stale(pane, agent)
+
+
+def test_backgrounded_agent_suppresses_stale(_isolate_state):
+    agent = "t-agent-bg"
+    pane = (
+        "● Agent(Pane-state classifier contradiction detection)\n"
+        "  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)\n"
+    )
+    _assert_never_stale(pane, agent)
+
+
+# --- Group D: TodoWrite task-list static view ------------------------------
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "1 tasks (0 done, 1 in progress, 0 open)",
+        "2 tasks (1 done, 1 in progress, 0 open)",
+        "5 tasks (2 done, 2 in progress, 1 open)",
+        "1 task (0 done, 1 in progress)",
+    ],
+)
+def test_todowrite_task_list_header_suppresses_stale(_isolate_state, header):
+    """Classic false-positive from the contradiction log: the TodoWrite
+    rendering is byte-identical across cycles but the agent is deep in
+    a deliberation turn."""
+    agent = f"t-agent-todo-{abs(hash(header)) % 1000}"
+    pane = (
+        f"  {header}\n"
+        "  ◼ pane-state classifier: 3rd-stale vs 4th-green contradiction dete…\n"
+    )
+    _assert_never_stale(pane, agent)
+
+
+def test_todowrite_bullet_alone_suppresses_stale(_isolate_state):
+    """Even without the numeric header, the '◼ ' checkbox glyph is
+    distinctive enough (no non-TodoWrite context uses it in CC)."""
+    agent = "t-agent-bullet"
+    pane = "  ◼ some active task description here\n"
+    _assert_never_stale(pane, agent)
+
+
+# --- Group E: regex patterns -----------------------------------------------
+
+
+def test_busy_animation_regexes_have_rationales():
+    """Each regex entry must carry a non-empty human-readable rationale
+    string — the whole point of the refactor was to move away from
+    opaque marker lists."""
+    assert len(_classifier._BUSY_ANIMATION_REGEXES) > 0
+    for pattern, rationale in _classifier._BUSY_ANIMATION_REGEXES:
+        assert pattern.pattern, "empty regex"
+        assert rationale and len(rationale) > 10, (
+            f"rationale too short for {pattern.pattern!r}"
+        )
+
+
+def test_has_busy_animation_matches_all_new_groups():
+    """Unit-level coverage of _has_busy_animation across the four new
+    groups. Guards against regressions where the consolidated
+    _BUSY_ANIMATION_MARKERS tuple loses an entry in a future refactor."""
+    samples = [
+        "* Deliberating… (18s)",  # group A
+        "✻ Cogitated for 39s",  # group B
+        "✻ Brewed for 35s · 1 local agent still running",  # groups B+C
+        "  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)",  # group C
+        "  2 tasks (1 done, 1 in progress, 0 open)",  # group D regex
+        "  ◼ some in-progress work item",  # group D literal
+        "Press up to edit queued messages",  # existing Crunched-like
+    ]
+    for sample in samples:
+        assert _classifier._has_busy_animation(sample), (
+            f"_has_busy_animation returned False for {sample!r}"
+        )
+
+
+def test_has_busy_animation_rejects_plain_static_text():
+    """Negative control: a genuinely static idle pane must NOT trigger
+    any of the new markers."""
+    plain = "$ ls\nfoo.py  bar.py  baz.py\n$ "
+    assert not _classifier._has_busy_animation(plain)
+
+
+def test_stale_still_fires_without_busy_markers(_isolate_state):
+    """End-to-end regression: after the expansion, a pane with zero
+    busy markers must still flip to `stale` on the 4th identical cycle.
+    Guards against accidentally matching every pane via an over-broad
+    regex."""
+    agent = "t-agent-still-stale"
+    pane = "just a shell prompt\n$ \n"
+    for _ in range(3):
+        assert (
+            _classifier._classify_pane_state(pane, pane, agent=agent) == "idle"
+        )
+    assert (
+        _classifier._classify_pane_state(pane, pane, agent=agent) == "stale"
+    )


### PR DESCRIPTION
## Summary

- Uses 480 KB of evidence from `~/.local/state/scitex/fleet-pane-contradictions.log` (head-ywata-note-win) to identify four pane patterns that consistently produce false-positive `stale` flags while the 4th-LED heartbeat stays green
- Splits `_BUSY_ANIMATION_MARKERS` from an opaque literal tuple into four rationale-commented groups (present-tense gerunds, past-tense "X for Ns" spinner, subagent footers, TodoWrite task-list views) plus a regex table for numeric/temporal variants
- Adds 28 new tests exercising each marker group end-to-end plus a negative-control regression test confirming `stale` still fires on genuinely static panes

## Evidence sample (head-ywata-note-win log)

- `✻ Baked for 1m 42s`, `✻ Brewed for 35s`, `✻ Cogitated for 39s`, `✻ Cooked for 1m 28s` — past-tense spinner was the dominant false-positive source
- `1 tasks (0 done, 1 in progress, 0 open)` + `◼ pane-state classifier: 3rd-stale vs 4th-green contradiction dete…` — TodoWrite static view
- `✻ Brewed for 35s · 1 local agent still running` — subagent-dispatch footer
- `  ⎿  Backgrounded agent (↓ to manage · ctrl+o to expand)` — background subagent marker

## Files

- `scripts/client/agent_meta_pkg/_classifier.py` — expanded marker groups + regex table + updated `_has_busy_animation()`
- `tests/test_pane_classifier_contradiction.py` — 28 new tests (42 total pass, up from 14)

## Follow-up

- mba's 81 KB contradiction log was not directly accessible from this workspace; if mba's evidence reveals additional false-positive classes, a follow-up PR can append to the already-documented groups without further restructuring
- Once deployed, the contradiction log rate should drop sharply — worth revisiting in a few days to confirm and to gather any residual classes

## Test plan

- [x] `pytest tests/test_pane_classifier_contradiction.py` — 42 passed locally
- [x] Broader suite `pytest tests/ --ignore=test_telegram_bridge --ignore=test_web --ignore=test_server` — 66 passed, 1 skipped
- [ ] Post-merge: watch `fleet-pane-contradictions.log` growth rate on head-mba and head-ywata-note-win; expect sharp drop

Ref: lead msg#15727, follow-up to #307.