### PR TITLE
fix(host-identity): apply hostname_aliases in TS/Python heartbeat post-PR#309 (msg#16102)

### DIFF
--- a/scripts/client/agent_meta_pkg/_collect.py
+++ b/scripts/client/agent_meta_pkg/_collect.py
@@ -109,14 +109,20 @@ def collect(agent: str) -> dict:
     # `agent` kwarg enables cross-cycle stagnation tracking; omit it
     # and the classifier degrades to its legacy stateless behavior.
     # Live hostname(1) — the kernel's answer to "where is this process
-    # running right now". This is the authoritative host-identity signal
-    # the hub's badge renderer (hostedAgentName) prefers over ``machine``.
-    # Collected here so ``_build_payload`` can forward it unconditionally,
-    # never letting env vars or server-side inference speak for the
-    # process (lead msg#15578 root fix).
-    import socket as _socket
+    # running right now", mapped through ``spec.hostname_aliases`` from
+    # ``~/.scitex/orochi/shared/config.yaml`` so raw OS hostnames like
+    # ``Yusukes-MacBook-Air`` surface as the canonical fleet short name
+    # (``mba``) the hub's badge renderer (hostedAgentName) displays.
+    #
+    # PR#309 correctly flipped env/hostname priority (lead msg#15578 —
+    # stale ``SCITEX_OROCHI_HOSTNAME=mba`` inherited into a spartan
+    # process) but pushed the raw ``socket.gethostname()`` here, which
+    # caused the ``Yusukes-MacBook-Air`` regression on the dashboard
+    # (ywatanabe msg#16102). Routing through ``resolve_machine_label``
+    # applies the alias map so both ``machine`` and ``hostname`` fields
+    # carry the same canonical label.
     try:
-        live_hostname = (_socket.gethostname() or "").split(".")[0].strip()
+        live_hostname = resolve_machine_label()
     except Exception:
         live_hostname = ""
 

--- a/scripts/client/agent_meta_pkg/_machine.py
+++ b/scripts/client/agent_meta_pkg/_machine.py
@@ -1,23 +1,28 @@
 """Canonical fleet-machine label resolution from shared/config.yaml hostname_aliases.
 
-Resolution chain (first wins):
-  1. hostname_aliases[hostname -s] from shared/config.yaml
-  2. hostname -s (identity fallback)
-  3. $SCITEX_OROCHI_HOSTNAME (explicit override, only used when the live
-     hostname is unresolvable — e.g. empty gethostname() in stripped
-     containers). Previously this env var was primary, which made
-     env-pollution (a shared tmux / systemd env with a stale
-     ``SCITEX_OROCHI_HOSTNAME=mba`` inherited into a spartan process)
-     silently misreport the host identity (lead msg#15578 — proj-
-     neurovista displayed as mba despite running on spartan). Per
-     lead's root fix: the agent's ``host`` field in the heartbeat
-     comes from its own ``hostname()`` call, never from inherited
-     env or server-side inference.
+Resolution chain (first non-empty wins):
+  1. hostname_aliases[hostname -s] from shared/config.yaml — canonical
+     per-fleet mapping (e.g. ``Yusukes-MacBook-Air`` → ``mba``).
+  2. hostname -s (identity fallback) — if the live hostname is not
+     aliased, trust the kernel's answer verbatim.
+  3. $SCITEX_OROCHI_HOSTNAME / $SCITEX_OROCHI_MACHINE /
+     $SCITEX_AGENT_CONTAINER_HOSTNAME (explicit override) — only used
+     when the live hostname is unresolvable (empty gethostname() in
+     stripped containers). An env override that DISAGREES with a
+     populated live hostname is ignored on purpose: that is how a
+     stale ``SCITEX_OROCHI_HOSTNAME=mba`` inherited into a spartan
+     process silently misreported identity before PR#309 (lead
+     msg#15578 — proj-neurovista displayed as mba despite running on
+     spartan).
 
-This matches config._host.resolve_hostname() on the sac side and the
-shared/scripts/resolve-hostname helper used by bootstrap + shell
-scripts, so the hub always sees a consistent "mba" / "nas" / "spartan"
-/ "ywata-note-win" regardless of raw OS hostname.
+PR#309 flipped the priority so hostname() beats env vars — which was
+the right fix, but it was incomplete: the TS heartbeat skipped the
+``hostname_aliases`` map entirely, so raw OS hostnames like
+``Yusukes-MacBook-Air`` started showing up on the dashboard instead
+of the canonical ``mba`` (ywatanabe msg#16102). This module + the
+TS ``resolveHostLabel`` share the same resolution order so the hub
+always sees a consistent "mba" / "nas" / "spartan" /
+"ywata-note-win" regardless of raw OS hostname or launch env.
 """
 
 from __future__ import annotations
@@ -25,6 +30,30 @@ from __future__ import annotations
 import os
 import socket
 from pathlib import Path
