### PR TITLE
feat(ui/overview): add Overview tab as leftmost + default landing (Step 3a, split from reverted #315)

### DIFF
--- a/hub/frontend/src/tabs.ts
+++ b/hub/frontend/src/tabs.ts
@@ -17,7 +17,13 @@ import { channelUnread } from "./app/utils";
 /* globals: activeTab, fetchTodoList, renderAgentsTab, renderResourcesTab,
    fetchWorkspaces */
 
-export var activeTab = "chat";
+/* Default landing tab — the Overview tab (internal id "activity" — see
+ * note below) is the leftmost tab and the first-load landing surface.
+ * The internal id stays "activity" even though the user-visible label
+ * reads "Overview"; renaming the id would churn every globalThis/SSE
+ * key that keys off it (_overviewExpanded, etc.), and the directory
+ * name `activity-tab/` is likewise left alone per Step 3 spec. */
+export var activeTab = "activity";
 
 /* PR #<this> Item 3 helper: pick a sensible default channel when the
  * Chat tab is activated without one. Preference order:
@@ -233,25 +239,39 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
   });
 });
 
-/* Restore last open tab across reloads */
+/* Restore last open tab across reloads.
+ *
+ * Step 3a (Overview promotion): default landing is the Overview tab
+ * (internal id "activity"). If localStorage has a remembered tab AND
+ * its button still exists in the DOM, honor it — otherwise fall back
+ * to Overview. Activating Overview on boot is what makes first paint
+ * land there; we intentionally do NOT rely on inline display:none on
+ * Chat surfaces — _activateTab("activity") hides them imperatively. */
 (function () {
   try {
     var last = localStorage.getItem("orochi_active_tab");
     /* Step 3c: the top-level Terminal tab has been removed (terminal
      * preview now lives only inside the agent-detail pane's SSH action).
-     * Users who left their last session on "terminal" would otherwise
-     * land on a nonexistent tab button; fall through to the default so
-     * the boot picks whatever the default tab is (initialised to "chat"
-     * above; a future Overview tab (Step 3a) can change that default
-     * without further work here). */
+     * Users who left their last session on "terminal" fall through. */
     if (last === "terminal") {
       last = null;
     }
-    if (last && last !== "chat") {
-      var btn = document.querySelector('.tab-btn[data-tab="' + last + '"]');
-      if (btn) _activateTab(last);
+    var target = last || "activity";
+    /* If the remembered tab no longer has a DOM button, fall back to
+     * Overview ("activity"). */
+    var btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
+    if (!btn) {
+      target = "activity";
+      btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
     }
-  } catch (_) {}
+    if (btn) _activateTab(target);
+  } catch (_) {
+    /* Even if localStorage is unavailable (private mode / quota), we
+     * still want to land on Overview. */
+    try {
+      _activateTab("activity");
+    } catch (__) {}
+  }
 })();
 
 /* Collapsible sidebar sections (#321 fix: use data-section for stable keys) */

--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -2,7 +2,12 @@
 /* globals: activeTab, fetchTodoList, renderAgentsTab, renderResourcesTab,
    fetchWorkspaces */
 
-var activeTab = "chat";
+/* Default landing tab — the Overview tab (internal id "activity") is
+ * the leftmost tab and the first-load landing surface. The internal id
+ * stays "activity" even though the user-visible label reads "Overview";
+ * renaming the id would churn every globalThis/SSE key that keys off it
+ * (_overviewExpanded, etc.). */
+var activeTab = "activity";
 
 function _activateTab(tab) {
   activeTab = tab;
@@ -138,25 +143,39 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
   });
 });
 
