### PR TITLE
feat(ui/agents): restore detail pane click wiring + min 400x400 + graph Open-in-Chat + preview-on-doubleclick (Step 3b + items 14/15)

### DIFF
--- a/hub/frontend/src/activity-tab/compose.ts
+++ b/hub/frontend/src/activity-tab/compose.ts
@@ -5,7 +5,7 @@ import { _showMiniToast } from "../app/agent-actions";
 import { _channelPrefs } from "../app/members";
 import { fetchAgents } from "../app/sidebar-agents";
 import { setCurrentChannel } from "../app/state";
-import { escapeHtml, sendOrochiMessage, userName } from "../app/utils";
+import { apiUrl, escapeHtml, sendOrochiMessage, userName } from "../app/utils";
 import { ws, wsConnected } from "../app/websocket";
 import { loadChannelHistory } from "../chat/chat-history";
 
@@ -264,7 +264,19 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     "Drop files to attach\n" +
     "Paste image/file to attach\n" +
     "Click ▾ for attach / camera / sketch / voice";
+  /* Item 15 (lead msg#15694): channel-node double-click now shows a
+   * last-5-messages preview ABOVE the input area, so the user can see
+   * the conversation context before replying without first having to
+   * hover (channel-hover-preview popover) or triple-click into the
+   * full Chat tab. The preview is chronological (oldest → newest),
+   * scrolls internally if content overflows, and renders a loading
+   * placeholder while the fetch is in flight; a failed fetch turns
+   * into a muted "(no recent messages)" row rather than an error
+   * block so the compose input stays usable. */
   pop.innerHTML =
+    '<div class="tcc-preview" data-tcc-preview>' +
+    '<div class="tcc-preview-loading">Loading recent messages\u2026</div>' +
+    "</div>" +
     '<textarea class="tcc-input" data-voice-input rows="2" placeholder="message #' +
     escapeHtml(channel).replace(/^#/, "") +
     '" title="' +
@@ -280,6 +292,11 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     tccShortcuts.replace(/"/g, "&quot;") +
     '" aria-label="More options">\u25BE</button>';
   document.body.appendChild(pop);
+  /* Item 15: fire off a last-5 history fetch. This is fire-and-forget
+   * — no await, no blocking of the compose input. If the popup has
+   * been closed by the time the response lands, the querySelector
+   * returns null and we silently skip painting. */
+  _tccLoadPreview(pop, channel);
   /* Wire the persistent graph feed to this channel so replies to the
    * outgoing post land in the right-docked panel instead of flashing
    * off-screen as a 1.3s landing bubble (lead msg#15701 blocker). */
@@ -532,6 +549,95 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
       for (var i = 0; i < files.length; i++) handleFileUpload(files[i]);
     }
   });
