### PR TITLE
feat(hub): cross-channel @mention push notifications via DM fan-out (msg#15767)

### DIFF
--- a/hub/consumers/_agent_message.py
+++ b/hub/consumers/_agent_message.py
@@ -197,3 +197,19 @@ async def handle_agent_message(consumer, content):
         )
     except Exception:
         log.exception("push fan-out failed (agent path)")
+
+    # Cross-channel @mention push (msg#15767). Best-effort; failures
+    # must never break the parent write. The helper no-ops on DM
+    # channels and on messages without mention tokens.
+    try:
+        from hub.mentions import expand_mentions_and_notify
+
+        await _sta(expand_mentions_and_notify)(
+            workspace_id=consumer.workspace_id,
+            source_channel=ch_name,
+            source_msg_id=msg["id"] if msg else None,
+            sender_username=f"agent-{consumer.agent_name}",
+            text=text,
+        )
+    except Exception:
+        log.exception("mention push fan-out failed (agent path)")

--- a/hub/consumers/_dashboard_message.py
+++ b/hub/consumers/_dashboard_message.py
@@ -118,6 +118,24 @@ async def handle_dashboard_message(consumer, content):
     except Exception:
         log.exception("push fan-out failed (dashboard path)")
 
+    # Cross-channel @mention push (msg#15767). Best-effort; wrapped in
+    # sync_to_async because the helper touches the ORM + channel layer
+    # synchronously. No-ops for DM channels and mention-less messages.
+    try:
+        from asgiref.sync import sync_to_async as _sta2
+
+        from hub.mentions import expand_mentions_and_notify
+
+        await _sta2(expand_mentions_and_notify)(
+            workspace_id=consumer.workspace_id,
+            source_channel=ch_name,
+            source_msg_id=msg["id"] if msg else None,
+            sender_username=consumer.user.username,
+            text=text,
+        )
+    except Exception:
+        log.exception("mention push fan-out failed (dashboard path)")
+
     # @mention auto-reply (issue #98): when a message contains @agentname,
     # hub immediately posts a brief system status for the mentioned agent
     # so the sender knows whether it's alive and what it's doing.

