### PR TITLE
fix(fleet-watch): install probe to stable bin path (todo#466)

### DIFF
--- a/deployment/host-setup/launchd/com.scitex.fleet-host-liveness-probe.plist
+++ b/deployment/host-setup/launchd/com.scitex.fleet-host-liveness-probe.plist
@@ -13,10 +13,11 @@
   Logs: ~/Library/Logs/scitex/fleet-host-liveness-probe.log (both stdout
   NDJSON and stderr advisories tee there; rotate manually when large).
 
-  Replace __HOME__ and __REPO__ with your actual paths before `launchctl
-  load`. The companion install helper
-  scripts/client/install-fleet-host-liveness-probe.sh does this rewrite
-  automatically.
+  Replace __HOME__, __REPO__, __STABLE_PROBE__, and __PROBE_MODE__ with
+  your actual values before `launchctl load`. The companion install
+  helper scripts/client/install-fleet-host-liveness-probe.sh does this
+  rewrite automatically and also places the stable probe copy at
+  __STABLE_PROBE__.
 
   Why --yes in production: the whole point of this LaunchAgent is to
   auto-revive dead agents without waiting for humans. The install helper
@@ -29,10 +30,18 @@
     <key>Label</key>
     <string>com.scitex.fleet-host-liveness-probe</string>
 
+    <!--
+      todo#466: ProgramArguments points at the STABLE copy installed under
+      ~/.scitex/orochi/bin/ rather than the shared working tree, so a
+      pre-PR#296 branch checkout no longer silently 404s the scheduler.
+      The working-tree path is retained in EnvironmentVariables below
+      (SCITEX_OROCHI_REPO_ROOT) so the probe can still locate
+      orochi-machines.yaml — reinstall to re-pin.
+    -->
     <key>ProgramArguments</key>
     <array>
       <string>/bin/bash</string>
-      <string>__REPO__/scripts/client/fleet-watch/host-liveness-probe.sh</string>
+      <string>__STABLE_PROBE__</string>
       <string>__PROBE_MODE__</string>
     </array>
 
@@ -57,6 +66,9 @@
     <dict>
       <key>PATH</key>
       <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+      <!-- todo#466: lets the stable-bin probe find orochi-machines.yaml -->
+      <key>SCITEX_OROCHI_REPO_ROOT</key>
+      <string>__REPO__</string>
     </dict>
   </dict>
 </plist>

--- a/scripts/client/install-fleet-host-liveness-probe.sh
+++ b/scripts/client/install-fleet-host-liveness-probe.sh
@@ -23,7 +23,20 @@ TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
 TARGET_LAUNCHD="${HOME}/Library/LaunchAgents/${LABEL}.plist"
 MAC_LOG_DIR="${HOME}/Library/Logs/scitex"
 LINUX_LOG_DIR="${HOME}/.local/state/scitex"
-PROBE_SCRIPT="${REPO_ROOT}/scripts/client/fleet-watch/host-liveness-probe.sh"
+
+# todo#466: install a stable copy of the probe under ~/.scitex/orochi/bin/.
+# Cron / launchd references the stable copy, NOT the shared working tree,
+# so checking out a pre-PR#296 branch in the repo no longer silently 404s
+# the scheduler. Updates propagate by re-running this installer.
+SOURCE_PROBE="${REPO_ROOT}/scripts/client/fleet-watch/host-liveness-probe.sh"
+STABLE_BIN_DIR="${HOME}/.scitex/orochi/bin"
+STABLE_PROBE="${STABLE_BIN_DIR}/host-liveness-probe.sh"
+# Sibling helpers the probe dynamically sources. Copy each alongside the
+# probe if it exists in the working tree; installer is forward-compatible
+# with helpers added post-merge.
+SOURCE_SIBLINGS=(
+    "${REPO_ROOT}/scripts/client/fleet-watch/revive_rate_limit.py"
+)
 
 mode="--yes"
 action="install"
@@ -41,6 +54,48 @@ done
 OS="$(uname -s)"
 
 # -----------------------------------------------------------------------------
+# Stable bin install (todo#466)
+#
+# Copies the probe + siblings into ~/.scitex/orochi/bin/ so the scheduler
+# does not reference files inside the shared working tree. Idempotent:
+# re-running on install overwrites the stable copy with the tree version,
+# which is how updates propagate.
+# -----------------------------------------------------------------------------
+install_stable_probe() {
+    if [[ ! -f "$SOURCE_PROBE" ]]; then
+        echo "probe source missing: $SOURCE_PROBE" >&2
+        exit 1
+    fi
+    mkdir -p "$STABLE_BIN_DIR"
+    cp -f "$SOURCE_PROBE" "$STABLE_PROBE"
+    chmod +x "$STABLE_PROBE"
+    local sib name
+    for sib in "${SOURCE_SIBLINGS[@]}"; do
+        if [[ -f "$sib" ]]; then
+            name="$(basename "$sib")"
+            cp -f "$sib" "${STABLE_BIN_DIR}/${name}"
+            # Preserve exec bit for shell/py helpers the probe may shell out to.
+            if [[ -x "$sib" ]]; then
+                chmod +x "${STABLE_BIN_DIR}/${name}"
+            fi
+        fi
+    done
+    echo "stable probe: $STABLE_PROBE (repo=$REPO_ROOT)"
+}
+
+uninstall_stable_probe() {
+    # Only remove files we own; preserve the bin dir in case other tools
+    # also install there.
+    local sib name
+    rm -f "$STABLE_PROBE"
+    for sib in "${SOURCE_SIBLINGS[@]}"; do
+        name="$(basename "$sib")"
+        rm -f "${STABLE_BIN_DIR}/${name}"
+    done
+    echo "uninstalled stable probe: $STABLE_PROBE"
+}
+
+# -----------------------------------------------------------------------------
 # macOS (LaunchAgent)
 # -----------------------------------------------------------------------------
 install_macos() {
@@ -48,13 +103,21 @@ install_macos() {
         echo "template missing: $TEMPLATE" >&2
         exit 1
     fi
+    install_stable_probe
     mkdir -p "$(dirname "$TARGET_LAUNCHD")" "$MAC_LOG_DIR"
 
-    local esc_home esc_repo
+    # The plist template still carries __REPO__ for backward-compat (e.g.
+    # if we ever add more binaries there), but ProgramArguments now points
+    # at the stable bin copy via __STABLE_PROBE__. We also inject
+    # SCITEX_OROCHI_REPO_ROOT into EnvironmentVariables so the stable-copy
+    # probe can locate orochi-machines.yaml.
+    local esc_home esc_repo esc_stable
     esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
     esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+    esc_stable="$(printf '%s' "$STABLE_PROBE" | sed 's|[|&]|\\&|g')"
     sed -e "s|__HOME__|${esc_home}|g" \
         -e "s|__REPO__|${esc_repo}|g" \
+        -e "s|__STABLE_PROBE__|${esc_stable}|g" \
         -e "s|__PROBE_MODE__|${mode}|g" \
         "$TEMPLATE" > "$TARGET_LAUNCHD"
 
@@ -62,6 +125,8 @@ install_macos() {
     launchctl load "$TARGET_LAUNCHD"
 
     echo "installed: $TARGET_LAUNCHD"
+    echo "probe:     $STABLE_PROBE"
+    echo "repo_root: $REPO_ROOT (injected as SCITEX_OROCHI_REPO_ROOT)"
     echo "mode:      $mode"
     echo "log:       ${MAC_LOG_DIR}/fleet-host-liveness-probe.log"
     echo "status:    launchctl list | grep ${LABEL}"
@@ -75,22 +140,28 @@ uninstall_macos() {
     else
         echo "nothing to uninstall (no $TARGET_LAUNCHD)"
     fi
+    uninstall_stable_probe
 }
 
 # -----------------------------------------------------------------------------
 # Linux (user crontab)
 # -----------------------------------------------------------------------------
 CRON_MARKER="# scitex-orochi host-liveness-probe (todo#271)"
-CRON_LINE_FMT='*/5 * * * * %s %s >> %s/fleet-host-liveness-probe.log 2>&1'
+# Cron format (todo#466): pin SCITEX_OROCHI_REPO_ROOT inline so the
+# stable-bin copy can locate orochi-machines.yaml; run the stable copy,
+# not the working-tree path, so feature-branch checkouts never 404 the
+# scheduler.
+CRON_LINE_FMT='*/5 * * * * SCITEX_OROCHI_REPO_ROOT=%s %s %s >> %s/fleet-host-liveness-probe.log 2>&1'
 
 install_linux() {
+    install_stable_probe
     mkdir -p "$LINUX_LOG_DIR"
     local existing
     existing="$(crontab -l 2>/dev/null || true)"
 
     # Idempotent: if marker present, replace; else append.
     local new_line
-    new_line="$(printf "$CRON_LINE_FMT" "$PROBE_SCRIPT" "$mode" "$LINUX_LOG_DIR")"
+    new_line="$(printf "$CRON_LINE_FMT" "$REPO_ROOT" "$STABLE_PROBE" "$mode" "$LINUX_LOG_DIR")"
 
     local rebuilt
     if printf '%s\n' "$existing" | grep -qF "$CRON_MARKER"; then
@@ -118,9 +189,11 @@ ${new_line}"
     echo "installed crontab entry:"
     echo "  ${CRON_MARKER}"
     echo "  ${new_line}"
-    echo "mode: $mode"
-    echo "log:  ${LINUX_LOG_DIR}/fleet-host-liveness-probe.log"
-    echo "view: crontab -l"
+    echo "probe: $STABLE_PROBE"
+    echo "repo:  $REPO_ROOT"
+    echo "mode:  $mode"
+    echo "log:   ${LINUX_LOG_DIR}/fleet-host-liveness-probe.log"
+    echo "view:  crontab -l"
 }
 
 uninstall_linux() {
@@ -128,10 +201,12 @@ uninstall_linux() {
     existing="$(crontab -l 2>/dev/null || true)"
     if [ -z "$existing" ]; then
         echo "nothing to uninstall (empty crontab)"
+        uninstall_stable_probe
         return 0
     fi
     if ! printf '%s\n' "$existing" | grep -qF "$CRON_MARKER"; then
         echo "nothing to uninstall (marker absent)"
+        uninstall_stable_probe
         return 0
     fi
     local rebuilt
@@ -145,6 +220,7 @@ uninstall_linux() {
     ')"
     printf '%s\n' "$rebuilt" | crontab -
     echo "uninstalled crontab marker + line"
+    uninstall_stable_probe
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Installer for the fleet host-liveness probe scheduler (cron on Linux,
launchd on macOS) used to point at the **working-tree** path
`~/proj/scitex-orochi/scripts/client/fleet-watch/host-liveness-probe.sh`.
Because `~/proj/scitex-orochi` is a shared checkout, switching to a
branch that predates PR #296 makes the scheduler silently 404.

This PR installs a **stable copy** under `~/.scitex/orochi/bin/` and
rewrites the cron entry / launchd `ProgramArguments` to reference it.

- `scripts/client/install-fleet-host-liveness-probe.sh`
  - `mkdir -p ~/.scitex/orochi/bin`
  - `cp -f` the probe (+ any sibling helpers like `revive_rate_limit.py`)
    into the stable dir on every install — idempotent updates
  - cron line now prefixes `SCITEX_OROCHI_REPO_ROOT=<resolved-repo>`
    so the stable probe can still locate `orochi-machines.yaml`
  - launchd template injects the same env var
- `deployment/host-setup/launchd/com.scitex.fleet-host-liveness-probe.plist`
  - `ProgramArguments` uses `__STABLE_PROBE__` placeholder
  - `EnvironmentVariables` carries `SCITEX_OROCHI_REPO_ROOT=__REPO__`
- `scripts/client/fleet-watch/host-liveness-probe.sh`
  - Accepts `$SCITEX_OROCHI_REPO_ROOT` override, falling back to the
    original `$SCRIPT_DIR/../../..` derivation for in-tree invocation

Closes todo#466.

## Test plan

- [x] `bash scripts/client/install-fleet-host-liveness-probe.sh --dry-run-only` on Linux
- [x] Verify crontab entry references `~/.scitex/orochi/bin/host-liveness-probe.sh`
- [x] Verify `~/.scitex/orochi/bin/host-liveness-probe.sh` exists and is executable
- [x] Run stable-bin probe with `SCITEX_OROCHI_REPO_ROOT` set → emits NDJSON with correct hosts
- [x] Run stable-bin probe without env var → fails loudly (as designed)
- [ ] mba / nas / spartan re-run installer post-merge to migrate their schedulers

## Cross-host rollout

After merge, each fleet head should re-run
`scripts/client/install-fleet-host-liveness-probe.sh` to switch its
local scheduler off the working-tree path. Affected hosts: `mba`,
`ywata-note-win`, `nas`, `spartan` (any host with the pre-#466
cron/launchd entry).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>