### PR TITLE
feat(ui/overview,agents): Overview = Viz only, Agents tab = List only (msg#16337)

### DIFF
--- a/hub/frontend/src/activity-tab/controls.ts
+++ b/hub/frontend/src/activity-tab/controls.ts
@@ -10,15 +10,20 @@ export var _overviewControlsWired = false;
 export function _wireOverviewControls() {
   if (_overviewControlsWired) return;
   var sortSelect = document.getElementById("activity-sort-select");
-  var viewSwitch = document.querySelector(".activity-view-switch");
   var colorSelect = document.getElementById("activity-color-select");
   var sizeSelect = document.getElementById("activity-size-select");
-  if (!sortSelect || !viewSwitch) return;
-  sortSelect.value = (globalThis as any)._overviewSort;
-  /* Legacy localStorage value "tiled" -> fall back to "list" since the
-   * switch is now binary (Viz / List). "topology" still accepted. */
-  if ((globalThis as any)._overviewView !== "list" && (globalThis as any)._overviewView !== "topology")
-    (globalThis as any)._overviewView = "list";
+  /* msg#16337: Overview is Viz-only; the List subtab (and its switch
+   * button) has been removed from the template. The remaining controls
+   * (sort / color live in the sidebar, size lives inline here) don't
+   * gate on the view switch. Keep going even when the switch is
+   * absent — skipping early here used to short-circuit the size
+   * dropdown wiring too. */
+  if (sortSelect) sortSelect.value = (globalThis as any)._overviewSort;
+  /* Overview is Viz-only — force the globalThis mirror to "topology"
+   * so row.ts/topology.ts dispatch always lands on the graph branch,
+   * regardless of any stale localStorage value that snuck past the
+   * state.ts migration. */
+  (globalThis as any)._overviewView = "topology";
   if (colorSelect) colorSelect.value = (globalThis as any)._overviewColor;
   if (sizeSelect) sizeSelect.value = (globalThis as any)._topoSizeBy;
   /* Filter input removed — users filter via the global Ctrl+K fuzzy
@@ -26,41 +31,20 @@ export function _wireOverviewControls() {
    * 19: "filtering should be always Ctrl K in the scope"). The module
    * var (globalThis as any)._overviewFilter stays zero so the old filter logic is a no-op. */
   (globalThis as any)._overviewFilter = "";
-  function _setViewBtnActive() {
-    viewSwitch
-      .querySelectorAll(".activity-view-switch-btn")
-      .forEach(function (b) {
-        b.classList.toggle(
-          "active",
-          b.getAttribute("data-view") === (globalThis as any)._overviewView,
-        );
-      });
+  if (sortSelect) {
+    sortSelect.addEventListener("change", function () {
+      (globalThis as any)._overviewSort = sortSelect.value;
+      try {
+        localStorage.setItem("orochi.overviewSort", (globalThis as any)._overviewSort);
+      } catch (_e) {}
+      renderActivityTab();
+      /* The sort dropdown now also drives the sidebar AGENTS list
+       * (ywatanabe 2026-04-21). Re-run fetchAgents on the existing
+       * cached payload so the new order takes effect without waiting
+       * for the next heartbeat. */
+      if (typeof fetchAgents === "function") fetchAgents();
+    });
   }
-  _setViewBtnActive();
-  sortSelect.addEventListener("change", function () {
-    (globalThis as any)._overviewSort = sortSelect.value;
-    try {
-      localStorage.setItem("orochi.overviewSort", (globalThis as any)._overviewSort);
-    } catch (_e) {}
-    renderActivityTab();
-    /* The sort dropdown now also drives the sidebar AGENTS list
-     * (ywatanabe 2026-04-21). Re-run fetchAgents on the existing
-     * cached payload so the new order takes effect without waiting
-     * for the next heartbeat. */
-    if (typeof fetchAgents === "function") fetchAgents();
-  });
-  viewSwitch.addEventListener("click", function (ev) {
-    var btn = ev.target.closest(".activity-view-switch-btn[data-view]");
-    if (!btn) return;
-    var next = btn.getAttribute("data-view");
-    if (next === (globalThis as any)._overviewView) return;
-    (globalThis as any)._overviewView = next;
-    try {
-      localStorage.setItem("orochi.overviewView", (globalThis as any)._overviewView);
-    } catch (_e) {}
-    _setViewBtnActive();
-    renderActivityTab();
-  });
   if (colorSelect) {
     colorSelect.addEventListener("change", function () {
       (globalThis as any)._overviewColor = colorSelect.value;

--- a/hub/frontend/src/activity-tab/row.ts
+++ b/hub/frontend/src/activity-tab/row.ts
@@ -1,36 +1,21 @@
 // @ts-nocheck
-import { _fetchActivityDetail } from "./data";
-import { _activityPaneSshState } from "./detail-bind";
-import { _renderActivityAgentDetail } from "./detail";
-import { _wireOverviewGridDelegation } from "./grid-delegation";
-import { _colorKeyFor } from "./state";
 import { _renderActivityTopology } from "./topology";
-import { _computeAgentState, _formatIdle } from "./utils";
-import { renderAgentBadge } from "../agent-badge";
-import { cleanAgentName, escapeHtml, getAgentColor, hostedAgentName } from "../app/utils";
-import { runFilter } from "../filter/runner";
 
-/* activity-tab/row.js — overview list + tiled card renderer
- * (_renderActivityCards) and view-class toggle. */
+/* activity-tab/row.js — overview canvas renderer and view-class toggle.
+ *
+ * Historically this module also rendered an agent LIST (one-line rows
+ * or compact tiles) for the legacy Viz/List toggle inside Overview.
+ * msg#16337 retired that toggle: Overview is Viz-only, the Agents tab
+ * owns the list surface. The entry point below now just delegates to
+ * the topology renderer (after the summary-pill counts are updated),
+ * and the view-class helper always applies the topology CSS scope. */
 
 
-/* Overview list/tile renderer. One-line rows (or compact tiles) for
- * every agent passing the visibility rule. Click a row → inline expand
- * (single at a time). Expand is toggled via (globalThis as any)._overviewExpanded state.
- *
- * Each row carries THREE indicators so connection, heartbeat-age, and
- * LLM-level activity are all visible at a glance without opening the
- * detail panel:
- *
- *   WS LED       — WebSocket functional connection (status online/offline)
- *   Functional LED — heartbeat-age liveness (online/idle/stale/offline)
- *   State chip   — synthesized pane+tool state: running/idle/selecting
- *
- * Visibility rule (functional, NOT duration-based):
- *   status==="online" (WS connected)  → always shown (online/idle/stale)
- *   status==="offline" + pinned       → shown as ghost (dimmed)
- *   status==="offline" + unpinned     → hidden
- */
+/* Overview canvas renderer — updates the summary pill counts and
+ * delegates to the topology view. Kept under the legacy name
+ * _renderActivityCards so callers in init.ts don't have to be touched
+ * on every iteration of this refactor; the implementation is now a
+ * thin shim over _renderActivityTopology. */
 export function _renderActivityCards(agents, grid) {
   var summary = document.getElementById("activity-summary");
   var all = agents || [];
@@ -93,167 +78,13 @@ export function _renderActivityCards(agents, grid) {
     return;
   }
 
-  if ((globalThis as any)._overviewView === "topology") {
-    _renderActivityTopology(visible, grid);
-    return;
-  }
-
-  var LIVENESS_HINTS = {
-    online: "connected & active — heartbeat <2 min",
-    idle: "connected, quiet 2–10 min",
-    stale: "connected, quiet >10 min — probably stuck",
-    offline: "not connected",
-  };
-
-  /* Preserve a live SSH inline-detail block across heartbeat
-   * re-renders — otherwise grid.innerHTML = ... below would wipe the
-   * xterm DOM and kill the shell session. If the currently-expanded
-   * agent has an active SSH session, snapshot its inline-detail
-   * element and splice it back in after the grid is rebuilt. */
-  var _preservedInlineDetail = null;
-  if (
-    (globalThis as any)._overviewExpanded &&
-    _activityPaneSshState &&
-    _activityPaneSshState[(globalThis as any)._overviewExpanded]
-  ) {
-    var _liveInline = grid.querySelector(
-      '.activity-inline-detail[data-detail-for="' +
-        String((globalThis as any)._overviewExpanded).replace(/"/g, '\\"') +
-        '"]',
-    );
-    if (
-      _liveInline &&
-      _liveInline.querySelector(".agent-detail-ssh-container")
-    ) {
-      _preservedInlineDetail = _liveInline;
-    }
-  }
-
-  grid.innerHTML = visible
-    .map(function (a) {
-      var rawName = a.name || "";
-      var liveness = a.liveness || a.status || "online";
-      var connected = (a.status || "online") !== "offline";
-      /* Shadow treatment when not all four indicators are green —
-       * makes degraded agents visually distinct without hiding them.
-       * ywatanabe 2026-04-20: "Registered agents must be shown as
-       * shadowed when all LEDs not green". The four-LED green test
-       * mirrors the visibility filter above (which keeps an agent
-       * listed as long as ≥1 LED is green or it's starred). */
-      var pongAge =
-        a.last_pong_ts != null
-          ? (Date.now() - new Date(a.last_pong_ts).getTime()) / 1000
-          : null;
-      var echoAge =
-        a.last_nonce_echo_at != null
-          ? (Date.now() - new Date(a.last_nonce_echo_at).getTime()) / 1000
-          : null;
-      var allGreen =
-        connected &&
-        pongAge != null &&
-        pongAge < 60 &&
-        liveness === "online" &&
-        echoAge != null &&
-        echoAge < 90;
-      var ghostClass = allGreen ? "" : " activity-card-ghost";
-      var idleStr = _formatIdle(a.idle_seconds);
-      var color = getAgentColor(_colorKeyFor(a));
-      var channels = Array.isArray(a.channels) ? a.channels : [];
-      var channelsStr = channels
-        .filter(function (c) {
-          return c && c.indexOf("dm:") !== 0;
-        })
-        .join(" ");
-      var name = escapeHtml(
-        typeof hostedAgentName === "function"
-          ? hostedAgentName(a)
-          : cleanAgentName(rawName),
-      );
-      var pinOn = a.pinned ? " activity-pin-on" : "";
-      var pinTitle = a.pinned
-        ? "Unstar (will hide when offline)"
-        : "Star (keeps as ghost when offline, floats to top)";
-      var livenessHint = LIVENESS_HINTS[liveness] || liveness;
-      var wsHint = connected ? "WebSocket connected" : "WebSocket disconnected";
-      var state = _computeAgentState(a);
-      var stateLabel = state.toUpperCase();
-      var stateHint =
-        {
-          running: "LLM fired a tool within the last 30s",
-          idle: "connected, no recent tool calls",
-          selecting: "agent is blocked on a choice or needs attention",
-          offline: "not connected",
-        }[state] || state;
-      var ageStr = idleStr ? idleStr : "";
-      // Single source of truth — agent-badge.js. Same call appears in
-      // app.js sidebar and topology pool chip. NEVER fork the markup.
-      var row =
-        '<div class="activity-card activity-' +
-        liveness +
-        ghostClass +
-        '" data-agent="' +
-        escapeHtml(rawName) +
-        '" data-machine="' +
-        escapeHtml(a.machine || "") +
-        '">' +
-        renderAgentBadge(a) +
-        '<span class="activity-channels" title="' +
-        escapeHtml(channelsStr || "no channels") +
-        '">' +
-        escapeHtml(channelsStr) +
-        "</span>" +
-        (ageStr
-          ? '<span class="activity-age" title="' +
-            escapeHtml(livenessHint) +
-            '">' +
-            escapeHtml(ageStr) +
-            "</span>"
-          : "") +
-        "</div>";
-      if ((globalThis as any)._overviewExpanded === rawName) {
-        row +=
-          '<div class="activity-inline-detail" data-detail-for="' +
-          escapeHtml(rawName) +
-          '"><p class="empty-notice">Loading detail…</p></div>';
-      }
-      return row;
-    })
-    .join("");
-
-  if (typeof runFilter === "function") runFilter();
-
-  /* Single delegated click listener on the grid — bound ONCE, survives
-   * innerHTML rewrites (the grid element itself is never replaced).
-   * Per-element listeners were silently lost between heartbeat re-
-   * renders, causing the pin button to become unclickable after a poll
-   * tick (ywatanabe 2026-04-19). */
-  _wireOverviewGridDelegation(grid);
-
-  if ((globalThis as any)._overviewExpanded) {
-    var agent = all.find(function (a) {
-      return a.name === (globalThis as any)._overviewExpanded;
-    });
-    var inlineBox = grid.querySelector(
-      '.activity-inline-detail[data-detail-for="' +
-        String((globalThis as any)._overviewExpanded).replace(/"/g, '\\"') +
-        '"]',
-    );
-    /* SSH active: splice the preserved inline-detail (with its live
-     * xterm) back in place of the fresh loading placeholder, and
-     * SKIP the detail re-render so the DOM node the xterm lives in
-     * is not replaced. */
-    if (_preservedInlineDetail && inlineBox && inlineBox.parentNode) {
-      inlineBox.parentNode.replaceChild(_preservedInlineDetail, inlineBox);
-    } else if (agent && inlineBox) {
-      _renderActivityAgentDetail(agent, inlineBox);
-      _fetchActivityDetail(agent.name);
-    }
-  }
+  _renderActivityTopology(visible, grid);
 }
 
-/* Apply layout class (list vs tiled vs topology) to the overview grid.
- * The three modes are mutually exclusive CSS scopes — each adds one
- * class and the renderer dispatches on (globalThis as any)._overviewView internally. */
+/* Apply layout class to the overview grid. Overview is Viz-only
+ * (msg#16337) — the grid always runs topology. The older "list" and
+ * "tiled" CSS scopes are still removed defensively so a stale class
+ * from a prior render can't leak into the topology canvas. */
 export function _applyOverviewViewClass(grid) {
   if (!grid) return;
   grid.classList.remove(
@@ -262,9 +93,6 @@ export function _applyOverviewViewClass(grid) {
     "activity-view-topology",
     "activity-grid-detail",
   );
-  var cls = "activity-view-list";
-  if ((globalThis as any)._overviewView === "tiled") cls = "activity-view-tiled";
-  else if ((globalThis as any)._overviewView === "topology") cls = "activity-view-topology";
-  grid.classList.add(cls);
+  grid.classList.add("activity-view-topology");
 }
 

--- a/hub/frontend/src/activity-tab/state.ts
+++ b/hub/frontend/src/activity-tab/state.ts
@@ -29,9 +29,15 @@ export var ACTIVITY_FOLLOW_INTERVAL_MS = 3000;
 
 
 /* ── Overview controls state (filter / sort / view / color / expand) ── */
+/* Overview = Viz only (msg#16337). The Agents list lives in the
+ * dedicated Agents tab, so _overviewView is now effectively a constant
+ * "topology" — kept as a var (not a const) so existing code paths that
+ * branch on it still compile, and so future view-modes remain cheap to
+ * add. Any legacy localStorage value ("list" / "tiled") is migrated to
+ * "topology" on boot. */
 var _overviewFilter = "";
 var _overviewSort = "name";
-var _overviewView = "list";
+var _overviewView = "topology";
 var _overviewColor = "name";
 var _overviewExpanded = null;
 /* Topology channel-node size mode. "equal" = fixed radius; "subscribers" =
@@ -44,13 +50,17 @@ try {
   var _savedSort = localStorage.getItem("orochi.overviewSort");
   if (_savedSort === "name" || _savedSort === "machine")
     _overviewSort = _savedSort;
+  /* Overview is Viz-only now — ignore any legacy saved value and keep
+   * the constant "topology". The _overviewView localStorage key is
+   * retained only so code that reads it back elsewhere doesn't blow
+   * up; we actively migrate stale "list"/"tiled" values over. */
   var _savedView = localStorage.getItem("orochi.overviewView");
-  if (
-    _savedView === "list" ||
-    _savedView === "tiled" ||
-    _savedView === "topology"
-  )
-    _overviewView = _savedView;
+  if (_savedView && _savedView !== "topology") {
+    try {
+      localStorage.setItem("orochi.overviewView", "topology");
+    } catch (_e) {}
+  }
+  _overviewView = "topology";
   var _savedColor = localStorage.getItem("orochi.overviewColor");
   if (
     _savedColor === "name" ||

--- a/hub/frontend/src/tabs.ts
+++ b/hub/frontend/src/tabs.ts
@@ -329,6 +329,24 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
     if (hash === "terminal") {
       hash = "";
     }
+    /* msg#16337: Overview loses its Viz/List toggle — Overview is
+     * Viz-only, and the List surface moves to the dedicated Agents
+     * tab. If the user's last session had activity + list subview
+     * selected, redirect their next boot to the Agents tab so they
+     * land on the list they were looking at (not an empty graph).
+     * Graph/topology users on activity land on Overview as before.
+     * Consumes the legacy orochi.overviewView key one time and
+     * rewrites it to "topology" to match the new UI contract. */
+    if (last === "activity") {
+      try {
+        var _legacyOverviewView = localStorage.getItem("orochi.overviewView");
+        if (_legacyOverviewView === "list" || _legacyOverviewView === "tiled") {
+          last = "agents-tab";
+          localStorage.setItem("orochi.overviewView", "topology");
+          localStorage.setItem("orochi_active_tab", "agents-tab");
+        }
+      } catch (_) {}
+    }
     var target = hash || last || "activity";
     /* If the requested tab no longer has a DOM button, fall back to
      * Overview ("activity"). */

--- a/hub/static/hub/activity-tab/controls.js
+++ b/hub/static/hub/activity-tab/controls.js
@@ -5,15 +5,13 @@ var _overviewControlsWired = false;
 function _wireOverviewControls() {
   if (_overviewControlsWired) return;
   var sortSelect = document.getElementById("activity-sort-select");
-  var viewSwitch = document.querySelector(".activity-view-switch");
   var colorSelect = document.getElementById("activity-color-select");
   var sizeSelect = document.getElementById("activity-size-select");
-  if (!sortSelect || !viewSwitch) return;
-  sortSelect.value = _overviewSort;
-  /* Legacy localStorage value "tiled" -> fall back to "list" since the
-   * switch is now binary (Viz / List). "topology" still accepted. */
-  if (_overviewView !== "list" && _overviewView !== "topology")
-    _overviewView = "list";
+  /* msg#16337: Overview is Viz-only — no Viz/List switch in the
+   * template. Don't gate control wiring on the (now removed)
+   * .activity-view-switch element. */
+  if (sortSelect) sortSelect.value = _overviewSort;
+  _overviewView = "topology";
   if (colorSelect) colorSelect.value = _overviewColor;
   if (sizeSelect) sizeSelect.value = _topoSizeBy;
   /* Filter input removed — users filter via the global Ctrl+K fuzzy
@@ -21,41 +19,20 @@ function _wireOverviewControls() {
    * 19: "filtering should be always Ctrl K in the scope"). The module
    * var _overviewFilter stays zero so the old filter logic is a no-op. */
   _overviewFilter = "";
-  function _setViewBtnActive() {
-    viewSwitch
-      .querySelectorAll(".activity-view-switch-btn")
-      .forEach(function (b) {
-        b.classList.toggle(
-          "active",
-          b.getAttribute("data-view") === _overviewView,
-        );
-      });
+  if (sortSelect) {
+    sortSelect.addEventListener("change", function () {
+      _overviewSort = sortSelect.value;
+      try {
+        localStorage.setItem("orochi.overviewSort", _overviewSort);
+      } catch (_e) {}
+      renderActivityTab();
+      /* The sort dropdown now also drives the sidebar AGENTS list
+       * (ywatanabe 2026-04-21). Re-run fetchAgents on the existing
+       * cached payload so the new order takes effect without waiting
+       * for the next heartbeat. */
+      if (typeof fetchAgents === "function") fetchAgents();
+    });
   }
-  _setViewBtnActive();
-  sortSelect.addEventListener("change", function () {
-    _overviewSort = sortSelect.value;
-    try {
-      localStorage.setItem("orochi.overviewSort", _overviewSort);
-    } catch (_e) {}
-    renderActivityTab();
-    /* The sort dropdown now also drives the sidebar AGENTS list
-     * (ywatanabe 2026-04-21). Re-run fetchAgents on the existing
-     * cached payload so the new order takes effect without waiting
-     * for the next heartbeat. */
-    if (typeof fetchAgents === "function") fetchAgents();
-  });
-  viewSwitch.addEventListener("click", function (ev) {
-    var btn = ev.target.closest(".activity-view-switch-btn[data-view]");
-    if (!btn) return;
-    var next = btn.getAttribute("data-view");
-    if (next === _overviewView) return;
-    _overviewView = next;
-    try {
-      localStorage.setItem("orochi.overviewView", _overviewView);
-    } catch (_e) {}
-    _setViewBtnActive();
-    renderActivityTab();
-  });
   if (colorSelect) {
     colorSelect.addEventListener("change", function () {
       _overviewColor = colorSelect.value;

--- a/hub/static/hub/activity-tab/row.js
+++ b/hub/static/hub/activity-tab/row.js
@@ -1,24 +1,18 @@
-/* activity-tab/row.js — overview list + tiled card renderer
- * (_renderActivityCards) and view-class toggle. */
+/* activity-tab/row.js — overview canvas renderer and view-class toggle.
+ *
+ * Historically this module also rendered an agent LIST (one-line rows
+ * or compact tiles) for the legacy Viz/List toggle inside Overview.
+ * msg#16337 retired that toggle: Overview is Viz-only, the Agents tab
+ * owns the list surface. The entry point below now just delegates to
+ * the topology renderer (after the summary-pill counts are updated),
+ * and the view-class helper always applies the topology CSS scope. */
 
 
-/* Overview list/tile renderer. One-line rows (or compact tiles) for
- * every agent passing the visibility rule. Click a row → inline expand
- * (single at a time). Expand is toggled via _overviewExpanded state.
- *
- * Each row carries THREE indicators so connection, heartbeat-age, and
- * LLM-level activity are all visible at a glance without opening the
- * detail panel:
- *
- *   WS LED       — WebSocket functional connection (status online/offline)
- *   Functional LED — heartbeat-age liveness (online/idle/stale/offline)
- *   State chip   — synthesized pane+tool state: running/idle/selecting
- *
- * Visibility rule (functional, NOT duration-based):
- *   status==="online" (WS connected)  → always shown (online/idle/stale)
- *   status==="offline" + pinned       → shown as ghost (dimmed)
- *   status==="offline" + unpinned     → hidden
- */
+/* Overview canvas renderer — updates the summary pill counts and
+ * delegates to the topology view. Kept under the legacy name
+ * _renderActivityCards so callers in init.js don't have to be touched
+ * on every iteration of this refactor; the implementation is now a
+ * thin shim over _renderActivityTopology. */
 function _renderActivityCards(agents, grid) {
   var summary = document.getElementById("activity-summary");
   var all = agents || [];
@@ -81,167 +75,13 @@ function _renderActivityCards(agents, grid) {
     return;
   }
 
-  if (_overviewView === "topology") {
-    _renderActivityTopology(visible, grid);
-    return;
-  }
-
-  var LIVENESS_HINTS = {
-    online: "connected & active — heartbeat <2 min",
-    idle: "connected, quiet 2–10 min",
-    stale: "connected, quiet >10 min — probably stuck",
-    offline: "not connected",
-  };
-
-  /* Preserve a live SSH inline-detail block across heartbeat
-   * re-renders — otherwise grid.innerHTML = ... below would wipe the
-   * xterm DOM and kill the shell session. If the currently-expanded
-   * agent has an active SSH session, snapshot its inline-detail
-   * element and splice it back in after the grid is rebuilt. */
-  var _preservedInlineDetail = null;
-  if (
-    _overviewExpanded &&
-    _activityPaneSshState &&
-    _activityPaneSshState[_overviewExpanded]
-  ) {
-    var _liveInline = grid.querySelector(
-      '.activity-inline-detail[data-detail-for="' +
-        String(_overviewExpanded).replace(/"/g, '\\"') +
-        '"]',
-    );
-    if (
-      _liveInline &&
-      _liveInline.querySelector(".agent-detail-ssh-container")
-    ) {
-      _preservedInlineDetail = _liveInline;
-    }
-  }
-
-  grid.innerHTML = visible
-    .map(function (a) {
-      var rawName = a.name || "";
-      var liveness = a.liveness || a.status || "online";
-      var connected = (a.status || "online") !== "offline";
-      /* Shadow treatment when not all four indicators are green —
-       * makes degraded agents visually distinct without hiding them.
-       * ywatanabe 2026-04-20: "Registered agents must be shown as
-       * shadowed when all LEDs not green". The four-LED green test
-       * mirrors the visibility filter above (which keeps an agent
-       * listed as long as ≥1 LED is green or it's starred). */
-      var pongAge =
-        a.last_pong_ts != null
-          ? (Date.now() - new Date(a.last_pong_ts).getTime()) / 1000
-          : null;
-      var echoAge =
-        a.last_nonce_echo_at != null
-          ? (Date.now() - new Date(a.last_nonce_echo_at).getTime()) / 1000
-          : null;
-      var allGreen =
-        connected &&
-        pongAge != null &&
-        pongAge < 60 &&
-        liveness === "online" &&
-        echoAge != null &&
-        echoAge < 90;
-      var ghostClass = allGreen ? "" : " activity-card-ghost";
-      var idleStr = _formatIdle(a.idle_seconds);
-      var color = getAgentColor(_colorKeyFor(a));
-      var channels = Array.isArray(a.channels) ? a.channels : [];
-      var channelsStr = channels
-        .filter(function (c) {
-          return c && c.indexOf("dm:") !== 0;
-        })
-        .join(" ");
-      var name = escapeHtml(
-        typeof hostedAgentName === "function"
-          ? hostedAgentName(a)
-          : cleanAgentName(rawName),
-      );
-      var pinOn = a.pinned ? " activity-pin-on" : "";
-      var pinTitle = a.pinned
-        ? "Unstar (will hide when offline)"
-        : "Star (keeps as ghost when offline, floats to top)";
-      var livenessHint = LIVENESS_HINTS[liveness] || liveness;
-      var wsHint = connected ? "WebSocket connected" : "WebSocket disconnected";
-      var state = _computeAgentState(a);
-      var stateLabel = state.toUpperCase();
-      var stateHint =
-        {
-          running: "LLM fired a tool within the last 30s",
-          idle: "connected, no recent tool calls",
-          selecting: "agent is blocked on a choice or needs attention",
-          offline: "not connected",
-        }[state] || state;
-      var ageStr = idleStr ? idleStr : "";
-      // Single source of truth — agent-badge.js. Same call appears in
-      // app.js sidebar and topology pool chip. NEVER fork the markup.
-      var row =
-        '<div class="activity-card activity-' +
-        liveness +
-        ghostClass +
-        '" data-agent="' +
-        escapeHtml(rawName) +
-        '" data-machine="' +
-        escapeHtml(a.machine || "") +
-        '">' +
-        renderAgentBadge(a) +
-        '<span class="activity-channels" title="' +
-        escapeHtml(channelsStr || "no channels") +
-        '">' +
-        escapeHtml(channelsStr) +
-        "</span>" +
-        (ageStr
-          ? '<span class="activity-age" title="' +
-            escapeHtml(livenessHint) +
-            '">' +
-            escapeHtml(ageStr) +
-            "</span>"
-          : "") +
-        "</div>";
-      if (_overviewExpanded === rawName) {
-        row +=
-          '<div class="activity-inline-detail" data-detail-for="' +
-          escapeHtml(rawName) +
-          '"><p class="empty-notice">Loading detail…</p></div>';
-      }
-      return row;
-    })
-    .join("");
-
-  if (typeof runFilter === "function") runFilter();
-
-  /* Single delegated click listener on the grid — bound ONCE, survives
-   * innerHTML rewrites (the grid element itself is never replaced).
-   * Per-element listeners were silently lost between heartbeat re-
-   * renders, causing the pin button to become unclickable after a poll
-   * tick (ywatanabe 2026-04-19). */
-  _wireOverviewGridDelegation(grid);
-
-  if (_overviewExpanded) {
-    var agent = all.find(function (a) {
-      return a.name === _overviewExpanded;
-    });
-    var inlineBox = grid.querySelector(
-      '.activity-inline-detail[data-detail-for="' +
-        String(_overviewExpanded).replace(/"/g, '\\"') +
-        '"]',
-    );
-    /* SSH active: splice the preserved inline-detail (with its live
-     * xterm) back in place of the fresh loading placeholder, and
-     * SKIP the detail re-render so the DOM node the xterm lives in
-     * is not replaced. */
-    if (_preservedInlineDetail && inlineBox && inlineBox.parentNode) {
-      inlineBox.parentNode.replaceChild(_preservedInlineDetail, inlineBox);
-    } else if (agent && inlineBox) {
-      _renderActivityAgentDetail(agent, inlineBox);
-      _fetchActivityDetail(agent.name);
-    }
-  }
+  _renderActivityTopology(visible, grid);
 }
 
-/* Apply layout class (list vs tiled vs topology) to the overview grid.
- * The three modes are mutually exclusive CSS scopes — each adds one
- * class and the renderer dispatches on _overviewView internally. */
+/* Apply layout class to the overview grid. Overview is Viz-only
+ * (msg#16337) — the grid always runs topology. The older "list" and
+ * "tiled" CSS scopes are still removed defensively so a stale class
+ * from a prior render can't leak into the topology canvas. */
 function _applyOverviewViewClass(grid) {
   if (!grid) return;
   grid.classList.remove(
@@ -250,9 +90,5 @@ function _applyOverviewViewClass(grid) {
     "activity-view-topology",
     "activity-grid-detail",
   );
-  var cls = "activity-view-list";
-  if (_overviewView === "tiled") cls = "activity-view-tiled";
-  else if (_overviewView === "topology") cls = "activity-view-topology";
-  grid.classList.add(cls);
+  grid.classList.add("activity-view-topology");
 }
-

--- a/hub/static/hub/activity-tab/state.js
+++ b/hub/static/hub/activity-tab/state.js
@@ -24,9 +24,12 @@ var ACTIVITY_FOLLOW_INTERVAL_MS = 3000;
 
 
 /* ── Overview controls state (filter / sort / view / color / expand) ── */
+/* msg#16337: Overview is Viz-only; the Agents list moves to its own
+ * tab. Keep _overviewView around (as a "topology" constant) so every
+ * branch that still reads it keeps working. */
 var _overviewFilter = "";
 var _overviewSort = "name";
-var _overviewView = "list";
+var _overviewView = "topology";
 var _overviewColor = "name";
 var _overviewExpanded = null;
 /* Topology channel-node size mode. "equal" = fixed radius; "subscribers" =
@@ -39,13 +42,14 @@ try {
   var _savedSort = localStorage.getItem("orochi.overviewSort");
   if (_savedSort === "name" || _savedSort === "machine")
     _overviewSort = _savedSort;
+  /* Overview is Viz-only — migrate any stale saved value to "topology". */
   var _savedView = localStorage.getItem("orochi.overviewView");
-  if (
-    _savedView === "list" ||
-    _savedView === "tiled" ||
-    _savedView === "topology"
-  )
-    _overviewView = _savedView;
+  if (_savedView && _savedView !== "topology") {
+    try {
+      localStorage.setItem("orochi.overviewView", "topology");
+    } catch (_e) {}
+  }
+  _overviewView = "topology";
   var _savedColor = localStorage.getItem("orochi.overviewColor");
   if (
     _savedColor === "name" ||

--- a/hub/static/hub/tabs.js
+++ b/hub/static/hub/tabs.js
@@ -193,6 +193,19 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
     if (hash === "terminal") {
       hash = "";
     }
+    /* msg#16337: Overview loses its Viz/List toggle — users whose
+     * last session was activity + list subview land on the dedicated
+     * Agents tab instead. */
+    if (last === "activity") {
+      try {
+        var _legacyOverviewView = localStorage.getItem("orochi.overviewView");
+        if (_legacyOverviewView === "list" || _legacyOverviewView === "tiled") {
+          last = "agents-tab";
+          localStorage.setItem("orochi.overviewView", "topology");
+          localStorage.setItem("orochi_active_tab", "agents-tab");
+        }
+      } catch (_) {}
+    }
     var target = hash || last || "activity";
     /* If the requested tab no longer has a DOM button, fall back to
      * Overview ("activity"). */

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -181,6 +181,7 @@
         <div class="main">
             <div class="tab-bar">
                 <button class="tab-btn active" data-tab="activity">Overview</button>
+                <button class="tab-btn" data-tab="agents-tab">Agents</button>
                 <button class="tab-btn" data-tab="chat">Chat</button>
                 <button class="tab-btn" data-tab="todo">TODO</button>
                 <button class="tab-btn" data-tab="resources">Machines</button>
@@ -290,19 +291,12 @@
             </div>
             <div id="activity-view" class="todo-view" style="display:none">
                 <!-- hook-bypass: inline-style -->
+                <!-- Overview (internal id "activity") is Viz-only per
+                     msg#16337 — the Agents list lives in the dedicated
+                     #agents-tab-view. The Viz/List switch that used to
+                     sit here is gone; only the topology size dropdown
+                     and the summary pill row remain. -->
                 <div id="activity-subtabs" class="activity-subtabs">
-                    <div class="activity-view-switch"
-                         role="tablist"
-                         aria-label="overview view mode">
-                        <button type="button"
-                                class="activity-view-switch-btn"
-                                data-view="topology"
-                                title="topology (agents ↔ channels map)">Viz</button>
-                        <button type="button"
-                                class="activity-view-switch-btn active"
-                                data-view="list"
-                                title="one-line rows">List</button>
-                    </div>
                     <!-- sort + color dropdowns moved to the sidebar (ywatanabe 2026-04-21) -->
                     <select id="activity-size-select"
                             class="activity-sort-select"


### PR DESCRIPTION
## Summary
- Overview tab loses its Viz/List toggle and renders the graph/topology only.
- A dedicated Agents tab button lands in the tab bar (data-tab="agents-tab") and becomes the canonical agent LIST surface -- it already shipped the richer table view + PR #319 detail-pane wiring.
- Legacy users whose last session was `activity + list` auto-redirect to the Agents tab on next boot so they land on the list, not an empty graph.

## Scope (msg#16337 / worker-progress msg#16338)

Before: Overview carried a Viz/List segmented switch (two subtabs), AND the Agents tab's rendering code (`#agents-tab-view` / `renderAgentsTab`) existed but had no tab-bar button.

After: Overview = Viz only. Agents tab = List only. Two surfaces, one job each.

## Files touched (9)

TypeScript (authoritative source):
- `hub/frontend/src/activity-tab/controls.ts` -- drop `.activity-view-switch` wiring, keep sort/color/size dropdowns.
- `hub/frontend/src/activity-tab/row.ts` -- `_renderActivityCards` becomes a thin shim that builds the summary pills and delegates to `_renderActivityTopology` unconditionally; `_applyOverviewViewClass` always applies `activity-view-topology`.
- `hub/frontend/src/activity-tab/state.ts` -- `_overviewView` defaults to `topology`; legacy `list`/`tiled` values in localStorage migrate to `topology` on boot.
- `hub/frontend/src/tabs.ts` -- on-boot migration: `orochi_active_tab === "activity"` + `orochi.overviewView in ["list","tiled"]` -> redirect to `agents-tab`.

JS mirrors (hand-maintained alongside TS):
- `hub/static/hub/activity-tab/controls.js`
- `hub/static/hub/activity-tab/row.js`
- `hub/static/hub/activity-tab/state.js`
- `hub/static/hub/tabs.js`

Template:
- `hub/templates/hub/dashboard.html` -- remove the Viz/List segmented row from `#activity-subtabs`; add `<button data-tab="agents-tab">Agents</button>` between Overview and Chat in `.tab-bar`.

## Authoritative list renderer

Agents tab (`agents-tab/overview.ts` + `agents-tab/controls.ts`) is the single source of truth for the agent list. It already shipped:
- The full registry table (`.agents-registry-table`) with Status / Role / Host / Model / Mux / Ctx / Skills / PID / Channels / Project / Workdir / Pane / Task / Subagents / Config / Uptime / Last Activity / Last Seen columns.
- Click-a-row -> per-agent sub-tab -> `_renderAgentDetail` detail pane (PR #319 400x400 floor).
- Purge-offline / pin / kill / restart actions.

The Overview list code (`.activity-card` rows in the old `row.ts` branch) is deleted; its click-to-inline-detail wiring was duplicated by the Agents tab's richer surface.

## Viz/List toggle removed fully?

Fully removed from the DOM template. The CSS rules for `.activity-view-switch` / `.activity-view-switch-btn` still live in `activity-tab-core.css` as orphan styles but don't match anything after the template change; left alone to keep the diff tight.

## Don't break

- PR #313 graph-feed persistent panel -- still lives inside Overview (rendered by `topology.ts`), which is now the only Overview mode.
- PR #317 last-tab localStorage persistence -- extended (migration block), not replaced.
- PR #319 detail pane 400x400 floor + click-to-detail -- untouched in the Agents tab.
- PR #323/#325 paste guards -- not in this diff's scope.
- Sidebar invariants (PR #293/#295/#306/#311) -- not touched.

## Test plan
- [ ] First-load: tab bar shows `Overview | Agents | Chat | TODO | Machines | Files | Releases`.
- [ ] Overview tab renders the graph/topology only; no Viz/List switch present.
- [ ] Agents tab renders the full registry table with per-agent sub-tabs.
- [ ] Click agent row in Agents tab -> detail pane opens at the 400x400 floor.
- [ ] Migration: with `localStorage.orochi_active_tab = "activity"` and `localStorage["orochi.overviewView"] = "list"`, reload -> lands on Agents tab and keys are rewritten.
- [ ] Migration: with `localStorage["orochi.overviewView"] = "topology"` or unset, Overview tab loads the graph as before.
- [ ] `cd hub/frontend && npm run typecheck && npm run build` both pass.

Bundle size after build: 738.10 kB / 167.72 kB gz.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