--- a/hub/mentions.py
+++ b/hub/mentions.py
@@ -1,0 +1,461 @@
+"""Cross-channel @mention push notifications (msg#15767).
+
+When a chat message contains ``@<principal>`` tokens, fan out a DM
+notification to each mentioned principal — even if they are not
+subscribed to the source channel. "Push" is implemented as a regular
+:class:`Message` row inserted into the canonical
+``dm:<sender>|<target>`` channel, lazy-created via
+:func:`hub.views.api._ensure_dm_channel` and broadcast on the channel
+layer. The DM notification carries a ``metadata["kind"]="mention-push"``
+marker so the UI can style it distinctly if it wishes.
+
+Public surface (imported by
+``hub/consumers/_agent_message.py``,
+``hub/consumers/_dashboard_message.py``, and
+``hub/views/api/_messages.py``):
+
+  - :func:`parse_mention_tokens` — pure-function @token scanner.
+  - :func:`resolve_mention_targets` — expand tokens into usernames.
+  - :func:`expand_mentions_and_notify` — scan + fan-out + persist + broadcast.
+
+Grammar (see spec in PR body):
+
+  * ``@<name>`` must be preceded by start-of-message, whitespace, or
+    non-identifier punctuation (``,.;:!?()[]{}<>`` etc.). An ``@``
+    adjacent to a word character on its left is NOT a mention, which
+    rules out ``foo@example.com`` and ``https://user@host``.
+  * ``<name>`` is one or more of ``[A-Za-z0-9._-]``; trailing ``.``
+    (e.g. sentence-final) is stripped.
+  * Group tokens: ``all``, ``agents``, ``heads``, ``healers``,
+    ``managers``, ``workers``, ``mambas`` (the last preserved for
+    legacy fleet compatibility).
+
+Rate limit: ``@all`` expansions are capped per sender per minute via
+``SCITEX_OROCHI_MENTION_ALL_RATE_LIMIT_PER_MIN`` (default 3). The counter
+is in-process — a hub restart resets it, which is acceptable because
+the cap's only purpose is to throttle a single runaway agent loop.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+import time
+from typing import Iterable
+
+log = logging.getLogger("orochi.mentions")
+
+# ---------------------------------------------------------------------------
+# Token parser
+# ---------------------------------------------------------------------------
+
+# ``@name`` scanner. ``(?<![\w@])`` forbids a word char OR a second ``@``
+# (the ``??`` in URLs like ``git@github.com`` is ruled out by ``\w``
+# already, but ``foo@@bar`` should also not double-fire). The name body
+# allows letters, digits, dots, underscores, hyphens. Trailing ``.``
+# (sentence-final) is stripped in post-processing.
+_MENTION_RE = re.compile(r"(?<![\w@.])@([A-Za-z0-9][\w.\-]*)")
+
+# Group tokens the hub knows how to expand. Each maps to a predicate
+# over ``User.username``; see :func:`resolve_mention_targets`. ``mambas``
+# is kept for backwards compatibility with the legacy fleet roster
+# established in ``hub/consumers/_dashboard_message.py``.
+_GROUP_PATTERNS: dict[str, object] = {
+    "all": lambda username: True,
+    "agents": lambda username: username.startswith("agent-"),
+    "heads": lambda username: username.startswith("agent-head-"),
+    "healers": lambda username: username.startswith("agent-healer-")
+    or username.startswith("agent-mamba-healer-"),
+    "managers": lambda username: username.startswith("agent-mgr-"),
+    "workers": lambda username: username.startswith("agent-worker-"),
+    "mambas": lambda username: username.startswith("agent-mamba-"),
+}
+
+
+def parse_mention_tokens(text: str) -> list[str]:
+    """Return the ordered list of raw mention tokens found in ``text``.
+
+    Tokens are lower-cased to match group-token keys case-insensitively,
+    but the caller is expected to preserve the original-case copy for
+    echo (the backend never auto-corrects the user's spelling).
+
+    Deduplication is intentionally NOT done here — the caller decides
+    whether to dedupe, because group mentions expand into distinct
+    usernames and the right place to dedupe is after expansion.
+
+    Examples::
+
+        >>> parse_mention_tokens("hi @head-mba and @worker-bee")
+        ['head-mba', 'worker-bee']
+        >>> parse_mention_tokens("reach me at foo@example.com")
+        []
+        >>> parse_mention_tokens("@ALL please check in")
+        ['all']
+    """
+    if not text:
+        return []
+    raw = _MENTION_RE.findall(text)
+    cleaned: list[str] = []
+    for token in raw:
+        # Strip trailing punctuation that the regex happens to consume
+        # (our body class allows ``.`` and ``-`` so ``@alice.`` keeps
+        # the dot; sentence-final dots should not be part of the name).
+        token = token.rstrip(".-_")
+        if not token:
+            continue
+        cleaned.append(token.lower())
+    return cleaned
+
+
+# ---------------------------------------------------------------------------
+# Target resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_mention_targets(
+    workspace_id: int,
+    tokens: Iterable[str],
+    *,
+    exclude_usernames: Iterable[str] = (),
+) -> list[str]:
+    """Expand mention tokens into a deduped, ordered list of Django usernames.
+
+    For each token in ``tokens``:
+
+      * If it's a known group token (``all``, ``agents``, ``heads``,
+        ``healers``, ``managers``, ``workers``, ``mambas``), iterate
+        over every :class:`WorkspaceMember` in the workspace and include
+        usernames matching the group's predicate.
+      * Otherwise, treat the token as a single-principal reference:
+        try ``agent-<token>`` first (canonical agent username), then
+        fall back to a bare ``<token>`` match against ``User.username``.
+
+    Usernames in ``exclude_usernames`` (typically the sender) are
+    dropped to avoid self-notification. The final list preserves
+    first-occurrence order so downstream DM threading is deterministic.
+    """
+    # Imports are local so this module can be imported at startup
+    # without dragging in Django model loading (unit tests that just
+    # hit the parser shouldn't need the ORM).
+    from django.contrib.auth.models import User
+
+    from hub.models import WorkspaceMember
+
+    tokens = list(tokens)
+    if not tokens:
+        return []
+
+    excluded = {u for u in exclude_usernames if u}
+    result: list[str] = []
+    seen: set[str] = set()
+
+    # Build the workspace-member username pool once; used by both the
+    # group-expansion branch and the fallback bare-name lookup.
+    member_usernames: list[str] = list(
+        WorkspaceMember.objects.filter(workspace_id=workspace_id)
+        .values_list("user__username", flat=True)
+    )
+
+    def _add(username: str) -> None:
+        if not username or username in excluded or username in seen:
+            return
+        seen.add(username)
+        result.append(username)
+
+    for token in tokens:
+        key = token.lower()
+        if key in _GROUP_PATTERNS:
+            predicate = _GROUP_PATTERNS[key]
+            for uname in member_usernames:
+                if predicate(uname):
+                    _add(uname)
+            continue
+
+        # Single-principal lookup. Prefer the synthetic agent-user
+        # (``agent-<name>``) because that's the canonical form agents
+        # register under; fall back to a bare match for humans.
+        agent_username = f"agent-{token}"
+        if agent_username in member_usernames:
+            _add(agent_username)
+            continue
+        if token in member_usernames:
+            _add(token)
+            continue
+        # Last resort: probe the User table outside the workspace
+        # pool so cross-workspace logins we haven't cached locally
+        # still resolve — but only if the user exists to avoid
+        # creating ghost DMs to non-existent principals.
+        if User.objects.filter(username=agent_username).exists():
+            _add(agent_username)
+        elif User.objects.filter(username=token).exists():
+            _add(token)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Rate limit for @all
+# ---------------------------------------------------------------------------
+
+
+def _rate_limit_setting() -> int:
+    """Return the per-sender @all cap per 60s window (env-configurable)."""
+    raw = os.environ.get("SCITEX_OROCHI_MENTION_ALL_RATE_LIMIT_PER_MIN", "3")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return 3
+    return max(value, 0)
+
+
+_rate_lock = threading.Lock()
+# Per-sender ring of recent @all send timestamps (unix seconds).
+_rate_events: dict[str, list[float]] = {}
+_RATE_WINDOW_S = 60.0
+
+
+def _consume_all_rate_token(sender_username: str) -> bool:
+    """Return True if the sender may fire an ``@all`` right now.
+
+    Sliding-window counter: keep only timestamps inside the last 60s,
+    allow up to ``_rate_limit_setting()`` per window. When a call is
+    denied, log the suppression so operators can tune the cap.
+    """
+    cap = _rate_limit_setting()
+    if cap <= 0:
+        return False
+    now = time.time()
+    with _rate_lock:
+        bucket = _rate_events.setdefault(sender_username, [])
+        # Drop stale entries.
+        bucket[:] = [t for t in bucket if now - t < _RATE_WINDOW_S]
+        if len(bucket) >= cap:
+            return False
+        bucket.append(now)
+    return True
+
+
+def _reset_rate_limit_for_tests() -> None:
+    """Test helper — clears the in-process rate-limit window."""
+    with _rate_lock:
+        _rate_events.clear()
+
+
+# ---------------------------------------------------------------------------
+# Fan-out
+# ---------------------------------------------------------------------------
+
+
+def _principal_key_for_username(username: str) -> str:
+    """Return ``agent:<name>`` for synthetic agent users, else ``human:<name>``."""
+    if username.startswith("agent-"):
+        return f"agent:{username[len('agent-'):]}"
+    return f"human:{username}"
+
+
+def _canonical_dm_name(a_username: str, b_username: str) -> str:
+    """Build the ``dm:<a>|<b>`` canonical channel name for a pair of users."""
+    keys = sorted(
+        [_principal_key_for_username(a_username), _principal_key_for_username(b_username)]
+    )
+    return "dm:" + "|".join(keys)
+
+
+def expand_mentions_and_notify(
+    *,
+    workspace_id: int,
+    source_channel: str,
+    source_msg_id: int | None,
+    sender_username: str,
+    text: str,
+) -> list[dict]:
+    """Parse mentions in ``text`` and fan out DM notifications.
+
+    Called synchronously from the message-persistence paths (WS agent,
+    WS dashboard, REST ``api_messages``). Returns the list of
+    notification records that were created (``[{"recipient": ..., "dm":
+    ..., "message_id": ...}, ...]``) for logging/inspection; the caller
+    is free to ignore the return value.
+
+    Side effects:
+
+      1. ``_ensure_dm_channel`` lazy-creates each
+         ``dm:<sender>|<target>`` channel + participants.
+      2. A :class:`Message` row is inserted into that DM channel with
+         ``metadata["kind"]="mention-push"``, ``source_channel``, and
+         ``source_msg_id`` set.
+      3. The message is broadcast on the DM channel group so any
+         already-connected recipient dashboard / MCP receives it in
+         real time.
+
+    Skipped when:
+
+      * There are no mention tokens.
+      * ``source_channel`` is already a DM (don't cross-notify within
+        private threads; the source DM already pushes to participants).
+      * A resolved target already has a ``ChannelMembership`` row on
+        the source channel — the normal channel fanout already reaches
+        them, so adding a DM would be duplicate noise.
+      * The target is the sender themselves.
+
+    ``@all`` expansions above the rate-limit are dropped with a log
+    line; other mentions in the same message still go through.
+    """
+    if not text:
+        return []
+    if source_channel and source_channel.startswith("dm:"):
+        # Mentions inside DMs don't need cross-channel push — the DM
+        # already hits the participants directly. Re-fanning would
+        # create a recursive notification loop between the same pair.
+        return []
+
+    raw_tokens = parse_mention_tokens(text)
+    if not raw_tokens:
+        return []
+
+    # ``@all`` rate limit — per sender, 60s window.
+    heavy_tokens = {"all"}
+    dropped_heavy: list[str] = []
+    effective_tokens: list[str] = []
+    for tok in raw_tokens:
+        if tok in heavy_tokens:
+            if _consume_all_rate_token(sender_username):
+                effective_tokens.append(tok)
+            else:
+                dropped_heavy.append(tok)
+        else:
+            effective_tokens.append(tok)
+    if dropped_heavy:
+        log.warning(
+            "mention-push: rate-limited @%s from %s (window=%ds, cap=%d)",
+            dropped_heavy[0],
+            sender_username,
+            int(_RATE_WINDOW_S),
+            _rate_limit_setting(),
+        )
+
+    if not effective_tokens:
+        return []
+
+    # Local imports so parser/rate-limit can be unit-tested without
+    # the full Django app context.
+    from asgiref.sync import async_to_sync
+    from channels.layers import get_channel_layer
+
+    from hub.consumers import _sanitize_group
+    from hub.models import Channel, ChannelMembership, Message, Workspace
+    from hub.views.api._dms import _ensure_dm_channel
+
+    try:
+        workspace = Workspace.objects.get(id=workspace_id)
+    except Workspace.DoesNotExist:
+        log.warning("mention-push: workspace %s missing", workspace_id)
+        return []
+
+    targets = resolve_mention_targets(
+        workspace_id=workspace_id,
+        tokens=effective_tokens,
+        exclude_usernames=[sender_username],
+    )
+    if not targets:
+        return []
+
+    # Fetch the source channel once so we can query memberships in one
+    # SQL roundtrip. Missing row => no existing subscribers, proceed.
+    try:
+        src_channel = Channel.objects.get(
+            workspace=workspace, name=source_channel
+        )
+    except Channel.DoesNotExist:
+        src_channel = None
+
+    subscriber_usernames: set[str] = set()
+    if src_channel is not None:
+        subscriber_usernames = set(
+            ChannelMembership.objects.filter(channel=src_channel)
+            .values_list("user__username", flat=True)
+        )
+
+    layer = get_channel_layer()
+    notifications: list[dict] = []
+    for target_username in targets:
+        # Recipient already subscribed — existing fanout reaches them.
+        if target_username in subscriber_usernames:
+            continue
+
+        dm_name = _canonical_dm_name(sender_username, target_username)
+        try:
+            dm_channel = _ensure_dm_channel(workspace, dm_name)
+        except Exception:
+            log.exception("mention-push: _ensure_dm_channel failed for %s", dm_name)
+            continue
+        if dm_channel is None:
+            log.warning(
+                "mention-push: could not resolve DM channel %s (sender=%s, target=%s)",
+                dm_name,
+                sender_username,
+                target_username,
+            )
+            continue
+
+        # Derive sender_type from the username shape — synthetic agent
+        # users carry the ``agent-`` prefix.
+        sender_type = "agent" if sender_username.startswith("agent-") else "human"
+        metadata = {
+            "kind": "mention-push",
+            "source_channel": source_channel,
+            "source_msg_id": source_msg_id,
+            "mentioned": target_username,
+        }
+        try:
+            dm_msg = Message.objects.create(
+                workspace=workspace,
+                channel=dm_channel,
+                sender=sender_username,
+                sender_type=sender_type,
+                content=text,
+                metadata=metadata,
+            )
+        except Exception:
+            log.exception(
+                "mention-push: Message.create failed dm=%s sender=%s target=%s",
+                dm_name,
+                sender_username,
+                target_username,
+            )
+            continue
+
+        # Broadcast on the DM channel group so any already-connected
+        # recipient socket delivers it live. Best-effort — a broken
+        # channel layer must not fail the parent write.
+        if layer is not None:
+            group = _sanitize_group(f"channel_{workspace.id}_{dm_name}")
+            try:
+                async_to_sync(layer.group_send)(
+                    group,
+                    {
+                        "type": "chat.message",
+                        "id": dm_msg.id,
+                        "sender": sender_username,
+                        "sender_type": sender_type,
+                        "channel": dm_name,
+                        "kind": "dm",
+                        "text": text,
+                        "ts": dm_msg.ts.isoformat(),
+                        "metadata": metadata,
+                    },
+                )
+            except Exception:
+                log.exception("mention-push: group_send failed for %s", dm_name)
+
+        notifications.append(
+            {
+                "recipient": target_username,
+                "dm": dm_name,
+                "message_id": dm_msg.id,
+            }
+        )
+
+    return notifications

--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -29,6 +29,7 @@ from hub.tests.registry.test_heartbeat import *  # noqa: F401,F403
 from hub.tests.registry.test_reexports import *  # noqa: F401,F403
 from hub.tests.registry.test_singleton_enforcement import *  # noqa: F401,F403
 from hub.tests.test_auth import *  # noqa: F401,F403
+from hub.tests.test_mention_expansion import *  # noqa: F401,F403
 from hub.tests.test_oauth_helper import *  # noqa: F401,F403
 from hub.tests.views.api.test_admin_subscribe import *  # noqa: F401,F403
 from hub.tests.views.api.test_agent_detail import *  # noqa: F401,F403

--- a/hub/tests/test_mention_expansion.py
+++ b/hub/tests/test_mention_expansion.py
@@ -1,0 +1,308 @@
+"""Tests for the cross-channel @mention push helper (``hub/mentions.py``).
+
+Covers three layers:
+
+  1. The pure-function :func:`parse_mention_tokens` — regex edge cases
+     (email-like, URL-like, punctuation, dedupe, case).
+  2. :func:`resolve_mention_targets` — group-token expansion, synthetic
+     agent-user lookup, sender exclusion.
+  3. :func:`expand_mentions_and_notify` — end-to-end fan-out: DM
+     channel lazy-create, mention-push metadata marker, subscriber
+     dedupe, rate-limit gate for ``@all``.
+
+Uses Django's in-memory channels layer via ``CHANNEL_LAYERS`` override
+so ``group_send`` calls don't fail.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+
+from hub.mentions import (
+    _reset_rate_limit_for_tests,
+    expand_mentions_and_notify,
+    parse_mention_tokens,
+    resolve_mention_targets,
+)
+from hub.models import (
+    Channel,
+    ChannelMembership,
+    Message,
+    Workspace,
+    WorkspaceMember,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Parser
+# ---------------------------------------------------------------------------
+
+
+class ParseMentionTokensTest(TestCase):
+    """The pure regex-based token scanner."""
+
+    def test_single_username_mention(self):
+        self.assertEqual(parse_mention_tokens("hi @alice"), ["alice"])
+
+    def test_two_distinct_mentions(self):
+        self.assertEqual(
+            parse_mention_tokens("ping @alice and @bob"),
+            ["alice", "bob"],
+        )
+
+    def test_group_tokens_lowercased(self):
+        self.assertEqual(parse_mention_tokens("@ALL please"), ["all"])
+        self.assertEqual(
+            parse_mention_tokens("@Heads @HEALERS"),
+            ["heads", "healers"],
+        )
+
+    def test_email_like_not_parsed(self):
+        # foo@example.com must not be interpreted as a mention of
+        # ``example`` — the ``(?<![\w@])`` lookbehind blocks the match
+        # because ``o`` (a word char) precedes ``@``.
+        self.assertEqual(
+            parse_mention_tokens("reach me at foo@example.com"),
+            [],
+        )
+
+    def test_url_like_not_parsed(self):
+        self.assertEqual(
+            parse_mention_tokens("Hello https://user@host.com/x"),
+            [],
+        )
+
+    def test_trailing_period_stripped(self):
+        self.assertEqual(parse_mention_tokens("ping @alice."), ["alice"])
+
+    def test_sentence_punctuation_surrounding(self):
+        self.assertEqual(
+            parse_mention_tokens("(@alice, @bob) see this!"),
+            ["alice", "bob"],
+        )
+
+    def test_double_at_not_matched(self):
+        self.assertEqual(parse_mention_tokens("@@doubled"), [])
+
+    def test_empty_and_none(self):
+        self.assertEqual(parse_mention_tokens(""), [])
+        self.assertEqual(parse_mention_tokens(None), [])
+
+    def test_agent_style_username(self):
+        self.assertEqual(
+            parse_mention_tokens("attn @agent-foo"),
+            ["agent-foo"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Group resolution
+# ---------------------------------------------------------------------------
+
+
+class ResolveMentionTargetsTest(TestCase):
+    """Group-token expansion + fallback lookup."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="mention-resolve-ws")
+        # Human members
+        self.alice = User.objects.create_user("alice", password="x")
+        self.bob = User.objects.create_user("bob", password="x")
+        # Agent-shaped members
+        self.head_mba = User.objects.create_user("agent-head-mba", password="x")
+        self.head_spa = User.objects.create_user("agent-head-spartan", password="x")
+        self.healer = User.objects.create_user("agent-healer-mba", password="x")
+        self.worker = User.objects.create_user("agent-worker-bee", password="x")
+        for u in [
+            self.alice,
+            self.bob,
+            self.head_mba,
+            self.head_spa,
+            self.healer,
+            self.worker,
+        ]:
+            WorkspaceMember.objects.create(workspace=self.ws, user=u, role="member")
+
+    def test_bare_human_resolved(self):
+        self.assertEqual(
+            resolve_mention_targets(self.ws.id, ["alice"]),
+            ["alice"],
+        )
+
+    def test_bare_agent_short_name_resolved_to_synthetic(self):
+        # ``@head-mba`` should map to ``agent-head-mba`` (the synthetic
+        # username agents authenticate under).
+        self.assertEqual(
+            resolve_mention_targets(self.ws.id, ["head-mba"]),
+            ["agent-head-mba"],
+        )
+
+    def test_heads_group_expansion(self):
+        got = resolve_mention_targets(self.ws.id, ["heads"])
+        self.assertEqual(set(got), {"agent-head-mba", "agent-head-spartan"})
+
+    def test_healers_group_expansion(self):
+        self.assertEqual(
+            resolve_mention_targets(self.ws.id, ["healers"]),
+            ["agent-healer-mba"],
+        )
+
+    def test_workers_group_expansion(self):
+        self.assertEqual(
+            resolve_mention_targets(self.ws.id, ["workers"]),
+            ["agent-worker-bee"],
+        )
+
+    def test_all_group_expansion_excludes_sender(self):
+        got = resolve_mention_targets(
+            self.ws.id, ["all"], exclude_usernames=["alice"]
+        )
+        # alice is excluded; every other member appears once.
+        self.assertNotIn("alice", got)
+        self.assertIn("bob", got)
+        self.assertIn("agent-head-mba", got)
+
+    def test_dedupe_across_group_and_single(self):
+        # @heads + @head-mba should not double-count head-mba.
+        got = resolve_mention_targets(self.ws.id, ["heads", "head-mba"])
+        self.assertEqual(got.count("agent-head-mba"), 1)
+
+    def test_unknown_token_returns_nothing(self):
+        self.assertEqual(
+            resolve_mention_targets(self.ws.id, ["does-not-exist"]),
+            [],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end fan-out
+# ---------------------------------------------------------------------------
+
+
+_INMEM_CHANNELS = {
+    "default": {
+        "BACKEND": "channels.layers.InMemoryChannelLayer",
+    },
+}
+
+
+@override_settings(CHANNEL_LAYERS=_INMEM_CHANNELS)
+class ExpandMentionsAndNotifyTest(TestCase):
+    """Fan-out: DM lazy-create, metadata marker, dedupe, rate-limit."""
+
+    def setUp(self):
+        _reset_rate_limit_for_tests()
+        self.ws = Workspace.objects.create(name="mention-e2e-ws")
+        self.alice = User.objects.create_user("alice", password="x")
+        self.bob = User.objects.create_user("bob", password="x")
+        self.carol = User.objects.create_user("carol", password="x")
+        self.head_mba = User.objects.create_user("agent-head-mba", password="x")
+        for u in [self.alice, self.bob, self.carol, self.head_mba]:
+            WorkspaceMember.objects.create(workspace=self.ws, user=u, role="member")
+        self.source = Channel.objects.create(
+            workspace=self.ws, name="#proj-neurovista", kind=Channel.KIND_GROUP
+        )
+
+    def _notify(self, text, sender="alice", channel=None):
+        return expand_mentions_and_notify(
+            workspace_id=self.ws.id,
+            source_channel=channel or self.source.name,
+            source_msg_id=None,
+            sender_username=sender,
+            text=text,
+        )
+
+    def test_bare_mention_creates_dm_notification(self):
+        res = self._notify("hey @bob look at this")
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["recipient"], "bob")
+        # The DM now exists with a mention-push message.
+        dm = Channel.objects.get(workspace=self.ws, name=res[0]["dm"])
+        self.assertEqual(dm.kind, Channel.KIND_DM)
+        msgs = list(Message.objects.filter(channel=dm))
+        self.assertEqual(len(msgs), 1)
+        self.assertEqual(msgs[0].metadata["kind"], "mention-push")
+        self.assertEqual(msgs[0].metadata["source_channel"], "#proj-neurovista")
+
+    def test_two_distinct_mentions_generate_two_notifications(self):
+        res = self._notify("ping @bob and @carol")
+        self.assertEqual({r["recipient"] for r in res}, {"bob", "carol"})
+
+    def test_duplicate_mention_dedupes_to_one(self):
+        res = self._notify("@bob @bob @bob")
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["recipient"], "bob")
+
+    def test_group_mention_fan_out(self):
+        # @heads should resolve to agent-head-mba and create a DM notif.
+        res = self._notify("heads up @heads", sender="alice")
+        recipients = {r["recipient"] for r in res}
+        self.assertIn("agent-head-mba", recipients)
+
+    def test_subscriber_recipient_skipped(self):
+        # If bob is already subscribed to the source channel, no DM
+        # mention-push should be generated.
+        ChannelMembership.objects.create(user=self.bob, channel=self.source)
+        res = self._notify("hey @bob")
+        self.assertEqual(res, [])
+
+    def test_email_like_does_not_notify(self):
+        res = self._notify("contact foo@example.com for help")
+        self.assertEqual(res, [])
+
+    def test_url_like_does_not_notify(self):
+        res = self._notify("see https://user@host.com")
+        self.assertEqual(res, [])
+
+    def test_dm_source_channel_skipped(self):
+        # A mention inside a DM thread does not trigger cross-push.
+        res = self._notify(
+            "hey @carol check", channel="dm:human:alice|human:bob"
+        )
+        self.assertEqual(res, [])
+
+    def test_sender_self_excluded_on_all(self):
+        res = self._notify("@all standup time", sender="alice")
+        recipients = {r["recipient"] for r in res}
+        self.assertNotIn("alice", recipients)
+        # Other members should be in there.
+        self.assertIn("bob", recipients)
+
+    def test_all_rate_limit_kicks_in_on_fourth_call(self):
+        # Default cap is 3 @all per minute per sender.
+        for _ in range(3):
+            res = self._notify("@all ping", sender="alice")
+            self.assertTrue(res, "first three @all should fan out")
+        # Fourth invocation must be rate-limited → empty result.
+        res4 = self._notify("@all ping", sender="alice")
+        self.assertEqual(res4, [])
+
+    def test_all_rate_limit_env_override(self):
+        # Override the cap to 1 via env var.
+        _reset_rate_limit_for_tests()
+        with mock.patch.dict(
+            os.environ, {"SCITEX_OROCHI_MENTION_ALL_RATE_LIMIT_PER_MIN": "1"}
+        ):
+            self.assertTrue(self._notify("@all one", sender="alice"))
+            self.assertEqual(self._notify("@all two", sender="alice"), [])
+
+    def test_rate_limit_does_not_affect_non_all_mentions(self):
+        # Even after @all is capped, a plain @bob mention still goes.
+        _reset_rate_limit_for_tests()
+        with mock.patch.dict(
+            os.environ, {"SCITEX_OROCHI_MENTION_ALL_RATE_LIMIT_PER_MIN": "0"}
+        ):
+            res = self._notify("@all @bob hi", sender="alice")
+            recipients = {r["recipient"] for r in res}
+            # @all was suppressed (cap=0); @bob still fans out.
+            self.assertEqual(recipients, {"bob"})
+
+    def test_empty_text_returns_empty(self):
+        self.assertEqual(self._notify(""), [])
+
+    def test_no_mentions_returns_empty(self):
+        self.assertEqual(self._notify("no tokens here"), [])

--- a/hub/views/api/_messages.py
+++ b/hub/views/api/_messages.py
@@ -170,6 +170,22 @@ def api_messages(request, slug=None):
     except Exception:
         log.exception("push fan-out failed (REST path)")
 
+    # Cross-channel @mention push (msg#15767). Best-effort — a failure
+    # in the helper must not 500 the REST caller. The helper itself
+    # no-ops on DM channels and mention-less messages.
+    try:
+        from hub.mentions import expand_mentions_and_notify
+
+        expand_mentions_and_notify(
+            workspace_id=workspace.id,
+            source_channel=ch_name,
+            source_msg_id=msg.id,
+            sender_username=request.user.username,
+            text=text,
+        )
+    except Exception:
+        log.exception("mention push fan-out failed (REST path)")
+
     return JsonResponse({"status": "ok", "id": msg.id}, status=201)
 
 


### PR DESCRIPTION
## Summary

Implements cross-channel `@mention` push notifications (lead `#heads msg#15767`, ywatanabe `msg#15762` option a). When a message contains `@<principal>` tokens, the hub lazy-creates a DM channel between the sender and each mentioned principal and inserts a `Message` row tagged with `metadata.kind="mention-push"` — so mentioned agents/humans see the message even if they aren't subscribed to the source channel.

- `hub/mentions.py::expand_mentions_and_notify(...)` — the new helper, called from all three write paths:
  - `hub/consumers/_agent_message.py::handle_agent_message` (WS agent path)
  - `hub/consumers/_dashboard_message.py::handle_dashboard_message` (WS dashboard path)
  - `hub/views/api/_messages.py::api_messages` (REST path)
- Reuses `hub/views/api/_dms.py::_ensure_dm_channel` for lazy DM creation — no new DB model, no migration.

## Token grammar

- `@<name>` must be preceded by start-of-message, whitespace, or non-identifier punctuation. `(?<![\w@.])` rejects `foo@example.com` (letter before `@`) and `https://user@host` (same).
- Name body: `[A-Za-z0-9][\w.\-]*`. Trailing `.-_` stripped.
- Group tokens (case-insensitive): `@all`, `@agents`, `@heads`, `@healers`, `@managers`, `@workers`, `@mambas` (legacy-compat).

## Fan-out rules

- Dedupe: same principal mentioned multiple times → one notification.
- Sender is excluded from `@all` expansion.
- Already-subscribed recipients are skipped (existing fan-out reaches them).
- DM-source channels are skipped (don't recurse mentions inside DMs).
- DM row is persisted with:
  ```json
  {"kind": "mention-push", "source_channel": "#X", "source_msg_id": N, "mentioned": "<username>"}
  ```
  plus a real-time `chat.message` broadcast on the DM group.

## Rate limit

- `@all` capped per sender per 60s window. Env var `SCITEX_OROCHI_MENTION_ALL_RATE_LIMIT_PER_MIN` (default **3**); set to `0` to disable `@all` entirely. In-process sliding window — hub restart resets the counter (acceptable; cap exists only to throttle runaway agent loops).

## Tests

32 new tests in `hub/tests/test_mention_expansion.py`, all passing:

- `ParseMentionTokensTest` (10 cases): single/double mentions, email-like, URL-like, trailing punctuation, double-`@`, empty/None, agent-style names, group lowercasing.
- `ResolveMentionTargetsTest` (8 cases): bare human, bare agent short-name → synthetic `agent-<name>` resolution, `@heads`/`@healers`/`@workers` group expansion, sender exclusion on `@all`, dedupe across `@heads + @head-mba`, unknown token no-match.
- `ExpandMentionsAndNotifyTest` (14 cases): DM lazy-create, `mention-push` metadata, two-distinct-mentions, duplicate dedupe, group fan-out, subscriber skip, email/URL guards, DM-source no-op, self-exclude, 4th `@all` rate-limited, env override, non-`@all` unaffected by cap, empty/no-mention no-ops.

## Test plan

- [x] `python3 manage.py test hub.tests.test_mention_expansion` — 32/32 pass
- [x] `python3 manage.py test hub.tests.consumers` — 55/55 pass (one pre-existing scheduler-loop DB-locked warning unrelated to this PR)
- [x] `python3 -c 'import ast; ast.parse(open(p).read())'` on all new/changed files — syntactically clean
- [ ] CI (GitHub Actions) green on this branch

## Judgment calls

- **Subscriber-skip rule**: chose to silently skip when the recipient is already a `ChannelMembership` of the source channel — avoids double notification. Alternative would be to always DM for consistency, but that doubles noise for the common case where a mention is made in a channel both parties are in. If lead prefers "always DM", easy to flip.
- **Mentions inside DMs**: no-op entirely. Re-fanning would loop between the same pair and pollute the DM with meta-notifications.
- **Rate-limit scope**: only `@all` is rate-limited. `@heads`/`@agents` could still fan out to dozens, but those are narrower and operationally useful. Can extend to all group tokens if needed.
- **Sender-type for mention-push row**: derived from username prefix (`agent-*` → `agent`, else `human`). Matches existing conventions.

## Coordination

- Parallel `feat/overview-tab-promotion` frontend branch — no files under `hub/frontend/` or `hub/static/hub/` touched. No conflicts expected.
- No `CHANGELOG.md` change (per instructions).
- No `ts-migration-v2` changes.
- No new migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