+}
+
+/* Item 15 (lead msg#15694): fetch & render the last 5 messages for
+ * the double-clicked channel inside the compose popup's .tcc-preview
+ * slot. Runs fire-and-forget — never blocks the input or closes the
+ * popup on failure. API shape mirrors /api/history/ as used by
+ * graph-feed / channel-hover-preview (newest-first; we reverse to
+ * chronological before rendering). */
+var _TCC_PREVIEW_LIMIT = 5;
+function _tccFmtTime(iso) {
+  if (!iso) return "";
+  try {
+    var d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    var hh = String(d.getHours()).padStart(2, "0");
+    var mm = String(d.getMinutes()).padStart(2, "0");
+    return hh + ":" + mm;
+  } catch (_e) {
+    return "";
+  }
+}
+function _tccTruncate(s, n) {
+  if (!s) return "";
+  s = String(s);
+  if (s.length <= n) return s;
+  return s.slice(0, n - 1) + "\u2026";
+}
+function _tccRenderRows(rows) {
+  if (!rows || !rows.length) {
+    return '<div class="tcc-preview-empty">(no recent messages)</div>';
+  }
+  return rows
+    .map(function (m) {
+      var sender = m.sender || "?";
+      var ts = _tccFmtTime(m.ts);
+      var content = _tccTruncate(m.content || "", 140);
+      return (
+        '<div class="tcc-preview-row">' +
+        '<div class="tcc-preview-meta">' +
+        '<span class="tcc-preview-sender">' +
+        escapeHtml(sender) +
+        "</span>" +
+        (ts
+          ? '<span class="tcc-preview-ts">' + escapeHtml(ts) + "</span>"
+          : "") +
+        "</div>" +
+        '<div class="tcc-preview-body">' +
+        escapeHtml(content) +
+        "</div>" +
+        "</div>"
+      );
+    })
+    .join("");
+}
+function _tccLoadPreview(pop, channel) {
+  if (!pop || !channel) return;
+  var encoded = encodeURIComponent(channel);
+  var url = apiUrl(
+    "/api/history/" + encoded + "?limit=" + _TCC_PREVIEW_LIMIT,
+  );
+  fetch(url, { credentials: "same-origin" })
+    .then(function (res) {
+      if (!res.ok) throw new Error("HTTP " + res.status);
+      return res.json();
+    })
+    .then(function (rows) {
+      /* Bail quietly if the popup is already gone (user pressed Esc,
+       * clicked outside, or double-clicked another channel). */
+      if (!pop.parentNode) return;
+      if (pop.getAttribute("data-channel") !== channel) return;
+      var slot = pop.querySelector("[data-tcc-preview]");
+      if (!slot) return;
+      /* API returns newest-first; flip so the compose preview reads
+       * chronologically (oldest → newest, same as Chat feed). */
+      var chrono = (rows || []).slice().reverse();
+      slot.innerHTML = _tccRenderRows(chrono);
+      /* Keep the latest message visible when overflow clips the
+       * preview — users care most about what they're about to reply
+       * to, which sits at the bottom. */
+      slot.scrollTop = slot.scrollHeight;
+    })
+    .catch(function () {
+      if (!pop.parentNode) return;
+      var slot = pop.querySelector("[data-tcc-preview]");
+      if (slot) {
+        slot.innerHTML =
+          '<div class="tcc-preview-empty">(no recent messages)</div>';
+      }
+    });
 }
 
 export function _topoSpawnGhost(svg, text, x, y) {

--- a/hub/frontend/src/app/context-menus.ts
+++ b/hub/frontend/src/app/context-menus.ts
@@ -2,7 +2,9 @@
 import { _agentSubscribe, _openAgentDmSimple, _toggleAgentChannelSubscription, openChannelExport } from "./agent-actions";
 import { _setChannelPref } from "./channel-prefs";
 import { _channelPrefs } from "./members";
+import { setCurrentChannel } from "./state";
 import { escapeHtml, userName } from "./utils";
+import { loadChannelHistory } from "../chat/chat-history";
 
 /* Context menu for channel items — right-click shows pref options */
 export function _addChannelContextMenu(el) {
@@ -44,6 +46,7 @@ export function _showChannelCtxMenu(ch, x, y) {
   menu.style.cssText =
     "position:fixed;z-index:9999;left:" + x + "px;top:" + y + "px;";
   var G_EXPORT = "\u2935"; /* ⤵ export */
+  var G_OPEN_CHAT = "\u21AA"; /* ↪ open-in-chat */
   var G_EMPTY = "";
   function _glyph(g) {
     return '<span class="ch-ctx-glyph">' + g + "</span>";
@@ -59,6 +62,17 @@ export function _showChannelCtxMenu(ch, x, y) {
    * this is a session-only viz hide, distinct from the persistent
    * eye-icon is_hidden that propagates across surfaces. */
   menu.innerHTML = [
+    /* Item 14 (lead msg#15694): graph channel-node right-click menu
+     * needs an "Open in Chat" entry so a user browsing the topology
+     * can jump straight to the full Chat surface for that channel
+     * without having to triple-click the node or navigate via the
+     * sidebar. Pinned to the top of the menu so it's the first thing
+     * users see after right-click; mirrors the muscle-memory of the
+     * channel-badge "→" affordance. */
+    '<div class="ch-ctx-item ch-ctx-open-chat" data-action="open-chat">' +
+      _glyph(G_OPEN_CHAT) +
+      "Open in Chat</div>",
+    '<div class="ch-ctx-sep"></div>',
     '<div class="ch-ctx-label">Notifications</div>',
     '<div class="ch-ctx-item ch-ctx-notif' +
       (notif === "all" ? " ch-ctx-active" : "") +
@@ -96,6 +110,20 @@ export function _showChannelCtxMenu(ch, x, y) {
        * clear-icon are now handled exclusively by the channel-badge
        * icons (delegation in channel-badge.ts attachChannelBadgeHandlers).
        * Remaining: notification-level trio, export, topo-hide. */
+      if (action === "open-chat") {
+        /* Item 14: switch the Chat tab to this channel and activate
+         * it. Mirrors the triple-click-channel path in
+         * activity-tab/click.ts _topoFlushClick so the behaviour is
+         * consistent across entry surfaces. */
+        _hideChannelCtxMenu();
+        try {
+          if (typeof setCurrentChannel === "function") setCurrentChannel(ch);
+          if (typeof loadChannelHistory === "function") loadChannelHistory(ch);
+          var chatBtn = document.querySelector('[data-tab="chat"]');
+          if (chatBtn) (chatBtn as HTMLElement).click();
+        } catch (_) {}
+        return;
+      }
       if (action === "notif-all")
         _setChannelPref(ch, { notification_level: "all" });
       else if (action === "notif-mentions")

--- a/hub/static/hub/activity-tab/activity-tab-compose-edges.css
+++ b/hub/static/hub/activity-tab/activity-tab-compose-edges.css
@@ -73,6 +73,57 @@
   min-height: 40px;
   box-sizing: border-box;
 }
+
+/* Item 15 (lead msg#15694): last-5-messages preview shown above the
+ * input on a channel-node double-click. Compact rendering — single
+ * line body with ellipsis truncation at 140 chars — so the 5 rows
+ * fit inside the popup's 360px max-width without dwarfing the input
+ * itself. max-height keeps the popup bounded even if a row wraps to
+ * two lines; overflow-y:auto so long content scrolls instead of
+ * expanding the modal past the viewport. */
+.topo-channel-compose .tcc-preview {
+  max-height: 140px;
+  overflow-y: auto;
+  margin-bottom: 6px;
+  padding: 4px 6px;
+  background: #070707;
+  border: 1px solid #1a1a1a;
+  border-radius: 3px;
+  font-size: 11px;
+}
+.topo-channel-compose .tcc-preview-loading,
+.topo-channel-compose .tcc-preview-empty {
+  color: #6a7785;
+  font-style: italic;
+  padding: 2px 0;
+}
+.topo-channel-compose .tcc-preview-row {
+  padding: 3px 0;
+  border-top: 1px solid #141414;
+}
+.topo-channel-compose .tcc-preview-row:first-child {
+  border-top: 0;
+}
+.topo-channel-compose .tcc-preview-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 10px;
+  color: #8a95a2;
+}
+.topo-channel-compose .tcc-preview-sender {
+  color: #4ecdc4;
+  font-weight: 600;
+  font-family: ui-monospace, monospace;
+}
+.topo-channel-compose .tcc-preview-ts {
+  color: #555;
+}
+.topo-channel-compose .tcc-preview-body {
+  color: #cbd5e1;
+  word-break: break-word;
+  line-height: 1.35;
+}
 .topo-channel-compose .tcc-input:focus {
   outline: none;
   border-color: #4ecdc4;

--- a/hub/static/hub/components/components-agent-detail.css
+++ b/hub/static/hub/components/components-agent-detail.css
@@ -43,6 +43,17 @@
 }
 .agent-tab-content {
   width: 100%;
+  /* Step 3b (lead msg#15734): on first click of an agent row in the
+   * list view the detail panel was collapsing to a single "Loading
+   * details..." line, barely visible. The inner pane had its own
+   * min-height: 320px but nothing enforced a usable floor on the
+   * outer wrappers, so a shrinking flex parent could squash the whole
+   * panel before the pane's own minimum kicked in. 400x400 is the
+   * explicit spec floor; apply it to all three stacked wrappers
+   * (.agent-tab-content, .agent-detail-view, .agent-detail-pane-wrap)
+   * so the floor holds regardless of which ancestor tries to squeeze. */
+  min-width: 400px;
+  min-height: 400px;
 }
 
 /* ── Per-agent detail view ── */
@@ -51,6 +62,10 @@
   flex-direction: column;
   gap: 12px;
   width: 100%;
+  /* Step 3b floor — matches .agent-tab-content; prevents the detail
+   * column from collapsing below a usable size. */
+  min-width: 400px;
+  min-height: 400px;
 }
 .agent-detail-header {
   font-size: 14px;
@@ -204,6 +219,13 @@
 .agent-detail-pane-wrap {
   flex: 1 1 auto;
   width: 100%;
+  /* Step 3b floor — the innermost of the three stacked min-400x400
+   * anchors; the terminal preview pane itself keeps a tighter
+   * min-height: 320px further down, but this wrapper guarantees room
+   * for it to live in even when the parent flex containers try to
+   * shrink. */
+  min-width: 400px;
+  min-height: 400px;
 }
 .agent-detail-pane {
   background: #0d1117;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -30,7 +30,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/components/components-messages.css' %}?v=105">
     <link rel="stylesheet"
-          href="{% static 'hub/components/components-agent-detail.css' %}?v=105">
+          href="{% static 'hub/components/components-agent-detail.css' %}?v=106">
     <link rel="stylesheet"
           href="{% static 'hub/components/components-mcp-viewer.css' %}?v=105">
     <link rel="stylesheet"
@@ -57,7 +57,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/activity-tab/activity-tab-topology-nodes.css' %}?v=166">
     <link rel="stylesheet"
-          href="{% static 'hub/activity-tab/activity-tab-compose-edges.css' %}?v=165">
+          href="{% static 'hub/activity-tab/activity-tab-compose-edges.css' %}?v=166">
     <link rel="stylesheet"
           href="{% static 'hub/activity-tab/activity-tab-detail-pane.css' %}?v=165">
     <link rel="stylesheet"


### PR DESCRIPTION
## Summary
Re-submit the **Step 3b** slice of the reverted PR #315 as a standalone change, plus two folded-in graph polish items (lead queue items 14 & 15 from msg#15694). No scope overlap with 3a (Overview promotion) or 3c (Terminal tab removal, already landed as #316).

- **Step 3b — agent detail panel 400x400 floor.** Lead msg#15734: clicking an agent row collapsed the detail panel to a single "Loading details..." line. Enforce `min-width: 400px; min-height: 400px` on three stacked wrappers (`.agent-tab-content`, `.agent-detail-view`, `.agent-detail-pane-wrap`) so the spec floor holds regardless of which ancestor tries to squeeze. Cache-bust `components-agent-detail.css` v=105 → v=106.
- **Item 14 (msg#15694) — "Open in Chat" entry in graph channel ctx-menu.** Pin an `Open in Chat` row to the top of `_showChannelCtxMenu` (`app/context-menus.ts`); mirrors the existing triple-click-channel path so entry surfaces stay consistent.
- **Item 15 (msg#15694) — last-5-msgs preview on channel dbl-click.** Extend `_topoOpenChannelCompose` to render a last-5-messages preview above the textarea. Chronological (oldest → newest), `max-height: 140px` with internal scroll, muted `(no recent messages)` fallback on empty/failed fetch. Fire-and-forget — never blocks the input.

## Files touched
| purpose | file |
|---|---|
| 3b CSS — 400x400 floor (×3 wrappers) | `hub/static/hub/components/components-agent-detail.css` |
| Item 14 — ctx-menu "Open in Chat" | `hub/frontend/src/app/context-menus.ts` |
| Item 15 — preview fetch + render | `hub/frontend/src/activity-tab/compose.ts` |
| Item 15 — preview styles | `hub/static/hub/activity-tab/activity-tab-compose-edges.css` |
| cache-bust | `hub/templates/hub/dashboard.html` |

## Test plan
- [ ] Open the Agents tab (list view), click an agent row → detail pane opens with header + meta grid + terminal preview + CLAUDE.md viewer; pane wrapper is at least 400×400 even on an initial paint before `/detail/` returns.
- [ ] Right-click a channel node on the graph (Agents tab → Viz) → top-most menu entry is **Open in Chat**; clicking it switches to the Chat tab focused on that channel.
- [ ] Double-click a channel node on the graph → compose popup opens with the last 5 messages above the textarea, scrolled to the newest; empty channels show `(no recent messages)`; input still focuses and `Enter` still sends.
- [ ] Triple-click a channel (legacy path) still jumps to Chat (Item 14 re-uses the same helpers — verify no regression).
- [ ] `cd hub/frontend && npm run typecheck && npm run build` — both pass (verified locally).

## Out of scope (do NOT merge into this branch)
- Tab-bar order / Overview tab promotion (3a)
- Terminal tab button removal (3c, already landed as #316)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
