### PR TITLE
feat(ui/todo-viz): BY REPO chart below LABELS (msg#16207)

### DIFF
--- a/hub/frontend/src/todo-tab/todo-tab-stats.ts
+++ b/hub/frontend/src/todo-tab/todo-tab-stats.ts
@@ -177,36 +177,80 @@ export function _renderTodoStatsLabels(labels) {
   );
 }
 
+/* BY REPO horizontal bar chart (msg#16206, msg#16207). Renders below
+ * DAILY VELOCITY + LABELS. Each repo is one row with a stacked
+ * open/closed bar and the pair of counts at the right. Sorted by
+ * total (open+closed) descending so the busiest repo is on top. The
+ * colour palette reuses the burndown legend swatches (opened=red,
+ * closed=green) so the three viz sections read consistently. */
 export function _renderTodoStatsByRepo(rows) {
   if (!rows || rows.length === 0) {
     return "";
   }
-  var body = rows
+  /* Work on a sorted copy so we don't mutate the cached payload the
+   * next render pass (or another section) may read. */
+  var sorted = rows.slice().sort(function (a, b) {
+    var ta = (a.open || 0) + (a.closed || 0);
+    var tb = (b.open || 0) + (b.closed || 0);
+    return tb - ta;
+  });
+  var maxTotal = 1;
+  sorted.forEach(function (r) {
+    var t = (r.open || 0) + (r.closed || 0);
+    if (t > maxTotal) maxTotal = t;
+  });
+  var body = sorted
     .map(function (r) {
+      var openN = r.open || 0;
+      var closedN = r.closed || 0;
+      /* Each segment's width is proportional to the count relative to
+       * the busiest repo's total — so repos with fewer issues render
+       * shorter bars, just like the LABELS chart. Clamp to >=0 so an
+       * empty row collapses rather than producing a negative width. */
+      var openPct = Math.max(0, (openN / maxTotal) * 100);
+      var closedPct = Math.max(0, (closedN / maxTotal) * 100);
       return (
-        "<tr>" +
-        "<td>" +
+        '<li class="todo-repo-row">' +
+        '<span class="todo-repo-name">' +
         escapeHtml(_shortRepo(r.repo)) +
-        "</td>" +
-        '<td class="todo-repo-num">' +
-        (r.open || 0) +
-        "</td>" +
-        '<td class="todo-repo-num">' +
-        (r.closed || 0) +
-        "</td>" +
-        "</tr>"
+        "</span>" +
+        '<span class="todo-repo-bar">' +
+        '<span class="todo-repo-fill todo-repo-fill-open" style="width:' +
+        openPct.toFixed(2) +
+        '%" title="Open: ' +
+        openN +
+        '"></span>' +
+        '<span class="todo-repo-fill todo-repo-fill-closed" style="width:' +
+        closedPct.toFixed(2) +
+        '%" title="Closed: ' +
+        closedN +
+        '"></span>' +
+        "</span>" +
+        '<span class="todo-repo-counts">' +
+        '<span class="todo-repo-count todo-repo-count-open">' +
+        openN +
+        "</span>" +
+        '<span class="todo-repo-count-sep">/</span>' +
+        '<span class="todo-repo-count todo-repo-count-closed">' +
+        closedN +
+        "</span>" +
+        "</span>" +
+        "</li>"
       );
     })
     .join("");
   return (
     '<div class="todo-stats-section">' +
-    '<div class="todo-stats-h">By repo</div>' +
-    '<table class="todo-repo-table">' +
-    "<thead><tr><th>Repo</th><th>Open</th><th>Closed</th></tr></thead>" +
-    "<tbody>" +
+    '<div class="todo-stats-h">By repo (open / closed, ' +
+    sorted.length +
+    ")</div>" +
+    '<div class="todo-chart-legend">' +
+    '<span class="todo-chart-swatch todo-chart-opened"></span>Open ' +
+    '<span class="todo-chart-swatch todo-chart-closed"></span>Closed' +
+    "</div>" +
+    '<ul class="todo-repo-list">' +
     body +
-    "</tbody>" +
-    "</table>" +
+    "</ul>" +
     "</div>"
   );
 }

--- a/hub/static/hub/todo-tab/todo-tab-stats.css
+++ b/hub/static/hub/todo-tab/todo-tab-stats.css
@@ -141,14 +141,80 @@
   font-variant-numeric: tabular-nums;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