+
+
+def _load_hostname_aliases() -> dict[str, str]:
+    """Return ``spec.hostname_aliases`` from shared/config.yaml, or ``{}``.
+
+    Never raises — host identity resolution MUST still succeed via the
+    raw-hostname fallback even if the config file is missing, malformed,
+    or PyYAML is unavailable.
+    """
+    try:
+        import yaml as _yaml  # PyYAML ships with the fleet.
+    except ImportError:
+        return {}
+    try:
+        cfg_path = Path.home() / ".scitex" / "orochi" / "shared" / "config.yaml"
+        if not cfg_path.exists():
+            return {}
+        _cfg = _yaml.safe_load(cfg_path.read_text()) or {}
+    except Exception:
+        return {}
+    _aliases = (_cfg.get("spec") or {}).get("hostname_aliases") or {}
+    if not isinstance(_aliases, dict):
+        return {}
+    return {str(k): str(v) for k, v in _aliases.items()}
 
 
 def resolve_machine_label() -> str:
@@ -39,28 +68,26 @@ def resolve_machine_label() -> str:
        is not aliased in config, fall through to it directly. This is
        the proof-of-life identity: whatever the kernel says this
        process is running on.
-    3. ``$SCITEX_OROCHI_HOSTNAME`` — explicit override, only honoured
-       when steps 1/2 produced an empty string (broken container,
-       ``gethostname()`` returning ""). An env override that DISAGREES
-       with the live hostname is ignored on purpose — that's how
-       ``mba`` env leaked into a spartan process before this fix.
+    3. ``$SCITEX_OROCHI_HOSTNAME`` / ``$SCITEX_OROCHI_MACHINE`` /
+       ``$SCITEX_AGENT_CONTAINER_HOSTNAME`` — explicit override, only
+       honoured when steps 1/2 produced an empty string (broken
+       container, ``gethostname()`` returning ""). An env override
+       that DISAGREES with the live hostname is ignored on purpose —
+       that's how ``mba`` env leaked into a spartan process before
+       PR#309.
     """
     raw_host = (socket.gethostname() or "").split(".")[0].strip()
     if raw_host:
-        try:
-            import yaml as _yaml  # PyYAML ships with the fleet.
-
-            cfg_path = Path.home() / ".scitex" / "orochi" / "shared" / "config.yaml"
-            if cfg_path.exists():
-                _cfg = _yaml.safe_load(cfg_path.read_text()) or {}
-                _aliases = (_cfg.get("spec") or {}).get("hostname_aliases") or {}
-                if isinstance(_aliases, dict) and raw_host in _aliases:
-                    return str(_aliases[raw_host])
-        except Exception:
-            pass
+        _aliases = _load_hostname_aliases()
+        if raw_host in _aliases:
+            return _aliases[raw_host]
         return raw_host
     # gethostname() returned empty — only now trust the env override.
-    return os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
+    return (
+        os.environ.get("SCITEX_OROCHI_HOSTNAME", "").strip()
+        or os.environ.get("SCITEX_OROCHI_MACHINE", "").strip()
+        or os.environ.get("SCITEX_AGENT_CONTAINER_HOSTNAME", "").strip()
+    )
 
 
 def find_session_pids(agent: str, multiplexer: str) -> tuple[int, int]:

--- a/tests/test_resolve_machine_label.py
+++ b/tests/test_resolve_machine_label.py
@@ -1,16 +1,26 @@
 """Regression tests for ``agent_meta_pkg._machine.resolve_machine_label``.
 
-Root cause of lead msg#15578 (proj-neurovista displayed as mba while
-actually running on spartan) was client-side env-first prioritisation:
-``resolve_machine_label()`` previously honoured
-``$SCITEX_OROCHI_HOSTNAME`` over the live ``socket.gethostname()``
-call, so a stale env var inherited into a spartan process silently
-misreported the host.
+Two incidents shape these tests:
 
