### PR TITLE
feat(ui/overview): promote graph to top-level "Overview" tab + restore agent detail panel (Step 3)

### DIFF
--- a/hub/frontend/src/tabs.ts
+++ b/hub/frontend/src/tabs.ts
@@ -17,7 +17,13 @@ import { channelUnread } from "./app/utils";
 /* globals: activeTab, fetchTodoList, renderAgentsTab, renderResourcesTab,
    fetchWorkspaces */
 
-export var activeTab = "chat";
+/* Default landing tab — the Overview tab (internal id "activity" — see
+ * note below) is the leftmost tab and the first-load landing surface.
+ * The internal id stays "activity" even though the user-visible label
+ * reads "Overview"; renaming the id would churn every globalThis/SSE
+ * key that keys off it (_overviewExpanded, etc.), and the directory
+ * name `activity-tab/` is likewise left alone per Step 3 spec. */
+export var activeTab = "activity";
 
 /* PR #<this> Item 3 helper: pick a sensible default channel when the
  * Chat tab is activated without one. Preference order:
@@ -233,15 +239,35 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
   });
 });
 
-/* Restore last open tab across reloads */
+/* Restore last open tab across reloads.
+ *
+ * PR Step 3 (Overview promotion): default landing is the Overview tab
+ * (internal id "activity"). If localStorage has a remembered tab AND
+ * its button still exists in the DOM, honor it — otherwise fall back
+ * to Overview. We activate Overview synchronously so first paint lands
+ * there without flashing through Chat; the inline `activity` default
+ * on the Overview tab-button plus activeTab="activity" above already
+ * gets us 90% of the way, but we still run _activateTab to trigger
+ * the poll start + render-hook side effects. */
 (function () {
   try {
     var last = localStorage.getItem("orochi_active_tab");
-    if (last && last !== "chat") {
-      var btn = document.querySelector('.tab-btn[data-tab="' + last + '"]');
-      if (btn) _activateTab(last);
+    var target = last || "activity";
+    /* If the remembered tab no longer has a DOM button (e.g. Terminal
+     * was demoted in this PR), fall through to Overview. */
+    var btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
+    if (!btn) {
+      target = "activity";
+      btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
     }
-  } catch (_) {}
+    if (btn) _activateTab(target);
+  } catch (_) {
+    /* Even if localStorage is unavailable (private mode / quota), we
+     * still want to land on Overview. */
+    try {
+      _activateTab("activity");
+    } catch (__) {}
+  }
 })();
 
 /* Collapsible sidebar sections (#321 fix: use data-section for stable keys) */

--- a/hub/static/hub/components/components-agent-detail.css
+++ b/hub/static/hub/components/components-agent-detail.css
@@ -43,6 +43,13 @@
 }
 .agent-tab-content {
   width: 100%;
+  /* PR Step 3 (Overview promotion) — enforce a usable baseline for
+   * the agent detail panel. Lead reported the panel was collapsed to
+   * a single "Loading details…" line on the first click (msg#15734).
+   * 400×400 is the explicit spec floor; we give the whole tab-content
+   * wrapper the same minimum so children stretch naturally. */
+  min-width: 400px;
+  min-height: 400px;
 }
 
 /* ── Per-agent detail view ── */
@@ -51,6 +58,11 @@
   flex-direction: column;
   gap: 12px;
   width: 100%;
+  /* PR Step 3 — match the floor set on .agent-tab-content so the
+   * detail view itself doesn't collapse below a usable size when
+   * parent flex containers try to shrink it. */
+  min-width: 400px;
+  min-height: 400px;
 }
 .agent-detail-header {
   font-size: 14px;
@@ -204,6 +216,12 @@
 .agent-detail-pane-wrap {
   flex: 1 1 auto;
   width: 100%;
+  /* PR Step 3 (Overview promotion): lead flagged that the detail
+   * pane collapsed to barely-readable on click (msg#15734). Enforce
+   * the spec floor 400×400 directly on the pane wrap so even inside
+   * a cramped flex parent the terminal preview gets room to breathe. */
+  min-width: 400px;
+  min-height: 400px;
 }
 .agent-detail-pane {
   background: #0d1117;

--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -2,7 +2,13 @@
 /* globals: activeTab, fetchTodoList, renderAgentsTab, renderResourcesTab,
    fetchWorkspaces */
 
-var activeTab = "chat";
+/* Default landing tab — the Overview tab (internal id "activity" — see
+ * note below) is the leftmost tab and the first-load landing surface.
+ * The internal id stays "activity" even though the user-visible label
+ * reads "Overview"; renaming the id would churn every globalThis/SSE
+ * key that keys off it (_overviewExpanded, etc.), and the directory
+ * name `activity-tab/` is likewise left alone per Step 3 spec. */
+var activeTab = "activity";
 
 function _activateTab(tab) {
   activeTab = tab;
@@ -138,15 +144,35 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
   });
 });
 