-/* By-repo + starvation tables */
-.todo-repo-table,
+/* By-repo horizontal bar chart (msg#16206). Same visual idiom as the
+ * Labels bar list above, but each row stacks open (red) + closed
+ * (green) segments proportional to the busiest repo's total, so at
+ * a glance you see both magnitude and open/closed split.            */
+.todo-repo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.todo-repo-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 30%) 1fr 80px;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+}
+.todo-repo-name {
+  color: #ccc;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+.todo-repo-bar {
+  position: relative;
+  display: flex;
+  background: #1a1a1a;
+  height: 10px;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.todo-repo-fill {
+  display: block;
+  height: 100%;
+}
+.todo-repo-fill-open {
+  background: #ef4444;
+}
+.todo-repo-fill-closed {
+  background: #3fb950;
+}
+.todo-repo-counts {
+  font-size: 10px;
+  color: #888;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  display: inline-flex;
+  justify-content: flex-end;
+  gap: 4px;
+}
+.todo-repo-count-open {
+  color: #ef4444;
+}
+.todo-repo-count-closed {
+  color: #3fb950;
+}
+.todo-repo-count-sep {
+  color: #555;
+}
+/* Starvation table (by-repo used to share this before msg#16206 flipped
+ * to the bar-chart idiom above — kept as the canonical class for the
+ * stale-issue list). */
 .todo-starve-table {
   width: 100%;
   border-collapse: collapse;
   font-size: 11px;
 }
-.todo-repo-table th,
 .todo-starve-table th {
   text-align: left;
   color: #888;
@@ -159,7 +225,6 @@
   padding: 4px 6px;
   border-bottom: 1px solid #222;
 }
-.todo-repo-table td,
 .todo-starve-table td {
   padding: 4px 6px;
   color: #ccc;

--- a/hub/static/hub/todo-tab/todo-tab-stats.js
+++ b/hub/static/hub/todo-tab/todo-tab-stats.js
@@ -174,36 +174,80 @@ function _renderTodoStatsLabels(labels) {
   );
 }
 
+/* BY REPO horizontal bar chart (msg#16206, msg#16207). Renders below
+ * DAILY VELOCITY + LABELS. Each repo is one row with a stacked
+ * open/closed bar and the pair of counts at the right. Sorted by
+ * total (open+closed) descending so the busiest repo is on top. The
+ * colour palette reuses the burndown legend swatches (opened=red,
+ * closed=green) so the three viz sections read consistently. */
 function _renderTodoStatsByRepo(rows) {
   if (!rows || rows.length === 0) {
     return "";
   }
-  var body = rows
+  /* Work on a sorted copy so we don't mutate the cached payload the
+   * next render pass (or another section) may read. */
+  var sorted = rows.slice().sort(function (a, b) {
+    var ta = (a.open || 0) + (a.closed || 0);
+    var tb = (b.open || 0) + (b.closed || 0);
+    return tb - ta;
+  });
+  var maxTotal = 1;
+  sorted.forEach(function (r) {
+    var t = (r.open || 0) + (r.closed || 0);
+    if (t > maxTotal) maxTotal = t;
+  });
+  var body = sorted
     .map(function (r) {
+      var openN = r.open || 0;
+      var closedN = r.closed || 0;
+      /* Each segment's width is proportional to the count relative to
+       * the busiest repo's total — so repos with fewer issues render
+       * shorter bars, just like the LABELS chart. Clamp to >=0 so an
+       * empty row collapses rather than producing a negative width. */
+      var openPct = Math.max(0, (openN / maxTotal) * 100);
+      var closedPct = Math.max(0, (closedN / maxTotal) * 100);
       return (
-        "<tr>" +
-        "<td>" +
+        '<li class="todo-repo-row">' +
+        '<span class="todo-repo-name">' +
         escapeHtml(_shortRepo(r.repo)) +
-        "</td>" +
-        '<td class="todo-repo-num">' +
-        (r.open || 0) +
-        "</td>" +
-        '<td class="todo-repo-num">' +
-        (r.closed || 0) +
-        "</td>" +
-        "</tr>"
+        "</span>" +
+        '<span class="todo-repo-bar">' +
+        '<span class="todo-repo-fill todo-repo-fill-open" style="width:' +
+        openPct.toFixed(2) +
+        '%" title="Open: ' +
+        openN +
+        '"></span>' +
+        '<span class="todo-repo-fill todo-repo-fill-closed" style="width:' +
+        closedPct.toFixed(2) +
+        '%" title="Closed: ' +
+        closedN +
+        '"></span>' +
+        "</span>" +
+        '<span class="todo-repo-counts">' +
+        '<span class="todo-repo-count todo-repo-count-open">' +
+        openN +
+        "</span>" +
+        '<span class="todo-repo-count-sep">/</span>' +
+        '<span class="todo-repo-count todo-repo-count-closed">' +
+        closedN +
+        "</span>" +
+        "</span>" +
+        "</li>"
       );
     })
     .join("");
   return (
     '<div class="todo-stats-section">' +
-    '<div class="todo-stats-h">By repo</div>' +
-    '<table class="todo-repo-table">' +
-    "<thead><tr><th>Repo</th><th>Open</th><th>Closed</th></tr></thead>" +
-    "<tbody>" +
+    '<div class="todo-stats-h">By repo (open / closed, ' +
+    sorted.length +
+    ")</div>" +
+    '<div class="todo-chart-legend">' +
+    '<span class="todo-chart-swatch todo-chart-opened"></span>Open ' +
+    '<span class="todo-chart-swatch todo-chart-closed"></span>Closed' +
+    "</div>" +
+    '<ul class="todo-repo-list">' +
     body +
-    "</tbody>" +
-    "</table>" +
+    "</ul>" +
     "</div>"
   );
 }

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -36,7 +36,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/todo-tab/todo-tab-list.css' %}?v=108">
     <link rel="stylesheet"
-          href="{% static 'hub/todo-tab/todo-tab-stats.css' %}?v=108">
+          href="{% static 'hub/todo-tab/todo-tab-stats.css' %}?v=109">
     <link rel="stylesheet"
           href="{% static 'hub/attachments/attachments-media.css' %}?v=101">
     <link rel="stylesheet"


### PR DESCRIPTION
## Summary

- Swap the BY REPO table in the TODO tab viz for a horizontal bar chart that matches the LABELS (open, top N) idiom one row above it: per-repo stacked open/closed bar, sorted by total (open+closed) descending, numeric counts on the right.
- Colour palette reuses the DAILY VELOCITY / burndown legend (open red `#ef4444`, closed green `#3fb950`) so the three viz sections read consistently.
- Data source is client-side aggregation of the existing `/api/todo/stats/` payload (`by_repo[]` was already in the backend response) -- no backend endpoint change, no GitHub rate-limit impact.

## Why

Per ywatanabe msg#16206 / worker-progress msg#16207, the TODO tab viz was missing a visual summary of where open vs closed work lives across the fleet repos. The old table-rendered `_renderTodoStatsByRepo` showed counts but no magnitude cue. The new chart follows the existing LABELS grid (`minmax(120px, 30%) 1fr 80px`) so repos, labels, and velocity all stack with matching vertical rhythm.

## Files touched

- `hub/frontend/src/todo-tab/todo-tab-stats.ts` -- swap `_renderTodoStatsByRepo` to bar-chart renderer.
- `hub/static/hub/todo-tab/todo-tab-stats.js` -- hand-maintained JS mirror of the TS source.
- `hub/static/hub/todo-tab/todo-tab-stats.css` -- new `.todo-repo-list` / `.todo-repo-row` / `.todo-repo-bar` / `.todo-repo-fill-{open,closed}` / `.todo-repo-counts*` classes. Dropped orphaned `.todo-repo-table` selectors (nothing references them now). Kept `.todo-repo-num` -- still used by Starvation rows.
- `hub/templates/hub/dashboard.html` -- bump `todo-tab-stats.css` cache-buster `v=108` -> `v=109`.

## Out of scope

- Overview-tab viz (lead msg#16193 regression is handled in parallel).
- `ts-migration-v2` branch (explicitly untouched).
- Existing LABELS / DAILY VELOCITY renderers (untouched -- only the CSS legend swatches are reused).

## Test plan

- [x] `npm run typecheck` in `hub/frontend/` -- clean.
- [x] `npm run build` in `hub/frontend/` -- clean, built bundle `orochi-DzbowmVe.js` (735 kB, same order-of-magnitude as the prior `orochi-C_8CthGR.js`).
- [ ] Manual: open dashboard -> TODO tab -> List view; BY REPO chart renders below LABELS, above Starvation, sorted by total issues desc.
- [ ] Manual: hover bar segments -- tooltip shows `Open: N` / `Closed: N`.
- [ ] Manual: verify CSS cache-buster `?v=109` serves the fresh CSS on reload.

Refs: msg#16206, msg#16207.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
