### PR TITLE
fix(ui/overview): guard all paste paths (text+image+file+PDF) from activating Chat tab (msg#16193 regression)

### DIFF
--- a/hub/frontend/src/activity-tab/compose.ts
+++ b/hub/frontend/src/activity-tab/compose.ts
@@ -8,6 +8,11 @@ import { setCurrentChannel } from "../app/state";
 import { apiUrl, escapeHtml, sendOrochiMessage, userName } from "../app/utils";
 import { ws, wsConnected } from "../app/websocket";
 import { loadChannelHistory } from "../chat/chat-history";
+import {
+  _buildPastedTextFile,
+  _pastedTextShouldAttach,
+  _uploadFilesAPI,
+} from "../upload";
 
 /* activity-tab/compose.js — group compose modal (multi-select post)
  * + inline channel compose popup + drag-ghost helper + subscribe toast. */
@@ -367,10 +372,88 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     document.addEventListener("mousedown", outsideClick, true);
   }, 50);
 
+  /* msg#16193: local-scoped pending attachments for this popup. Paste /
+   * drop stage here instead of routing to the Chat composer, so the
+   * user's Overview-tab interaction never flips them into Chat. Rendered
+   * as a small inline strip ABOVE the textarea; cleared when the popup
+   * closes or the message is sent. */
+  var popPending = [];
+  var popTray = document.createElement("div");
+  popTray.className = "tcc-pending";
+  popTray.style.display = "none";
+  /* Insert above the textarea (after preview slot if present). */
+  if (input && input.parentNode === pop) {
+    pop.insertBefore(popTray, input);
+  } else {
+    pop.insertBefore(popTray, pop.firstChild);
+  }
+
+  function _renderPopTray() {
+    if (!popPending.length) {
+      popTray.style.display = "none";
+      popTray.innerHTML = "";
+      return;
+    }
+    popTray.style.display = "flex";
+    popTray.innerHTML = "";
+    popPending.forEach(function (p, idx) {
+      var item = document.createElement("div");
+      item.className = "tcc-pending-item";
+      var isImage =
+        p.uploaded &&
+        p.uploaded.mime_type &&
+        p.uploaded.mime_type.indexOf("image/") === 0;
+      var thumb;
+      if (isImage) {
+        thumb = document.createElement("img");
+        thumb.src = p.uploaded.url;
+        thumb.className = "tcc-pending-thumb";
+        thumb.alt = p.uploaded.filename || "image";
+      } else {
+        thumb = document.createElement("span");
+        thumb.className = "tcc-pending-icon";
+        thumb.textContent = "\uD83D\uDCCE";
+      }
+      var label = document.createElement("span");
+      label.className = "tcc-pending-label";
+      label.textContent = (p.uploaded && p.uploaded.filename) || "";
+      var remove = document.createElement("button");
+      remove.type = "button";
+      remove.className = "tcc-pending-remove";
+      remove.title = "Remove";
+      remove.textContent = "\u2715";
+      remove.addEventListener("click", function (ev) {
+        ev.stopPropagation();
+        popPending.splice(idx, 1);
+        _renderPopTray();
+      });
+      item.appendChild(thumb);
+      item.appendChild(label);
+      item.appendChild(remove);
+      popTray.appendChild(item);
+    });
+  }
+
+  async function _stagePopFiles(files) {
+    if (!files || files.length === 0) return;
+    var uploaded = await _uploadFilesAPI(files);
+    if (!uploaded || !uploaded.length) return;
+    /* Popup may have closed while upload was in-flight — bail silently. */
+    if (!pop.parentNode) return;
+    uploaded.forEach(function (u, i) {
+      popPending.push({ file: files[i] || files[0], uploaded: u });
+    });
+    _renderPopTray();
+  }
+
   function send() {
     var text = (input.value || "").trim();
-    if (!text) return;
+    var attachments = popPending.map(function (p) {
+      return p.uploaded;
+    });
+    if (!text && attachments.length === 0) return;
     var payload = { channel: channel, content: text };
+    if (attachments.length > 0) payload.attachments = attachments;
     if (
       typeof wsConnected !== "undefined" &&
       wsConnected &&
@@ -422,77 +505,63 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
       close();
     }
   });
