### PR TITLE
fix(ui/graph): persistent message feed on graph tab — two-way conversation UX (msg#15699 blocker)

### DIFF
--- a/hub/frontend/src/activity-tab/compose.ts
+++ b/hub/frontend/src/activity-tab/compose.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { _activityChannelRequest, _invalidateTopoPerms } from "./data";
+import { _graphFeedSetChannel } from "./graph-feed";
 import { _showMiniToast } from "../app/agent-actions";
 import { _channelPrefs } from "../app/members";
 import { fetchAgents } from "../app/sidebar-agents";
@@ -279,6 +280,14 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     tccShortcuts.replace(/"/g, "&quot;") +
     '" aria-label="More options">\u25BE</button>';
   document.body.appendChild(pop);
+  /* Wire the persistent graph feed to this channel so replies to the
+   * outgoing post land in the right-docked panel instead of flashing
+   * off-screen as a 1.3s landing bubble (lead msg#15701 blocker). */
+  if (typeof _graphFeedSetChannel === "function") {
+    try {
+      _graphFeedSetChannel(channel);
+    } catch (_) {}
+  }
   var input = pop.querySelector(".tcc-input");
   var extras = pop.querySelector(".tcc-extras");
   var expandBtn = pop.querySelector(".tcc-expand");

--- a/hub/frontend/src/activity-tab/graph-feed.ts
+++ b/hub/frontend/src/activity-tab/graph-feed.ts
@@ -1,0 +1,501 @@
+// @ts-nocheck
+import { getResolvedAgentColor, getSenderIcon } from "../agent-icons";
+import { cleanAgentName, escapeHtml, hostedAgentName, timeAgo, apiUrl } from "../app/utils";
+import { _processMessageMarkdown } from "../chat/chat-markdown";
+import { buildAttachmentsHtml } from "../chat/chat-attachments";
+
+/* activity-tab/graph-feed.ts — persistent message feed panel docked
+ * on the right side of the graph (topology) canvas.
+ *
+ * Background (lead msg#15701, ywatanabe msg#15699): the Agents-tab
+ * graph was one-way — posts worked but inbound replies only surfaced
+ * as a 1.3s landing bubble on the destination node (see
+ * topology-packets.ts _topoLandingBubble + _TOPO_LANDING_DUR_MS), then
+ * disappeared. Users had to switch to the Chat tab to read responses,
+ * making graph-tab conversations impossible.
+ *
+ * Design:
+ *   - A right-docked collapsible panel hosts a scrollable feed.
+ *   - Feed is wired to a "graph focus channel": defaults to the global
+ *     currentChannel (same channel the Chat tab is focused on), or can
+ *     be picked via the panel's channel selector, or gets auto-set
+ *     when the user double-clicks a channel node to compose (see
+ *     compose.ts _topoOpenChannelCompose → _graphFeedSetChannel).
+ *   - Inbound WS messages: handleMessage() in websocket.ts mirrors
+ *     each `msg` to _graphFeedAppendMessage so the feed lives in
+ *     parallel with the Chat #messages feed. No flash/auto-dismiss.
+ *   - Scroll-top loads older history (reuses /api/history/<ch> —
+ *     same endpoint the Chat tab uses).
+ *
+ * Complements — does NOT replace — the hover-preview planned on PR
+ * #311 item 11 (a popover over a channel NODE that shows the last 7
+ * msgs for THAT channel). This panel is always-on for the compose
+ * box's currently-wired channel.
+ */
+
+/* Feed rendering state */
+var _graphFeedChannel = null; /* current wired channel */
+var _graphFeedMountedForChannel = null; /* channel whose history is loaded */
+var _graphFeedCollapsed = false;
+var _graphFeedOldestTs = null; /* scroll-back cursor */
+var _graphFeedLoadingOlder = false;
+var _graphFeedKnownIds = Object.create(null); /* dedupe map */
+var _graphFeedInitialLoadDone = false;
+
+try {
+  _graphFeedCollapsed =
+    localStorage.getItem("orochi.graphFeedCollapsed") === "1";
+} catch (_) {}
+
+function _saveCollapsed() {
+  try {
+    localStorage.setItem(
+      "orochi.graphFeedCollapsed",
+      _graphFeedCollapsed ? "1" : "0",
+    );
+  } catch (_) {}
+}
+
+/* Stable feed root query — scoped to the topology view so we never
+ * accidentally render into the Chat tab's #messages. */
+function _graphFeedRoot() {
+  return document.querySelector(
+    ".activity-view-topology .graph-feed-messages",
+  );
+}
+
+function _graphFeedPanel() {
+  return document.querySelector(".activity-view-topology .graph-feed-panel");
+}
+
+/* HTML scaffold — injected by topology.ts into .topo-wrap on every
+ * render. Guarded by a signature: if the panel already exists and the
+ * channel is unchanged, we leave its message DOM intact so live-
+ * appended messages aren't wiped by heartbeat re-renders. */
+export function _graphFeedPanelHtml() {
+  var ch = _graphFeedChannel || "";
+  var collapsedCls = _graphFeedCollapsed ? " graph-feed-collapsed" : "";
+  var label = ch ? "#" + ch : "(pick a channel)";
+  return (
+    '<div class="graph-feed-panel' +
+    collapsedCls +
+    '" data-graph-feed>' +
+    '<div class="graph-feed-header">' +
+    '<button type="button" class="graph-feed-toggle" ' +
+    'data-graph-feed-action="toggle" ' +
+    'title="Collapse / expand the graph message feed">' +
+    (_graphFeedCollapsed ? "\u25C0" : "\u25B6") +
+    "</button>" +
+    '<span class="graph-feed-title">Feed</span>' +
+    '<span class="graph-feed-channel" title="' +
+    escapeHtml(ch ? "Channel: " + ch : "No channel wired") +
+    '">' +
+    escapeHtml(label) +
+    "</span>" +
+    "</div>" +
+    '<div class="graph-feed-messages" ' +
+    'data-graph-feed-messages ' +
+    'aria-live="polite" aria-atomic="false">' +
+    '<div class="graph-feed-older-hint" style="display:none">' +
+    "Loading older…</div>" +
+    '<div class="graph-feed-empty" ' +
+    'data-graph-feed-empty>' +
+    (ch
+      ? "Loading recent messages…"
+      : "Double-click a channel node or pick one above to start a conversation here.") +
+    "</div>" +
+    "</div>" +
+    "</div>"
+  );
+}
+
+/* Delegated click + scroll wiring. Called once per grid via the
+ * delegation guard (same pattern as _wireTopoSeekbar). */
+var _graphFeedWired = false;
+export function _wireGraphFeed(grid) {
+  if (_graphFeedWired || !grid) return;
+  _graphFeedWired = true;
+  grid.addEventListener("click", function (ev) {
+    var btn = ev.target.closest
+      ? ev.target.closest("[data-graph-feed-action]")
+      : null;
+    if (!btn) return;
+    var action = btn.getAttribute("data-graph-feed-action");
+    if (action === "toggle") {
+      _graphFeedCollapsed = !_graphFeedCollapsed;
+      _saveCollapsed();
+      var panel = _graphFeedPanel();
+      if (panel) {
+        panel.classList.toggle("graph-feed-collapsed", _graphFeedCollapsed);
+        btn.textContent = _graphFeedCollapsed ? "\u25C0" : "\u25B6";
+      }
+    }
+  });
+  /* Scroll-top → load older. Attach directly to the messages element
+   * when it mounts (event bubbling for scroll doesn't cross shadow
+   * boundaries; `scroll` doesn't bubble at all). We re-attach after
+   * every render by checking a data flag. */
+  grid.addEventListener(
+    "scroll",
+    function (ev) {
+      var el = ev.target;
+      if (!el || !el.classList || !el.classList.contains("graph-feed-messages"))
+        return;
+      if (el.scrollTop < 30 && !_graphFeedLoadingOlder) {
+        _loadOlderMessages();
+      }
+    },
+    true,
+  );
+}
+
+/* Post-render hook — called by topology.ts after grid.innerHTML is set.
+ * Responsibilities:
+ *   1) Ensure feed history matches _graphFeedChannel.
+ *   2) If the channel is unchanged, restore previously-rendered
+ *      message DOM (we stashed it aside before innerHTML rewrite).
+ * We stash in a module-level DocumentFragment so heartbeat re-renders
+ * don't flicker the feed. */
+var _graphFeedCachedDom = null;
+
+export function _graphFeedPreRender() {
+  /* Save the current feed DOM (messages, not header) so we can
+   * restore after the re-render wipes innerHTML. Only meaningful when
+   * the channel is unchanged. */
+  var root = _graphFeedRoot();
+  if (!root) {
+    _graphFeedCachedDom = null;
+    return;
+  }
+  _graphFeedCachedDom = {
+    channel: _graphFeedChannel,
+    html: root.innerHTML,
+    scrollTop: root.scrollTop,
+    scrollHeight: root.scrollHeight,
+  };
+}
+
+export function _graphFeedPostRender() {
+  var root = _graphFeedRoot();
+  if (!root) return;
+  /* If channel unchanged and we have cached DOM, restore it wholesale
+   * so the heartbeat re-render doesn't flash the feed. */
+  if (
+    _graphFeedCachedDom &&
+    _graphFeedCachedDom.channel === _graphFeedChannel &&
+    _graphFeedMountedForChannel === _graphFeedChannel
+  ) {
+    root.innerHTML = _graphFeedCachedDom.html;
+    /* Preserve scroll — if user was near bottom, pin to bottom;
+     * otherwise keep their scrollTop. */
+    var wasAtBottom =
+      _graphFeedCachedDom.scrollHeight -
+        _graphFeedCachedDom.scrollTop -
+        100 <
+      100;
+    if (wasAtBottom) {
+      root.scrollTop = root.scrollHeight;
+    } else {
+      root.scrollTop = _graphFeedCachedDom.scrollTop;
+    }
+    _graphFeedCachedDom = null;
+    return;
+  }
+  _graphFeedCachedDom = null;
+
+  /* New (or first) channel wiring — fetch history. */
+  if (_graphFeedChannel && _graphFeedMountedForChannel !== _graphFeedChannel) {
+    _loadInitialHistory(_graphFeedChannel);
+  }
+}
+
+/* Public: change the wired channel. Called from compose.ts when the
+ * inline channel-compose popup opens (so replies land in the feed
+ * under the focused channel), and from the panel's own channel picker
+ * (future), and from topology.ts's initial wire to currentChannel. */
+export function _graphFeedSetChannel(channel) {
+  channel = channel || "";
+  if (channel === _graphFeedChannel) return;
+  _graphFeedChannel = channel;
+  _graphFeedMountedForChannel = null;
+  _graphFeedOldestTs = null;
+  _graphFeedKnownIds = Object.create(null);
+  _graphFeedInitialLoadDone = false;
+  var panel = _graphFeedPanel();
+  if (panel) {
+    var ch = panel.querySelector(".graph-feed-channel");
+    if (ch) {
+      ch.textContent = channel ? "#" + channel : "(pick a channel)";
+      ch.setAttribute(
+        "title",
+        channel ? "Channel: " + channel : "No channel wired",
+      );
+    }
+  }
+  var root = _graphFeedRoot();
+  if (root) {
+    root.innerHTML =
+      '<div class="graph-feed-older-hint" style="display:none">' +
+      "Loading older…</div>" +
+      '<div class="graph-feed-empty" data-graph-feed-empty>' +
+      (channel
+        ? "Loading recent messages…"
+        : "Double-click a channel node or pick one above to start a conversation here.") +
+      "</div>";
+  }
+  if (channel) _loadInitialHistory(channel);
+}
+
+/* Default initial wiring — called by topology.ts on first render. If
+ * no channel is already set, adopt the global currentChannel so the
+ * feed "just works" for users coming from Chat. */
+export function _graphFeedEnsureDefaultChannel() {
+  if (_graphFeedChannel) return;
+  var ch = (globalThis as any).currentChannel || "";
+  if (ch) _graphFeedSetChannel(ch);
+}
+
+/* Expose the module-local current channel for compose.ts etc. */
+export function _graphFeedGetChannel() {
+  return _graphFeedChannel || "";
+}
+
+async function _loadInitialHistory(channel) {
+  if (!channel) return;
+  _graphFeedMountedForChannel = channel;
+  try {
+    var encoded = encodeURIComponent(channel);
+    var res = await fetch(apiUrl("/api/history/" + encoded + "?limit=50"), {
+      credentials: "same-origin",
+    });
+    if (!res.ok) return;
+    var rows = await res.json();
+    /* API returns newest-first; reverse for chronological rendering. */
+    rows.reverse();
+    var root = _graphFeedRoot();
+    if (!root) return;
+    /* Guard: if the user switched channels while we were fetching,
+     * abort — otherwise we'd paint stale rows. */
+    if (_graphFeedChannel !== channel) return;
+    root.innerHTML =
+      '<div class="graph-feed-older-hint" style="display:none">' +
+      "Loading older…</div>";
+    _graphFeedKnownIds = Object.create(null);
+    if (!rows.length) {
+      root.innerHTML +=
+        '<div class="graph-feed-empty" data-graph-feed-empty>' +
+        "No messages in this channel yet. Send one to get started.</div>";
+      _graphFeedInitialLoadDone = true;
+      return;
+    }
+    rows.forEach(function (row) {
+      if (row.id) _graphFeedKnownIds[row.id] = true;
+      _appendRow(row, /*append=*/ true);
+      if (!_graphFeedOldestTs || row.ts < _graphFeedOldestTs) {
+        _graphFeedOldestTs = row.ts;
+      }
+    });
+    _graphFeedInitialLoadDone = true;
+    /* Snap to bottom on initial load. */
+    root.scrollTop = root.scrollHeight;
+  } catch (e) {
+    console.warn("[graph-feed] initial history failed:", e);
+  }
+}
+
+async function _loadOlderMessages() {
+  if (!_graphFeedChannel || !_graphFeedOldestTs) return;
+  _graphFeedLoadingOlder = true;
+  var root = _graphFeedRoot();
+  if (!root) {
+    _graphFeedLoadingOlder = false;
+    return;
+  }
+  var hint = root.querySelector(".graph-feed-older-hint");
+  if (hint) hint.style.display = "";
+  try {
+    var encoded = encodeURIComponent(_graphFeedChannel);
+    var before = encodeURIComponent(_graphFeedOldestTs);
+    /* Same `before` cursor-style paging the Chat tab uses; if the API
+     * doesn't honour it, we just get the same 50 rows back and the
+     * dedupe map skips them all — harmless worst case. */
+    var res = await fetch(
+      apiUrl(
+        "/api/history/" + encoded + "?limit=50&before=" + before,
+      ),
+      { credentials: "same-origin" },
+    );
+    if (!res.ok) return;
+    var rows = await res.json();
+    rows.reverse();
+    var prevScrollHeight = root.scrollHeight;
+    var newRowsAdded = 0;
+    /* Prepend in reverse so chronological order stays correct: the
+     * oldest of the new batch lands at the top. */
+    for (var i = rows.length - 1; i >= 0; i--) {
+      var row = rows[i];
+      if (row.id && _graphFeedKnownIds[row.id]) continue;
+      if (row.id) _graphFeedKnownIds[row.id] = true;
+      _appendRow(row, /*append=*/ false); /* prepend */
+      newRowsAdded++;
+      if (!_graphFeedOldestTs || row.ts < _graphFeedOldestTs) {
+        _graphFeedOldestTs = row.ts;
+      }
+    }
+    /* Preserve visual scroll position — added rows pushed everything
+     * down by (scrollHeight - prevScrollHeight). */
+    if (newRowsAdded > 0) {
+      root.scrollTop += root.scrollHeight - prevScrollHeight;
+    }
+  } catch (e) {
+    console.warn("[graph-feed] older history failed:", e);
+  } finally {
+    if (hint) hint.style.display = "none";
+    _graphFeedLoadingOlder = false;
+  }
+}
+
+/* Public: called from websocket.ts on every inbound WS message so
+ * the graph feed stays in sync with the Chat tab without its own
+ * subscription infrastructure. */
+export function _graphFeedAppendMessage(msg) {
+  if (!msg || !_graphFeedChannel) return;
+  var ch = msg.channel || (msg.payload && msg.payload.channel) || "";
+  if (ch !== _graphFeedChannel) return;
+  /* Dedupe — the REST poll path and the WS path can both deliver the
+   * same message (observed on hub). */
+  if (msg.id && _graphFeedKnownIds[msg.id]) return;
+  if (msg.id) _graphFeedKnownIds[msg.id] = true;
+  /* Map flat WS shape → the row shape _appendRow expects. */
+  var row = {
+    id: msg.id,
+    sender: msg.sender,
+    sender_type: msg.sender_type,
+    ts: msg.ts,
+    channel: ch,
+    content:
+      msg.text ||
+      msg.content ||
+      (msg.payload && (msg.payload.content || msg.payload.text)) ||
+      "",
+    metadata: (msg.payload && msg.payload.metadata) || msg.metadata || {},
+    attachments:
+      (msg.payload && msg.payload.attachments) ||
+      (msg.metadata && msg.metadata.attachments) ||
+      msg.attachments ||
+      [],
+  };
+  _appendRow(row, /*append=*/ true);
+}
+
+/* Core row renderer — compact variant of chat-render.appendMessage.
+ * Drops the heavy toolbar (thread / react / edit / delete) to keep
+ * the panel uncluttered. Click on the message opens the thread in
+ * the Chat tab (see _wireGraphFeed click delegation). */
+function _appendRow(row, append) {
+  var root = _graphFeedRoot();
+  if (!root) return;
+  /* Remove empty-state placeholder on first real row. */
+  var empty = root.querySelector("[data-graph-feed-empty]");
+  if (empty) empty.remove();
+  var senderName = row.sender || "unknown";
+  var isAgent = row.sender_type === "agent";
+  var senderColor = getResolvedAgentColor(senderName);
+  var ts = "";
+  var fullTs = "";
+  if (row.ts) {
+    var d = new Date(row.ts);
+    if (!isNaN(d.getTime())) {
+      ts = timeAgo(row.ts);
+      fullTs = d.toLocaleString();
+    }
+  }
+  var content = row.content || "";
+  var attachments = row.attachments || [];
+  if (!content && (!attachments || !attachments.length)) return;
+  var highlightedContent = _processMessageMarkdown(content);
+  var senderIcon = getSenderIcon(senderName, isAgent);
+  var el = document.createElement("div");
+  el.className = "graph-feed-msg" + (isAgent ? "" : " graph-feed-msg-human");
+  if (row.id) el.setAttribute("data-msg-id", String(row.id));
+  el.setAttribute("data-sender", senderName);
+  el.setAttribute("data-channel", row.channel || _graphFeedChannel || "");
+  /* Clickable — jumps to the corresponding thread on the Chat tab. */
+  if (row.id) {
+    el.setAttribute("role", "button");
+    el.setAttribute("tabindex", "0");
+    el.setAttribute("title", "Click to open in Chat / thread view");
+    el.addEventListener("click", function () {
+      /* Route to the Chat tab's thread for this message. openThread
+       * logic already exists on window from threads/panel.ts. */
+      if (typeof (window as any).openThreadForMessage === "function") {
+        try {
+          (window as any).openThreadForMessage(row.id);
+          return;
+        } catch (_) {}
+      }
+      /* Fallback: switch to Chat tab and let the user find it. */
+      var tabBtn = document.querySelector('[data-tab="chat"]');
+      if (tabBtn) (tabBtn as HTMLElement).click();
+    });
+  }
+  var senderDisplay = isAgent
+    ? (function () {
+        var rec = (window.__lastAgents || []).find(function (a) {
+          return a && a.name === senderName;
+        });
+        return rec ? hostedAgentName(rec) : cleanAgentName(senderName);
+      })()
+    : cleanAgentName(senderName);
+  var attachmentsHtml =
+    typeof buildAttachmentsHtml === "function"
+      ? buildAttachmentsHtml(attachments)
+      : "";
+  el.innerHTML =
+    '<div class="graph-feed-msg-header">' +
+    '<span class="graph-feed-msg-icon">' +
+    senderIcon +
+    "</span>" +
+    '<span class="graph-feed-msg-sender" style="color:' +
+    senderColor +
+    '">' +
+    escapeHtml(senderDisplay) +
+    "</span>" +
+    '<span class="graph-feed-msg-ts" title="' +
+    escapeHtml(fullTs) +
+    '">' +
+    ts +
+    "</span>" +
+    (row.id
+      ? '<span class="graph-feed-msg-id">#' + row.id + "</span>"
+      : "") +
+    "</div>" +
+    '<div class="graph-feed-msg-content">' +
+    highlightedContent +
+    "</div>" +
+    attachmentsHtml;
+  /* Older-hint placeholder must stay at the top when we prepend. */
+  var hint = root.querySelector(".graph-feed-older-hint");
+  if (append) {
+    var atBottom =
+      root.scrollHeight - root.scrollTop - root.clientHeight < 80;
+    root.appendChild(el);
+    if (atBottom) {
+      root.scrollTop = root.scrollHeight;
+    }
+  } else {
+    /* Prepend: land just after the hint so older batches stay above
+     * the current top-visible message. */
+    if (hint && hint.nextSibling) {
+      root.insertBefore(el, hint.nextSibling);
+    } else {
+      root.insertBefore(el, root.firstChild);
+    }
+  }
+}
+
+/* Expose for cross-file callers via window, mirroring the pattern the
+ * rest of activity-tab/ uses for module-local state. */
+(window as any)._graphFeedAppendMessage = _graphFeedAppendMessage;
+(window as any)._graphFeedSetChannel = _graphFeedSetChannel;
+(window as any)._graphFeedGetChannel = _graphFeedGetChannel;

--- a/hub/frontend/src/activity-tab/topology.ts
+++ b/hub/frontend/src/activity-tab/topology.ts
@@ -1,6 +1,13 @@
 // @ts-nocheck
 import { _fetchActivityDetail, _refreshTopoPerms } from "./data";
 import { _renderActivityAgentDetail } from "./detail";
+import {
+  _graphFeedEnsureDefaultChannel,
+  _graphFeedPanelHtml,
+  _graphFeedPostRender,
+  _graphFeedPreRender,
+  _wireGraphFeed,
+} from "./graph-feed";
 import { _wireOverviewGridDelegation } from "./grid-delegation";
 import { _topoPoolApplyCanvasFilter, _topoPoolSelectionPaint, _topoSelectedNames } from "./multiselect";
 import { _topoSeekHeatRefresh, _topoSeekUpdateUI, _topoSeekbarHtml, _wireTopoSeekbar } from "./seekbar";
@@ -68,6 +75,9 @@ export function _renderActivityTopology(visible, grid) {
      * that slip in without changing the signature (rare but possible)
      * still get the correct dim treatment. */
     _topoPoolApplyCanvasFilter(grid);
+    /* Signature-unchanged path: the SVG is reused verbatim, so the
+     * graph-feed panel DOM is preserved automatically (we only rewrite
+     * innerHTML in the full-render branch). No-op here. */
     return;
   }
   (globalThis as any)._topoLastSig = sig;
@@ -356,16 +366,31 @@ export function _renderActivityTopology(visible, grid) {
    * from the playhead. All event listeners are attached via delegation
    * in _wireTopoSeekbar so they survive heartbeat-driven re-renders. */
   var seekBar = _topoSeekbarHtml();
+  /* Snapshot the current graph-feed DOM before grid.innerHTML is
+   * overwritten. Heartbeat re-renders would otherwise wipe the
+   * message feed every 2s. _graphFeedPostRender re-inflates it
+   * after the rebuild when the wired channel is unchanged. */
+  _graphFeedPreRender();
+  /* Persistent right-docked message feed (lead msg#15701): replaces
+   * the flash-and-disappear landing bubble as the primary way to read
+   * incoming replies while on the graph tab. Wired to the currently-
+   * focused channel; double-clicking a channel node or posting via
+   * the compose popup re-wires it. */
+  var feedPanel = _graphFeedPanelHtml();
   grid.innerHTML =
     '<div class="topo-wrap">' +
     hint +
     ctrls +
     pool +
     svg +
+    feedPanel +
     actionBar +
     seekBar +
     "</div>" +
     detailBox;
+  _graphFeedPostRender();
+  _graphFeedEnsureDefaultChannel();
+  _wireGraphFeed(grid);
 
   /* Delegated click: agent node → toggle expand. Bound ONCE on the
    * grid (the delegation helper guards with _overviewGridWired). We

--- a/hub/frontend/src/app/websocket.ts
+++ b/hub/frontend/src/app/websocket.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { _graphFeedAppendMessage } from "../activity-tab/graph-feed";
 import { renderActivityTab } from "../activity-tab/init";
 import { _topoPulseEdge } from "../activity-tab/topology-pulse";
 import { cacheChannelIdentity } from "../agent-icons";
@@ -138,6 +139,18 @@ export function handleMessage(msg) {
     if ((globalThis as any).knownMessageKeys[key]) return;
     (globalThis as any).knownMessageKeys[key] = true;
     appendMessage(msg);
+    /* Graph-tab persistent feed — mirror inbound messages into the
+     * right-docked panel so graph-tab conversations are two-way (lead
+     * msg#15701 blocker). No-op when the feed's wired channel doesn't
+     * match this message's channel, or when the topology view isn't
+     * mounted. */
+    if (typeof _graphFeedAppendMessage === "function") {
+      try {
+        _graphFeedAppendMessage(msg);
+      } catch (_) {
+        /* Never let a feed-render error disrupt message delivery. */
+      }
+    }
     /* Topology view — pulse a glowing packet along the edge from the
      * sender to the channel so the map animates as traffic flows.
      * Silently no-ops when topology isn't visible. */

--- a/hub/frontend/src/index.ts
+++ b/hub/frontend/src/index.ts
@@ -67,6 +67,7 @@ import "./activity-tab/topology-signature";
 import "./activity-tab/topology-edges";
 import "./activity-tab/topology-nodes";
 import "./activity-tab/topology-pool";
+import "./activity-tab/graph-feed";
 import "./activity-tab/topology";
 import "./activity-tab/row";
 import "./activity-tab/click";

--- a/hub/static/hub/activity-tab/activity-tab-topology.css
+++ b/hub/static/hub/activity-tab/activity-tab-topology.css
@@ -333,3 +333,189 @@
   color: #4ecdc4;
   border-color: #1f3a3a;
 }
+
+/* ─── Persistent graph-feed panel (lead msg#15701 blocker) ───
+ * Right-docked panel that mirrors inbound messages for the currently-
+ * wired channel, so graph-tab conversations are two-way instead of
+ * flash-and-disappear landing bubbles. Collapsible to stay out of the
+ * way when the user is focused on the topology itself. */
+.activity-grid.activity-view-topology .graph-feed-panel {
+  position: absolute;
+  right: 8px;
+  top: 40px;
+  bottom: 60px; /* leave room for the seekbar docked at the bottom */
+  width: 320px;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  background: rgba(10, 10, 10, 0.82);
+  border: 1px solid #1f2937;
+  border-radius: 6px;
+  overflow: hidden;
+  transition: width 0.15s ease;
+}
+.activity-grid.activity-view-topology .graph-feed-panel.graph-feed-collapsed {
+  width: 32px;
+}
+.activity-grid.activity-view-topology .graph-feed-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid #1f2937;
+  font-size: 11px;
+  color: #cbd5e1;
+  flex: 0 0 auto;
+  user-select: none;
+}
+.activity-grid.activity-view-topology .graph-feed-toggle {
+  background: transparent;
+  border: 1px solid #273241;
+  color: #94a3b8;
+  border-radius: 3px;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  font-size: 10px;
+  padding: 0;
+  line-height: 1;
+}
+.activity-grid.activity-view-topology .graph-feed-toggle:hover {
+  color: #4ecdc4;
+  border-color: #4ecdc4;
+}
+.activity-grid.activity-view-topology .graph-feed-title {
+  color: #94a3b8;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.5px;
+}
+.activity-grid.activity-view-topology .graph-feed-channel {
+  color: #4ecdc4;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1 1 auto;
+}
+.activity-grid.activity-view-topology
+  .graph-feed-collapsed
+  .graph-feed-title,
+.activity-grid.activity-view-topology
+  .graph-feed-collapsed
+  .graph-feed-channel {
+  display: none;
+}
+.activity-grid.activity-view-topology .graph-feed-messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  /* Stable scrollbar — avoids width jumps on content changes. */
+  scrollbar-gutter: stable;
+}
+.activity-grid.activity-view-topology
+  .graph-feed-collapsed
+  .graph-feed-messages {
+  display: none;
+}
+.activity-grid.activity-view-topology .graph-feed-older-hint {
+  font-size: 10px;
+  color: #64748b;
+  text-align: center;
+  padding: 3px;
+  font-style: italic;
+}
+.activity-grid.activity-view-topology .graph-feed-empty {
+  font-size: 11px;
+  color: #64748b;
+  padding: 16px 8px;
+  text-align: center;
+  line-height: 1.4;
+}
+.activity-grid.activity-view-topology .graph-feed-msg {
+  padding: 4px 6px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  background: rgba(15, 20, 25, 0.6);
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.activity-grid.activity-view-topology .graph-feed-msg:hover {
+  background: #152028;
+  border-color: #273241;
+}
+.activity-grid.activity-view-topology .graph-feed-msg:focus-visible {
+  outline: 1px solid #4ecdc4;
+  outline-offset: 1px;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  margin-bottom: 2px;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  height: 14px;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-icon img {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-sender {
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 0 1 auto;
+  max-width: 180px;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-ts {
+  color: #64748b;
+  font-size: 9px;
+  flex: 0 0 auto;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-id {
+  color: #475569;
+  font-size: 9px;
+  margin-left: auto;
+  flex: 0 0 auto;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-content {
+  color: #e2e8f0;
+  font-size: 12px;
+  line-height: 1.35;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-content pre {
+  max-width: 100%;
+  overflow-x: auto;
+  font-size: 11px;
+}
+.activity-grid.activity-view-topology .graph-feed-msg-content img {
+  max-width: 100%;
+  height: auto;
+}
+/* Human-authored messages get a subtle left-accent so the user's own
+ * posts stand out from agent chatter, mirroring the Chat feed. */
+.activity-grid.activity-view-topology .graph-feed-msg-human {
+  border-left: 2px solid #4ecdc4;
+  padding-left: 5px;
+}
+/* Responsive: on narrow canvases, shrink the panel so it doesn't
+ * crowd out the SVG. The collapse toggle remains available. */
+@media (max-width: 900px) {
+  .activity-grid.activity-view-topology .graph-feed-panel {
+    width: 240px;
+  }
+}

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -53,7 +53,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/activity-tab/activity-tab-list.css' %}?v=166">
     <link rel="stylesheet"
-          href="{% static 'hub/activity-tab/activity-tab-topology.css' %}?v=165">
+          href="{% static 'hub/activity-tab/activity-tab-topology.css' %}?v=167">
     <link rel="stylesheet"
           href="{% static 'hub/activity-tab/activity-tab-topology-nodes.css' %}?v=166">
     <link rel="stylesheet"


### PR DESCRIPTION
## Blocker

Lead msg#15701, ywatanabe msg#15699: the Agents-tab graph is one-way — posting works but inbound replies flash as a 1.3s landing bubble on the destination node, then disappear. No inline feed, no preview pane, no scroll-back. Users can't hold a conversation without jumping back to the Chat tab.

## Root cause

`_topoLandingBubble` in `hub/frontend/src/activity-tab/topology-packets.ts` uses `setTimeout(..., _TOPO_LANDING_DUR_MS)` (1300ms, defined in `state.ts`) to remove the speech-bubble SVG. That bubble was the ONLY in-graph display of inbound messages — the graph tab never rendered an inline feed.

## Fix

Right-docked collapsible feed panel inside `.topo-wrap` that mirrors the same channel the Chat tab renders:

- **`activity-tab/graph-feed.ts`** (new) — owns panel lifecycle, scroll-back paging, wired-channel state, dedupe.
- **`activity-tab/topology.ts`** — emits the panel HTML alongside pool/svg/seekbar; calls `_graphFeedPreRender`/`_graphFeedPostRender` so the 2s heartbeat `grid.innerHTML` rewrite doesn't flash the feed.
- **`activity-tab/compose.ts`** — `_graphFeedSetChannel(ch)` on double-click-channel compose popup, so replies land in the feed next to the compose box.
- **`app/websocket.ts`** — `handleMessage()` also calls `_graphFeedAppendMessage(msg)`. No-op when feed's wired channel doesn't match, so the Chat tab is unaffected.
- **`activity-tab-topology.css`** — panel styles (right-docked, collapsible, responsive). Sits above the seekbar vertically, clamped to `320px` (`240px` on narrow viewports).
- **`dashboard.html`** — cache-buster bump on topology.css.

### Data flow

1. Initial history: `GET /api/history/<ch>?limit=50` — same endpoint `chat-history.loadChannelHistory` uses.
2. Live updates: WS `handleMessage` fans out to `appendMessage` (Chat) AND `_graphFeedAppendMessage` (graph).
3. Scroll-back: scrolling within 30px of the top triggers `GET /api/history/<ch>?limit=50&before=<oldestTs>`, prepends new rows, preserves visual scroll position.
4. Click a message → `openThreadForMessage` (Chat thread panel) for deeper view / reactions / edit etc.

### Default channel wiring

- If user arrives on graph tab with `currentChannel` set (normal flow coming from Chat), feed auto-wires to that channel.
- If user double-clicks a channel node to compose, feed re-wires to THAT channel.
- Feed title shows `#<channel>` so the wired-channel is always visible.

### What's kept (not deleted)

The 1.3s landing-bubble animation stays as a pleasant visual cue. It's no longer the primary read path, so its short TTL stops being a bug. This also avoids ripping through `_topoLandingBubble` + seekbar replay code that depends on it.

### Complements PR #311 item 11 (not in conflict)

Item 11 = hover-on-channel-node popover showing last 7 msgs for THAT node. This is a **transient** popover bound to a node. The blocker fix here is an **always-on** feed bound to the currently-wired channel (compose-box target). Both can coexist — they use disjoint DOM and disjoint state.

## Test plan

- [ ] Open graph tab, confirm right-docked feed panel renders.
- [ ] Confirm channel label matches `currentChannel`.
- [ ] Post a message via double-click channel compose; confirm own-post appears in the feed.
- [ ] Have an agent reply; confirm reply lands in the feed and stays (no flash).
- [ ] Scroll feed upward; confirm older messages load on reaching top.
- [ ] Click a feed row; confirm thread opens in Chat.
- [ ] Toggle collapse; reload; confirm collapse state persists.
- [ ] Switch to Chat tab; confirm no regression (feed is not visible there).
- [ ] 2s heartbeat on topology tab; confirm feed does NOT flicker.

## CI

- `tsc --noEmit` clean.
- `vite build` succeeds (`723.75 kB`).

## Parallel work note

PR #311 (`feat/channel-badge-ssot-and-ui-polish`, items 11/12/13) is polished in parallel and was NOT touched. No file-level conflicts with that branch.

Ref: `#heads msg#15701`, `msg#15699`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
