### PR TITLE
fix(ui): selection-highlight inversion + paste regression + cmd-click new-tab + subagent_count badge (msg#16116)

### DIFF
--- a/hub/frontend/src/agent-badge-svg.ts
+++ b/hub/frontend/src/agent-badge-svg.ts
@@ -410,6 +410,29 @@ import { escapeHtml, getAgentColor } from "./app/utils";
           "</text>";
       }
 
+      /* msg#16116 Item 4: subagent count chip — SVG mirror of the
+       * .agent-badge-subcount HTML chip. Rendered AFTER the name so
+       * topology nodes get the same "🧒 N" cue as sidebar + detail
+       * rows. Hidden entirely when count is 0/undefined. Uses a
+       * yellow fill matching the HTML chip colour. */
+      var subCount =
+        a && a.subagent_count != null ? Number(a.subagent_count) : 0;
+      var subSvg = "";
+      if (subCount && isFinite(subCount) && subCount >= 1) {
+        var subX = nameX + textW + 4;
+        subSvg =
+          '<text class="topo-label topo-agent-subcount" x="' +
+          subX.toFixed(1) +
+          '" y="' +
+          (y + 4).toFixed(1) +
+          '" fill="#ffd93d" font-size="10">' +
+          "\uD83E\uDDD2 " +
+          _escape(String(subCount)) +
+          "<title>" +
+          _escape(subCount + " active subagent(s)") +
+          "</title></text>";
+      }
+
       var badgeLeft = clusterLeft - 4;
       var badgeWidth = total + 8;
       var badgeY = y - 11;
@@ -429,7 +452,9 @@ import { escapeHtml, getAgentColor } from "./app/utils";
       if (opts.extraClass) cls += " " + opts.extraClass;
 
       /* Order matches the HTML agent-badge.ts canonical order:
-       *   icon + star + eye + 4 LEDs + name (Task 7, msg#15548). */
+       *   icon + star + eye + 4 LEDs + name (Task 7, msg#15548).
+       * msg#16116 Item 4: subagent-count chip (subSvg) appended after
+       * name, mirroring the HTML composition in renderAgentBadge. */
       return (
         '<g class="' +
         cls +
@@ -445,6 +470,7 @@ import { escapeHtml, getAgentColor } from "./app/utils";
         eyeSvg +
         ledBlock.svg +
         nameSvg +
+        subSvg +
         "</g>"
       );
     }

--- a/hub/frontend/src/agent-badge.ts
+++ b/hub/frontend/src/agent-badge.ts
@@ -128,6 +128,33 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
     );
   }
 
+  // ── 2c. Subagent count (msg#16116 Item 4 / lead msg#16116).
+  //        Tiny chip showing the number of active Agent-tool subagents
+  //        spawned by this agent. Source: ``a.subagent_count`` from the
+  //        /api/agents/ payload (already present per PR #318 — fleet-wide
+  //        terse whitelist). Hidden entirely when the value is undefined
+  //        or 0 so idle agents keep the compact row silhouette.
+  //        Rendered in every surface that uses renderAgentBadge (sidebar
+  //        list, detail-pane header, agent-card composer). The SVG
+  //        topology node renders its own variant via agent-badge-svg.ts.
+  function renderAgentSubagentCount(a) {
+    var n = a && a.subagent_count != null ? Number(a.subagent_count) : 0;
+    if (!n || !isFinite(n) || n < 1) return "";
+    /* Class name ``agent-badge-subcount`` intentionally distinct from
+     * the pre-existing ``.agent-badge-subagents`` pill in
+     * components-agent-cards.css — that rule is a full-width meta pill
+     * rendered on the Agents-tab card; this one is an inline count
+     * chip appended to the badge strip. */
+    return (
+      '<span class="agent-badge-subcount" title="' +
+      _escape(n + " active subagent(s)") +
+      '">' +
+      "\uD83E\uDDD2\uFE0F\u00A0" + /* 🧒 + non-breaking space */
+      n +
+      "</span>"
+    );
+  }
+
   // ── 2b. Eye (togglable show/hide, always visible, placeholder even when
   //        not hidden so column geometry stays constant across rows).
   // Mirrors the channel .ch-eye pattern 1:1: same 👁 glyph in both states,