-/* Restore last open tab across reloads */
+/* Restore last open tab across reloads.
+ *
+ * PR Step 3 (Overview promotion): default landing is the Overview tab
+ * (internal id "activity"). If localStorage has a remembered tab AND
+ * its button still exists in the DOM, honor it — otherwise fall back
+ * to Overview. We activate Overview synchronously so first paint lands
+ * there without flashing through Chat; the inline `activity` default
+ * on the Overview tab-button plus activeTab="activity" above already
+ * gets us 90% of the way, but we still run _activateTab to trigger
+ * the poll start + render-hook side effects. */
 (function () {
   try {
     var last = localStorage.getItem("orochi_active_tab");
-    if (last && last !== "chat") {
-      var btn = document.querySelector('.tab-btn[data-tab="' + last + '"]');
-      if (btn) _activateTab(last);
+    var target = last || "activity";
+    /* If the remembered tab no longer has a DOM button (e.g. Terminal
+     * was demoted in this PR), fall through to Overview. */
+    var btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
+    if (!btn) {
+      target = "activity";
+      btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
     }
-  } catch (_) {}
+    if (btn) _activateTab(target);
+  } catch (_) {
+    /* Even if localStorage is unavailable (private mode / quota), we
+     * still want to land on Overview. */
+    try {
+      _activateTab("activity");
+    } catch (__) {}
+  }
 })();
 
 /* Collapsible sidebar sections (#321 fix: use data-section for stable keys) */

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -179,14 +179,23 @@
                 aria-label="Collapse sidebar"
                 title="Collapse sidebar (Ctrl+B)">&lsaquo;</button>
         <div class="main">
