### PR TITLE
feat(ops): Layer 2 hungry-signal — idle heads DM lead, lead dispatches high-priority todo (msg#16310)

### DIFF
--- a/deployment/host-setup/launchd/com.scitex.hungry-signal.plist
+++ b/deployment/host-setup/launchd/com.scitex.hungry-signal.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent: Layer 2 hungry-signal probe (lead msg#16310).
+
+  Runs scripts/client/hungry-signal.sh every 10 minutes. On each tick the
+  probe reads local `scitex-agent-container status --terse --json` for
+  this head's subagent_count and, if zero for HUNGRY_THRESHOLD consecutive
+  cycles, DMs `lead` asking for a coordinated dispatch pick.
+
+  Install:
+    ./scripts/client/install-hungry-signal.sh
+
+  Logs: ~/Library/Logs/scitex/hungry-signal.log. State file:
+  ~/.local/state/scitex/hungry-signal.state.
+
+  __HOME__, __REPO__, __STABLE_PROBE__ are replaced by the installer
+  (stable-bin-path pattern, same shape as PR #326 todo#466). Kill switch:
+  set SCITEX_HUNGRY_DISABLED=1 in the user env to pause without
+  uninstalling.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.scitex.hungry-signal</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>__STABLE_PROBE__</string>
+      <string>__PROBE_MODE__</string>
+    </array>
+
+    <!-- Every 10 minutes. Layer 1 runs every 5 min; we want this cadence
+         to be half the rate so the counter only trips after real idleness,
+         not micro-gaps between probes. -->
+    <key>StartInterval</key>
+    <integer>600</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/scitex/hungry-signal.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/scitex/hungry-signal.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+      <key>SCITEX_OROCHI_REPO_ROOT</key>
+      <string>__REPO__</string>
+    </dict>
+  </dict>
+</plist>

--- a/deployment/host-setup/systemd/scitex-hungry-signal.service
+++ b/deployment/host-setup/systemd/scitex-hungry-signal.service
@@ -1,0 +1,27 @@
+[Unit]
+# SciTeX Orochi — Layer 2 hungry-signal probe (lead msg#16310)
+#
+# Runs scripts/client/hungry-signal.sh every 10 minutes. Paired with
+# scitex-hungry-signal.timer in the same directory. Install via
+# scripts/client/install-hungry-signal.sh.
+#
+# __REPO__ / __STABLE_PROBE__ / __PROBE_MODE__ templated by installer;
+# stable-bin-path pattern (PR #326 todo#466) so feature-branch checkouts
+# never 404 the scheduler.
+#
+# For hosts without systemd --user support, the installer falls back to
+# a cron entry.
+Description=SciTeX Orochi — hungry-signal probe (idle heads DM lead for coordinated dispatch)
+Documentation=https://github.com/ywatanabe1989/scitex-orochi
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/systemd/user/orochi.env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=SCITEX_OROCHI_REPO_ROOT=__REPO__
+ExecStart=/bin/bash -lc '__STABLE_PROBE__ __PROBE_MODE__'
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60

--- a/deployment/host-setup/systemd/scitex-hungry-signal.timer
+++ b/deployment/host-setup/systemd/scitex-hungry-signal.timer
@@ -1,0 +1,16 @@
+[Unit]
+# Timer companion for scitex-hungry-signal.service. Fires every 10 minutes
+# with a 30s AccuracySec window. Layer 1 (auto-dispatch-probe) runs every
+# 5 min; this runs half as often so HUNGRY_THRESHOLD=2 cycles maps to
+# ~20 min of real idleness before lead gets DM'd.
+Description=SciTeX Orochi — trigger hungry-signal probe every 10 minutes
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=10min
+AccuracySec=30s
+Unit=scitex-hungry-signal.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/client/hungry-signal.sh
+++ b/scripts/client/hungry-signal.sh
@@ -1,0 +1,594 @@
+#!/usr/bin/env bash
+# hungry-signal.sh — Layer 2 coordinated dispatch: idle heads DM lead
+# -----------------------------------------------------------------------------
+# Problem statement (lead msg#16310)
+#   Layer 1 (auto-dispatch-probe.sh, PR #320) forces idle heads to grab any
+#   local-lane high-priority todo. That solves "idle = forbidden" but routes
+#   blindly. Layer 2 adds a coordinated path: when a head has seen
+#   subagent_count == 0 for N consecutive cycles, it DMs `lead` saying
+#   "ready for dispatch" and lead picks a better-matched todo with context.
+#
+# Logic
+#   * Query local `scitex-agent-container status head-<hostname> --terse
+#     --json` (fallback to hub registry if sac is absent).
+#   * If subagent_count == 0 this cycle AND the state file shows the same
+#     reading N=HUNGRY_THRESHOLD cycles ago, compose and send a DM to lead:
+#        channel = dm:agent:head-<host>|agent:lead       (sorted-pair canonical)
+#        text    = "head-<host>: hungry — 0 subagents × <N> cycles, ready
+#                   for dispatch. lane: <label>, alive: <list>"
+#   * Once fired, write "fired" marker to state; skip further DMs until a
+#     non-zero reading resets the counter. This is the spam guard.
+#   * --dry-run logs "would-DM" without touching the hub or marker.
+#   * --yes posts the DM and arms the fired marker.
+#   * SCITEX_HUNGRY_DISABLED=1 silent no-op exit (kill switch).
+#
+# Cadence: 10 min (HUNGRY_CADENCE_SECONDS=600, launchd/systemd).
+# Threshold: 2 cycles (HUNGRY_THRESHOLD=2) → DM fires at the 2nd consecutive
+#            zero-reading, i.e. roughly 10–20 min of real idleness.
+#
+# This script shares idiom with auto-dispatch-probe.sh (PR #320): NDJSON to
+# stdout, severity to stderr, log file under ~/Library/Logs/scitex (mac) or
+# ~/.local/state/scitex (linux). State + log directories match.
+#
+# Exit codes
+#   0  ok (or benign skip: disabled / no-token / non-head host)
+#   1  advisory (DM already fired this stretch — state machine intact)
+#   2  warn (hub/sac reachable but no subagent_count payload returned)
+#   3  critical (can't parse machines yaml / write state file)
+# -----------------------------------------------------------------------------
+
+set -o pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Repo root for in-tree invocation: scripts/client/hungry-signal.sh → ../..
+# Stable-bin invocation honours $SCITEX_OROCHI_REPO_ROOT injected by the
+# installer (same pattern as PR #326 todo#466).
+if [ -n "${SCITEX_OROCHI_REPO_ROOT:-}" ] && [ -d "$SCITEX_OROCHI_REPO_ROOT" ]; then
+  REPO_ROOT="$SCITEX_OROCHI_REPO_ROOT"
+else
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+MACHINES_YAML="${MACHINES_YAML:-$REPO_ROOT/orochi-machines.yaml}"
+
+STATE_DIR="${HUNGRY_STATE_DIR:-$HOME/.local/state/scitex}"
+STATE_FILE="${HUNGRY_STATE_FILE:-$STATE_DIR/hungry-signal.state}"
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  LOG_DIR="${HUNGRY_LOG_DIR:-$HOME/Library/Logs/scitex}"
+else
+  LOG_DIR="${HUNGRY_LOG_DIR:-$HOME/.local/state/scitex}"
+fi
+LOG_FILE="$LOG_DIR/hungry-signal.log"
+
+HUB_URL_DEFAULT="${SCITEX_OROCHI_HUB_URL:-https://scitex-orochi.com}"
+HUB_URL="${HUB_URL_DEFAULT%/}"
+CURL_TIMEOUT="${HUNGRY_CURL_TIMEOUT:-8}"
+HUNGRY_THRESHOLD="${HUNGRY_THRESHOLD:-2}"
+
+dry_run=1
+only_host=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) dry_run=1; shift ;;
+    --yes|-y)  dry_run=0; shift ;;
+    --host)    only_host="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,45p' "$0"; exit 0 ;;
+    *) printf 'unknown arg: %s\n' "$1" >&2; exit 64 ;;
+  esac
+done
+
+mkdir -p "$LOG_DIR" "$STATE_DIR" 2>/dev/null || {
+  printf 'hungry-signal: cannot create state/log dirs\n' >&2
+  exit 3
+}
+
+TS_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+NOW_EPOCH="$(date -u +%s)"
+LOCAL_HOST="$(hostname -s 2>/dev/null || hostname)"
+
+log()    { printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >>"$LOG_FILE"; }
+stderr() { printf '%s\n' "$*" >&2; }
+
+worst_exit=0
+bump_exit() {
+  local code="$1"
+  if [ "$code" -gt "$worst_exit" ]; then
+    worst_exit="$code"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Kill switch — silent exit 0.
+# -----------------------------------------------------------------------------
+if [ "${SCITEX_HUNGRY_DISABLED:-0}" = "1" ]; then
+  log "disabled via SCITEX_HUNGRY_DISABLED=1 — no-op"
+  exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# Lane map — mirrors auto-dispatch-probe.sh for consistency. The DM payload
+# only includes the lane label; lead-side handler does the todo lookup.
+# -----------------------------------------------------------------------------
+lane_for_host() {
+  case "$1" in
+    mba)            printf 'infrastructure' ;;
+    ywata-note-win) printf 'specialized-wsl-access' ;;
+    spartan)        printf 'specialized-domain' ;;
+    nas)            printf 'hub-admin' ;;
+    *)              printf '' ;;
+  esac
+}
+
+# -----------------------------------------------------------------------------
+# parse_machines_yaml — same shape as auto-dispatch-probe.sh. Returns a
+# newline-separated list of head canonical names.
+# -----------------------------------------------------------------------------
+parse_machines_yaml() {
+  if [ ! -f "$MACHINES_YAML" ]; then
+    stderr "hungry-signal: machines yaml missing: $MACHINES_YAML"
+    return 1
+  fi
+  python3 - "$MACHINES_YAML" <<'PY'
+import sys
+path = sys.argv[1]
+try:
+    import yaml
+    with open(path) as f:
+        doc = yaml.safe_load(f) or {}
+    for m in (doc.get("machines") or []):
+        name = (m.get("canonical_name") or "").strip()
+        role = ((m.get("fleet_role") or {}).get("role") or "").strip()
+        if name and role == "head":
+            print(name)
+except ImportError:
+    import re
+    with open(path) as f:
+        text = f.read()
+    for blk in re.split(r'^\s*-\s+canonical_name:\s*', text, flags=re.MULTILINE)[1:]:
+        m = re.match(r'([A-Za-z0-9_.-]+)', blk)
+        if not m:
+            continue
+        if re.search(r'role:\s*head\b', blk):
+            print(m.group(1).strip())
+PY
+}
+
+# -----------------------------------------------------------------------------
+# resolve_self_host — canonical fleet label for the box we're on.
+# -----------------------------------------------------------------------------
+resolve_self_host() {
+  if [ -n "${SCITEX_OROCHI_HOSTNAME:-}" ]; then
+    printf '%s' "$SCITEX_OROCHI_HOSTNAME"
+    return
+  fi
+  if [ -x "$SCRIPT_DIR/resolve-hostname" ]; then
+    local out
+    out="$("$SCRIPT_DIR/resolve-hostname" 2>/dev/null)"
+    if [ -n "$out" ]; then
+      printf '%s' "$out"
+      return
+    fi
+  fi
+  printf '%s' "$LOCAL_HOST"
+}
+
+# -----------------------------------------------------------------------------
+# read_subagent_count — prefer `scitex-agent-container status --terse --json`
+# when sac is on PATH (source of truth), fall back to the hub registry. The
+# sac path is cheaper and works even when the hub is unreachable.
+#
+# Prints two lines:
+#   <subagent_count>
+#   <comma-sep alive agent names>   (for the DM context blob; may be "")
+# Returns non-zero if neither source yields a reading.
+# -----------------------------------------------------------------------------
+read_subagent_count() {
+  local host="$1"
+  local agent_name="head-$host"
+  local count="" alive=""
+
+  # Source 1: local sac, if available. We ask for *all* agents on this box
+  # (so the "alive" list can fill the DM context blob), then extract
+  # head-<host>.subagent_count from the resulting payload.
+  if command -v scitex-agent-container >/dev/null 2>&1; then
+    local sac_json
+    sac_json="$(scitex-agent-container status --terse --json 2>/dev/null || true)"
+    if [ -n "$sac_json" ]; then
+      read -r count alive < <(
+        SAC_JSON="$sac_json" AGENT_NAME="$agent_name" python3 -c '
+import json, os, sys
+agent = os.environ["AGENT_NAME"]
+try:
+    data = json.loads(os.environ.get("SAC_JSON") or "{}")
+except Exception:
+    print("")
+    print("")
+    sys.exit(0)
+# sac status --terse --json shapes seen in the wild: either a list of
+# agent dicts, or a dict keyed by agent name, or a top-level dict with
+# "agents": [...]. Handle all three.
+agents = []
+if isinstance(data, list):
+    agents = data
+elif isinstance(data, dict):
+    if isinstance(data.get("agents"), list):
+        agents = data["agents"]
+    else:
+        # dict keyed by agent name
+        for k, v in data.items():
+            if isinstance(v, dict):
+                v = {**v, "name": v.get("name") or k}
+                agents.append(v)
+count = ""
+alive_names = []
+for a in agents:
+    if not isinstance(a, dict):
+        continue
+    name = str(a.get("name") or a.get("agent_id") or "")
+    if not name:
+        continue
+    status = str(a.get("status") or "")
+    # "alive" by sac convention: online OR running (sac has its own label
+    # set; tolerate common variants).
+    if status in ("online", "running", "up", "active"):
+        alive_names.append(name)
+    if name == agent:
+        c = a.get("subagent_count")
+        if c is not None:
+            try:
+                count = str(int(c))
+            except (TypeError, ValueError):
+                pass
+print(count or "")
+print(",".join(alive_names))
+'
+      )
+      if [ -n "$count" ]; then
+        printf '%s\n%s\n' "$count" "$alive"
+        return 0
+      fi
+    fi
+  fi
+
+  # Source 2: hub /api/agents/. Uses the same token resolution as
+  # auto-dispatch-probe.sh.
+  local token="${SCITEX_OROCHI_TOKEN:-}"
+  if [ -z "$token" ]; then
+    local token_src="$HOME/.dotfiles/src/.bash.d/secrets/010_scitex/01_orochi.src"
+    if [ -r "$token_src" ]; then
+      # shellcheck disable=SC1090
+      . "$token_src" 2>/dev/null || true
+      token="${SCITEX_OROCHI_TOKEN:-}"
+    fi
+  fi
+  if [ -z "$token" ]; then
+    log "skip: no SCITEX_OROCHI_TOKEN and sac unavailable"
+    return 1
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    log "skip: curl not installed"
+    return 1
+  fi
+
+  local endpoint="$HUB_URL/api/agents/?token=$token"
+  local http_code body tmp
+  tmp="$(mktemp -t hungry-signal.XXXXXX)"
+  http_code="$(curl -sS -o "$tmp" -w '%{http_code}' \
+      --max-time "$CURL_TIMEOUT" \
+      -H 'Accept: application/json' \
+      "$endpoint" 2>/dev/null || echo 000)"
+  body="$(cat "$tmp" 2>/dev/null || true)"
+  rm -f "$tmp" 2>/dev/null || true
+  if [ "$http_code" != "200" ]; then
+    log "hub error ($http_code) — cannot read subagent_count"
+    return 1
+  fi
+  read -r count alive < <(
+    AGENTS_JSON="$body" AGENT_NAME="$agent_name" python3 -c '
+import json, os
+agent = os.environ["AGENT_NAME"]
+try:
+    data = json.loads(os.environ.get("AGENTS_JSON") or "[]")
+except Exception:
+    data = []
+if not isinstance(data, list):
+    data = []
+count = ""
+alive_names = []
+for a in data:
+    if not isinstance(a, dict):
+        continue
+    name = str(a.get("name") or "")
+    if not name:
+        continue
+    status = str(a.get("status") or "")
+    if status == "online":
+        alive_names.append(name)
+    if name == agent:
+        c = a.get("subagent_count")
+        if c is not None:
+            try:
+                count = str(int(c))
+            except (TypeError, ValueError):
+                pass
+print(count or "")
+print(",".join(alive_names))
+'
+  )
+  if [ -z "$count" ]; then
+    return 1
+  fi
+  printf '%s\n%s\n' "$count" "$alive"
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# State file — one line per head, TAB-separated:
+#   <host>\t<consecutive_zero_cycles>\t<fired_flag>\t<last_update_epoch>
+#
+# fired_flag is "1" after a DM is actually sent; cleared on the first
+# non-zero reading that follows (spam guard — one DM per idle stretch).
+# -----------------------------------------------------------------------------
+state_get() {
+  local host="$1"
+  if [ ! -f "$STATE_FILE" ]; then
+    printf '0\t0\t0\n'
+    return
+  fi
+  awk -F'\t' -v h="$host" '$1==h { print $2 "\t" $3 "\t" $4; found=1 } END { if (!found) print "0\t0\t0" }' \
+    "$STATE_FILE"
+}
+
+state_update() {
+  local host="$1" cycles="$2" fired="$3" epoch="$4"
+  local tmp
+  tmp="$(mktemp -t hungry-signal-state.XXXXXX)"
+  if [ -f "$STATE_FILE" ]; then
+    awk -F'\t' -v h="$host" '$1 != h { print }' "$STATE_FILE" >"$tmp" 2>/dev/null || true
+  fi
+  printf '%s\t%s\t%s\t%s\n' "$host" "$cycles" "$fired" "$epoch" >>"$tmp"
+  mv -f "$tmp" "$STATE_FILE"
+}
+
+# -----------------------------------------------------------------------------
+# send_dm — POST /api/messages/ to the canonical agent↔agent DM channel.
+# Canonical channel name: dm:agent:<A>|agent:<B> with names sorted so A↔B
+# and B↔A collapse to a single channel (matches hub/static/hub/app/
+# agent-actions.js:_openAgentDmSimple).
+# -----------------------------------------------------------------------------
+send_dm() {
+  local sender="$1" recipient="$2" text="$3"
+  local token="${SCITEX_OROCHI_TOKEN:-}"
+  if [ -z "$token" ]; then
+    local token_src="$HOME/.dotfiles/src/.bash.d/secrets/010_scitex/01_orochi.src"
+    if [ -r "$token_src" ]; then
+      # shellcheck disable=SC1090
+      . "$token_src" 2>/dev/null || true
+      token="${SCITEX_OROCHI_TOKEN:-}"
+    fi
+  fi
+  if [ -z "$token" ]; then
+    log "send_dm skip: no SCITEX_OROCHI_TOKEN"
+    return 1
+  fi
+  if ! command -v curl >/dev/null 2>&1; then
+    log "send_dm skip: curl missing"
+    return 1
+  fi
+
+  # Canonical channel = sorted pair joined with "|".
+  local channel
+  channel="$(python3 -c '
+import sys
+a, b = sys.argv[1:3]
+pair = sorted([a, b])
+print("dm:agent:" + pair[0] + "|agent:" + pair[1])
+' "$sender" "$recipient")"
+
+  local endpoint="$HUB_URL/api/messages/?token=$token"
+  local payload
+  payload="$(python3 -c '
+import json, sys
+ch, snd, txt = sys.argv[1:4]
+print(json.dumps({
+    "channel": ch,
+    "sender": snd,
+    "payload": {"channel": ch, "content": txt},
+}))
+' "$channel" "$sender" "$text")"
+
+  local http_code tmp
+  tmp="$(mktemp -t hungry-signal-dm.XXXXXX)"
+  http_code="$(curl -sS -o "$tmp" -w '%{http_code}' \
+      --max-time "$CURL_TIMEOUT" \
+      -X POST \
+      -H 'Content-Type: application/json' \
+      -H 'Accept: application/json' \
+      --data "$payload" \
+      "$endpoint" 2>/dev/null || echo 000)"
+  local body
+  body="$(cat "$tmp" 2>/dev/null || true)"
+  rm -f "$tmp" 2>/dev/null || true
+
+  case "$http_code" in
+    200|201)
+      log "DM sent: ${channel} http=${http_code}"
+      return 0 ;;
+    *)
+      log "DM failed: http=${http_code} body=${body:0:200}"
+      return 1 ;;
+  esac
+}
+
+# -----------------------------------------------------------------------------
+# emit_ndjson — one NDJSON line on stdout per run (one-head-per-host model).
+# -----------------------------------------------------------------------------
+emit_ndjson() {
+  local host="$1" agent="$2" decision="$3" reason="$4"
+  local subagent_count="$5" cycles="$6" fired="$7" lane="$8"
+  python3 - "$TS_ISO" "$host" "$agent" "$decision" "$reason" \
+                     "$subagent_count" "$cycles" "$fired" "$lane" \
+                     "$dry_run" "$HUNGRY_THRESHOLD" <<'PY'
+import json, sys
+ts, host, agent, decision, reason, sc, cycles, fired, lane, dry, thresh = sys.argv[1:]
+def _ival(x, d=0):
+    try:
+        return int(x)
+    except (TypeError, ValueError):
+        return d
+obj = {
+    "schema": "scitex-orochi/hungry-signal/v1",
+    "ts": ts,
+    "host": host,
+    "agent": agent,
+    "decision": decision,
+    "reason": reason,
+    "subagent_count": _ival(sc, -1),
+    "consecutive_zero_cycles": _ival(cycles, 0),
+    "fired": fired == "1",
+    "threshold": _ival(thresh, 2),
+    "lane": lane or "",
+    "dry_run": dry == "1",
+}
+print(json.dumps(obj, separators=(",", ":"), sort_keys=False))
+PY
+}
+
+# -----------------------------------------------------------------------------
+# probe_head — per-host cycle. Contract: idempotent state machine.
+#
+#   subagent_count > 0  → cycles=0, fired=0 (reset everything)
+#   subagent_count == 0
+#     cycles+1 < threshold        → cycles++, fired unchanged, no DM
+#     cycles+1 >= threshold
+#       fired == 0                → DM lead, fired=1 (arm guard)
+#       fired == 1                → skip (spam guard; already DM'd once)
+# -----------------------------------------------------------------------------
+probe_head() {
+  local host="$1"
+  local agent_name="head-$host"
+  local lane; lane="$(lane_for_host "$host")"
+
+  local two_lines count alive
+  if ! two_lines="$(read_subagent_count "$host")"; then
+    emit_ndjson "$host" "$agent_name" "skip" "no_subagent_count_source" \
+      "-1" "0" "0" "$lane"
+    bump_exit 2
+    return
+  fi
+  count="$(printf '%s' "$two_lines" | awk 'NR==1')"
+  alive="$(printf '%s' "$two_lines" | awk 'NR==2')"
+  : "${count:=-1}"
+  : "${alive:=}"
+
+  local prior prior_cycles prior_fired
+  prior="$(state_get "$host")"
+  prior_cycles="$(printf '%s' "$prior" | awk -F'\t' '{print $1}')"
+  prior_fired="$(printf '%s' "$prior" | awk -F'\t' '{print $2}')"
+  : "${prior_cycles:=0}"
+  : "${prior_fired:=0}"
+
+  # Non-zero reading: reset counter + fired flag. Silent-success at exit 0.
+  if [ "$count" -gt 0 ] 2>/dev/null; then
+    if [ "$prior_cycles" != "0" ] || [ "$prior_fired" != "0" ]; then
+      if [ "$dry_run" -eq 0 ]; then
+        state_update "$host" 0 0 "$NOW_EPOCH"
+      fi
+    fi
+    emit_ndjson "$host" "$agent_name" "noop" "subagent_count=${count}_reset" \
+      "$count" "0" "0" "$lane"
+    return
+  fi
+
+  if [ "$count" != "0" ]; then
+    # Unknown / parse error.
+    emit_ndjson "$host" "$agent_name" "skip" "subagent_count_unknown(${count})" \
+      "$count" "$prior_cycles" "$prior_fired" "$lane"
+    bump_exit 2
+    return
+  fi
+
+  # count == 0
+  local new_cycles=$((prior_cycles + 1))
+
+  if [ "$new_cycles" -lt "$HUNGRY_THRESHOLD" ]; then
+    # Still warming up — increment counter, don't DM yet.
+    if [ "$dry_run" -eq 0 ]; then
+      state_update "$host" "$new_cycles" "$prior_fired" "$NOW_EPOCH"
+    fi
+    emit_ndjson "$host" "$agent_name" "counting" \
+      "zero_cycles=${new_cycles}/${HUNGRY_THRESHOLD}" \
+      "$count" "$new_cycles" "$prior_fired" "$lane"
+    return
+  fi
+
+  # Threshold met. Spam guard: already fired this stretch?
+  if [ "$prior_fired" = "1" ]; then
+    if [ "$dry_run" -eq 0 ]; then
+      state_update "$host" "$new_cycles" 1 "$NOW_EPOCH"
+    fi
+    emit_ndjson "$host" "$agent_name" "skip" "already_fired_awaiting_reset" \
+      "$count" "$new_cycles" "1" "$lane"
+    bump_exit 1
+    return
+  fi
+
+  # Fire.
+  local text
+  text="${agent_name}: hungry — 0 subagents × ${new_cycles} cycles, ready for dispatch. lane: ${lane:-none}, alive: ${alive:-none}"
+
+  if [ "$dry_run" -eq 1 ]; then
+    log "DRY-RUN would-DM lead: ${text}"
+    emit_ndjson "$host" "$agent_name" "would_dm" "dry_run" \
+      "$count" "$new_cycles" "$prior_fired" "$lane"
+    return
+  fi
+
+  if send_dm "$agent_name" "lead" "$text"; then
+    state_update "$host" "$new_cycles" 1 "$NOW_EPOCH"
+    log "DM host=${host} cycles=${new_cycles} threshold=${HUNGRY_THRESHOLD} lane=${lane}"
+    emit_ndjson "$host" "$agent_name" "dm_sent" "hungry_signal_posted" \
+      "$count" "$new_cycles" "1" "$lane"
+  else
+    # Leave fired=0 so we can retry next tick — DM failures are transient.
+    state_update "$host" "$new_cycles" 0 "$NOW_EPOCH"
+    emit_ndjson "$host" "$agent_name" "dm_failed" "send_dm_nonzero" \
+      "$count" "$new_cycles" "0" "$lane"
+    bump_exit 1
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+main() {
+  log "cycle start dry_run=${dry_run} only_host='${only_host}' threshold=${HUNGRY_THRESHOLD}"
+
+  local heads
+  if ! heads="$(parse_machines_yaml)"; then
+    stderr "hungry-signal: failed to parse $MACHINES_YAML"
+    return 3
+  fi
+  if [ -z "$heads" ]; then
+    stderr "hungry-signal: no head-role machines in $MACHINES_YAML"
+    return 3
+  fi
+
+  local self; self="$(resolve_self_host)"
+  local target_host="${only_host:-$self}"
+
+  if ! printf '%s\n' "$heads" | grep -qx "$target_host"; then
+    log "target host '${target_host}' is not a head — exit 0"
+    return 0
+  fi
+
+  probe_head "$target_host"
+
+  log "cycle end worst_severity_code=${worst_exit}"
+  return "$worst_exit"
+}
+
+main

--- a/scripts/client/install-hungry-signal.sh
+++ b/scripts/client/install-hungry-signal.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# install-hungry-signal.sh
+#
+# Installer for the Layer 2 hungry-signal scheduler (lead msg#16310).
+# When a head has seen subagent_count==0 for HUNGRY_THRESHOLD consecutive
+# cycles (default 2), it DMs lead to request a coordinated dispatch pick.
+#
+# On macOS: installs a LaunchAgent that runs the probe every 10 min.
+# On Linux: installs a systemd --user timer if available; else cron fallback.
+#
+# Stable-bin-path pattern (same shape as PR #326 todo#466):
+#   - mkdir -p ~/.scitex/orochi/bin
+#   - cp -f scripts/client/hungry-signal.sh → ~/.scitex/orochi/bin/
+#   - scheduler references the stable copy, not the working tree
+#   - SCITEX_OROCHI_REPO_ROOT=<resolved repo> injected so the stable copy
+#     can still locate orochi-machines.yaml
+#
+# Default mode is --yes (DM enabled). Use --dry-run-only to install the
+# scheduler but only log "would-DM" decisions.
+#
+# Usage:
+#   ./scripts/client/install-hungry-signal.sh             # install (--yes)
+#   ./scripts/client/install-hungry-signal.sh --dry-run-only
+#   ./scripts/client/install-hungry-signal.sh --uninstall
+
+set -u
+set -o pipefail
+
+LABEL="com.scitex.hungry-signal"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
+TARGET_LAUNCHD="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+MAC_LOG_DIR="${HOME}/Library/Logs/scitex"
+LINUX_LOG_DIR="${HOME}/.local/state/scitex"
+
+SOURCE_PROBE="${REPO_ROOT}/scripts/client/hungry-signal.sh"
+STABLE_BIN_DIR="${HOME}/.scitex/orochi/bin"
+STABLE_PROBE="${STABLE_BIN_DIR}/hungry-signal.sh"
+
+SYSTEMD_UNIT_DIR="${HOME}/.config/systemd/user"
+SYSTEMD_SERVICE_TEMPLATE="${REPO_ROOT}/deployment/host-setup/systemd/scitex-hungry-signal.service"
+SYSTEMD_TIMER_TEMPLATE="${REPO_ROOT}/deployment/host-setup/systemd/scitex-hungry-signal.timer"
+SYSTEMD_SERVICE_NAME="scitex-hungry-signal.service"
+SYSTEMD_TIMER_NAME="scitex-hungry-signal.timer"
+
+mode="--yes"
+action="install"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uninstall)    action="uninstall"; shift ;;
+        --dry-run-only) mode="--dry-run"; shift ;;
+        --yes)          mode="--yes"; shift ;;
+        -h|--help)
+            sed -n '2,25p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+OS="$(uname -s)"
+
+# -----------------------------------------------------------------------------
+# Stable bin install (same shape as PR #326 todo#466)
+# -----------------------------------------------------------------------------
+install_stable_probe() {
+    if [[ ! -f "$SOURCE_PROBE" ]]; then
+        echo "probe source missing: $SOURCE_PROBE" >&2
+        exit 1
+    fi
+    mkdir -p "$STABLE_BIN_DIR"
+    cp -f "$SOURCE_PROBE" "$STABLE_PROBE"
+    chmod +x "$STABLE_PROBE"
+    echo "stable probe: $STABLE_PROBE (repo=$REPO_ROOT)"
+}
+
+uninstall_stable_probe() {
+    rm -f "$STABLE_PROBE"
+    echo "uninstalled stable probe: $STABLE_PROBE"
+}
+
+# -----------------------------------------------------------------------------
+# macOS (LaunchAgent)
+# -----------------------------------------------------------------------------
+install_macos() {
+    if [[ ! -f "$TEMPLATE" ]]; then
+        echo "template missing: $TEMPLATE" >&2
+        exit 1
+    fi
+    install_stable_probe
+    mkdir -p "$(dirname "$TARGET_LAUNCHD")" "$MAC_LOG_DIR"
+
+    local esc_home esc_repo esc_stable
+    esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+    esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+    esc_stable="$(printf '%s' "$STABLE_PROBE" | sed 's|[|&]|\\&|g')"
+    sed -e "s|__HOME__|${esc_home}|g" \
+        -e "s|__REPO__|${esc_repo}|g" \
+        -e "s|__STABLE_PROBE__|${esc_stable}|g" \
+        -e "s|__PROBE_MODE__|${mode}|g" \
+        "$TEMPLATE" > "$TARGET_LAUNCHD"
+
+    launchctl unload "$TARGET_LAUNCHD" 2>/dev/null || true
+    launchctl load "$TARGET_LAUNCHD"
+
+    echo "installed: $TARGET_LAUNCHD"
+    echo "probe:     $STABLE_PROBE"
+    echo "repo_root: $REPO_ROOT (injected as SCITEX_OROCHI_REPO_ROOT)"
+    echo "mode:      $mode"
+    echo "log:       ${MAC_LOG_DIR}/hungry-signal.log"
+    echo "status:    launchctl list | grep ${LABEL}"
+}
+
+uninstall_macos() {
+    if [[ -f "$TARGET_LAUNCHD" ]]; then
+        launchctl unload "$TARGET_LAUNCHD" 2>/dev/null || true
+        rm -f "$TARGET_LAUNCHD"
+        echo "uninstalled: $TARGET_LAUNCHD"
+    else
+        echo "nothing to uninstall (no $TARGET_LAUNCHD)"
+    fi
+    uninstall_stable_probe
+}
+
+# -----------------------------------------------------------------------------
+# Linux — systemd --user if available, else cron.
+# -----------------------------------------------------------------------------
+CRON_MARKER="# scitex-orochi hungry-signal (lead msg#16310)"
+CRON_LINE_FMT='*/10 * * * * SCITEX_OROCHI_REPO_ROOT=%s %s %s >> %s/hungry-signal.log 2>&1'
+
+_systemd_user_available() {
+    command -v systemctl >/dev/null 2>&1 && \
+        systemctl --user status >/dev/null 2>&1
+}
+
+install_linux_systemd() {
+    if [[ ! -f "$SYSTEMD_SERVICE_TEMPLATE" ]] || [[ ! -f "$SYSTEMD_TIMER_TEMPLATE" ]]; then
+        echo "systemd templates missing — falling back to cron" >&2
+        return 1
+    fi
+    install_stable_probe
+    mkdir -p "$SYSTEMD_UNIT_DIR" "$LINUX_LOG_DIR"
+
+    local esc_home esc_repo esc_stable
+    esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+    esc_repo="$(printf '%s' "$REPO_ROOT" | sed 's|[|&]|\\&|g')"
+    esc_stable="$(printf '%s' "$STABLE_PROBE" | sed 's|[|&]|\\&|g')"
+    sed -e "s|__HOME__|${esc_home}|g" \
+        -e "s|__REPO__|${esc_repo}|g" \
+        -e "s|__STABLE_PROBE__|${esc_stable}|g" \
+        -e "s|__PROBE_MODE__|${mode}|g" \
+        "$SYSTEMD_SERVICE_TEMPLATE" > "$SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME"
+    sed -e "s|__HOME__|${esc_home}|g" \
+        -e "s|__REPO__|${esc_repo}|g" \
+        "$SYSTEMD_TIMER_TEMPLATE" > "$SYSTEMD_UNIT_DIR/$SYSTEMD_TIMER_NAME"
+
+    systemctl --user daemon-reload
+    systemctl --user enable --now "$SYSTEMD_TIMER_NAME"
+    echo "installed systemd user units in $SYSTEMD_UNIT_DIR"
+    echo "  ${SYSTEMD_SERVICE_NAME}"
+    echo "  ${SYSTEMD_TIMER_NAME}"
+    echo "probe: $STABLE_PROBE"
+    echo "repo:  $REPO_ROOT"
+    echo "mode:  $mode"
+    echo "status: systemctl --user list-timers ${SYSTEMD_TIMER_NAME}"
+    return 0
+}
+
+uninstall_linux_systemd() {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        return 1
+    fi
+    systemctl --user disable --now "$SYSTEMD_TIMER_NAME" 2>/dev/null || true
+    local removed=0
+    if [[ -f "$SYSTEMD_UNIT_DIR/$SYSTEMD_TIMER_NAME" ]]; then
+        rm -f "$SYSTEMD_UNIT_DIR/$SYSTEMD_TIMER_NAME"
+        removed=1
+    fi
+    if [[ -f "$SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME" ]]; then
+        rm -f "$SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME"
+        removed=1
+    fi
+    if [ "$removed" -eq 1 ]; then
+        systemctl --user daemon-reload 2>/dev/null || true
+        echo "uninstalled systemd user units"
+    fi
+    return 0
+}
+
+install_linux_cron() {
+    install_stable_probe
+    mkdir -p "$LINUX_LOG_DIR"
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+
+    local new_line
+    # shellcheck disable=SC2059
+    new_line="$(printf "$CRON_LINE_FMT" "$REPO_ROOT" "$STABLE_PROBE" "$mode" "$LINUX_LOG_DIR")"
+
+    local rebuilt
+    if printf '%s\n' "$existing" | grep -qF "$CRON_MARKER"; then
+        rebuilt="$(printf '%s\n' "$existing" | awk -v marker="$CRON_MARKER" -v line="$new_line" '
+            BEGIN { printed=0 }
+            {
+                if ($0 == marker) {
+                    print $0
+                    getline next_line
+                    print line
+                    printed=1
+                } else {
+                    print $0
+                }
+            }
+        ')"
+    else
+        rebuilt="${existing}
+${CRON_MARKER}
+${new_line}"
+    fi
+
+    printf '%s\n' "$rebuilt" | crontab -
+    echo "installed crontab entry:"
+    echo "  ${CRON_MARKER}"
+    echo "  ${new_line}"
+    echo "probe: $STABLE_PROBE"
+    echo "repo:  $REPO_ROOT"
+    echo "mode:  $mode"
+    echo "log:   ${LINUX_LOG_DIR}/hungry-signal.log"
+    echo "view:  crontab -l"
+}
+
+uninstall_linux_cron() {
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+    if [ -z "$existing" ]; then
+        echo "nothing to uninstall (empty crontab)"
+        return 0
+    fi
+    if ! printf '%s\n' "$existing" | grep -qF "$CRON_MARKER"; then
+        echo "nothing to uninstall (cron marker absent)"
+        return 0
+    fi
+    local rebuilt
+    rebuilt="$(printf '%s\n' "$existing" | awk -v marker="$CRON_MARKER" '
+        BEGIN { skip=0 }
+        {
+            if ($0 == marker) { skip=2; next }
+            if (skip > 0)     { skip--; next }
+            print $0
+        }
+    ')"
+    printf '%s\n' "$rebuilt" | crontab -
+    echo "uninstalled crontab marker + line"
+}
+
+install_linux() {
+    if _systemd_user_available && install_linux_systemd; then
+        return 0
+    fi
+    install_linux_cron
+}
+
+uninstall_linux() {
+    uninstall_linux_systemd || true
+    uninstall_linux_cron || true
+    uninstall_stable_probe
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------------
+case "$OS" in
+    Darwin)
+        case "$action" in
+            install)   install_macos ;;
+            uninstall) uninstall_macos ;;
+        esac
+        ;;
+    Linux)
+        case "$action" in
+            install)   install_linux ;;
+            uninstall) uninstall_linux ;;
+        esac
+        ;;
+    *)
+        echo "install-hungry-signal: unsupported OS ($OS)" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/server/hungry-signal-handler.py
+++ b/scripts/server/hungry-signal-handler.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""hungry-signal-handler.py — lead-side responder for Layer 2 hungry DMs.
+
+Companion to ``scripts/client/hungry-signal.sh``. When an idle head DMs
+``lead`` with a ``head-<host>: hungry …`` message, lead needs to pick a
+high-priority todo matching the head's lane (skipping claimed and
+under-review issues) and reply in the same DM.
+
+This file is both:
+
+1. A **pure-function library** (``parse_hungry_signal``, ``pick_for_lane``,
+   ``format_dispatch_reply``) that lead's agent loop or an in-context
+   subagent can call directly. No side effects.
+2. A **CLI** that can run as a standalone responder — read hungry DMs
+   arriving in lead's inbox, invoke the same picker, and POST the reply
+   back via the hub REST API.
+
+Most deployments will use (1): lead's Claude pane reads its own DM traffic
+via MCP, calls :func:`handle_hungry_message` on each match, and sends the
+reply via the MCP ``reply`` tool. The CLI form exists for out-of-band
+smoke tests and for hosts where lead is offline but the responder still
+needs to answer.
+
+Data source: ``gh issue list`` + ``gh pr list`` against the todo repo.
+Filtering rules (lead msg#16310):
+
+* ``--state open --label high-priority``
+* skip issues whose number appears in any open PR title
+* skip issues with the ``audit-review-2026-04-22`` label
+  (stale-under-review)
+* prefer issues with the sender's lane label; fall back to any unlabeled
+  high-priority issue when no lane match exists
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from typing import Iterable
+
+TODO_REPO = os.environ.get("SCITEX_TODO_REPO", "ywatanabe1989/todo")
+
+# Label used to suppress stale issues that are under review but still open
+# (lead msg#16310). Keep as a module constant so tests can reference it
+# without string-copy drift.
+AUDIT_REVIEW_LABEL = os.environ.get(
+    "SCITEX_HUNGRY_AUDIT_LABEL", "audit-review-2026-04-22"
+)
+
+# Hungry-signal DM format, emitted by scripts/client/hungry-signal.sh:
+#   "head-<host>: hungry — 0 subagents × N cycles, ready for dispatch.
+#    lane: <label>, alive: <list>"
+# We only need sender + lane for the handler; "alive" is cosmetic.
+_HUNGRY_RE = re.compile(
+    r"""^\s*
+        (?P<sender>head-[A-Za-z0-9_.-]+)
+        \s*:\s*hungry\b
+        .*?
+        lane:\s*(?P<lane>[A-Za-z0-9_.-]+)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+# Re-used from auto-dispatch-pick-todo.py — any "#123" / "todo#45" reference.
+_ISSUE_REF_RE = re.compile(r"(?:^|[\s\(\[#])#?(\d+)\b")
+
+
+# -----------------------------------------------------------------------------
+# Pure-function core (unit-tested)
+# -----------------------------------------------------------------------------
+
+
+def parse_hungry_signal(text: str) -> dict | None:
+    """Extract sender + lane from a hungry-signal DM.
+
+    Returns ``{"sender": "head-mba", "lane": "infrastructure"}`` or
+    ``None`` if the text doesn't match. Lane is lower-cased because
+    GitHub labels are case-insensitive on the client side and the DM
+    generator may vary over time.
+    """
+    if not text:
+        return None
+    m = _HUNGRY_RE.search(text)
+    if not m:
+        return None
+    return {"sender": m.group("sender"), "lane": m.group("lane").strip()}
+
+
+def _extract_issue_refs(text: str) -> set[int]:
+    out: set[int] = set()
+    if not text:
+        return out
+    for m in _ISSUE_REF_RE.finditer(text):
+        try:
+            out.add(int(m.group(1)))
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def claimed_numbers_from_prs(open_prs: list[dict]) -> set[int]:
+    """Collect issue numbers referenced by any open PR's title/body.
+
+    Mirrors the auto-dispatch helper so the two daemons treat "already
+    claimed" identically. Best-effort: PRs that forget to cross-reference
+    slip through.
+    """
+    claimed: set[int] = set()
+    for pr in open_prs or []:
+        claimed.update(_extract_issue_refs(pr.get("title") or ""))
+        claimed.update(_extract_issue_refs(pr.get("body") or ""))
+    return claimed
+
+
+def _issue_labels(issue: dict) -> set[str]:
+    return {(lab.get("name") or "").strip() for lab in issue.get("labels") or []}
+
+
+def pick_for_lane(
+    issues: list[dict],
+    open_prs: list[dict],
+    lane: str,
+    extra_exclude: Iterable[int] = (),
+    audit_label: str = AUDIT_REVIEW_LABEL,
+) -> dict | None:
+    """Pick the best open high-priority issue for the sender's ``lane``.
+
+    1. Skip issues already referenced in any open PR title/body.
+    2. Skip issues carrying ``audit_label`` (stale-under-review).
+    3. Skip issues already assigned to a human.
+    4. Prefer issues with the ``lane`` label. Fall back to first open
+       high-priority without any lane label when no direct match exists
+       (lead msg#16310 spec: "fall back to any unlabelled high-priority").
+
+    The returned dict matches :func:`auto_dispatch_pick_todo.pick_todo` so
+    downstream formatters can treat them interchangeably.
+    """
+    claimed = claimed_numbers_from_prs(open_prs) | set(extra_exclude)
+
+    KNOWN_LANES = {
+        "infrastructure",
+        "hub-admin",
+        "scitex-cloud",
+        "specialized-hub-admin",
+        "specialized-wsl-access",
+        "specialized-domain",
+    }
+
+    best_lane: dict | None = None
+    best_unlabelled: dict | None = None
+
+    for issue in issues or []:
+        num = int(issue.get("number") or 0)
+        if not num or num in claimed:
+            continue
+        if issue.get("assignees"):
+            continue
+        labels = _issue_labels(issue)
+        if audit_label in labels:
+            continue
+
+        if lane in labels and best_lane is None:
+            best_lane = {
+                "number": num,
+                "title": issue.get("title") or "",
+                "labels": sorted(labels),
+                "reason": f"lane={lane};direct-match",
+            }
+            continue
+
+        # Fall-back pool: high-priority without any recognised lane label.
+        has_any_lane = bool(labels & KNOWN_LANES)
+        if not has_any_lane and best_unlabelled is None:
+            best_unlabelled = {
+                "number": num,
+                "title": issue.get("title") or "",
+                "labels": sorted(labels),
+                "reason": "fallback=unlabelled-high-priority",
+            }
+
+    return best_lane or best_unlabelled
+
+
+def format_dispatch_reply(
+    pick: dict | None,
+    sender: str,
+    lane: str,
+    brief: str | None = None,
+) -> str:
+    """Compose the one-line DM reply in the `dispatch:` idiom (msg#16310)."""
+    if not pick:
+        return (
+            f"dispatch: none matching lane={lane} — "
+            f"no open high-priority todo fits {sender}. "
+            f"Stand by; I'll route when one appears."
+        )
+    title = pick.get("title") or ""
+    tail = f" — {brief}" if brief else ""
+    return f"dispatch: todo#{pick['number']} — {title}{tail}"
+
+
+def handle_hungry_message(
+    text: str,
+    issues: list[dict],
+    open_prs: list[dict],
+    brief: str | None = None,
+    audit_label: str = AUDIT_REVIEW_LABEL,
+) -> dict | None:
+    """One-shot: parse a DM, pick a todo, format a reply.
+
+    Returns ``None`` when ``text`` is not a hungry signal. Otherwise
+    returns a dict with ``sender``, ``lane``, ``pick`` (or ``None``), and
+    ``reply`` (the text lead should DM back).
+    """
+    parsed = parse_hungry_signal(text)
+    if not parsed:
+        return None
+    pick = pick_for_lane(issues, open_prs, parsed["lane"], audit_label=audit_label)
+    return {
+        "sender": parsed["sender"],
+        "lane": parsed["lane"],
+        "pick": pick,
+        "reply": format_dispatch_reply(pick, parsed["sender"], parsed["lane"], brief),
+    }
+
+
+# -----------------------------------------------------------------------------
+# CLI — shell out to gh for issues + PRs. Useful for out-of-band smoke tests.
+# -----------------------------------------------------------------------------
+
+
+def _gh_json(args: list[str]) -> list[dict]:
+    try:
+        out = subprocess.run(
+            ["gh", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        ).stdout
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+    try:
+        data = json.loads(out or "[]")
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _fetch_todo_context(repo: str, limit: int = 50) -> tuple[list[dict], list[dict]]:
+    issues = _gh_json(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            "high-priority",
+            "--json",
+            "number,title,labels,assignees",
+            "--limit",
+            str(limit),
+        ]
+    )
+    open_prs = _gh_json(
+        [
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "title,body",
+            "--limit",
+            "100",
+        ]
+    )
+    return issues, open_prs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--text",
+        help="hungry-signal DM text to parse + respond to. If omitted, read stdin.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=TODO_REPO,
+        help=f"todo repo (default: {TODO_REPO})",
+    )
+    parser.add_argument(
+        "--brief",
+        default=None,
+        help="optional brief appended to the reply",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="max issues to fetch",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the full response dict as JSON on stdout",
+    )
+    args = parser.parse_args()
+
+    text = args.text
+    if not text:
+        text = sys.stdin.read()
+
+    issues, open_prs = _fetch_todo_context(args.repo, limit=args.limit)
+    result = handle_hungry_message(text, issues, open_prs, brief=args.brief)
+
+    if result is None:
+        print("not-a-hungry-signal", file=sys.stderr)
+        return 2
+
+    if args.json:
+        sys.stdout.write(json.dumps(result, separators=(",", ":")) + "\n")
+    else:
+        sys.stdout.write(result["reply"] + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_orochi/_skills/scitex-orochi/fleet-hungry-signal-protocol.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/fleet-hungry-signal-protocol.md
@@ -1,0 +1,107 @@
+---
+name: orochi-fleet-hungry-signal-protocol
+description: Layer 2 coordinated dispatch — idle heads DM lead ("ready for dispatch"), lead responds with a chosen high-priority todo + brief. Companion to the auto-dispatch-probe Layer 1 (PR #320) which handles "grab-anything-local"; this layer routes with context.
+---
+
+# Fleet Hungry-Signal Protocol (Layer 2 coordinated dispatch)
+
+> **Status**: canonical, landed with PR feat/hungry-signal-layer2 (lead
+> msg#16310).
+>
+> Layer 1 is `scripts/client/auto-dispatch-probe.sh` (PR #320): idle heads
+> auto-claim any local-lane high-priority todo. That fixes "idle =
+> forbidden" but routes blindly. Layer 2 adds a coordinated path so lead
+> can pick a better-matched todo with context.
+
+## Why
+
+Layer 1 grabs whatever matches the head's lane label. That's fast but
+can fork subagents onto low-relevance todos while a higher-relevance
+todo (out of lane, or mis-labelled) waits. Layer 2 adds an "intentional
+pickup" path: an idle head tells lead it's ready; lead picks with full
+fleet context (claimed PRs, audit-review flags, cross-lane priorities)
+and replies with a todo number + one-line brief.
+
+## Wire format
+
+### Head → lead DM
+
+Sent by `scripts/client/hungry-signal.sh` on a 10-min cadence when the
+head has seen `subagent_count == 0` for `HUNGRY_THRESHOLD=2` consecutive
+cycles (≈ 20 min of real idleness).
+
+Canonical DM channel: `dm:agent:<sorted-pair>` (matches the hub's
+`_openAgentDmSimple` helper in `hub/static/hub/app/agent-actions.js`).
+
+Text format (exact, so lead can parse):
+
+    head-<hostname>: hungry — 0 subagents × <N> cycles, ready for dispatch. lane: <label>, alive: <comma-sep-agent-list>
+
+Example (verbatim from a real run):
+
+    head-mba: hungry — 0 subagents × 2 cycles, ready for dispatch. lane: infrastructure, alive: head-mba,healer-mba
+
+### Lead → head reply
+
+One-line DM in the same channel. Format:
+
+    dispatch: todo#<N> — <title> — <brief>
+
+…or, when nothing matches:
+
+    dispatch: none matching lane=<label> — no open high-priority todo fits <head>. Stand by; I'll route when one appears.
+
+## Lead-side responsibilities
+
+When lead sees a DM whose text matches
+`^head-[\w.-]+: hungry .* lane: <label>` in any of its DM channels:
+
+1. **Parse** the sender (`head-<hostname>`) and lane (label).
+2. **Fetch context**:
+
+       gh issue list --repo ywatanabe1989/todo --state open \
+           --label high-priority --json number,title,labels,assignees
+       gh pr list --repo ywatanabe1989/todo --state open \
+           --json title,body
+
+3. **Filter** — in this order:
+   - Skip any issue whose number appears in an open PR title/body
+     (already claimed).
+   - Skip any issue carrying the `audit-review-2026-04-22` label
+     (stale-under-review).
+   - Skip any issue already assigned to a human (explicit ownership).
+4. **Pick**:
+   - Prefer the first issue with the sender's lane label.
+   - Fall back to the first unlabelled high-priority issue (no lane
+     tag at all). Do **not** pick an issue carrying a *different*
+     lane's label — that's someone else's lane.
+5. **Reply** in the same DM channel with the `dispatch: todo#<N> …`
+   format above.
+
+The canonical implementation of steps 2–5 is
+`scripts/server/hungry-signal-handler.py` — it can be imported as a
+library (`handle_hungry_message(text, issues, open_prs)`) or shelled
+out as a CLI. Reuse it rather than reimplementing in-context to avoid
+drift.
+
+## Spam guard
+
+The head-side probe writes a "fired" marker into
+`~/.local/state/scitex/hungry-signal.state` once a DM is posted, and
+only clears it on the next non-zero `subagent_count` reading. This
+means lead receives at most **one hungry DM per idle stretch** per
+head. If lead is slow to reply (or unavailable), the head does not
+re-DM until it's had at least one non-zero cycle.
+
+## Related
+
+- Layer 1: `scripts/client/auto-dispatch-probe.sh` (PR #320) —
+  "idle = forbidden" via local auto-claim.
+- Install: `scripts/client/install-hungry-signal.sh` — LaunchAgent /
+  systemd timer / cron, 10-min cadence.
+- Kill switch: `SCITEX_HUNGRY_DISABLED=1` on the head's env.
+- State file: `~/.local/state/scitex/hungry-signal.state` (single line
+  per head — cycles, fired flag, last-update epoch).
+- Tests: `tests/test_hungry_signal_handler.py` (pure-function picker)
+  and `tests/test_hungry_signal_counter.py` (state-machine integration
+  via a stubbed sac).

--- a/tests/test_hungry_signal_counter.py
+++ b/tests/test_hungry_signal_counter.py
@@ -1,0 +1,202 @@
+"""Integration test for scripts/client/hungry-signal.sh state-machine.
+
+Drives the real bash probe in --dry-run mode against a stubbed
+``scitex-agent-container`` binary so we can assert:
+
+* The consecutive-zero counter increments on each zero reading.
+* A non-zero reading resets counter + fired flag.
+* The DM fires once when the threshold is met and then the fired flag
+  is set (spam guard).
+* --dry-run never writes to the state file (so real runs aren't masked
+  by observation-mode ticks).
+
+We inject a stub sac via PATH so the probe calls our fake instead of
+the real binary. PATH=<tmpdir>:... puts our fake first.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROBE = REPO_ROOT / "scripts" / "client" / "hungry-signal.sh"
+MACHINES_YAML_FIXTURE = textwrap.dedent(
+    """\
+    machines:
+      - canonical_name: mba
+        fleet_role:
+          role: head
+      - canonical_name: nas
+        fleet_role:
+          role: head
+    """
+)
+
+
+def _write_stub_sac(tmpdir: Path, subagent_count: int) -> Path:
+    """Write a stub scitex-agent-container that returns the desired count."""
+    bin_dir = tmpdir / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "scitex-agent-container"
+    payload = [
+        {
+            "name": "head-mba",
+            "status": "online",
+            "subagent_count": subagent_count,
+        }
+    ]
+    # The stub must be robust to flag ordering — sac is called as
+    # "scitex-agent-container status --terse --json" so we just echo a
+    # fixed JSON doc regardless of argv.
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f"echo {json.dumps(json.dumps(payload))}\n"
+    )
+    stub.chmod(0o755)
+    return bin_dir
+
+
+def _invoke(
+    tmpdir: Path,
+    subagent_count: int,
+    *,
+    dry_run: bool = True,
+    threshold: int = 2,
+    state_dir: Path | None = None,
+) -> dict:
+    state_dir = state_dir or (tmpdir / "state")
+    state_dir.mkdir(exist_ok=True)
+    log_dir = tmpdir / "log"
+    log_dir.mkdir(exist_ok=True)
+    machines_yaml = tmpdir / "orochi-machines.yaml"
+    machines_yaml.write_text(MACHINES_YAML_FIXTURE)
+
+    stub_bindir = _write_stub_sac(tmpdir, subagent_count)
+    env = {
+        **os.environ,
+        "PATH": f"{stub_bindir}:{os.environ.get('PATH', '')}",
+        "MACHINES_YAML": str(machines_yaml),
+        "HUNGRY_STATE_DIR": str(state_dir),
+        "HUNGRY_STATE_FILE": str(state_dir / "hungry-signal.state"),
+        "HUNGRY_LOG_DIR": str(log_dir),
+        "HUNGRY_THRESHOLD": str(threshold),
+        # Force self-host to 'mba' so the probe targets our stub regardless
+        # of the box the test runs on.
+        "SCITEX_OROCHI_HOSTNAME": "mba",
+        # Make sure we don't accidentally hit the network in --dry-run.
+        "SCITEX_OROCHI_TOKEN": "",
+    }
+    args = ["bash", str(PROBE)]
+    if dry_run:
+        args.append("--dry-run")
+    else:
+        args.append("--yes")
+    proc = subprocess.run(
+        args, capture_output=True, text=True, env=env, timeout=30
+    )
+    stdout = proc.stdout.strip()
+    # Parse the last NDJSON line emitted.
+    lines = [ln for ln in stdout.splitlines() if ln.startswith("{")]
+    assert lines, f"probe emitted no NDJSON: rc={proc.returncode} out={stdout!r} err={proc.stderr!r}"
+    return json.loads(lines[-1])
+
+
+def _read_state(state_dir: Path) -> dict | None:
+    f = state_dir / "hungry-signal.state"
+    if not f.exists():
+        return None
+    line = f.read_text().strip()
+    if not line:
+        return None
+    # <host>\t<cycles>\t<fired>\t<epoch>
+    parts = line.split("\t")
+    if len(parts) < 4:
+        return None
+    return {"host": parts[0], "cycles": int(parts[1]), "fired": int(parts[2])}
+
+
+# -----------------------------------------------------------------------------
+# Counter semantics — the heart of the spam guard.
+# -----------------------------------------------------------------------------
+
+
+def test_dry_run_never_writes_state_file(tmp_path):
+    """dry-run must not touch the state file — real runs would be masked."""
+    state_dir = tmp_path / "state"
+    result = _invoke(tmp_path, subagent_count=0, dry_run=True, threshold=2, state_dir=state_dir)
+    assert result["decision"] in {"counting", "would_dm"}
+    assert _read_state(state_dir) is None
+
+
+def test_counter_increments_on_repeated_zero(tmp_path):
+    """Two --yes ticks at subagent_count=0 → counter reaches threshold."""
+    state_dir = tmp_path / "state"
+
+    # Tick 1: first zero. cycles=1, below threshold=2 → "counting".
+    r1 = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=2, state_dir=state_dir)
+    assert r1["decision"] == "counting"
+    assert r1["consecutive_zero_cycles"] == 1
+    assert r1["fired"] is False
+    s1 = _read_state(state_dir)
+    assert s1 is not None
+    assert s1["cycles"] == 1
+    assert s1["fired"] == 0
+
+    # Tick 2: second zero. cycles=2, hits threshold. Would DM lead, but the
+    # hub call will fail (no token) so decision=dm_failed. Either way, the
+    # state file must record cycles=2 (fired depends on outcome).
+    r2 = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=2, state_dir=state_dir)
+    assert r2["decision"] in {"dm_sent", "dm_failed"}
+    assert r2["consecutive_zero_cycles"] == 2
+    s2 = _read_state(state_dir)
+    assert s2 is not None
+    assert s2["cycles"] == 2
+
+
+def test_non_zero_reading_resets_counter(tmp_path):
+    """A healthy tick wipes cycles + fired flag so the next idle stretch starts fresh."""
+    state_dir = tmp_path / "state"
+
+    # Start with a zero to plant cycles=1.
+    _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=2, state_dir=state_dir)
+    assert _read_state(state_dir)["cycles"] == 1
+
+    # Non-zero reading resets to 0/0.
+    r = _invoke(tmp_path, subagent_count=2, dry_run=False, threshold=2, state_dir=state_dir)
+    assert r["decision"] == "noop"
+    assert r["consecutive_zero_cycles"] == 0
+    s = _read_state(state_dir)
+    assert s["cycles"] == 0
+    assert s["fired"] == 0
+
+
+def test_already_fired_flag_suppresses_duplicate_dm(tmp_path):
+    """Once fired=1 is armed, further zero ticks must not re-fire."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    # Seed state: cycles=5, fired=1 (as if we DM'd 3 cycles ago and heard nothing).
+    (state_dir / "hungry-signal.state").write_text("mba\t5\t1\t0\n")
+
+    r = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=2, state_dir=state_dir)
+    assert r["decision"] == "skip"
+    assert r["reason"] == "already_fired_awaiting_reset"
+    assert r["fired"] is True
+    # cycles continues to increment so we can see how long the idle stretch
+    # has been going (visibility), but no DM.
+    assert r["consecutive_zero_cycles"] == 6
+
+
+def test_non_zero_clears_prior_fired_flag(tmp_path):
+    """Once the head is busy again, the spam-guard flag releases."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "hungry-signal.state").write_text("mba\t5\t1\t0\n")
+
+    _invoke(tmp_path, subagent_count=1, dry_run=False, threshold=2, state_dir=state_dir)
+    s = _read_state(state_dir)
+    assert s["cycles"] == 0
+    assert s["fired"] == 0

--- a/tests/test_hungry_signal_handler.py
+++ b/tests/test_hungry_signal_handler.py
@@ -1,0 +1,240 @@
+"""Unit tests for scripts/server/hungry-signal-handler.py (Layer 2 — lead-side).
+
+Exercise the pure-function core of the lead-side responder:
+
+* ``parse_hungry_signal`` — DM format round-trips
+* ``pick_for_lane``       — skips claimed + audit-flagged + assigned issues;
+                             prefers lane match; falls back to unlabelled
+* ``format_dispatch_reply`` + ``handle_hungry_message`` — end-to-end shape
+
+No network — ``gh`` is never shelled out in these tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HANDLER = REPO_ROOT / "scripts" / "server" / "hungry-signal-handler.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("hungry_signal_handler", HANDLER)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+handler = _load_module()
+
+
+# -----------------------------------------------------------------------------
+# parse_hungry_signal
+# -----------------------------------------------------------------------------
+
+
+def test_parse_hungry_signal_canonical_shape():
+    text = (
+        "head-mba: hungry — 0 subagents × 2 cycles, ready for dispatch. "
+        "lane: infrastructure, alive: head-mba,healer-mba"
+    )
+    got = handler.parse_hungry_signal(text)
+    assert got == {"sender": "head-mba", "lane": "infrastructure"}
+
+
+def test_parse_hungry_signal_handles_multi_word_lane():
+    text = (
+        "head-ywata-note-win: hungry — 0 subagents × 2 cycles, ready for "
+        "dispatch. lane: specialized-wsl-access, alive: head-ywata-note-win"
+    )
+    got = handler.parse_hungry_signal(text)
+    assert got is not None
+    assert got["sender"] == "head-ywata-note-win"
+    assert got["lane"] == "specialized-wsl-access"
+
+
+def test_parse_hungry_signal_rejects_unrelated_dm():
+    assert handler.parse_hungry_signal("hey lead, ping") is None
+    assert handler.parse_hungry_signal("") is None
+    assert handler.parse_hungry_signal(None) is None  # type: ignore[arg-type]
+
+
+def test_parse_hungry_signal_rejects_malformed_no_lane():
+    # Missing "lane: ..." segment — refuse rather than guess.
+    text = "head-mba: hungry — 0 subagents × 2 cycles, ready for dispatch."
+    assert handler.parse_hungry_signal(text) is None
+
+
+# -----------------------------------------------------------------------------
+# claimed_numbers_from_prs
+# -----------------------------------------------------------------------------
+
+
+def test_claimed_numbers_from_prs_collects_title_and_body():
+    prs = [
+        {"title": "fix(scope): thing (#123)", "body": "also closes #124"},
+        {"title": "no refs here", "body": ""},
+        {"title": "chore: drop stale flag", "body": "refs todo#300"},
+    ]
+    assert handler.claimed_numbers_from_prs(prs) == {123, 124, 300}
+
+
+# -----------------------------------------------------------------------------
+# pick_for_lane
+# -----------------------------------------------------------------------------
+
+
+def _issue(num, *labels, assignees=(), title=None):
+    return {
+        "number": num,
+        "title": title or f"feat: thing {num}",
+        "labels": [{"name": lab} for lab in labels],
+        "assignees": list(assignees),
+    }
+
+
+def test_pick_for_lane_returns_first_lane_match():
+    issues = [
+        _issue(100, "high-priority", "infrastructure"),
+        _issue(101, "high-priority", "scitex-cloud"),
+        _issue(102, "high-priority", "infrastructure"),
+    ]
+    got = handler.pick_for_lane(issues, open_prs=[], lane="infrastructure")
+    assert got is not None
+    assert got["number"] == 100
+    assert "direct-match" in got["reason"]
+
+
+def test_pick_for_lane_skips_issues_claimed_by_open_pr():
+    issues = [
+        _issue(200, "high-priority", "infrastructure"),
+        _issue(201, "high-priority", "infrastructure"),
+    ]
+    open_prs = [{"title": "wip: #200", "body": ""}]
+    got = handler.pick_for_lane(issues, open_prs, lane="infrastructure")
+    assert got is not None
+    assert got["number"] == 201
+
+
+def test_pick_for_lane_skips_audit_review_label():
+    issues = [
+        _issue(300, "high-priority", "infrastructure", handler.AUDIT_REVIEW_LABEL),
+        _issue(301, "high-priority", "infrastructure"),
+    ]
+    got = handler.pick_for_lane(issues, open_prs=[], lane="infrastructure")
+    assert got is not None
+    assert got["number"] == 301
+
+
+def test_pick_for_lane_custom_audit_label_argument_overrides_default():
+    issues = [
+        _issue(310, "high-priority", "infrastructure", "custom-audit-flag"),
+        _issue(311, "high-priority", "infrastructure"),
+    ]
+    got = handler.pick_for_lane(
+        issues, open_prs=[], lane="infrastructure", audit_label="custom-audit-flag"
+    )
+    assert got is not None
+    assert got["number"] == 311
+
+
+def test_pick_for_lane_skips_issues_already_assigned():
+    issues = [
+        _issue(400, "high-priority", "infrastructure", assignees=[{"login": "alice"}]),
+        _issue(401, "high-priority", "infrastructure"),
+    ]
+    got = handler.pick_for_lane(issues, open_prs=[], lane="infrastructure")
+    assert got is not None
+    assert got["number"] == 401
+
+
+def test_pick_for_lane_falls_back_to_unlabelled_when_no_lane_match():
+    issues = [
+        _issue(500, "high-priority", "scitex-cloud"),   # wrong lane
+        _issue(501, "high-priority"),                    # unlabelled: eligible fallback
+        _issue(502, "high-priority", "hub-admin"),       # wrong lane
+    ]
+    got = handler.pick_for_lane(issues, open_prs=[], lane="infrastructure")
+    assert got is not None
+    assert got["number"] == 501
+    assert "fallback" in got["reason"]
+
+
+def test_pick_for_lane_prefers_direct_match_over_fallback():
+    # Unlabelled issue first in list, direct lane match later: direct
+    # match must still win over the fallback to preserve routing quality.
+    issues = [
+        _issue(600, "high-priority"),                       # unlabelled fallback
+        _issue(601, "high-priority", "infrastructure"),      # direct match
+    ]
+    got = handler.pick_for_lane(issues, open_prs=[], lane="infrastructure")
+    assert got is not None
+    assert got["number"] == 601
+
+
+def test_pick_for_lane_extra_exclude_skips_recently_dispatched():
+    issues = [
+        _issue(700, "high-priority", "infrastructure"),
+        _issue(701, "high-priority", "infrastructure"),
+    ]
+    got = handler.pick_for_lane(
+        issues, open_prs=[], lane="infrastructure", extra_exclude=[700]
+    )
+    assert got is not None
+    assert got["number"] == 701
+
+
+def test_pick_for_lane_returns_none_when_nothing_eligible():
+    # Everything is either claimed, assigned, or audit-flagged → None.
+    issues = [
+        _issue(800, "high-priority", "infrastructure", assignees=[{"login": "a"}]),
+        _issue(801, "high-priority", "infrastructure", handler.AUDIT_REVIEW_LABEL),
+    ]
+    open_prs = [{"title": "#801", "body": ""}]
+    got = handler.pick_for_lane(issues, open_prs, lane="infrastructure")
+    assert got is None
+
+
+# -----------------------------------------------------------------------------
+# format_dispatch_reply / handle_hungry_message
+# -----------------------------------------------------------------------------
+
+
+def test_format_dispatch_reply_shape_with_brief():
+    pick = {"number": 42, "title": "feat: do thing", "reason": ""}
+    reply = handler.format_dispatch_reply(
+        pick, sender="head-mba", lane="infrastructure", brief="land PR first"
+    )
+    assert reply.startswith("dispatch: todo#42 — feat: do thing")
+    assert "land PR first" in reply
+
+
+def test_format_dispatch_reply_none_match_explicit():
+    reply = handler.format_dispatch_reply(
+        None, sender="head-mba", lane="infrastructure"
+    )
+    assert "dispatch: none" in reply
+    assert "head-mba" in reply
+    assert "infrastructure" in reply
+
+
+def test_handle_hungry_message_end_to_end():
+    dm_text = (
+        "head-mba: hungry — 0 subagents × 2 cycles, ready for dispatch. "
+        "lane: infrastructure, alive: head-mba"
+    )
+    issues = [
+        _issue(900, "high-priority", "infrastructure", title="feat: ship layer-2"),
+    ]
+    result = handler.handle_hungry_message(dm_text, issues, [])
+    assert result is not None
+    assert result["sender"] == "head-mba"
+    assert result["lane"] == "infrastructure"
+    assert result["pick"]["number"] == 900
+    assert "todo#900" in result["reply"]
+
+
+def test_handle_hungry_message_returns_none_on_unrelated_dm():
+    assert handler.handle_hungry_message("hi lead", [], []) is None


### PR DESCRIPTION
## Summary

- **Layer 2 coordinated dispatch** (lead msg#16310). Layer 1 (`auto-dispatch-probe`, PR #320) handles "grab-anything-local"; Layer 2 adds "intentional pickup": an idle head DMs `lead` after 2 consecutive zero-subagent cycles, and lead replies with a high-priority todo chosen with full fleet context (claimed PRs, audit-review flags, cross-lane priorities).
- New head-side probe `scripts/client/hungry-signal.sh` on a **10-min cadence** with `HUNGRY_THRESHOLD=2` → DM fires after ~20 min of real idleness. State machine increments cycles on zero readings, resets on non-zero, and arms a `fired` flag so lead receives **at most one DM per idle stretch per head** (spam guard).
- Lead-side handler `scripts/server/hungry-signal-handler.py` is both a pure-function library (`handle_hungry_message`) for in-context use from lead's Claude pane *and* a standalone CLI for out-of-band smoke tests. Filter order: skip claimed → skip audit-review-labelled → skip assigned; prefer lane match, fall back to unlabelled high-priority.
- Canonical DM channel `dm:agent:<sorted-pair>` matches the hub's existing `_openAgentDmSimple` helper.
- Install helper `scripts/client/install-hungry-signal.sh` uses the **stable-bin-path pattern** (mirrors PR #326 todo#466): copies the probe to `~/.scitex/orochi/bin/` and injects `SCITEX_OROCHI_REPO_ROOT` so feature-branch checkouts can't 404 the scheduler.
- Skill doc at `src/scitex_orochi/_skills/scitex-orochi/fleet-hungry-signal-protocol.md` so lead reads it on boot and follows the protocol without re-implementing in-context.
- Kill switch: `SCITEX_HUNGRY_DISABLED=1` (silent no-op).
- Defaults: installer `--yes` (DM enabled); `--dry-run-only` logs would-DM without hub calls. Destructive kill switches are opt-in only.

## Components

| Surface | File | Purpose |
|---|---|---|
| Head probe | `scripts/client/hungry-signal.sh` | Counter-based DM emitter |
| Lead handler | `scripts/server/hungry-signal-handler.py` | Parser + picker + reply formatter |
| Install | `scripts/client/install-hungry-signal.sh` | LaunchAgent / systemd / cron |
| LaunchAgent | `deployment/host-setup/launchd/com.scitex.hungry-signal.plist` | macOS 10-min schedule |
| systemd | `deployment/host-setup/systemd/scitex-hungry-signal.{service,timer}` | Linux 10-min schedule |
| Skill doc | `src/scitex_orochi/_skills/scitex-orochi/fleet-hungry-signal-protocol.md` | Protocol reference |
| Tests | `tests/test_hungry_signal_handler.py` (18) | DM parse + picker filters |
| Tests | `tests/test_hungry_signal_counter.py` (5) | State-machine integration against stubbed sac |

## Test plan

- [x] `pytest tests/test_hungry_signal_handler.py tests/test_hungry_signal_counter.py -v` — 23/23 pass
- [x] `pytest tests/` full suite — 121 pass, no regressions (DB-bound tests unaffected)
- [x] `ruff check src/ tests/` — clean
- [x] Smoke: `bash scripts/client/hungry-signal.sh --dry-run` against a stubbed sac — emits schema-v1 NDJSON with `decision=counting`, does not touch state file
- [x] Smoke: CLI handler parses a real hungry-DM and returns `dispatch: todo#<N>` against live `ywatanabe1989/todo`
- [ ] Post-merge: re-run `scripts/client/install-hungry-signal.sh` on mba / nas / spartan / ywata-note-win to wire the 10-min cadence
- [ ] Post-merge: confirm first hungry DM arrives at lead within ~20 min of a forced idle stretch; verify lead replies with `dispatch: todo#<N>`

## Constraints honoured

- No `ts-migration-v2` touched.
- No `hub/frontend/` or `hub/static/hub/` touched.
- No destructive kill-switch default. Kill switch is opt-in via env var.
- No commits to Orochi chat; head-mba will relay.

## Judgment calls

1. **New script vs `--mode=hungry` flag on `auto-dispatch-probe.sh`.** Spec allowed either. Went with a new script because the state machines are fundamentally different (Layer 1: cooldown + single-shot dispatch; Layer 2: consecutive-zero counter + one-DM-per-stretch spam guard). The shared idioms — lane map, machines-yaml parse, hub token resolution, NDJSON shape — are duplicated rather than extracted into a third common module, to keep each script self-contained and resistant to the other's changes.
2. **State-file location.** `~/.local/state/scitex/hungry-signal.state` (linux + mac) — same dir as `auto-dispatch.state` so operators have one place to look. Log dir still splits on OS per the existing convention.
3. **sac → hub fallback for subagent_count.** The probe prefers local `scitex-agent-container status --terse --json` because sac heartbeat is the source of truth and works even when the hub is unreachable. Hub `/api/agents/` is the fallback. This matches the existing Layer 1 approach but adds cross-host resilience.
4. **Lead handler shape.** Skill doc + pure-function library + standalone CLI. Most use will be in-context from lead's pane (call `handle_hungry_message()` directly). The CLI exists for smoke tests and for hosts where lead is offline. A standalone daemon felt overkill given lead already reads DMs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
