### PR TITLE
feat(ui): remove top-level Terminal tab — terminal preview stays in agent detail pane (Step 3c, split from reverted #315)

### DIFF
--- a/hub/frontend/src/tabs.ts
+++ b/hub/frontend/src/tabs.ts
@@ -237,6 +237,16 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
 (function () {
   try {
     var last = localStorage.getItem("orochi_active_tab");
+    /* Step 3c: the top-level Terminal tab has been removed (terminal
+     * preview now lives only inside the agent-detail pane's SSH action).
+     * Users who left their last session on "terminal" would otherwise
+     * land on a nonexistent tab button; fall through to the default so
+     * the boot picks whatever the default tab is (initialised to "chat"
+     * above; a future Overview tab (Step 3a) can change that default
+     * without further work here). */
+    if (last === "terminal") {
+      last = null;
+    }
     if (last && last !== "chat") {
       var btn = document.querySelector('.tab-btn[data-tab="' + last + '"]');
       if (btn) _activateTab(last);

--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -142,6 +142,16 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
 (function () {
   try {
     var last = localStorage.getItem("orochi_active_tab");
+    /* Step 3c: the top-level Terminal tab has been removed (terminal
+     * preview now lives only inside the agent-detail pane's SSH action).
+     * Users who left their last session on "terminal" would otherwise
+     * land on a nonexistent tab button; fall through to the default so
+     * the boot picks whatever the default tab is (initialised to "chat"
+     * above; a future Overview tab (Step 3a) can change that default
+     * without further work here). */
+    if (last === "terminal") {
+      last = null;
+    }
     if (last && last !== "chat") {
       var btn = document.querySelector('.tab-btn[data-tab="' + last + '"]');
       if (btn) _activateTab(last);

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -186,7 +186,6 @@
                 <button class="tab-btn" data-tab="resources">Machines</button>
                 <button class="tab-btn" data-tab="files">Files</button>
                 <button class="tab-btn" data-tab="releases">Releases</button>
-                <button class="tab-btn" data-tab="terminal">Terminal</button>
                 {% if is_admin %}<button class="tab-btn" data-tab="settings">Settings</button>{% endif %}
             </div>
             <div id="channel-topic-banner"


### PR DESCRIPTION
## Summary

Third of three split PRs resubmitting the reverted #315. Scope: **ONLY** remove the top-level Terminal tab from the dashboard tab bar.

- Parallel peers in flight on separate branches:
  - 3a (Overview tab promotion) — separate PR
  - 3b (Agents detail pane) — separate PR
- This PR (3c) keeps its diff surgically scoped to the Terminal tab removal.

## What changes

- **hub/templates/hub/dashboard.html** — delete the `<button class="tab-btn" data-tab="terminal">Terminal</button>` row from the tab bar.
- **hub/frontend/src/tabs.ts** and **hub/static/hub/tabs.js** — add a boot-time fallback: if `localStorage.orochi_active_tab === "terminal"` on boot, clear it and fall through to the default (currently `"chat"`; when 3a lands it will be `"overview"` and this fallback picks that up automatically).

## What intentionally stays

- `#terminal-view` container in the DOM — the terminal preview code still powers the agent-detail pane's SSH action.
- `hub/frontend/src/terminal-tab.ts`, `hub/static/hub/terminal-tab.js`, and `window._termLoadAssets` — all untouched.
- `terminal` branch inside `_activateTab()` — kept so that programmatic activation from the agent-detail pane still works.

## Out of scope (do NOT touch in this PR)

- Overview tab (3a's job)
- Agents detail pane (3b's job)
- `ts-migration-v2`, backend, unrelated files

## Test plan

- [x] `npm run typecheck` passes in `hub/frontend`
- [x] `npm run build` passes in `hub/frontend`
- [ ] Manual: reload dashboard — tab bar no longer shows Terminal
- [ ] Manual: with `localStorage.orochi_active_tab = "terminal"` set (simulating a pre-upgrade user session), reload — boot lands on default Chat tab without error
- [ ] Manual: agent-detail pane SSH action still renders the terminal preview (terminal-tab code still loads on demand)

Generated with Claude Code (https://claude.com/claude-code)