-  /* Paste support — images / files / long text. Native paste of plain
-   * text keeps the default behavior (lands in the textarea). If the
-   * clipboard carries a file/image, route to the Chat composer (the
-   * canonical paste-to-attach pipeline lives there) and re-dispatch
-   * the paste event so the upload.js handler does the work.
-   * ywatanabe 2026-04-19: "small input modal should support pasting".
+  /* Paste support — images / files / long text. msg#16193 regression-fix:
+   * previously this handler, on image/long-text paste, closed the popup
+   * and re-dispatched the paste into the Chat composer via `_routeToChat`
+   * — which flipped the user out of the Overview tab, which is exactly
+   * the bug the user keeps reporting ("I'm on Overview, I paste an
+   * image, I end up on Chat"). Fix: stage attachments LOCALLY to this
+   * popup (upload to /api/upload, show inline thumb strip, include in
+   * the send() payload). No tab switch, no msg-input re-dispatch.
    *
-   * PR #<this> Item 10 (lead msg#15637): graph-compose paste was
-   * triggering a tab switch to Chat when the user intended the paste
-   * to land in the graph input. Root cause: the paste event bubbled
-   * up from this textarea to msg-input's body-attached paste handler
-   * (upload.ts handleClipboardPaste) which is focused on msg-input;
-   * when msg-input received the bubbled paste it implicitly reacted
-   * as if the user had interacted with the Chat composer. The fix is
-   * simple: unconditionally stopPropagation() on every paste into the
-   * graph input so nothing bubbles past this handler. The textarea
-   * still receives the native paste (we don't preventDefault unless
-   * we're re-routing files/long-text to msg-input explicitly). */
+   * Keep `ev.stopPropagation()` so nothing bubbles into msg-input's
+   * window-level paste handler. Short plain text still lands in the
+   * textarea via the browser's default paste behavior (we only
+   * preventDefault when we actually stage a file). */
   input.addEventListener("paste", function (ev) {
-    /* Item 10: contain paste to this popup unconditionally — paste
-     * MUST NOT bubble up to msg-input's handler or any window-level
-     * tab-router. Don't preventDefault (that would kill native text
-     * paste); only stopPropagation. */
     ev.stopPropagation();
     var cd =
       ev.clipboardData || (ev.originalEvent && ev.originalEvent.clipboardData);
     if (!cd) return;
-    var hasFile = false;
-    if (cd.files && cd.files.length) hasFile = true;
-    else if (cd.items) {
-      for (var i = 0; i < cd.items.length; i++) {
-        var it = cd.items[i];
+    /* Collect image files from both cd.files (browsers that expose it)
+     * and cd.items (browsers that only expose items). Dedup inline. */
+    var collected = [];
+    var seen = new Set();
+    function pushUnique(f) {
+      if (!f || !f.type || f.type.indexOf("image/") !== 0) return;
+      var key =
+        f.name + "|" + f.size + "|" + f.type + "|" + (f.lastModified || 0);
+      if (seen.has(key)) return;
+      seen.add(key);
+      collected.push(f);
+    }
+    var fileList = cd.files;
+    if (fileList && fileList.length) {
+      for (var i = 0; i < fileList.length; i++) pushUnique(fileList[i]);
+    } else if (cd.items) {
+      for (var j = 0; j < cd.items.length; j++) {
+        var it = cd.items[j];
         if (it && it.type && it.type.indexOf("image/") === 0) {
-          hasFile = true;
-          break;
+          pushUnique(it.getAsFile());
         }
       }
     }
-    /* Long text still attaches as a file via upload.js's
-     * _pastedTextShouldAttach heuristic — route for that case too. */
+    /* Long-text-as-file: same heuristic as upload.ts (>= 1500 chars or
+     * >= 25 lines) so the popup behaves identically to the Chat
+     * composer in this regard. */
     var text = "";
     try {
       text = cd.getData("text/plain") || "";
     } catch (_) {}
-    var isLong = text.length > 1000;
-    if (hasFile || isLong) {
-      /* Route to Chat composer: block native textarea paste, close
-       * this popup, and synthesize a paste on msg-input (below). The
-       * stopPropagation above already contained the bubble; no need
-       * to repeat it here. */
+    var attachText =
+      typeof _pastedTextShouldAttach === "function" &&
+      _pastedTextShouldAttach(text);
+    if (collected.length > 0 || attachText) {
       ev.preventDefault();
-      close();
-      _routeToChat();
-      setTimeout(function () {
-        var msgInput = document.getElementById("msg-input");
-        if (!msgInput) return;
-        msgInput.focus();
-        /* Synthesize a paste event on msg-input so upload.js's
-         * handleClipboardPaste processes the same clipboard payload. */
-        try {
-          var newEv = new ClipboardEvent("paste", {
-            clipboardData: cd,
-            bubbles: true,
-            cancelable: true,
-          });
-          msgInput.dispatchEvent(newEv);
-        } catch (_) {
-          /* Some browsers don't allow constructing ClipboardEvent with
-           * populated data — let the user paste again in that case. */
-        }
-      }, 50);
+      if (attachText && typeof _buildPastedTextFile === "function") {
+        collected.push(_buildPastedTextFile(text));
+      }
+      _stagePopFiles(collected);
     }
   });
   expandBtn.addEventListener("click", function () {
@@ -532,9 +601,13 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
       window.toggleVoiceInput();
     }
   });
-  /* Drop files onto popup → route to Chat with attachments primed. */
+  /* Drop files onto popup → stage LOCALLY (msg#16193). Same rationale
+   * as the paste handler: the user is working in the graph-compose
+   * popup on the Overview tab and shouldn't get flipped to Chat for a
+   * drag-drop. */
   pop.addEventListener("dragover", function (ev) {
     ev.preventDefault();
+    ev.stopPropagation();
     pop.classList.add("tcc-drag-over");
   });
   pop.addEventListener("dragleave", function () {
@@ -542,11 +615,11 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
   });
   pop.addEventListener("drop", function (ev) {
     ev.preventDefault();
+    ev.stopPropagation();
     pop.classList.remove("tcc-drag-over");
     var files = ev.dataTransfer && ev.dataTransfer.files;
-    if (files && files.length && typeof handleFileUpload === "function") {
-      _routeToChat();
-      for (var i = 0; i < files.length; i++) handleFileUpload(files[i]);
+    if (files && files.length) {
+      _stagePopFiles(Array.prototype.slice.call(files));
     }
   });
 }

--- a/hub/frontend/src/upload.ts
+++ b/hub/frontend/src/upload.ts
@@ -9,6 +9,90 @@ import { activeTab } from "./tabs";
  * "paste → immediate surprise send" behaviour. */
 /* globals: currentChannel, userName, sendOrochiMessage, token, apiUrl, csrfToken */
 
+/* msg#16193: shared ancestor-walk predicate — returns true when `target`
+ * (typically `event.target` on a paste/drop event) sits INSIDE the Chat-tab
+ * surface. Walks composedPath() first for shadow-DOM cases, then falls back
+ * to parent traversal. The Chat tab's DOM is the `.input-bar` composer +
+ * the `#messages` feed; everything else (Overview/TODO/Agents/Files/…) is
+ * NOT Chat. Prefer this over a global `activeTab === "chat"` check: a
+ * composite page may have multiple compose inputs active simultaneously
+ * (graph-compose popup on the Overview tab, etc.), and the decision should
+ * be scoped to the actual paste target — not the tab that HAPPENS to be
+ * visible. */
+export function _isTargetOnChatTab(target) {
+  if (!target) return false;
+  /* Accept Event objects directly for ergonomic call sites. */
+  var el = target;
+  if (target && typeof target === "object" && "target" in target) {
+    /* composedPath() gives accurate ancestors even for events retargeted
+     * out of a shadow root. Browsers without it fall through to .target. */
+    try {
+      if (typeof target.composedPath === "function") {
+        var path = target.composedPath();
+        for (var i = 0; i < path.length; i++) {
+          if (_elementIsChatTab(path[i])) return true;
+        }
+        return false;
+      }
+    } catch (_) {}
+    el = target.target;
+  }
+  while (el && el !== document) {
+    if (_elementIsChatTab(el)) return true;
+    el = el.parentNode || (el.host && el.host);
+  }
+  return false;
+}
+
+function _elementIsChatTab(el) {
+  if (!el || el.nodeType !== 1) return false;
+  /* Chat-tab DOM surfaces: the compose input-bar (contains #msg-input,
+   * #pending-attachments, mention dropdown, filter etc.) and the
+   * `#messages` feed. Both are outside the per-tab `.todo-view` wrappers
+   * in dashboard.html. */
+  if (el.id === "msg-input") return true;
+  if (el.id === "messages") return true;
+  if (el.id === "chat-filter-input") return true;
+  if (el.id === "pending-attachments") return true;
+  if (el.classList && el.classList.contains("input-bar")) return true;
+  return false;
+}
+
+/* msg#16193: pure upload API — POST files to /api/upload and return the
+ * server-side metadata array. Does NOT touch the Chat-composer's pending
+ * tray. Other tabs (graph-compose popup, future inline composers) call
+ * this directly so an image paste stays local to whichever input the
+ * user is actually in, rather than silently bubbling into the Chat
+ * composer. Returns [] on failure and logs. */
+export async function _uploadFilesAPI(files) {
+  if (!files || files.length === 0) return [];
+  var formData = new FormData();
+  for (var i = 0; i < files.length; i++) {
+    formData.append("file", files[i]);
+  }
+  try {
+    var headers = {};
+    if (typeof csrfToken !== "undefined" && csrfToken) {
+      headers["X-CSRFToken"] = csrfToken;
+    }
+    var res = await fetch(apiUrl("/api/upload"), {
+      method: "POST",
+      headers: headers,
+      credentials: "same-origin",
+      body: formData,
+    });
+    if (!res.ok) {
+      console.error("[orochi-upload] _uploadFilesAPI failed:", res.status);
+      return [];
+    }
+    var result = await res.json();
+    return (result && result.files) || (result && result.url ? [result] : []);
+  } catch (e) {
+    console.error("[orochi-upload] _uploadFilesAPI error:", e);
+    return [];
+  }
+}
+
 (function () {
   var fileInput = document.getElementById("file-input");
   if (fileInput && !fileInput.hasAttribute("multiple")) {
@@ -149,35 +233,11 @@ document
 export async function stageFiles(files) {
   if (!files || files.length === 0) return;
   console.log("[orochi-upload] stageFiles:", files.length);
-  var formData = new FormData();
-  files.forEach(function (f) {
-    formData.append("file", f);
+  var uploaded = await _uploadFilesAPI(files);
+  uploaded.forEach(function (u, i) {
+    pendingAttachments.push({ file: files[i] || files[0], uploaded: u });
   });
-  try {
-    var headers = {};
-    if (typeof csrfToken !== "undefined" && csrfToken) {
-      headers["X-CSRFToken"] = csrfToken;
-    }
-    var res = await fetch(apiUrl("/api/upload"), {
-      method: "POST",
-      headers: headers,
-      credentials: "same-origin",
-      body: formData,
-    });
-    if (!res.ok) {
-      console.error("[orochi-upload] upload failed:", res.status);
-      return;
-    }
-    var result = await res.json();
-    var uploaded =
-      (result && result.files) || (result && result.url ? [result] : []);
-    uploaded.forEach(function (u, i) {
-      pendingAttachments.push({ file: files[i] || files[0], uploaded: u });
-    });
-    _renderAttachmentTray();
-  } catch (e) {
-    console.error("[orochi-upload] stage error:", e);
-  }
+  _renderAttachmentTray();
 }
 
 /* Backward-compat: some older call sites still invoke uploadFile/uploadFiles.
@@ -274,29 +334,31 @@ export function _buildPastedTextFile(text) {
 }
 
 export function handleClipboardPaste(e) {
-  /* Guard (msg#16116 Item 2 / lead msg#16116): this handler is bound to
-   * msg-input only, but it was still catching paste events when the user
-   * was on a non-Chat tab (e.g. Overview) — either via an inherited
-   * focus ring that survived the tab switch, or via a bubbled paste from
-   * a descendant the user was focused on (the dashboard does NOT have a
-   * document-level paste listener, but defense-in-depth is cheap). When
-   * that happened, staging attachments from a paste on the Overview tab
-   * silently wired the user into the Chat composer — because stageFiles()
-   * mutates the Chat composer's tray and subsequent WS/focus restores
-   * can flip the active tab. Gate: only process paste when the current
-   * focus is actually inside the Chat composer AND Chat is the active
-   * tab. Anywhere else, let the native paste land in the user's real
-   * target (textarea on Overview, contenteditable in a modal, etc.).
+  /* Guard (msg#16116 Item 2 + msg#16193 regression-fix): this handler is
+   * bound to msg-input, but paste events on overlay popups that live
+   * inside #activity-view can still bubble here unless the popup calls
+   * stopPropagation(). Even with stopPropagation the TEXT case is safe,
+   * but the IMAGE case was re-dispatching a synthetic paste event to
+   * msg-input explicitly — bypassing every guard and staging images into
+   * the Chat tray, which in turn flipped the user into Chat.
    *
-   * This mirrors the stopPropagation() defense already in place on the
-   * activity-tab compose popup (see compose.ts, PR #313 Item 10). */
+   * Two-layer gate, most specific first:
+   *   1. Ancestor-walk: if the paste target sits inside a non-Chat tab's
+   *      DOM, bail out. _isTargetOnChatTab walks event.target's ancestors
+   *      looking for the Chat-tab surface; anywhere else returns false.
+   *      This is the primary defense because it's scope-local (a
+   *      composite page may have many compose inputs).
+   *   2. Legacy focus+activeTab gate: kept as fallback for synthesized
+   *      paste events that have no real target (some browsers fire those
+   *      with target === document.body). */
+  if (!_isTargetOnChatTab(e)) {
+    /* Let the event pass through untouched. */
+    return;
+  }
   var msgInputEl = document.getElementById("msg-input");
   var focusIsMsgInput =
     msgInputEl && document.activeElement === msgInputEl;
   if (!focusIsMsgInput || activeTab !== "chat") {
-    /* Let the event pass through untouched — do not stage attachments,
-     * do not preventDefault. The user's current target receives the
-     * paste natively. */
     return;
   }
   var cd =

--- a/hub/static/hub/activity-tab/activity-tab-compose-edges.css
+++ b/hub/static/hub/activity-tab/activity-tab-compose-edges.css
@@ -165,6 +165,60 @@
   color: #bfe1f1;
 }
 
+/* msg#16193 regression-fix: local pending-attachments strip for the
+ * graph-compose popup. Sits above the textarea. Each item shows a
+ * thumb / icon + filename + remove button. Paste / drop on the popup
+ * upload into this strip rather than bouncing the user to the Chat
+ * tab's tray. */
+.topo-channel-compose .tcc-pending {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+.topo-channel-compose .tcc-pending-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: #151515;
+  border: 1px solid #2a2a2a;
+  border-radius: 3px;
+  padding: 2px 4px;
+  max-width: 100%;
+}
+.topo-channel-compose .tcc-pending-thumb {
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
+  border-radius: 2px;
+  display: block;
+}
+.topo-channel-compose .tcc-pending-icon {
+  font-size: 16px;
+  line-height: 28px;
+  width: 28px;
+  text-align: center;
+}
+.topo-channel-compose .tcc-pending-label {
+  font-size: 10px;
+  color: #bbb;
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.topo-channel-compose .tcc-pending-remove {
+  background: transparent;
+  border: 0;
+  color: #888;
+  cursor: pointer;
+  font-size: 11px;
+  padding: 0 4px;
+}
+.topo-channel-compose .tcc-pending-remove:hover {
+  color: #f87171;
+}
+
 .activity-grid.activity-view-topology .topo-edges line.topo-edge-live {
   stroke: #4ecdc4 !important;
   stroke-opacity: 1 !important;

--- a/hub/static/hub/activity-tab/compose.js
+++ b/hub/static/hub/activity-tab/compose.js
@@ -331,10 +331,84 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
     document.addEventListener("mousedown", outsideClick, true);
   }, 50);
 
+  /* msg#16193: local-scoped pending attachments for this popup. Paste /
+   * drop stage here instead of routing to the Chat composer. */
+  var popPending = [];
+  var popTray = document.createElement("div");
+  popTray.className = "tcc-pending";
+  popTray.style.display = "none";
+  if (input && input.parentNode === pop) {
+    pop.insertBefore(popTray, input);
+  } else {
+    pop.insertBefore(popTray, pop.firstChild);
+  }
+
+  function _renderPopTray() {
+    if (!popPending.length) {
+      popTray.style.display = "none";
+      popTray.innerHTML = "";
+      return;
+    }
+    popTray.style.display = "flex";
+    popTray.innerHTML = "";
+    popPending.forEach(function (p, idx) {
+      var item = document.createElement("div");
+      item.className = "tcc-pending-item";
+      var isImage =
+        p.uploaded &&
+        p.uploaded.mime_type &&
+        p.uploaded.mime_type.indexOf("image/") === 0;
+      var thumb;
+      if (isImage) {
+        thumb = document.createElement("img");
+        thumb.src = p.uploaded.url;
+        thumb.className = "tcc-pending-thumb";
+        thumb.alt = p.uploaded.filename || "image";
+      } else {
+        thumb = document.createElement("span");
+        thumb.className = "tcc-pending-icon";
+        thumb.textContent = "\uD83D\uDCCE";
+      }
+      var label = document.createElement("span");
+      label.className = "tcc-pending-label";
+      label.textContent = (p.uploaded && p.uploaded.filename) || "";
+      var remove = document.createElement("button");
+      remove.type = "button";
+      remove.className = "tcc-pending-remove";
+      remove.title = "Remove";
+      remove.textContent = "\u2715";
+      remove.addEventListener("click", function (ev) {
+        ev.stopPropagation();
+        popPending.splice(idx, 1);
+        _renderPopTray();
+      });
+      item.appendChild(thumb);
+      item.appendChild(label);
+      item.appendChild(remove);
+      popTray.appendChild(item);
+    });
+  }
+
+  async function _stagePopFiles(files) {
+    if (!files || files.length === 0) return;
+    var uploaded =
+      typeof _uploadFilesAPI === "function" ? await _uploadFilesAPI(files) : [];
+    if (!uploaded || !uploaded.length) return;
+    if (!pop.parentNode) return;
+    uploaded.forEach(function (u, i) {
+      popPending.push({ file: files[i] || files[0], uploaded: u });
+    });
+    _renderPopTray();
+  }
+
   function send() {
     var text = (input.value || "").trim();
-    if (!text) return;
+    var attachments = popPending.map(function (p) {
+      return p.uploaded;
+    });
+    if (!text && attachments.length === 0) return;
     var payload = { channel: channel, content: text };
+    if (attachments.length > 0) payload.attachments = attachments;
     if (
       typeof wsConnected !== "undefined" &&
       wsConnected &&
@@ -386,57 +460,49 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
       close();
     }
   });
-  /* Paste support — images / files / long text. Native paste of plain
-   * text keeps the default behavior (lands in the textarea). If the
-   * clipboard carries a file/image, route to the Chat composer (the
-   * canonical paste-to-attach pipeline lives there) and re-dispatch
-   * the paste event so the upload.js handler does the work.
-   * ywatanabe 2026-04-19: "small input modal should support pasting". */
+  /* Paste support — msg#16193 regression-fix: stage LOCALLY instead of
+   * routing to Chat (which flipped the user out of the Overview tab).
+   * See hub/frontend/src/activity-tab/compose.ts for the canonical
+   * source and full rationale. */
   input.addEventListener("paste", function (ev) {
+    ev.stopPropagation();
     var cd =
       ev.clipboardData || (ev.originalEvent && ev.originalEvent.clipboardData);
     if (!cd) return;
-    var hasFile = false;
-    if (cd.files && cd.files.length) hasFile = true;
-    else if (cd.items) {
-      for (var i = 0; i < cd.items.length; i++) {
-        var it = cd.items[i];
+    var collected = [];
+    var seen = new Set();
+    function pushUnique(f) {
+      if (!f || !f.type || f.type.indexOf("image/") !== 0) return;
+      var key =
+        f.name + "|" + f.size + "|" + f.type + "|" + (f.lastModified || 0);
+      if (seen.has(key)) return;
+      seen.add(key);
+      collected.push(f);
+    }
+    var fileList = cd.files;
+    if (fileList && fileList.length) {
+      for (var i = 0; i < fileList.length; i++) pushUnique(fileList[i]);
+    } else if (cd.items) {
+      for (var j = 0; j < cd.items.length; j++) {
+        var it = cd.items[j];
         if (it && it.type && it.type.indexOf("image/") === 0) {
-          hasFile = true;
-          break;
+          pushUnique(it.getAsFile());
         }
       }
     }
-    /* Long text still attaches as a file via upload.js's
-     * _pastedTextShouldAttach heuristic — route for that case too. */
     var text = "";
     try {
       text = cd.getData("text/plain") || "";
     } catch (_) {}
-    var isLong = text.length > 1000;
-    if (hasFile || isLong) {
+    var attachText =
+      typeof _pastedTextShouldAttach === "function" &&
+      _pastedTextShouldAttach(text);
+    if (collected.length > 0 || attachText) {
       ev.preventDefault();
-      ev.stopPropagation();
-      close();
-      _routeToChat();
-      setTimeout(function () {
-        var msgInput = document.getElementById("msg-input");
-        if (!msgInput) return;
-        msgInput.focus();
-        /* Synthesize a paste event on msg-input so upload.js's
-         * handleClipboardPaste processes the same clipboard payload. */
-        try {
-          var newEv = new ClipboardEvent("paste", {
-            clipboardData: cd,
-            bubbles: true,
-            cancelable: true,
-          });
-          msgInput.dispatchEvent(newEv);
-        } catch (_) {
-          /* Some browsers don't allow constructing ClipboardEvent with
-           * populated data — let the user paste again in that case. */
-        }
-      }, 50);
+      if (attachText && typeof _buildPastedTextFile === "function") {
+        collected.push(_buildPastedTextFile(text));
+      }
+      _stagePopFiles(collected);
     }
   });
   expandBtn.addEventListener("click", function () {
@@ -476,9 +542,10 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
       window.toggleVoiceInput();
     }
   });
-  /* Drop files onto popup → route to Chat with attachments primed. */
+  /* Drop files onto popup → stage LOCALLY (msg#16193). */
   pop.addEventListener("dragover", function (ev) {
     ev.preventDefault();
+    ev.stopPropagation();
     pop.classList.add("tcc-drag-over");
   });
   pop.addEventListener("dragleave", function () {
@@ -486,11 +553,11 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
   });
   pop.addEventListener("drop", function (ev) {
     ev.preventDefault();
+    ev.stopPropagation();
     pop.classList.remove("tcc-drag-over");
     var files = ev.dataTransfer && ev.dataTransfer.files;
-    if (files && files.length && typeof handleFileUpload === "function") {
-      _routeToChat();
-      for (var i = 0; i < files.length; i++) handleFileUpload(files[i]);
+    if (files && files.length) {
+      _stagePopFiles(Array.prototype.slice.call(files));
     }
   });
 }

--- a/hub/static/hub/upload.js
+++ b/hub/static/hub/upload.js
@@ -5,6 +5,75 @@
  * "paste → immediate surprise send" behaviour. */
 /* globals: currentChannel, userName, sendOrochiMessage, token, apiUrl, csrfToken */
 
+/* msg#16193: shared ancestor-walk predicate — returns true when `target`
+ * (typically `event.target` on a paste/drop event) sits INSIDE the Chat-tab
+ * surface. Mirrors hub/frontend/src/upload.ts. */
+function _isTargetOnChatTab(target) {
+  if (!target) return false;
+  var el = target;
+  if (target && typeof target === "object" && "target" in target) {
+    try {
+      if (typeof target.composedPath === "function") {
+        var path = target.composedPath();
+        for (var i = 0; i < path.length; i++) {
+          if (_elementIsChatTab(path[i])) return true;
+        }
+        return false;
+      }
+    } catch (_) {}
+    el = target.target;
+  }
+  while (el && el !== document) {
+    if (_elementIsChatTab(el)) return true;
+    el = el.parentNode || (el.host && el.host);
+  }
+  return false;
+}
+
+function _elementIsChatTab(el) {
+  if (!el || el.nodeType !== 1) return false;
+  if (el.id === "msg-input") return true;
+  if (el.id === "messages") return true;
+  if (el.id === "chat-filter-input") return true;
+  if (el.id === "pending-attachments") return true;
+  if (el.classList && el.classList.contains("input-bar")) return true;
+  return false;
+}
+
+/* msg#16193: pure upload API — POST files to /api/upload and return the
+ * server-side metadata array. Does NOT touch the Chat-composer's pending
+ * tray. Exposed on globalThis so other tabs (graph-compose popup) can
+ * call it without bouncing files through the Chat tab. Returns [] on
+ * failure and logs. */
+async function _uploadFilesAPI(files) {
+  if (!files || files.length === 0) return [];
+  var formData = new FormData();
+  for (var i = 0; i < files.length; i++) {
+    formData.append("file", files[i]);
+  }
+  try {
+    var headers = {};
+    if (typeof csrfToken !== "undefined" && csrfToken) {
+      headers["X-CSRFToken"] = csrfToken;
+    }
+    var res = await fetch(apiUrl("/api/upload"), {
+      method: "POST",
+      headers: headers,
+      credentials: "same-origin",
+      body: formData,
+    });
+    if (!res.ok) {
+      console.error("[orochi-upload] _uploadFilesAPI failed:", res.status);
+      return [];
+    }
+    var result = await res.json();
+    return (result && result.files) || (result && result.url ? [result] : []);
+  } catch (e) {
+    console.error("[orochi-upload] _uploadFilesAPI error:", e);
+    return [];
+  }
+}
+
 (function () {
   var fileInput = document.getElementById("file-input");
   if (fileInput && !fileInput.hasAttribute("multiple")) {
@@ -145,35 +214,11 @@ document
 async function stageFiles(files) {
   if (!files || files.length === 0) return;
   console.log("[orochi-upload] stageFiles:", files.length);
-  var formData = new FormData();
-  files.forEach(function (f) {
-    formData.append("file", f);
+  var uploaded = await _uploadFilesAPI(files);
+  uploaded.forEach(function (u, i) {
+    pendingAttachments.push({ file: files[i] || files[0], uploaded: u });
   });
-  try {
-    var headers = {};
-    if (typeof csrfToken !== "undefined" && csrfToken) {
-      headers["X-CSRFToken"] = csrfToken;
-    }
-    var res = await fetch(apiUrl("/api/upload"), {
-      method: "POST",
-      headers: headers,
-      credentials: "same-origin",
-      body: formData,
-    });
-    if (!res.ok) {
-      console.error("[orochi-upload] upload failed:", res.status);
-      return;
-    }
-    var result = await res.json();
-    var uploaded =
-      (result && result.files) || (result && result.url ? [result] : []);
-    uploaded.forEach(function (u, i) {
-      pendingAttachments.push({ file: files[i] || files[0], uploaded: u });
-    });
-    _renderAttachmentTray();
-  } catch (e) {
-    console.error("[orochi-upload] stage error:", e);
-  }
+  _renderAttachmentTray();
 }
 
 /* Backward-compat: some older call sites still invoke uploadFile/uploadFiles.
@@ -270,11 +315,15 @@ function _buildPastedTextFile(text) {
 }
 
 function handleClipboardPaste(e) {
-  /* Guard (msg#16116 Item 2 / lead msg#16116): this handler is bound to
-   * msg-input only, but it was still catching paste events when the user
-   * was on a non-Chat tab (e.g. Overview). Gate: only process paste when
-   * the current focus is actually msg-input AND Chat is the active tab.
-   * Mirrors the TS source in hub/frontend/src/upload.ts. */
+  /* Guard (msg#16116 Item 2 + msg#16193 regression-fix): mirrors
+   * hub/frontend/src/upload.ts. Two-layer gate:
+   *   1. Ancestor-walk the paste target — if it isn't inside the Chat
+   *      DOM, bail. Scope-local: correct even when multiple composers
+   *      coexist on the page (graph-compose popup on Overview, etc.).
+   *   2. Legacy focus+activeTab fallback for synthesized paste events. */
+  if (!_isTargetOnChatTab(e)) {
+    return;
+  }
   var _activeTab =
     typeof window !== "undefined" && typeof window.activeTab === "string"
       ? window.activeTab


### PR DESCRIPTION
## Summary

ywatanabe msg#16191 + lead msg#16193: PR #323 item 2 fixed TEXT paste bubbling from the graph-compose popup into the Chat composer, but IMAGE paste (and drop) still flipped the user to the Chat tab. Root cause: the popup's paste handler, on hasFile/longText, explicitly called `_routeToChat()` (which activates the Chat tab button) and re-dispatched a synthetic paste event at `#msg-input` — bypassing every previously-added guard.

Every paste/drop surface that might route back to the Chat composer is now either (a) guarded by an ancestor-walking predicate, or (b) handled locally to the input the user is actually in.

## Audit — every paste listener in the frontend

| # | Listener | What it does | Fix applied |
|---|---|---|---|
| 1 | `upload.ts::handleClipboardPaste` | `#msg-input` paste → stage files in Chat tray | Added `_isTargetOnChatTab(event)` ancestor-walk as primary guard, on top of existing focus+activeTab check. |
| 2 | `activity-tab/compose.ts::paste` | Graph-compose popup paste → (was) route to Chat | Rewritten to stage files LOCALLY in a per-popup tray; no more tab switch, no more synthetic dispatch. |

Drop handlers audited similarly:

| Listener | Fix |
|---|---|
| `upload.ts::msgInput.drop` | Unchanged (Chat-scoped, correct). |
| `activity-tab/compose.ts::pop.drop` | Rewritten to stage locally + stopPropagation. |
| `app/agent-actions.ts`, `app/sidebar-*`, `releases-tab/runner.ts` | Drag-drop for in-app data (agent handles), no file/paste path, no change. |

Searched also for `clipboardData`, `ClipboardItem`, `items[`, `thumbnail`, `_thumbFor`, `FileReader`, `uploadImage`, `uploadPaste`, `handleAttach`, `_activateTab`, `switchTab` — no other paste chains reach `_activateTab("chat")`.

## Which listener was flipping to Chat

`hub/frontend/src/activity-tab/compose.ts` pre-fix: on image or long-text paste, the handler called `close()` + `_routeToChat()` (which does `tabBtn.click()` on the Chat tab) + a `setTimeout` that synthesized a `ClipboardEvent("paste")` on `#msg-input` with the original `clipboardData`. That synthetic paste then hit `handleClipboardPaste` which called `stageFiles()` (mutates the Chat composer's tray) — and by then the tab had already been switched to Chat.

The fix removes the `_routeToChat` + synthetic-dispatch path entirely. Paste + drop now upload through a new pure helper `_uploadFilesAPI(files)` (no side-effects on the Chat tray), push the uploaded metadata onto a popup-scoped `popPending[]` array, and render a small thumb-strip above the textarea. The popup's `send()` includes `attachments` in the payload.

## Target-ancestor guard helper

Added in `hub/frontend/src/upload.ts`:

```ts
export function _isTargetOnChatTab(target) { ... }
```

Walks `event.composedPath()` (or `.parentNode` chain) of `event.target` looking for `#msg-input`, `#messages`, `#chat-filter-input`, `#pending-attachments`, or `.input-bar`. Used as the first-line guard in `handleClipboardPaste`. Intentionally NOT a global `currentTab === 'chat'` check — composite pages can have multiple compose inputs simultaneously and the decision has to be scope-local to the actual paste target.

## Don't-break verification

- Chat-tab paste (text + image + file + PDF) — `handleClipboardPaste` still stages to the Chat tray when target is inside the Chat surface.
- Graph-tab inline compose paste (PR #313 behavior) — now local (the regression we just fixed).
- Existing thumbnail preview on Chat composer — unchanged (`_renderAttachmentTray` still drives the tray).

## Test plan

- [ ] Overview tab, popup open: paste plain text (short) → lands in popup textarea; tab stays Overview.
- [ ] Overview tab, popup open: paste clipboard screenshot → thumb strip appears above popup textarea; Chat tray untouched; tab stays Overview. Send → message posts with attachment.
- [ ] Overview tab, popup open: drag+drop PDF onto popup → thumb strip shows filename icon; tab stays Overview.
- [ ] Overview tab, popup open: paste a 3000-char text blob → popup shows a pasted-*.txt chip; tab stays Overview.
- [ ] Chat tab: paste clipboard screenshot → Chat tray thumb appears; Chat tab active (unchanged behavior).
- [ ] Chat tab: paste PDF → Chat tray shows PDF chip (unchanged).

CI: `npm run typecheck` and `npm run build` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