@@ -284,13 +311,20 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
      * finds the same on agents. The eye was inserted between ★ and
      * the LED strip per lead's explicit ordering directive in
      * msg#15548 (deviation from Task 3's baseline, but Task 7 owns
-     * the slot for agents going forward). */
+     * the slot for agents going forward).
+     *
+     * msg#16116 Item 4: a tiny subagent-count chip is appended AFTER
+     * the name. Hidden by default when count is 0/undefined so idle
+     * agents keep their existing row silhouette; only busy agents
+     * grow the extra glyph. Caller can opt out via
+     * ``opts.hideSubagentCount``. */
     var icon = renderAgentIcon(a, opts.iconSize);
     var star = renderAgentStar(a);
     var eye = opts.hideEye ? "" : renderAgentEye(a);
     var leds = renderAgentLeds(a, { extraClass: opts.extraClass });
     var name = opts.hideName ? "" : renderAgentName(a, opts);
-    return icon + star + eye + leds + name;
+    var subs = opts.hideSubagentCount ? "" : renderAgentSubagentCount(a);
+    return icon + star + eye + leds + name + subs;
   }
 
   // ── Background-class helper: dim when not all four LEDs green ─────
@@ -401,6 +435,7 @@ import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "./ap
   window.renderAgentIcon = renderAgentIcon;
   window.renderAgentStar = renderAgentStar;
   window.renderAgentEye = renderAgentEye;
+  window.renderAgentSubagentCount = renderAgentSubagentCount;
   window.renderAgentLeds = renderAgentLeds;
   window.renderAgentName = renderAgentName;
   window.renderAgentBadge = renderAgentBadge;
@@ -420,3 +455,4 @@ export const renderAgentIcon = (window as any).renderAgentIcon;
 export const renderAgentLeds = (window as any).renderAgentLeds;
 export const renderAgentName = (window as any).renderAgentName;
 export const renderAgentStar = (window as any).renderAgentStar;
+export const renderAgentSubagentCount = (window as any).renderAgentSubagentCount;

--- a/hub/frontend/src/agents-tab/detail.ts
+++ b/hub/frontend/src/agents-tab/detail.ts
@@ -208,6 +208,19 @@ export function _renderAgentDetail(a) {
       );
     })
     .join("");
+  /* msg#16116 Item 4: inline subagent-count chip in the detail header.
+   * Visible only when the agent has >=1 active subagent; hidden by the
+   * `return ""` branch inside renderAgentSubagentCount when 0. Source:
+   * d.subagent_count (detail endpoint) falling back to a.subagent_count
+   * (registry). Separate from the Subagents meta-field row below — the
+   * header chip is an at-a-glance cue so users don't need to scan the
+   * meta grid. */
+  var headerSubagents =
+    typeof (window as any).renderAgentSubagentCount === "function"
+      ? (window as any).renderAgentSubagentCount({
+          subagent_count: subagentCount,
+        })
+      : "";
   var headerHtml =
     '<div class="agent-detail-header">' +
     '<div class="agent-detail-header-line">' +