-/* Restore last open tab across reloads */
+/* Restore last open tab across reloads.
+ *
+ * Step 3a (Overview promotion): default landing is the Overview tab
+ * (internal id "activity"). If localStorage has a remembered tab AND
+ * its button still exists in the DOM, honor it — otherwise fall back
+ * to Overview. Activating Overview on boot is what makes first paint
+ * land there; we intentionally do NOT rely on inline display:none on
+ * Chat surfaces — _activateTab("activity") hides them imperatively. */
 (function () {
   try {
     var last = localStorage.getItem("orochi_active_tab");
     /* Step 3c: the top-level Terminal tab has been removed (terminal
      * preview now lives only inside the agent-detail pane's SSH action).
-     * Users who left their last session on "terminal" would otherwise
-     * land on a nonexistent tab button; fall through to the default so
-     * the boot picks whatever the default tab is (initialised to "chat"
-     * above; a future Overview tab (Step 3a) can change that default
-     * without further work here). */
+     * Users who left their last session on "terminal" fall through. */
     if (last === "terminal") {
       last = null;
     }
-    if (last && last !== "chat") {
-      var btn = document.querySelector('.tab-btn[data-tab="' + last + '"]');
-      if (btn) _activateTab(last);
+    var target = last || "activity";
+    /* If the remembered tab no longer has a DOM button, fall back to
+     * Overview ("activity"). */
+    var btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
+    if (!btn) {
+      target = "activity";
+      btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
     }
-  } catch (_) {}
+    if (btn) _activateTab(target);
+  } catch (_) {
+    /* Even if localStorage is unavailable (private mode / quota), we
+     * still want to land on Overview. */
+    try {
+      _activateTab("activity");
+    } catch (__) {}
+  }
 })();
 
 /* Collapsible sidebar sections (#321 fix: use data-section for stable keys) */

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -180,9 +180,9 @@
                 title="Collapse sidebar (Ctrl+B)">&lsaquo;</button>
         <div class="main">
             <div class="tab-bar">
-                <button class="tab-btn active" data-tab="chat">Chat</button>
+                <button class="tab-btn active" data-tab="activity">Overview</button>
+                <button class="tab-btn" data-tab="chat">Chat</button>
                 <button class="tab-btn" data-tab="todo">TODO</button>
-                <button class="tab-btn" data-tab="activity">Agents</button>
                 <button class="tab-btn" data-tab="resources">Machines</button>
                 <button class="tab-btn" data-tab="files">Files</button>
                 <button class="tab-btn" data-tab="releases">Releases</button>


### PR DESCRIPTION
## Summary

Split from the reverted #315 (commit `6462079` on develop). This PR carries ONLY the Step 3a slice: promoting the graph/topology view to a top-level "Overview" tab and making it the first-load landing surface. Sibling PRs `feat/step3b-agents-detail-restore` and `feat/step3c-terminal-tab-removal` carry the other two concerns.

## Scope

- Tab-bar button order becomes: `Overview → Chat → TODO → Machines → Files → Releases → Terminal → [Settings if admin]`.
  - Agents button is **not** added here — that is 3b's job.
  - Terminal button is **not** removed here — that is 3c's job.
- Internal `data-tab` id stays `"activity"` even though the user-visible label now reads "Overview". Renaming the id would churn the dozens of globalThis/SSE keys and CSS selectors that key off it (`_overviewExpanded`, `#activity-view`, `.activity-*`) and the `activity-tab/` source directory. Only the label flips.
- First-load default lands on Overview. `localStorage.orochi_active_tab` persists last-tab; on boot we honor the remembered tab if (and only if) its button still exists in the DOM, otherwise we fall back to Overview. This also handles stale values pointing at tabs that get demoted in a sibling PR.

## Explicitly avoided (vs. reverted #315)

- No inline `display:none` flash guard on `#messages` / `.input-bar` / `#chat-filter-input`. The prior attempt did that and ywatanabe suspected it contributed to the "raw HTML visible" regression. This PR relies only on `_activateTab("activity")` running at boot to hide Chat surfaces imperatively.
- No Django template comments (`{# ... #}`) introduced in `dashboard.html` — lead suspects their presence in commit bodies confused the GitHub-webhook feed into looking like a regression.
- No changes to `#agent-tab-content` / `#agents-tab-view` internals, `activity-tab/detail*.ts`, or `terminal-tab.ts`.

## Files touched

- `hub/frontend/src/tabs.ts` — source of truth via Vite: default `activeTab = "activity"`, boot-time restore logic falls back to Overview on missing button or localStorage failure.
- `hub/static/hub/tabs.js` — legacy mirror kept in sync.
- `hub/templates/hub/dashboard.html` — tab-bar button reorder + Agents→Overview label flip.

## Test plan

- [ ] First-load with no `orochi_active_tab` in localStorage → lands on Overview (graph visible, Chat hidden).
- [ ] Switch to Chat, reload → lands on Chat (last-tab honored).
- [ ] Switch to Terminal, reload → lands on Terminal (still present post-3a).
- [ ] Set `localStorage.orochi_active_tab = "bogus-tab"`, reload → falls back to Overview.
- [ ] `npm run typecheck` passes.
- [ ] `npm run build` passes.