-The fix flips the priority order: live ``hostname()`` first
-(potentially mapped through ``config.yaml`` aliases), env vars only
-when the kernel returns an empty hostname. These tests guard against
-regression of that priority flip.
+1. Lead msg#15578 — proj-neurovista displayed as mba while actually
+   running on spartan. Root cause: env-first prioritisation. The fix
+   (PR#309) made live ``socket.gethostname()`` win over env vars.
+
+2. ywatanabe msg#16102 — mba host displayed as the raw
+   ``Yusukes-MacBook-Air`` on the Agents dashboard. Root cause: PR#309
+   skipped the ``hostname_aliases`` map in
+   ``~/.scitex/orochi/shared/config.yaml`` that used to translate
+   ``Yusukes-MacBook-Air`` → ``mba``. The follow-up fix restores alias
+   application before the raw-hostname fallback.
+
+Final resolution order (first non-empty wins):
+  1. ``hostname_aliases[gethostname()]`` from shared/config.yaml.
+  2. Raw ``gethostname()`` (short form).
+  3. Env fallback (``SCITEX_OROCHI_HOSTNAME`` /
+     ``SCITEX_OROCHI_MACHINE`` / ``SCITEX_AGENT_CONTAINER_HOSTNAME``) —
+     only honoured when ``gethostname()`` is empty.
+
+These tests guard against regression of that ordering.
 """
 
 from __future__ import annotations
@@ -43,27 +53,35 @@ def _clear_env(monkeypatch):
     test runner can't skew the result."""
     monkeypatch.delenv("SCITEX_OROCHI_HOSTNAME", raising=False)
     monkeypatch.delenv("SCITEX_OROCHI_MACHINE", raising=False)
+    monkeypatch.delenv("SCITEX_AGENT_CONTAINER_HOSTNAME", raising=False)
     yield
 
 
+def _stub_aliases(monkeypatch, aliases: dict[str, str] | None) -> None:
+    """Monkeypatch the alias loader so tests don't touch the real
+    shared/config.yaml. Passing ``None`` simulates a missing file."""
+    monkeypatch.setattr(
+        _machine, "_load_hostname_aliases", lambda: aliases or {}
+    )
+
+
 def test_returns_live_hostname_when_env_unset(monkeypatch):
-    """With no env overrides, the resolver returns whatever
-    ``socket.gethostname()`` says (trimmed to the short form)."""
+    """With no env overrides and no alias entry, the resolver returns
+    whatever ``socket.gethostname()`` says (trimmed to the short
+    form)."""
     monkeypatch.setattr(socket, "gethostname", lambda: "spartan-login1")
-    # Force the config.yaml lookup to miss so we exercise the raw-host
-    # fallback path directly.
-    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    _stub_aliases(monkeypatch, {})
     assert resolve_machine_label() == "spartan-login1"
 
 
 def test_env_var_ignored_when_hostname_populated(monkeypatch):
-    """This is the direct regression test for lead msg#15578. A stale
+    """Direct regression test for lead msg#15578. A stale
     ``SCITEX_OROCHI_HOSTNAME=mba`` env var — inherited from a shared
     tmux / systemd env that originally ran on mba — must NOT override
     the live hostname when the kernel knows who it is."""
     monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "mba")
     monkeypatch.setattr(socket, "gethostname", lambda: "spartan-login1")
-    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    _stub_aliases(monkeypatch, {})
     # Despite the misleading env, the resolver trusts the kernel.
     assert resolve_machine_label() == "spartan-login1"
 
@@ -74,7 +92,7 @@ def test_env_var_used_when_hostname_empty(monkeypatch):
     identity signal available and IS honoured as a last-resort."""
     monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "mba")
     monkeypatch.setattr(socket, "gethostname", lambda: "")
-    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    _stub_aliases(monkeypatch, {})
     assert resolve_machine_label() == "mba"
 
 
@@ -85,28 +103,53 @@ def test_short_name_stripped_from_fqdn(monkeypatch):
     monkeypatch.setattr(
         socket, "gethostname", lambda: "spartan-login1.hpc.unimelb.edu.au"
     )
-    monkeypatch.setattr(_machine, "Path", _NoConfigPath)
+    _stub_aliases(monkeypatch, {})
     assert resolve_machine_label() == "spartan-login1"
 
 
-class _NoConfigPath:
-    """Minimal ``pathlib.Path`` stand-in that makes the config.yaml
-    lookup in ``resolve_machine_label`` miss, so tests exercise the
-    plain ``gethostname()`` return path without touching a real
-    filesystem."""
+def test_alias_map_translates_raw_hostname(monkeypatch):
+    """Direct regression test for ywatanabe msg#16102. Given the live
+    hostname ``Yusukes-MacBook-Air`` and an alias map entry mapping
+    it to ``mba``, the resolver returns ``mba`` — NOT the raw
+    macOS hostname. Without this, the hub dashboard displays
+    ``Yusukes-MacBook-Air`` as the mba host's @host label."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "Yusukes-MacBook-Air")
+    _stub_aliases(monkeypatch, {"Yusukes-MacBook-Air": "mba"})
+    assert resolve_machine_label() == "mba"
 
-    def __init__(self, *parts):
-        pass
 
-    @staticmethod
-    def home():
-        return _NoConfigPath()
+def test_alias_map_wins_over_env_var(monkeypatch):
+    """Aliases are the declarative truth for canonical fleet names.
+    Even if an env var is set, when the live hostname has an alias
+    entry the alias wins — an env var cannot override the alias
+    map, only supplement it when the live hostname is empty."""
+    monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "totally-wrong")
+    monkeypatch.setattr(socket, "gethostname", lambda: "Yusukes-MacBook-Air")
+    _stub_aliases(monkeypatch, {"Yusukes-MacBook-Air": "mba"})
+    assert resolve_machine_label() == "mba"
 
-    def __truediv__(self, other):
-        return _NoConfigPath()
 
-    def exists(self):
-        return False
+def test_raw_hostname_returned_when_no_alias_and_no_env(monkeypatch):
+    """Hosts whose raw short hostname already matches the fleet label
+    (e.g. ``ywata-note-win``) have no alias entry and no env override,
+    yet the resolver must still return the live name verbatim."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "ywata-note-win")
+    _stub_aliases(monkeypatch, {"Yusukes-MacBook-Air": "mba"})
+    assert resolve_machine_label() == "ywata-note-win"
 
-    def read_text(self):  # pragma: no cover — exists() returns False
-        raise AssertionError("should not be called when exists() is False")
+
+def test_env_fallback_covers_all_three_vars(monkeypatch):
+    """When ``gethostname()`` is empty, any of the three documented
+    env vars is honoured (matches the TS client's behaviour):
+    ``SCITEX_OROCHI_HOSTNAME`` first, then
+    ``SCITEX_OROCHI_MACHINE``, then
+    ``SCITEX_AGENT_CONTAINER_HOSTNAME``."""
+    monkeypatch.setattr(socket, "gethostname", lambda: "")
+    _stub_aliases(monkeypatch, {})
+    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_HOSTNAME", "container-host")
+    assert resolve_machine_label() == "container-host"
+    # Higher-priority env wins.
+    monkeypatch.setenv("SCITEX_OROCHI_MACHINE", "machine-env")
+    assert resolve_machine_label() == "machine-env"
+    monkeypatch.setenv("SCITEX_OROCHI_HOSTNAME", "hostname-env")
+    assert resolve_machine_label() == "hostname-env"