@@ -215,6 +228,7 @@ export function _renderAgentDetail(a) {
     '<span class="agent-detail-header-title">' +
     escapeHtml(a.name) +
     "</span>" +
+    headerSubagents +
     (currentTask
       ? '<em class="agent-detail-task">' + escapeHtml(currentTask) + "</em>"
       : "") +

--- a/hub/frontend/src/chat/chat-composer.ts
+++ b/hub/frontend/src/chat/chat-composer.ts
@@ -4,6 +4,7 @@ import { sendOrochiMessage, userName } from "../app/utils";
 import { ws, wsConnected } from "../app/websocket";
 import { _renderMermaidIn } from "./chat-attachments";
 import { clearPendingAttachments, getPendingAttachments } from "../upload";
+import { activeTab } from "../tabs";
 
 export function updateChannelSelect() {
   /* Channel select removed -- using sidebar selection instead */
@@ -238,6 +239,14 @@ document.addEventListener("click", function (e) {
   if (!msgInput) return;
   msgInput.addEventListener("blur", function (e) {
     if (window.__voiceInputAllowBlur) return;
+    /* msg#16116 Item 2: never re-focus msg-input from a non-Chat tab.
+     * When the user is on Overview/TODO/etc the input bar is display:none
+     * and the watchdog's rAF refocus either silently no-ops (browsers
+     * refuse to focus display:none elements) or — under race conditions
+     * with rapid tab switches — can briefly park focus on msg-input and
+     * cascade into a Chat-tab flip via downstream focus-in handlers.
+     * Guard: if Chat isn't the active tab, leave the blur where it is. */
+    if (activeTab !== "chat") return;
     var savedStart = msgInput.selectionStart || 0;
     var savedEnd = msgInput.selectionEnd || 0;
     var rt = e && e.relatedTarget;

--- a/hub/frontend/src/tabs.ts
+++ b/hub/frontend/src/tabs.ts
@@ -231,11 +231,69 @@ export function _activateTab(tab) {
   } catch (_) {}
 }
 
+/* msg#16116 Item 3: cmd-click / ctrl-click / middle-click on a tab
+ * button should open that view in a new browser tab so the user can
+ * lay Overview + TODO side-by-side. Tab buttons are <button> elements
+ * (dashboard.html), not <a>, so browsers don't offer the native
+ * "open in new tab" affordance by default. Rather than change the
+ * markup (which would cascade into every .tab-btn CSS selector), we
+ * intercept modifier-key and middle clicks at the JS layer:
+ *   - auxclick listener catches middle-button presses and calls
+ *     window.open(pathname + "#tab", "_blank").
+ *   - Regular click listener checks metaKey / ctrlKey / shiftKey; if
+ *     any is pressed, preventDefault and route through window.open.
+ *   - Plain left-click still runs _activateTab for the in-place
+ *     switch (the existing flow).
+ * The ``data-href`` attribute stays on the button as a hint for
+ * developers / a11y tools but is not honoured by the browser itself.
+ * The new tab lands on ``dashboard/#<tab>`` and the boot code below
+ * reads the hash to activate the requested tab. */
+function _isNewTabClick(ev) {
+  /* Middle mouse button = ev.button === 1. Cmd (mac) = metaKey.
+   * Ctrl (win/linux) = ctrlKey. Shift opens in a new window on most
+   * browsers; treat it the same (user intent = "not in place"). */
+  return ev.button === 1 || ev.metaKey || ev.ctrlKey || ev.shiftKey;
+}
+
 document.querySelectorAll(".tab-btn").forEach(function (btn) {
-  btn.addEventListener("click", function () {
-    var tab = btn.getAttribute("data-tab");
-    if (tab === activeTab) return;
-    _activateTab(tab);
+  /* Install an anchor-style href so the browser exposes the standard
+   * "Open in new tab" / "Open in new window" context menu entries, and
+   * so middle-click raises a new background tab by default. Buttons
+   * themselves don't honour href (they're not anchors), but modifier-
+   * key clicks still get our custom handler below which opens a fresh
+   * tab via window.open. The href stays consistent with the hash-route
+   * the new tab's boot code looks for. */
+  var tab = btn.getAttribute("data-tab") || "";
+  if (tab && !btn.hasAttribute("data-href")) {
+    btn.setAttribute("data-href", "#" + tab);
+  }
+  /* Middle-click (auxclick) on a <button> fires regardless of href. */
+  btn.addEventListener("auxclick", function (ev) {
+    /* Middle button only (1). Right-click (2) lets the browser show
+     * its own context menu. */
+    if (ev.button !== 1) return;
+    ev.preventDefault();
+    var t = btn.getAttribute("data-tab");
+    if (!t) return;
+    try {
+      window.open(window.location.pathname + "#" + t, "_blank");
+    } catch (_) {}
+  });
+  btn.addEventListener("click", function (ev) {
+    var t = btn.getAttribute("data-tab");
+    if (!t) return;
+    if (_isNewTabClick(ev)) {
+      /* Cmd/Ctrl/Shift click — open a new tab/window. Use a blank
+       * target so each click spawns its own surface; suppress the
+       * in-place switch. */
+      ev.preventDefault();
+      try {
+        window.open(window.location.pathname + "#" + t, "_blank");
+      } catch (_) {}
+      return;
+    }
+    if (t === activeTab) return;
+    _activateTab(t);
   });
 });
 
@@ -249,6 +307,18 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
  * Chat surfaces — _activateTab("activity") hides them imperatively. */
 (function () {
   try {
+    /* msg#16116 Item 3: hash-based tab routing. When a cmd/middle-click
+     * on a tab button opens a new browser tab, the fresh tab loads the
+     * dashboard with ``#<tab>`` as the URL fragment. Honor that hash
+     * FIRST — it reflects the explicit "open this view in a new tab"
+     * intent. Fall back to localStorage (in-place session continuity)
+     * and finally Overview. */
+    var hash = "";
+    try {
+      hash = (window.location.hash || "").replace(/^#/, "");
+    } catch (_) {
+      hash = "";
+    }
     var last = localStorage.getItem("orochi_active_tab");
     /* Step 3c: the top-level Terminal tab has been removed (terminal
      * preview now lives only inside the agent-detail pane's SSH action).
@@ -256,8 +326,11 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
     if (last === "terminal") {
       last = null;
     }
-    var target = last || "activity";
-    /* If the remembered tab no longer has a DOM button, fall back to
+    if (hash === "terminal") {
+      hash = "";
+    }
+    var target = hash || last || "activity";
+    /* If the requested tab no longer has a DOM button, fall back to
      * Overview ("activity"). */
     var btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
     if (!btn) {

--- a/hub/frontend/src/upload.ts
+++ b/hub/frontend/src/upload.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { apiUrl, csrfToken } from "./app/utils";
+import { activeTab } from "./tabs";
 
 /* File upload — attach, drag-drop, clipboard paste (multi-file) with
  * staged preview. Files picked via paste/drag/file-picker are held in a
@@ -273,6 +274,31 @@ export function _buildPastedTextFile(text) {
 }
 
 export function handleClipboardPaste(e) {
+  /* Guard (msg#16116 Item 2 / lead msg#16116): this handler is bound to
+   * msg-input only, but it was still catching paste events when the user
+   * was on a non-Chat tab (e.g. Overview) — either via an inherited
+   * focus ring that survived the tab switch, or via a bubbled paste from
+   * a descendant the user was focused on (the dashboard does NOT have a
+   * document-level paste listener, but defense-in-depth is cheap). When
+   * that happened, staging attachments from a paste on the Overview tab
+   * silently wired the user into the Chat composer — because stageFiles()
+   * mutates the Chat composer's tray and subsequent WS/focus restores
+   * can flip the active tab. Gate: only process paste when the current
+   * focus is actually inside the Chat composer AND Chat is the active
+   * tab. Anywhere else, let the native paste land in the user's real
+   * target (textarea on Overview, contenteditable in a modal, etc.).
+   *
+   * This mirrors the stopPropagation() defense already in place on the
+   * activity-tab compose popup (see compose.ts, PR #313 Item 10). */
+  var msgInputEl = document.getElementById("msg-input");
+  var focusIsMsgInput =
+    msgInputEl && document.activeElement === msgInputEl;
+  if (!focusIsMsgInput || activeTab !== "chat") {
+    /* Let the event pass through untouched — do not stage attachments,
+     * do not preventDefault. The user's current target receives the
+     * paste natively. */
+    return;
+  }
   var cd =
     e.clipboardData || (e.originalEvent && e.originalEvent.clipboardData);
   if (!cd) return;

--- a/hub/static/hub/agent-badge-svg.js
+++ b/hub/static/hub/agent-badge-svg.js
@@ -388,6 +388,26 @@
           "</text>";
       }
 
+      /* msg#16116 Item 4: subagent count chip — SVG mirror of the
+       * .agent-badge-subcount HTML chip. Hidden when 0/undefined. */
+      var subCount =
+        a && a.subagent_count != null ? Number(a.subagent_count) : 0;
+      var subSvg = "";
+      if (subCount && isFinite(subCount) && subCount >= 1) {
+        var subX = nameX + textW + 4;
+        subSvg =
+          '<text class="topo-label topo-agent-subcount" x="' +
+          subX.toFixed(1) +
+          '" y="' +
+          (y + 4).toFixed(1) +
+          '" fill="#ffd93d" font-size="10">' +
+          "\uD83E\uDDD2 " +
+          _escape(String(subCount)) +
+          "<title>" +
+          _escape(subCount + " active subagent(s)") +
+          "</title></text>";
+      }
+
       var badgeLeft = clusterLeft - 4;
       var badgeWidth = total + 8;
       var badgeY = y - 11;
@@ -407,7 +427,8 @@
       if (opts.extraClass) cls += " " + opts.extraClass;
 
       /* Order matches the HTML agent-badge.js canonical order:
-       *   icon + star + eye + 4 LEDs + name (Task 7, msg#15548). */
+       *   icon + star + eye + 4 LEDs + name + subcount (Task 7 +
+       *   msg#16116 Item 4). */
       return (
         '<g class="' +
         cls +
@@ -423,6 +444,7 @@
         eyeSvg +
         ledBlock.svg +
         nameSvg +
+        subSvg +
         "</g>"
       );
     }

--- a/hub/static/hub/agent-badge.js
+++ b/hub/static/hub/agent-badge.js
@@ -117,6 +117,21 @@
     );
   }
 
+  // ── 2c. Subagent count (msg#16116 Item 4). Tiny chip showing the
+  //        number of active subagents. Hidden when 0/undefined.
+  function renderAgentSubagentCount(a) {
+    var n = a && a.subagent_count != null ? Number(a.subagent_count) : 0;
+    if (!n || !isFinite(n) || n < 1) return "";
+    return (
+      '<span class="agent-badge-subcount" title="' +
+      _escape(n + " active subagent(s)") +
+      '">' +
+      "\uD83E\uDDD2\uFE0F\u00A0" +
+      n +
+      "</span>"
+    );
+  }
+
   // ── 2b. Eye (togglable show/hide, always visible, placeholder even when
   //        not hidden so column geometry stays constant across rows).
   // Mirrors the channel .ch-eye pattern 1:1: same 👁 glyph in both states,
@@ -279,7 +294,9 @@
     var eye = opts.hideEye ? "" : renderAgentEye(a);
     var leds = renderAgentLeds(a, { extraClass: opts.extraClass });
     var name = opts.hideName ? "" : renderAgentName(a, opts);
-    return icon + star + eye + leds + name;
+    /* msg#16116 Item 4: append subagent count chip (hidden when 0). */
+    var subs = opts.hideSubagentCount ? "" : renderAgentSubagentCount(a);
+    return icon + star + eye + leds + name + subs;
   }
 
   // ── Background-class helper: dim when not all four LEDs green ─────
@@ -379,6 +396,7 @@
   window.renderAgentIcon = renderAgentIcon;
   window.renderAgentStar = renderAgentStar;
   window.renderAgentEye = renderAgentEye;
+  window.renderAgentSubagentCount = renderAgentSubagentCount;
   window.renderAgentLeds = renderAgentLeds;
   window.renderAgentName = renderAgentName;
   window.renderAgentBadge = renderAgentBadge;

--- a/hub/static/hub/agents-tab/detail.js
+++ b/hub/static/hub/agents-tab/detail.js
@@ -203,6 +203,11 @@ function _renderAgentDetail(a) {
       );
     })
     .join("");
+  /* msg#16116 Item 4: inline subagent-count chip in the detail header. */
+  var headerSubagents =
+    typeof window.renderAgentSubagentCount === "function"
+      ? window.renderAgentSubagentCount({ subagent_count: subagentCount })
+      : "";
   var headerHtml =
     '<div class="agent-detail-header">' +
     '<div class="agent-detail-header-line">' +
@@ -210,6 +215,7 @@ function _renderAgentDetail(a) {
     '<span class="agent-detail-header-title">' +
     escapeHtml(a.name) +
     "</span>" +
+    headerSubagents +
     (currentTask
       ? '<em class="agent-detail-task">' + escapeHtml(currentTask) + "</em>"
       : "") +

--- a/hub/static/hub/chat/chat-composer.js
+++ b/hub/static/hub/chat/chat-composer.js
@@ -231,6 +231,14 @@ document.addEventListener("click", function (e) {
   if (!msgInput) return;
   msgInput.addEventListener("blur", function (e) {
     if (window.__voiceInputAllowBlur) return;
+    /* msg#16116 Item 2: never re-focus msg-input from a non-Chat tab. */
+    var _activeTab =
+      typeof window !== "undefined" && typeof window.activeTab === "string"
+        ? window.activeTab
+        : typeof activeTab === "string"
+          ? activeTab
+          : "";
+    if (_activeTab !== "chat") return;
     var savedStart = msgInput.selectionStart || 0;
     var savedEnd = msgInput.selectionEnd || 0;
     var rt = e && e.relatedTarget;

--- a/hub/static/hub/style/style-agents.css
+++ b/hub/static/hub/style/style-agents.css
@@ -539,6 +539,30 @@
   opacity: 1;
 }
 
+/* msg#16116 Item 4: subagent count chip — rendered inline at the end
+ * of the canonical agent-badge strip when the agent has >=1 active
+ * Agent-tool subagent. Hidden entirely when count == 0 (the render
+ * fn returns an empty string), so idle agents keep the existing row
+ * silhouette untouched. Tone matches the running-subagent bubble in
+ * components-agent-cards.css (.subagent-running) so callers who see
+ * the yellow glyph associate it with "currently working". */
+.agent-badge-subcount {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 4px;
+  margin-left: 4px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  color: #ffd93d;
+  background: rgba(255, 217, 61, 0.12);
+  border: 1px solid rgba(255, 217, 61, 0.3);
+  line-height: 1.4;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
 /* todo#305 Task 7: hidden-agent row — mirrors .channel-item.ch-hidden.
  * Keep the row at full opacity (PR #293/#295 rule — no row-level
  * dimming); hidden state is communicated ONLY via the eye-with-slash

--- a/hub/static/hub/style/style-messages.css
+++ b/hub/static/hub/style/style-messages.css
@@ -155,11 +155,45 @@ blockquote.chat-blockquote {
  * outer glow, just a gentle rounded background tint.
  *
  * Applies to .sidebar .channel-item, .sidebar .agent-card and
- * .sidebar .dm-item. */
+ * .sidebar .dm-item.
+ *
+ * msg#16116 fix (ywatanabe msg#16106/#16108/#16109): channel rows carry
+ * class ``ch-badge ch-badge-sidebar`` (see sidebar-channel-tree.ts), so
+ * the generic ``.ch-badge { background: #333 }`` rule in
+ * components-agent-cards.css used to paint EVERY sidebar channel row
+ * #333 — brighter than the sidebar #111 bg. The .selected row at 8%
+ * white then read *darker* than the unselected bright-#333 rows.
+ * ywatanabe reported this as "the unselected channels look white/bright,
+ * the selected one looks darker — opposite of intent".
+ *
+ * Fix: two prongs.
+ *   1. Reset ``.ch-badge-sidebar`` to a transparent background so
+ *      unselected channel rows read as plain sidebar-bg (#111) rows.
+ *   2. Bump ``.selected`` alpha from 0.08 → 0.12 so the selected row
+ *      reads as a clearly accented rounded rect on the dark bg (spec
+ *      in lead msg#16116, and matches the ctrl+click highlight
+ *      ywatanabe liked).
+ *
+ * Net effect: unselected = transparent = #111 bg, selected = clear
+ * white-tinted rounded rect. Selection reads BRIGHTER than unselected
+ * rows again — intent restored. */
+/* Unset the generic .ch-badge { background: #333 } inline-chip paint
+ * for FULL-WIDTH sidebar rows. The .ch-badge class was originally
+ * designed for tiny inline channel chips rendered on agent cards
+ * (components-agent-cards.css). When sidebar-channel-tree.ts started
+ * reusing ``ch-badge ch-badge-sidebar`` classes to pick up shared
+ * badge geometry, the #333 bg leaked onto every channel row —
+ * brighter than the sidebar #111 bg, inverting selection signalling.
+ * Restrict to rows that are neither hovered nor selected so the
+ * hover (#1a1a1a, style-base.css) and .selected (white 12% below)
+ * states keep their explicit backgrounds. */
+.sidebar .channel-item.ch-badge:not(:hover):not(.selected) {
+  background: transparent;
+}
 .sidebar .channel-item.selected,
 .sidebar .agent-card.selected,
 .sidebar .dm-item.selected {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.12);
   border-radius: 6px;
 }
 /* #294: normalise font-weight on every sidebar channel/DM row so no

--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -135,11 +135,37 @@ function _activateTab(tab) {
   } catch (_) {}
 }
 
+/* msg#16116 Item 3: cmd-click / middle-click a tab → open in a new
+ * browser tab. See hub/frontend/src/tabs.ts for the full rationale. */
+function _isNewTabClick(ev) {
+  return ev.button === 1 || ev.metaKey || ev.ctrlKey || ev.shiftKey;
+}
 document.querySelectorAll(".tab-btn").forEach(function (btn) {
-  btn.addEventListener("click", function () {
-    var tab = btn.getAttribute("data-tab");
-    if (tab === activeTab) return;
-    _activateTab(tab);
+  var tab = btn.getAttribute("data-tab") || "";
+  if (tab && !btn.hasAttribute("data-href")) {
+    btn.setAttribute("data-href", "#" + tab);
+  }
+  btn.addEventListener("auxclick", function (ev) {
+    if (ev.button !== 1) return;
+    ev.preventDefault();
+    var t = btn.getAttribute("data-tab");
+    if (!t) return;
+    try {
+      window.open(window.location.pathname + "#" + t, "_blank");
+    } catch (_) {}
+  });
+  btn.addEventListener("click", function (ev) {
+    var t = btn.getAttribute("data-tab");
+    if (!t) return;
+    if (_isNewTabClick(ev)) {
+      ev.preventDefault();
+      try {
+        window.open(window.location.pathname + "#" + t, "_blank");
+      } catch (_) {}
+      return;
+    }
+    if (t === activeTab) return;
+    _activateTab(t);
   });
 });
 
@@ -153,15 +179,22 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
  * Chat surfaces — _activateTab("activity") hides them imperatively. */
 (function () {
   try {
+    /* msg#16116 Item 3: honor #hash for cmd/middle-click new-tab flow. */
+    var hash = "";
+    try {
+      hash = (window.location.hash || "").replace(/^#/, "");
+    } catch (_) {
+      hash = "";
+    }
     var last = localStorage.getItem("orochi_active_tab");
-    /* Step 3c: the top-level Terminal tab has been removed (terminal
-     * preview now lives only inside the agent-detail pane's SSH action).
-     * Users who left their last session on "terminal" fall through. */
     if (last === "terminal") {
       last = null;
     }
-    var target = last || "activity";
-    /* If the remembered tab no longer has a DOM button, fall back to
+    if (hash === "terminal") {
+      hash = "";
+    }
+    var target = hash || last || "activity";
+    /* If the requested tab no longer has a DOM button, fall back to
      * Overview ("activity"). */
     var btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
     if (!btn) {

--- a/hub/static/hub/upload.js
+++ b/hub/static/hub/upload.js
@@ -270,6 +270,23 @@ function _buildPastedTextFile(text) {
 }
 
 function handleClipboardPaste(e) {
+  /* Guard (msg#16116 Item 2 / lead msg#16116): this handler is bound to
+   * msg-input only, but it was still catching paste events when the user
+   * was on a non-Chat tab (e.g. Overview). Gate: only process paste when
+   * the current focus is actually msg-input AND Chat is the active tab.
+   * Mirrors the TS source in hub/frontend/src/upload.ts. */
+  var _activeTab =
+    typeof window !== "undefined" && typeof window.activeTab === "string"
+      ? window.activeTab
+      : typeof activeTab === "string"
+        ? activeTab
+        : "";
+  var _msgInputEl = document.getElementById("msg-input");
+  var _focusIsMsgInput =
+    _msgInputEl && document.activeElement === _msgInputEl;
+  if (!_focusIsMsgInput || _activeTab !== "chat") {
+    return;
+  }
   var cd =
     e.clipboardData || (e.originalEvent && e.originalEvent.clipboardData);
   if (!cd) return;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -12,11 +12,11 @@
     <link rel="stylesheet" href="{% static 'hub/style/style-base.css' %}?v=137">
     <link rel="stylesheet" href="{% static 'hub/style/style-main.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-messages.css' %}?v=135">
+          href="{% static 'hub/style/style-messages.css' %}?v=136">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-composer.css' %}?v=134">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-agents.css' %}?v=135">
+          href="{% static 'hub/style/style-agents.css' %}?v=136">
     <link rel="stylesheet"
           href="{% static 'hub/style/style-channels.css' %}?v=139">
     <link rel="stylesheet"


### PR DESCRIPTION
## Summary

Four UI regressions reported by ywatanabe in `#heads msg#16106-#16109` + lead's batching directive in `msg#16116`. Each item lands as its own commit for reviewability.

- **Item 1 (selection-highlight inversion):** Unselected sidebar channel rows rendered brighter than the selected row. Root cause: the generic `.ch-badge { background: #333 }` rule in `components-agent-cards.css` (originally for tiny inline chips on agent cards) leaked onto every full-width sidebar channel row via the shared `ch-badge ch-badge-sidebar` classes — brighter than the `#111` sidebar bg, so the `.selected` row at 8% white overlay read as *darker*. Fix: reset `.ch-badge` bg on sidebar channel rows + bump selected accent to 12% white per lead spec.
- **Item 2 (Overview-tab paste → Chat-tab regression):** `upload.ts handleClipboardPaste` on `#msg-input` fired when focus was still on msg-input across a tab-switch (chat-composer.ts blur watchdog race), staging attachments into the Chat tray and cascading the user back into Chat. Fix: gate both the paste handler and the watchdog to `activeTab === "chat"`.
- **Item 3 (cmd/middle-click new-tab):** `.tab-btn` click handler swallowed modifier clicks. Implemented with `window.open(pathname + "#tab", "_blank")` intercept (not `<a>` wrapping — keeps existing button CSS intact). Boot code now reads `location.hash` before `localStorage.orochi_active_tab`, so new tabs land on the requested view.
- **Item 4 (subagent_count badge):** New `renderAgentSubagentCount(a)` composable in `agent-badge.ts` (HTML) + SVG mirror in `agent-badge-svg.ts`. Surfaces inline `🧒 N` chip on sidebar rows, topology nodes, and agent-detail header line. Hidden entirely when count is 0/undefined so idle agents keep the compact silhouette.

All four items respect invariants from PRs #293 / #295 / #306 / #310 / #311 / #317 / #319 (no row-level dim, no per-row font-weight, single-select hard rule, Overview as default tab, list-view + detail pane, Terminal tab removal, sidebar channel renames).

## Test plan
- [ ] Reload dashboard — selected channel row reads clearly brighter than unselected rows; hover still dims to `#1a1a1a`; agent + DM selection unchanged.
- [ ] On Overview tab, Cmd+V into a plain textarea — paste lands there, Chat tab does NOT activate.
- [ ] On Chat tab with msg-input focused, Cmd+V with an image in clipboard — attaches as before (regression sanity).
- [ ] Cmd-click the TODO tab button — new browser tab opens on `dashboard/#todo` and lands on TODO.
- [ ] Middle-click the Overview tab button — new background tab on `#activity` (Overview).
- [ ] Plain left-click a tab — switches in-place, no new tab spawned.
- [ ] Agent with `subagent_count >= 1` shows `🧒 N` chip on the sidebar row, on the topology agent node, and on the Agents-tab detail-pane header. Idle agents (count 0) show no chip.
- [ ] `npm run typecheck` and `npm run build` pass locally (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