+            {# Tab bar — Step 3 (UI restructure): Overview is leftmost
+               and the first-load default; Agents is a list-view only
+               (graph/topology lives in Overview now); Terminal tab was
+               demoted — the terminal preview code still powers the
+               agent-detail pane's SSH action. Initial .active class is
+               set on Overview here so first paint lands there even
+               before tabs.ts runs its restore logic. The internal
+               data-tab values ("activity" / "agents-tab") are kept as
+               is; only the user-visible labels flip. #}
             <div class="tab-bar">
-                <button class="tab-btn active" data-tab="chat">Chat</button>
+                <button class="tab-btn active" data-tab="activity">Overview</button>
+                <button class="tab-btn" data-tab="chat">Chat</button>
                 <button class="tab-btn" data-tab="todo">TODO</button>
-                <button class="tab-btn" data-tab="activity">Agents</button>
+                <button class="tab-btn" data-tab="agents-tab">Agents</button>
                 <button class="tab-btn" data-tab="resources">Machines</button>
                 <button class="tab-btn" data-tab="files">Files</button>
                 <button class="tab-btn" data-tab="releases">Releases</button>
-                <button class="tab-btn" data-tab="terminal">Terminal</button>
                 {% if is_admin %}<button class="tab-btn" data-tab="settings">Settings</button>{% endif %}
             </div>
             <div id="channel-topic-banner"
@@ -224,12 +233,17 @@
                 </div>
                 <div id="ch-members-list" class="ch-members-list"></div>
             </div>
+            {# Chat surfaces — hidden on first paint because Overview
+               is now the default landing tab (PR Step 3). tabs.ts
+               `_activateTab("chat")` flips these back to their visible
+               values when the user switches to Chat. #}
             <input id="chat-filter-input"
                    class="chat-filter-input"
                    placeholder="filter messages in this channel&hellip;"
                    autocomplete="off"
+                   style="display:none"
                    oninput="chatFilterApply(this.value)">
-            <div id="messages" class="messages"></div>
+            <div id="messages" class="messages" style="display:none"></div>
             <!-- hook-bypass: inline-style -->
             <div id="todo-view" class="todo-view" style="display:none">
                 <div class="todo-view-switch-wrap">
@@ -289,7 +303,13 @@
             <div id="workspaces-view" class="todo-view" style="display:none">
                 <div id="workspaces-grid" class="todo-grid"></div>
             </div>
-            <div id="activity-view" class="todo-view" style="display:none">
+            {# #activity-view is the Overview tab container (PR Step 3
+               rename: tab label changed to "Overview" but the id + css
+               classes keep "activity" to avoid churning dozens of CSS
+               selectors and globalThis keys). Default landing tab, so
+               starts visible; tabs.ts `_activateTab` will toggle the
+               display between tabs normally. #}
+            <div id="activity-view" class="todo-view">
                 <!-- hook-bypass: inline-style -->
                 <div id="activity-subtabs" class="activity-subtabs">
                     <div class="activity-view-switch"
@@ -422,7 +442,9 @@
                     class="feed-scroll-btn"
                     title="Jump to bottom"
                     aria-label="Scroll to bottom">&#8681;</button>
-            <div class="input-bar">
+            {# Compose bar — hidden on first paint (Overview is default
+               landing per PR Step 3); _activateTab("chat") shows it. #}
+            <div class="input-bar" style="display:none">
                 <div id="composer-target" class="composer-target">
                     &#8594; <span id="composer-target-name">#general</span>
                 </div>


### PR DESCRIPTION
## Summary

Step 3 in the UI restructure series (follows #310, #311). Promotes the graph/topology view to a new top-level "Overview" tab and separates out a list-view-only Agents tab.

## Changes

### Tab bar
- **Overview** tab (leftmost, default landing). Internal `data-tab="activity"` id preserved; only the user-visible label flipped from "Agents" to "Overview". All globalThis keys, CSS selectors, and the `activity-tab/` directory name are deliberately kept as-is to avoid churn (see `activity` rename note in commit message).
- **Agents** tab added as a separate entry. Wires `data-tab="agents-tab"` to the already-extant `#agents-tab-view` + `renderAgentsTab()` which were in the codebase but never exposed in the tab bar. This is the list-view-only surface.
- **Terminal** tab removed from the tab bar. `terminal-tab.ts` + `#terminal-view` + `window._termLoadAssets` are all kept intact — the detail pane's SSH action still depends on the asset loader.

Final order: `Overview, Chat, TODO, Agents, Machines, Files, Releases, Settings`.

### Default landing + last-tab persistence
- `activeTab` default changed from `"chat"` to `"activity"`.
- The localStorage-based restore logic now falls through to `"activity"` (Overview) when the remembered tab id doesn't resolve to a live tab-btn (handles users whose last session ended on the just-demoted Terminal tab).
- Chat surfaces (`#messages`, `.input-bar`, `#chat-filter-input`) start with inline `display:none` so first paint lands cleanly on Overview without a Chat flash; `_activateTab("chat")` still flips them back on re-entry.
- The tab-button's initial `.active` class also moved from Chat to Overview so first paint picks the right one even before tabs.ts runs.

### Agent detail panel restoration
The click wiring in `agents-tab/controls.ts::_bindSubTabBar` + `_renderAgentContent` already covers row-click -> detail-pane-render via `_renderAgentDetail` (subagent tree, tool-call history, metadata, CLAUDE.md viewer, terminal preview). This PR only needed to make the panel visible at a usable size:

- Lead reported (msg#15734) the panel collapsed to a barely-visible "Loading details…" line.
- Root cause: `.agent-detail-pane` had `min-height: 320px` but nothing enforced a floor on the outer wrappers; when parent flex tried to shrink on first paint, the whole panel collapsed before the inner pane ever asserted its minimum.
- Fix: `min-width: 400px; min-height: 400px` on three stacked wrappers — `.agent-tab-content`, `.agent-detail-view`, `.agent-detail-pane-wrap` — so the spec floor holds regardless of which ancestor tries to squeeze. The existing `max-height: calc(100vh - 320px)` cap on the pane still prevents it from pushing other sections off-screen.

## Files touched

- TS source: `hub/frontend/src/tabs.ts`
- JS mirror: `hub/static/hub/tabs.js`
- CSS: `hub/static/hub/components/components-agent-detail.css`
- Template: `hub/templates/hub/dashboard.html`

## Out of scope

- Backend Python (untouched; parallel cross-channel mention-push PR owns any backend changes).
- `ts-migration-v2` (untouched).
- PR #313's persistent graph-feed (stays, now lives inside Overview).
- PR #311's SSoT channel/agent badge modules (no changes).
- Renaming the `activity-tab/` directory (deferred per Step 3 spec).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (728.45 kB bundle, same size class as pre-PR)
- [ ] Live-hub smoke: load dashboard, verify Overview is the default landing, verify Chat/TODO/Agents/Machines/Files/Releases/Settings tabs all still activate correctly
- [ ] Click an agent row in the Agents list-view — confirm the detail pane renders at >= 400x400 with the terminal preview visible
- [ ] Reload with `localStorage.orochi_active_tab = "chat"` — verify Chat is restored on boot
- [ ] Reload with `localStorage.orochi_active_tab = "terminal"` (the demoted tab) — verify fallback to Overview
- [ ] Confirm PR #313 persistent graph-feed still works inside Overview

## Judgment calls

- **Kept internal ids.** The spec called out that the `activity-tab/` directory name could stay, but I extended the same reasoning to the `data-tab="activity"` id and the `activeTab="activity"` constant — renaming those would churn ~50 call sites (globalThis keys, CSS selectors, renderActivityTab refs) for a semantic-only improvement. Only the visible labels flip.
- **Terminal tab code retained.** Per spec. Removed only the tab-bar button; `#terminal-view` DOM container and all `terminal-tab.ts` exports stay — `window._termLoadAssets` still gets called from `activity-tab/detail-bind.ts`.
- **No directory rename.** Per spec.
- **Two commits instead of one.** The tab restructure (commit 1) and the detail-pane CSS floor (commit 2) are logically independent sub-items; keeping them separate keeps the review surface small per change.

Worktree used for this PR: `/tmp/step3-overview` (per the recommendation to pre-empt concurrent-branch-switch issues on the main checkout while the parallel backend PR was running).

Generated with [Claude Code](https://claude.com/claude-code)