--- a/ts/mcp_channel/connection.ts
+++ b/ts/mcp_channel/connection.ts
@@ -6,7 +6,7 @@
  */
 import WebSocket from "ws";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { hostname, homedir } from "os";
+import { homedir } from "os";
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 import {
@@ -18,6 +18,7 @@ import {
 import { dbg } from "./guards.js";
 import { pushRegistryHeartbeat } from "./heartbeat.js";
 import { handleWsMessage } from "./dispatch.js";
+import { resolveHostLabel } from "./hostname.js";
 
 let _ws: WebSocket | null = null;
 let _heartbeatInterval: ReturnType<typeof setInterval> | null = null;
@@ -101,26 +102,26 @@ function onOpen(ws: WebSocket): void {
 
   // Register with the hub.
   //
-  // Host identity source order (lead msg#15578 root fix):
-  //   1. Live ``hostname()`` — the kernel's answer to "where am I
-  //      running right now". Always trusted when non-empty.
-  //   2. ``SCITEX_OROCHI_*`` env vars — explicit override, only honoured
-  //      if ``hostname()`` is empty (e.g. stripped container).
+  // Host identity source order (post-PR#309 / post-ywatanabe msg#16102):
+  //   1. Live ``hostname()`` mapped through
+  //      ``spec.hostname_aliases`` in
+  //      ``~/.scitex/orochi/shared/config.yaml`` — so
+  //      ``Yusukes-MacBook-Air`` → ``mba``,
+  //      ``DXP480TPLUS-994`` → ``nas``, etc.
+  //   2. Raw short ``hostname()`` when no alias entry matches.
+  //   3. Env fallback (``SCITEX_OROCHI_MACHINE`` /
+  //      ``SCITEX_OROCHI_HOSTNAME`` /
+  //      ``SCITEX_AGENT_CONTAINER_HOSTNAME``) — only when
+  //      ``hostname()`` returns empty (stripped container).
   //
-  // Previously the env vars were primary, which caused the
-  // proj-neurovista misreport: a stale ``SCITEX_OROCHI_HOSTNAME=mba``
-  // inherited from the shell/tmux env of the process that spawned the
-  // agent overrode the real host identity, so an agent running on
-  // spartan reported itself as mba. Per the lead fix: the agent sets
-  // its ``host`` field from its own ``hostname()``, never from
-  // inherited env or server-side inference.
-  const _liveHostname = hostname() || "";
-  const _machine =
-    _liveHostname ||
-    process.env.SCITEX_OROCHI_MACHINE ||
-    process.env.SCITEX_OROCHI_HOSTNAME ||
-    process.env.SCITEX_AGENT_CONTAINER_HOSTNAME ||
-    "";
+  // PR#309 flipped env/hostname priority (root fix for lead
+  // msg#15578 — stale ``SCITEX_OROCHI_HOSTNAME=mba`` inherited into
+  // a spartan process) but skipped the alias map on the TS side,
+  // which caused the ``Yusukes-MacBook-Air`` regression (ywatanabe
+  // msg#16102). Alias application restored here so the hub sees the
+  // canonical fleet short name.
+  const _machine = resolveHostLabel();
+  const _liveHostname = _machine;
   ws.send(
     JSON.stringify({
       type: "register",

--- a/ts/mcp_channel/heartbeat.ts
+++ b/ts/mcp_channel/heartbeat.ts
@@ -20,7 +20,7 @@
  * agent_meta.py path bypasses the broken registry lookup entirely (todo#155).
  */
 import { spawnSync } from "child_process";
-import { hostname, homedir } from "os";
+import { homedir } from "os";
 import { existsSync } from "fs";
 import { join } from "path";
 import {
@@ -30,6 +30,7 @@ import {
   maskUrl,
 } from "../src/config.js";
 import { dbg } from "./guards.js";
+import { resolveHostLabel } from "./hostname.js";
 
 export async function pushRegistryHeartbeat(): Promise<void> {
   if (process.env.SCITEX_OROCHI_REGISTRY_DISABLE === "1") return;
@@ -90,21 +91,32 @@ export async function pushRegistryHeartbeat(): Promise<void> {
     name: OROCHI_AGENT,
     agent_id: OROCHI_AGENT,
     role: process.env.SCITEX_OROCHI_ROLE || "agent",
-    // Host identity: trust live ``hostname()`` first, fall back to env
-    // only when the kernel returns empty (stripped container). Env-
-    // first was the root cause of lead msg#15578 (proj-neurovista
-    // misreporting as mba) — a stale SCITEX_OROCHI_HOSTNAME env var
-    // inherited into a spartan process would override the real host.
-    machine:
-      hostname() ||
-      process.env.SCITEX_OROCHI_MACHINE ||
-      process.env.SCITEX_OROCHI_HOSTNAME ||
-      process.env.SCITEX_AGENT_CONTAINER_HOSTNAME ||
-      "",
-    // Live hostname(1) — surfaced distinctly from ``machine`` so the
-    // hub / frontend can prefer this authoritative signal when deriving
-    // the ``<name>@<host>`` badge. Never sourced from env.
-    hostname: hostname() || "",
+    // Host identity (post-PR#309 / post-ywatanabe msg#16102):
+    //
+    //   1. Live ``hostname()`` mapped through
+    //      ``spec.hostname_aliases`` in
+    //      ``~/.scitex/orochi/shared/config.yaml`` — so
+    //      ``Yusukes-MacBook-Air`` → ``mba``,
+    //      ``DXP480TPLUS-994`` → ``nas``, etc.
+    //   2. Raw short ``hostname()`` when no alias entry matches.
+    //   3. Env fallback (``SCITEX_OROCHI_MACHINE`` /
+    //      ``SCITEX_OROCHI_HOSTNAME`` /
+    //      ``SCITEX_AGENT_CONTAINER_HOSTNAME``) — only when
+    //      ``hostname()`` returns empty (stripped container).
+    //
+    // PR#309 flipped env/hostname priority correctly (root cause of
+    // lead msg#15578 — stale ``SCITEX_OROCHI_HOSTNAME=mba`` inherited
+    // into a spartan process) but skipped the alias map on the TS
+    // side, which caused the ``Yusukes-MacBook-Air`` regression
+    // (ywatanabe msg#16102). Both ``machine`` and ``hostname`` now
+    // resolve through ``resolveHostLabel()`` so the hub sees the
+    // canonical fleet short name.
+    machine: resolveHostLabel(),
+    // Live hostname(1), alias-mapped — surfaced distinctly from
+    // ``machine`` so the hub / frontend can prefer this authoritative
+    // signal when deriving the ``<name>@<host>`` badge. Never sourced
+    // from env unless ``hostname()`` is empty.
+    hostname: resolveHostLabel(),
     multiplexer: process.env.SCITEX_OROCHI_MULTIPLEXER || "tmux",
   };
 

--- a/ts/mcp_channel/hostname.test.ts
+++ b/ts/mcp_channel/hostname.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Regression tests for ``resolveHostLabel`` — the TS client-side host
+ * identity resolver.
+ *
+ * Two incidents shape these tests:
+ *
+ *   1. Lead msg#15578 — proj-neurovista displayed as mba on spartan
+ *      because env vars beat ``hostname()``. PR#309 flipped the
+ *      priority so ``hostname()`` wins.
+ *   2. ywatanabe msg#16102 — mba host displayed as the raw
+ *      ``Yusukes-MacBook-Air`` on the Agents dashboard because PR#309
+ *      skipped the ``hostname_aliases`` map that used to translate
+ *      ``Yusukes-MacBook-Air`` → ``mba``. The follow-up fix restores
+ *      alias application before the raw-hostname fallback.
+ *
+ * Final resolution order (first non-empty wins):
+ *   1. ``hostname_aliases[hostname()]`` from shared/config.yaml.
+ *   2. Raw short ``hostname()``.
+ *   3. Env fallback (``SCITEX_OROCHI_HOSTNAME`` /
+ *      ``SCITEX_OROCHI_MACHINE`` /
+ *      ``SCITEX_AGENT_CONTAINER_HOSTNAME``) — only when
+ *      ``hostname()`` returns empty.
+ *
+ * Run with ``bun test ts/mcp_channel/hostname.test.ts``.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { resolveHostLabel, loadHostnameAliases } from "./hostname";
+
+let tmpConfigDir: string;
+let tmpConfigPath: string;
+
+const ENV_KEYS = [
+  "SCITEX_OROCHI_HOSTNAME",
+  "SCITEX_OROCHI_MACHINE",
+  "SCITEX_AGENT_CONTAINER_HOSTNAME",
+];
+let _savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  tmpConfigDir = mkdtempSync(join(tmpdir(), "orochi-hostname-test-"));
+  tmpConfigPath = join(tmpConfigDir, "config.yaml");
+  _savedEnv = {};
+  for (const k of ENV_KEYS) {
+    _savedEnv[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (_savedEnv[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = _savedEnv[k];
+    }
+  }
+  try {
+    rmSync(tmpConfigDir, { recursive: true, force: true });
+  } catch {}
+});
+
+function writeConfig(body: string): void {
+  writeFileSync(tmpConfigPath, body, "utf-8");
+}
+
+const SAMPLE_ALIASES_YAML = `
+apiVersion: scitex-orochi/v1
+kind: Config
+metadata:
+  machine: ywata-note-win
+spec:
+  hub:
+    hosts: [192.168.11.22, scitex-orochi.com]
+    port: 8559
+  hostname_aliases:
+    Yusukes-MacBook-Air: mba
+    DXP480TPLUS-994: nas
+    spartan-login1: spartan
+    # ywata-note-win: identity, no entry needed
+`;
+
+describe("loadHostnameAliases", () => {
+  test("parses the documented alias entries", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    const aliases = loadHostnameAliases(tmpConfigPath);
+    expect(aliases).toEqual({
+      "Yusukes-MacBook-Air": "mba",
+      "DXP480TPLUS-994": "nas",
+      "spartan-login1": "spartan",
+    });
+  });
+
+  test("returns empty dict when config file is missing", () => {
+    expect(loadHostnameAliases(join(tmpConfigDir, "missing.yaml"))).toEqual({});
+  });
+
+  test("returns empty dict when hostname_aliases section is absent", () => {
+    writeConfig("apiVersion: scitex-orochi/v1\nspec:\n  hub:\n    port: 8559\n");
+    expect(loadHostnameAliases(tmpConfigPath)).toEqual({});
+  });
+
+  test("ignores inline comments and preserves multi-host values", () => {
+    writeConfig(
+      "spec:\n" +
+        "  hostname_aliases:\n" +
+        "    Yusukes-MacBook-Air: mba   # mba host\n" +
+        "    DXP480TPLUS-994: nas\n",
+    );
+    expect(loadHostnameAliases(tmpConfigPath)).toEqual({
+      "Yusukes-MacBook-Air": "mba",
+      "DXP480TPLUS-994": "nas",
+    });
+  });
+});
+
+describe("resolveHostLabel", () => {
+  test("returns raw hostname when no alias entry and no env", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    const result = resolveHostLabel({
+      configPath: tmpConfigPath,
+      rawHostname: "ywata-note-win",
+    });
+    expect(result).toBe("ywata-note-win");
+  });
+
+  test("applies alias map to translate Yusukes-MacBook-Air -> mba (msg#16102)", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    const result = resolveHostLabel({
+      configPath: tmpConfigPath,
+      rawHostname: "Yusukes-MacBook-Air",
+    });
+    expect(result).toBe("mba");
+  });
+
+  test("alias map wins over env var when both are present", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    const result = resolveHostLabel({
+      configPath: tmpConfigPath,
+      rawHostname: "Yusukes-MacBook-Air",
+      env: { SCITEX_OROCHI_HOSTNAME: "totally-wrong" } as NodeJS.ProcessEnv,
+    });
+    expect(result).toBe("mba");
+  });
+
+  test("env var ignored when live hostname is populated (msg#15578 regression)", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    const result = resolveHostLabel({
+      configPath: tmpConfigPath,
+      rawHostname: "spartan-login1",
+      env: { SCITEX_OROCHI_HOSTNAME: "mba" } as NodeJS.ProcessEnv,
+    });
+    // Alias applies first — spartan-login1 -> spartan. The stale mba
+    // env var does NOT leak in.
+    expect(result).toBe("spartan");
+  });
+
+  test("FQDN reduced to the short-form hostname before lookup", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    const result = resolveHostLabel({
+      configPath: tmpConfigPath,
+      rawHostname: "spartan-login1.hpc.unimelb.edu.au",
+    });
+    expect(result).toBe("spartan");
+  });
+
+  test("env fallback honoured only when hostname is empty", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    const result = resolveHostLabel({
+      configPath: tmpConfigPath,
+      rawHostname: "",
+      env: { SCITEX_OROCHI_HOSTNAME: "container-host" } as NodeJS.ProcessEnv,
+    });
+    expect(result).toBe("container-host");
+  });
+
+  test("env fallback covers all three documented env vars", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    // Only SCITEX_AGENT_CONTAINER_HOSTNAME set.
+    expect(
+      resolveHostLabel({
+        configPath: tmpConfigPath,
+        rawHostname: "",
+        env: {
+          SCITEX_AGENT_CONTAINER_HOSTNAME: "container-host",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).toBe("container-host");
+    // MACHINE beats AGENT_CONTAINER_HOSTNAME.
+    expect(
+      resolveHostLabel({
+        configPath: tmpConfigPath,
+        rawHostname: "",
+        env: {
+          SCITEX_AGENT_CONTAINER_HOSTNAME: "container-host",
+          SCITEX_OROCHI_MACHINE: "machine-env",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).toBe("machine-env");
+    // HOSTNAME beats MACHINE.
+    expect(
+      resolveHostLabel({
+        configPath: tmpConfigPath,
+        rawHostname: "",
+        env: {
+          SCITEX_AGENT_CONTAINER_HOSTNAME: "container-host",
+          SCITEX_OROCHI_MACHINE: "machine-env",
+          SCITEX_OROCHI_HOSTNAME: "hostname-env",
+        } as NodeJS.ProcessEnv,
+      }),
+    ).toBe("hostname-env");
+  });
+
+  test("returns empty string when hostname is empty and no env set", () => {
+    writeConfig(SAMPLE_ALIASES_YAML);
+    expect(
+      resolveHostLabel({
+        configPath: tmpConfigPath,
+        rawHostname: "",
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).toBe("");
+  });
+
+  test("raw hostname returned verbatim when config.yaml is missing", () => {
+    const result = resolveHostLabel({
+      configPath: join(tmpConfigDir, "missing.yaml"),
+      rawHostname: "Yusukes-MacBook-Air",
+    });
+    // No alias map available → raw hostname verbatim.
+    expect(result).toBe("Yusukes-MacBook-Air");
+  });
+});

--- a/ts/mcp_channel/hostname.ts
+++ b/ts/mcp_channel/hostname.ts
@@ -1,0 +1,139 @@
+/**
+ * Canonical host-identity resolution for Orochi heartbeats.
+ *
+ * Mirrors the Python ``agent_meta_pkg._machine.resolve_machine_label`` and
+ * ``scripts/client/resolve-hostname`` logic so TS clients produce the same
+ * ``mba`` / ``nas`` / ``spartan`` / ``ywata-note-win`` label as the
+ * Python-side heartbeat.
+ *
+ * Resolution order (first non-empty wins):
+ *   1. Live ``os.hostname()`` (short form), mapped through
+ *      ``spec.hostname_aliases`` from ``~/.scitex/orochi/shared/config.yaml``
+ *      when an entry matches — e.g. ``Yusukes-MacBook-Air`` → ``mba``.
+ *   2. Raw short ``os.hostname()`` — if no alias entry matches, use the
+ *      live hostname verbatim. This is the proof-of-life identity:
+ *      whatever the kernel says this process is running on.
+ *   3. Env fallback (``SCITEX_OROCHI_HOSTNAME`` / ``SCITEX_OROCHI_MACHINE``
+ *      / ``SCITEX_AGENT_CONTAINER_HOSTNAME``) — only honoured when
+ *      ``hostname()`` returned an empty string. An env override that
+ *      disagrees with a populated live hostname is ignored on purpose;
+ *      that is how a stale ``mba`` env leaked into a spartan process
+ *      before PR#309 (lead msg#15578).
+ *
+ * PR#309 flipped priority so ``hostname()`` beats env vars. That fix
+ * reintroduced a different regression (ywatanabe msg#16102): raw host
+ * names like ``Yusukes-MacBook-Air`` were shown on the Agents dashboard
+ * instead of the canonical fleet short name ``mba``, because the TS
+ * heartbeat skipped the ``hostname_aliases`` map that the Python
+ * resolver had always applied. This module restores alias application
+ * so the resolution order matches the shared config contract.
+ */
+import { hostname as osHostname, homedir } from "os";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+const DEFAULT_CONFIG_PATH = join(
+  homedir(),
+  ".scitex",
+  "orochi",
+  "shared",
+  "config.yaml",
+);
+
+/**
+ * Parse ``spec.hostname_aliases`` out of the shared config YAML without
+ * pulling in a full YAML dependency. The aliases block is a flat
+ * ``key: value`` mapping (raw-hostname → canonical-short-name) and the
+ * shared/config.yaml is tiny, so a tolerant line scanner is sufficient
+ * — we never round-trip, never edit, only read known-shape entries.
+ *
+ * Returns an empty dict on any parse problem; host-identity resolution
+ * must always succeed via the raw hostname fallback even if the config
+ * file is missing or malformed.
+ */
+export function loadHostnameAliases(
+  configPath: string = DEFAULT_CONFIG_PATH,
+): Record<string, string> {
+  try {
+    if (!existsSync(configPath)) return {};
+    const text = readFileSync(configPath, "utf-8");
+    const aliases: Record<string, string> = {};
+    let inSpec = false;
+    let inAliases = false;
+    let aliasesIndent = -1;
+    for (const raw of text.split(/\r?\n/)) {
+      // Strip inline comments after a ``#`` preceded by whitespace
+      // (safe for this file — no ``#`` inside legitimate values).
+      const line = raw.replace(/\s+#.*$/, "").replace(/\s+$/, "");
+      if (!line.trim()) continue;
+      const indent = line.length - line.trimStart().length;
+      if (indent === 0) {
+        inSpec = line.startsWith("spec:");
+        inAliases = false;
+        aliasesIndent = -1;
+        continue;
+      }
+      if (!inSpec) continue;
+      if (!inAliases) {
+        if (line.trimStart().startsWith("hostname_aliases:")) {
+          inAliases = true;
+          aliasesIndent = indent;
+        }
+        continue;
+      }
+      // Still inside hostname_aliases as long as the indent is deeper
+      // than the ``hostname_aliases:`` line itself.
+      if (indent <= aliasesIndent) {
+        inAliases = false;
+        aliasesIndent = -1;
+        // Re-evaluate this line at its own indent in case it's a
+        // sibling ``spec`` key.
+        if (indent === 0) {
+          inSpec = line.startsWith("spec:");
+        }
+        continue;
+      }
+      const match = line.trimStart().match(/^([^:\s#][^:]*):\s*(.+)$/);
+      if (!match) continue;
+      const key = match[1].trim();
+      // Strip surrounding quotes if YAML quoted the value.
+      const value = match[2].trim().replace(/^['"]|['"]$/g, "");
+      if (key && value) aliases[key] = value;
+    }
+    return aliases;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Return the canonical fleet-machine label for THIS host.
+ *
+ * See module docstring for full resolution order. Env fallbacks are
+ * honoured only when the live hostname is empty.
+ */
+export function resolveHostLabel(opts?: {
+  configPath?: string;
+  rawHostname?: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const env = opts?.env ?? process.env;
+  const rawFull = opts?.rawHostname ?? osHostname() ?? "";
+  const raw = (rawFull || "").split(".")[0].trim();
+  if (raw) {
+    const aliases = loadHostnameAliases(
+      opts?.configPath ?? DEFAULT_CONFIG_PATH,
+    );
+    if (Object.prototype.hasOwnProperty.call(aliases, raw)) {
+      return aliases[raw];
+    }
+    return raw;
+  }
+  // ``hostname()`` returned empty — only now trust the env overrides.
+  return (
+    (env.SCITEX_OROCHI_HOSTNAME || "").trim() ||
+    (env.SCITEX_OROCHI_MACHINE || "").trim() ||
+    (env.SCITEX_AGENT_CONTAINER_HOSTNAME || "").trim() ||
+    ""
+  );
+}


### PR DESCRIPTION
## Summary

Regression fix for ywatanabe msg#16102 / lead msg#16116 — hub Agents
display showed the raw OS hostname ``Yusukes-MacBook-Air`` for the mba
host instead of the canonical short name ``mba`` that it displayed
before PR #309.

**Root cause confirmed**: PR #309 correctly flipped env/``hostname()``
priority (fixing lead msg#15578 — stale ``SCITEX_OROCHI_HOSTNAME=mba``
inherited into a spartan process made proj-neurovista misreport as
mba), but the TS heartbeat now pushed the raw ``os.hostname()`` verbatim
and bypassed the ``spec.hostname_aliases`` map in
``~/.scitex/orochi/shared/config.yaml`` that translates
``Yusukes-MacBook-Air`` → ``mba``, ``DXP480TPLUS-994`` → ``nas``, and
``spartan-login1`` → ``spartan``.

## Fix

Restore alias-map application on both the TS and Python heartbeat
paths. Final resolution order (first non-empty wins):

1. ``hostname_aliases[hostname()]`` from shared/config.yaml
2. Raw short ``hostname()``
3. Env fallback (``SCITEX_OROCHI_HOSTNAME`` / ``SCITEX_OROCHI_MACHINE``
   / ``SCITEX_AGENT_CONTAINER_HOSTNAME``) — only when ``hostname()`` is
   empty

### Files changed

**Client (TS):**
- ``ts/mcp_channel/hostname.ts`` (new) — ``resolveHostLabel()`` shared
  resolver + minimal YAML parser for shared/config.yaml. Mirrors the
  Python resolver's order exactly.
- ``ts/mcp_channel/connection.ts`` — route ``machine`` + ``hostname``
  through ``resolveHostLabel()``.
- ``ts/mcp_channel/heartbeat.ts`` — same.

**Client (Python):**
- ``scripts/client/agent_meta_pkg/_machine.py`` — factor out
  ``_load_hostname_aliases()``; expand env fallback to all three
  documented env vars so Python matches TS.
- ``scripts/client/agent_meta_pkg/_collect.py`` — route
  ``live_hostname`` through ``resolve_machine_label()`` so both the
  ``machine`` and ``hostname`` fields carry the canonical short name.

## Tests

**Python (tests/test_resolve_machine_label.py):** 8 tests, all pass.

- ``test_returns_live_hostname_when_env_unset`` — raw hostname path
- ``test_env_var_ignored_when_hostname_populated`` — msg#15578 guard
- ``test_env_var_used_when_hostname_empty`` — env fallback
- ``test_short_name_stripped_from_fqdn`` — FQDN reduction
- ``test_alias_map_translates_raw_hostname`` — **direct msg#16102 guard**
  (``Yusukes-MacBook-Air`` → ``mba``)
- ``test_alias_map_wins_over_env_var`` — declarative aliases win over env
- ``test_raw_hostname_returned_when_no_alias_and_no_env`` — identity
  fallback (``ywata-note-win``)
- ``test_env_fallback_covers_all_three_vars`` — TS/Python parity

**TS (ts/mcp_channel/hostname.test.ts):** 13 tests, all pass via
``bun test``.

- ``loadHostnameAliases`` parses documented entries; tolerates missing
  file / missing section / inline comments
- ``resolveHostLabel``: raw hostname path, alias translation
  (msg#16102), alias-over-env, env-ignored-when-populated (msg#15578),
  FQDN reduction, env fallback for each of the three vars with correct
  precedence, empty-input empty-output, missing-config falls through
  to raw hostname

## Test plan

- [x] ``python -m pytest tests/test_resolve_machine_label.py -xvs`` — 8/8 pass
- [x] ``cd ts && bun test mcp_channel/hostname.test.ts`` — 13/13 pass
- [x] ``cd ts && bun build mcp_channel/connection.ts mcp_channel/heartbeat.ts`` — compiles clean
- [x] ``python manage.py test hub.tests.registry`` — 58/58 pass (no hub-side regressions)
- [ ] After merge: restart ywata-note-win / mba / spartan / nas sidecars and verify
      dashboard shows ``<agent>@mba``, ``@nas``, ``@spartan``, ``@ywata-note-win``
      rather than raw hostnames. Lead + heads will confirm on their own hosts.

## Follow-up

- dotfiles config audit: ``~/.dotfiles/src/.scitex/orochi/shared/config.yaml``
  matches the deployed ``~/.scitex/orochi/shared/config.yaml`` on ywata-note-win,
  so no dotfiles drift there. Heads should confirm on their own hosts as they
  restart the sidecars.
- No changes to ``scripts/client/resolve-hostname`` (shell helper) — it
  already applies aliases correctly; only the TS/Python heartbeat path
  was affected by PR #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)