### PR TITLE
feat(ui/composer): unify Chat / Overview / Reply into renderComposer SSoT (msg#16286)

### DIFF
--- a/hub/frontend/src/activity-tab/compose.ts
+++ b/hub/frontend/src/activity-tab/compose.ts
@@ -4,15 +4,10 @@ import { _graphFeedSetChannel } from "./graph-feed";
 import { _showMiniToast } from "../app/agent-actions";
 import { _channelPrefs } from "../app/members";
 import { fetchAgents } from "../app/sidebar-agents";
-import { setCurrentChannel } from "../app/state";
 import { apiUrl, escapeHtml, sendOrochiMessage, userName } from "../app/utils";
 import { ws, wsConnected } from "../app/websocket";
-import { loadChannelHistory } from "../chat/chat-history";
-import {
-  _buildPastedTextFile,
-  _pastedTextShouldAttach,
-  _uploadFilesAPI,
-} from "../upload";
+import { _uploadFilesAPI } from "../upload";
+import { renderComposer } from "../composer/composer";
 import {
   _debounceSave,
   clearDraft,
@@ -256,17 +251,9 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
   pop.id = "topo-channel-compose";
   pop.className = "topo-channel-compose";
   pop.setAttribute("data-channel", channel);
+  pop.setAttribute("data-composer-surface", "overview");
   pop.style.left = Math.max(8, clientX - 140) + "px";
   pop.style.top = Math.max(8, clientY + 12) + "px";
-  /* Minimal popup: no header, no close button, no + button, no send
-   * button. Just a textarea whose tooltip documents all the keyboard
-   * shortcuts, plus a small ▾ chevron at the bottom-right corner that
-   * reveals attach / camera / sketch / voice buttons. Enter sends, Esc
-   * closes, outside click closes. ywatanabe 2026-04-19: "make the
-   * modal minimal; no send button needed; no dm nor channel label
-   * needed; no plus button needed; not x button needed; just add a
-   * small chevron to the bottom to show other buttons; show tooltip
-   * with keyboard shortcuts even when they are not expanded to use". */
   var tccShortcuts =
     "Enter — send\n" +
     "Shift+Enter — newline\n" +
@@ -285,22 +272,20 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
    *
    * (msg#16319: the older settled-hover channel-hover-preview popover
    * has been removed — this in-popup preview is now the sole inline
-   * last-N surfacing for channels.) */
+   * last-N surfacing for channels.)
+   *
+   * Composer DOM (textarea + action buttons) is injected by
+   * renderComposer into .tcc-composer-slot since the SSoT unification
+   * (msg#16286). The preview, pending tray, and chevron stay popup-
+   * owned chrome — the composer slots into .tcc-composer-slot and its
+   * action row is moved into .tcc-extras so the chevron can toggle
+   * visibility (matches pre-SSoT UX). */
   pop.innerHTML =
     '<div class="tcc-preview" data-tcc-preview>' +
     '<div class="tcc-preview-loading">Loading recent messages\u2026</div>' +
     "</div>" +
-    '<textarea class="tcc-input" data-voice-input rows="2" placeholder="message #' +
-    escapeHtml(channel).replace(/^#/, "") +
-    '" title="' +
-    tccShortcuts.replace(/"/g, "&quot;") +
-    '"></textarea>' +
-    '<div class="tcc-extras" style="display:none">' +
-    '<button type="button" class="tcc-x tcc-attach" title="Attach file (paste also works)">\uD83D\uDCCE</button>' +
-    '<button type="button" class="tcc-x tcc-camera" title="Camera">\uD83D\uDCF7</button>' +
-    '<button type="button" class="tcc-x tcc-sketch" title="Sketch">\u270F\uFE0F</button>' +
-    '<button type="button" class="tcc-x tcc-voice" title="Voice input">\uD83C\uDFA4</button>' +
-    "</div>" +
+    '<div class="tcc-pending" style="display:none"></div>' +
+    '<div class="tcc-composer-slot"></div>' +
     '<button type="button" class="tcc-expand" title="' +
     tccShortcuts.replace(/"/g, "&quot;") +
     '" aria-label="More options">\u25BE</button>';
@@ -318,108 +303,18 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
       _graphFeedSetChannel(channel);
     } catch (_) {}
   }
-  var input = pop.querySelector(".tcc-input");
-  var extras = pop.querySelector(".tcc-extras");
+
+  var popTray = pop.querySelector(".tcc-pending");
+  var composerSlot = pop.querySelector(".tcc-composer-slot");
   var expandBtn = pop.querySelector(".tcc-expand");
-  /* msg#16324: restore any draft the user was typing into this channel
-   * popup before the last reload. loadDraft returns null when nothing
-   * is stored, stored-but-stale (>24h), or localStorage is unavailable.
-   * Cursor lands at end so continued typing "just works". */
-  try {
-    var _savedPopDraft = loadDraft("overview-popup", channel);
-    if (input && _savedPopDraft) {
-      input.value = _savedPopDraft;
-    }
-  } catch (_) {}
-  /* Persist every keystroke (debounced at 300ms via draft-store). */
-  if (input) {
-    input.addEventListener("input", function () {
-      try {
-        _debounceSave("overview-popup", channel, input.value);
-      } catch (_) {}
-    });
-  }
-  setTimeout(function () {
-    if (input) {
-      input.focus();
-      /* Place cursor at end of restored draft. */
-      try {
-        var len = input.value ? input.value.length : 0;
-        input.setSelectionRange(len, len);
-      } catch (_) {}
-    }
-  }, 10);
-
-  /* todo#305 Task 6 (lead msg#15528): Cmd+V / ⌘V / context-menu Paste
-   * was failing on this popup. Root cause: macOS Safari does NOT focus
-   * a textarea on right-click (unlike Chrome/Firefox). A right-click on
-   * our textarea therefore left document.activeElement on whatever had
-   * focus before the popup opened (often <body> or the topology
-   * canvas), so the subsequent native "Paste" from the OS context menu
-   * fired a paste event on THAT element — not the textarea.
-   *
-   * Keyboard Cmd+V was only intermittent for the same reason: if the
-   * user clicked anywhere inside the popup that wasn't a focusable
-   * child, the textarea could lose focus and the next Cmd+V landed
-   * outside.
-   *
-   * Fix: refocus the textarea on ANY pointer interaction inside the
-   * popup (mousedown covers left + right click + middle click on all
-   * browsers), unless the target is one of the action buttons that
-   * legitimately owns focus (attach / camera / sketch / voice /
-   * expand). Also listen to `contextmenu` explicitly — belt & braces
-   * for browsers that fire contextmenu without a prior mousedown
-   * (some trackpad two-finger-tap paths on macOS). */
-  function _refocusInput(ev) {
-    if (!input) return;
-    /* Don't steal focus from action buttons. */
-    if (
-      ev.target &&
-      ev.target.closest &&
-      ev.target.closest(".tcc-x, .tcc-expand")
-    ) {
-      return;
-    }
-    /* If the user clicked directly on the textarea, the browser will
-     * focus it anyway and move the caret — don't fight that. Only
-     * refocus when the target is a non-focusable child (the popup
-     * chrome, a label, etc.) or the textarea but unfocused (e.g.
-     * right-click on macOS Safari). */
-    if (document.activeElement !== input) {
-      try {
-        input.focus();
-      } catch (_) {}
-    }
-  }
-  pop.addEventListener("mousedown", _refocusInput);
-  pop.addEventListener("contextmenu", _refocusInput);
-
-  function close() {
-    if (pop.parentNode) pop.parentNode.removeChild(pop);
-    document.removeEventListener("mousedown", outsideClick, true);
-  }
-  function outsideClick(ev) {
-    if (!pop.contains(ev.target)) close();
-  }
-  setTimeout(function () {
-    document.addEventListener("mousedown", outsideClick, true);
-  }, 50);
 
   /* msg#16193: local-scoped pending attachments for this popup. Paste /
    * drop stage here instead of routing to the Chat composer, so the
-   * user's Overview-tab interaction never flips them into Chat. Rendered
-   * as a small inline strip ABOVE the textarea; cleared when the popup
-   * closes or the message is sent. */
+   * user's Overview-tab interaction never flips them into Chat. The
+   * tray lives in popup chrome; the composer delegates file-staging to
+   * _stagePopFiles via opts.stageFiles (composer-paste.ts handles paste,
+   * popup-level drop handler below handles drag-drop onto the chrome). */
   var popPending = [];
-  var popTray = document.createElement("div");
-  popTray.className = "tcc-pending";
-  popTray.style.display = "none";
-  /* Insert above the textarea (after preview slot if present). */
-  if (input && input.parentNode === pop) {
-    pop.insertBefore(popTray, input);
-  } else {
-    pop.insertBefore(popTray, pop.firstChild);
-  }
 
   function _renderPopTray() {
     if (!popPending.length) {
@@ -479,6 +374,139 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     _renderPopTray();
   }
 
+  /* Build the composer via the SSoT module. Mention autocomplete, paste,
+   * attach/camera/sketch/voice, keyboard shortcuts — all shared with
+   * Chat and Reply. Drag-drop is handled at the popup level (below) so
+   * the whole popup chrome is a drop target, not just the composer
+   * subtree. */
+  var composerInstance = renderComposer(composerSlot as HTMLElement, {
+    surface: "overview",
+    placeholder: "message #" + String(channel || "").replace(/^#/, ""),
+    stageFiles: _stagePopFiles,
+    features: {
+      mention: true,
+      paste: true,
+      dragDrop: false,
+      attach: true,
+      camera: true,
+      sketch: true,
+      voice: true,
+      sendButton: false /* chevron + Enter = send, matches pre-SSoT UX */,
+      shiftEnterNewline: true,
+      autoResize: false,
+      cmdEnterSubmit: true,
+      tabAwareFocus: false,
+      /* Overview popup is outside the voice-input.ts global chord
+       * handler's allowed surfaces (it bails on #topo-channel-compose),
+       * so the composer owns the local Alt/Ctrl+Enter handling. */
+      localVoiceChord: true,
+    },
+    maxResizePx: 0,
+    onSubmit: function () {
+      send();
+    },
+  });
+  var input = composerInstance.input;
+  input.classList.add("tcc-input");
+  input.title = tccShortcuts;
+  input.rows = 2;
+
+  /* Move composer's action row into a .tcc-extras wrapper so the
+   * chevron can toggle visibility (matches pre-SSoT UX). */
+  var actionsRow = composerSlot.querySelector(".composer-actions");
+  var extras = document.createElement("div");
+  extras.className = "tcc-extras";
+  extras.style.display = "none";
+  if (actionsRow) {
+    extras.appendChild(actionsRow);
+  }
+  composerSlot.appendChild(extras);
+
+  /* Tag individual action buttons with their legacy tcc-x classes so
+   * existing CSS rules keep working. Add-only: we do NOT drop the new
+   * composer-btn-* classes. */
+  var actionBtns = extras.querySelectorAll(".composer-btn");
+  actionBtns.forEach(function (b) {
+    b.classList.add("tcc-x");
+    if (b.classList.contains("composer-btn-attach")) b.classList.add("tcc-attach");
+    else if (b.classList.contains("composer-btn-camera")) b.classList.add("tcc-camera");
+    else if (b.classList.contains("composer-btn-sketch")) b.classList.add("tcc-sketch");
+    else if (b.classList.contains("composer-btn-voice")) b.classList.add("tcc-voice");
+  });
+
+  /* msg#16324: restore any draft the user was typing into this channel
+   * popup before the last reload. loadDraft returns null when nothing
+   * is stored, stored-but-stale (>24h), or localStorage is unavailable.
+   * Cursor lands at end so continued typing "just works". */
+  try {
+    var _savedPopDraft = loadDraft("overview-popup", channel);
+    if (input && _savedPopDraft) {
+      input.value = _savedPopDraft;
+    }
+  } catch (_) {}
+  /* Persist every keystroke (debounced at 300ms via draft-store). */
+  if (input) {
+    input.addEventListener("input", function () {
+      try {
+        _debounceSave("overview-popup", channel, input.value);
+      } catch (_) {}
+    });
+  }
+  setTimeout(function () {
+    if (input) {
+      try {
+        input.focus();
+        var len = input.value ? input.value.length : 0;
+        input.setSelectionRange(len, len);
+      } catch (_) {}
+    }
+  }, 10);
+
+  /* todo#305 Task 6 (lead msg#15528): Cmd+V / ⌘V / context-menu Paste
+   * was failing on this popup (Safari right-click focus issue). Refocus
+   * the textarea on ANY pointer interaction inside the popup unless the
+   * target is one of the action buttons. */
+  function _refocusInput(ev) {
+    if (!input) return;
+    if (
+      ev.target &&
+      ev.target.closest &&
+      ev.target.closest(".tcc-x, .tcc-expand, .composer-btn")
+    ) {
+      return;
+    }
+    if (document.activeElement !== input) {
+      try {
+        input.focus();
+      } catch (_) {}
+    }
+  }
+  pop.addEventListener("mousedown", _refocusInput);
+  pop.addEventListener("contextmenu", _refocusInput);
+
+  function close() {
+    try {
+      composerInstance.destroy();
+    } catch (_) {}
+    if (pop.parentNode) pop.parentNode.removeChild(pop);
+    document.removeEventListener("mousedown", outsideClick, true);
+  }
+  function outsideClick(ev) {
+    if (!pop.contains(ev.target)) close();
+  }
+  setTimeout(function () {
+    document.addEventListener("mousedown", outsideClick, true);
+  }, 50);
+
+  /* Esc closes the popup — composer's renderComposer handles
+   * Enter/Shift+Enter via onSubmit; Esc is popup-level chrome. */
+  input.addEventListener("keydown", function (ev) {
+    if (ev.key === "Escape") {
+      ev.preventDefault();
+      close();
+    }
+  });
+
   function send() {
     var text = (input.value || "").trim();
     var attachments = popPending.map(function (p) {
@@ -506,14 +534,13 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
     /* msg#16316 / ywatanabe msg#16313: keep the popup OPEN after send so
      * the user can keep replying without re-double-clicking the channel
      * node. Clear the textarea + pending attachment tray, refocus the
-     * input, and leave the popup mounted. The popup still closes via
-     * Esc, outside-click, or routing to Chat (existing paths). */
+     * input, and leave the popup mounted. */
     input.value = "";
     popPending.length = 0;
     _renderPopTray();
     /* Spec msg#16324: clear the stored draft ONLY on successful send.
-     * Close-without-send (Esc / outside-click below) keeps the draft so
-     * the user can come back and finish the thought later. */
+     * Close-without-send (Esc / outside-click) keeps the draft so the
+     * user can come back and finish the thought later. */
     try {
       clearDraft("overview-popup", channel);
     } catch (_) {}
@@ -521,139 +548,16 @@ export function _topoOpenChannelCompose(channel, clientX, clientY) {
       input.focus();
     } catch (_) {}
   }
-  input.addEventListener("keydown", function (ev) {
-    /* Voice-toggle shortcuts — same as Chat composer. Keep these BEFORE
-     * the plain-Enter branch so Ctrl+Enter / Alt+Enter don't fall through
-     * to send(). Ctrl+M and Alt+V also toggle voice. */
-    if (ev.key === "Enter" && (ev.ctrlKey || ev.altKey)) {
-      ev.preventDefault();
-      ev.stopPropagation(); /* prevent global voice handler from double-firing */
-      if (typeof window.toggleVoiceInput === "function") {
-        input.focus(); /* ensure _toggleVoice sees our textarea as active */
-        window.toggleVoiceInput();
-      }
-      return;
-    }
-    if (
-      (ev.ctrlKey && (ev.key === "m" || ev.key === "M")) ||
-      (ev.altKey && (ev.key === "v" || ev.key === "V"))
-    ) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      if (typeof window.toggleVoiceInput === "function") {
-        input.focus();
-        window.toggleVoiceInput();
-      }
-      return;
-    }
-    if (ev.key === "Enter" && !ev.shiftKey) {
-      ev.preventDefault();
-      send();
-    } else if (ev.key === "Escape") {
-      ev.preventDefault();
-      close();
-    }
-  });
-  /* Paste support — images / files / long text. msg#16193 regression-fix:
-   * previously this handler, on image/long-text paste, closed the popup
-   * and re-dispatched the paste into the Chat composer via `_routeToChat`
-   * — which flipped the user out of the Overview tab, which is exactly
-   * the bug the user keeps reporting ("I'm on Overview, I paste an
-   * image, I end up on Chat"). Fix: stage attachments LOCALLY to this
-   * popup (upload to /api/upload, show inline thumb strip, include in
-   * the send() payload). No tab switch, no msg-input re-dispatch.
-   *
-   * Keep `ev.stopPropagation()` so nothing bubbles into msg-input's
-   * window-level paste handler. Short plain text still lands in the
-   * textarea via the browser's default paste behavior (we only
-   * preventDefault when we actually stage a file). */
-  input.addEventListener("paste", function (ev) {
-    ev.stopPropagation();
-    var cd =
-      ev.clipboardData || (ev.originalEvent && ev.originalEvent.clipboardData);
-    if (!cd) return;
-    /* Collect image files from both cd.files (browsers that expose it)
-     * and cd.items (browsers that only expose items). Dedup inline. */
-    var collected = [];
-    var seen = new Set();
-    function pushUnique(f) {
-      if (!f || !f.type || f.type.indexOf("image/") !== 0) return;
-      var key =
-        f.name + "|" + f.size + "|" + f.type + "|" + (f.lastModified || 0);
-      if (seen.has(key)) return;
-      seen.add(key);
-      collected.push(f);
-    }
-    var fileList = cd.files;
-    if (fileList && fileList.length) {
-      for (var i = 0; i < fileList.length; i++) pushUnique(fileList[i]);
-    } else if (cd.items) {
-      for (var j = 0; j < cd.items.length; j++) {
-        var it = cd.items[j];
-        if (it && it.type && it.type.indexOf("image/") === 0) {
-          pushUnique(it.getAsFile());
-        }
-      }
-    }
-    /* Long-text-as-file: same heuristic as upload.ts (>= 1500 chars or
-     * >= 25 lines) so the popup behaves identically to the Chat
-     * composer in this regard. */
-    var text = "";
-    try {
-      text = cd.getData("text/plain") || "";
-    } catch (_) {}
-    var attachText =
-      typeof _pastedTextShouldAttach === "function" &&
-      _pastedTextShouldAttach(text);
-    if (collected.length > 0 || attachText) {
-      ev.preventDefault();
-      if (attachText && typeof _buildPastedTextFile === "function") {
-        collected.push(_buildPastedTextFile(text));
-      }
-      _stagePopFiles(collected);
-    }
-  });
+
   expandBtn.addEventListener("click", function () {
     var on = extras.style.display === "none";
     extras.style.display = on ? "" : "none";
     expandBtn.textContent = on ? "\u25B4" : "\u25BE";
   });
-  /* Delegate extras — pop the channel into currentChannel so existing
-   * global helpers target the right place, then invoke them. Fallback
-   * to focusing the main composer for modes that don't have a headless
-   * API surface. */
-  function _routeToChat() {
-    if (typeof setCurrentChannel === "function") setCurrentChannel(channel);
-    if (typeof loadChannelHistory === "function") loadChannelHistory(channel);
-    var tabBtn = document.querySelector('[data-tab="chat"]');
-    if (tabBtn) tabBtn.click();
-    close();
-  }
-  pop.querySelector(".tcc-attach").addEventListener("click", function () {
-    _routeToChat();
-    if (typeof openAttachmentPicker === "function") openAttachmentPicker();
-  });
-  pop.querySelector(".tcc-camera").addEventListener("click", function () {
-    _routeToChat();
-    if (typeof openCameraCapture === "function") openCameraCapture();
-  });
-  pop.querySelector(".tcc-sketch").addEventListener("click", function () {
-    _routeToChat();
-    if (typeof openSketchPanel === "function") openSketchPanel();
-  });
-  pop.querySelector(".tcc-voice").addEventListener("click", function () {
-    /* Dictate into THIS popup's textarea — don't route to Chat.
-     * Focus the popup textarea so _toggleVoice's selector-based
-     * target resolution picks it up, then toggle. */
-    if (typeof window.toggleVoiceInput === "function") {
-      input.focus();
-      window.toggleVoiceInput();
-    }
-  });
-  /* Drop files onto popup → stage LOCALLY (msg#16193). Same rationale
-   * as the paste handler: the user is working in the graph-compose
-   * popup on the Overview tab and shouldn't get flipped to Chat for a
-   * drag-drop. */
+
+  /* Drop files onto popup → stage LOCALLY (msg#16193). Kept popup-level
+   * (not composer-level) because the drop zone includes the preview +
+   * pending-attachments chrome around the composer. */
   pop.addEventListener("dragover", function (ev) {
     ev.preventDefault();
     ev.stopPropagation();

--- a/hub/frontend/src/chat/chat-composer.ts
+++ b/hub/frontend/src/chat/chat-composer.ts
@@ -3,18 +3,29 @@ import { lastActiveChannel } from "../app/state";
 import { sendOrochiMessage, userName } from "../app/utils";
 import { ws, wsConnected } from "../app/websocket";
 import { _renderMermaidIn } from "./chat-attachments";
-import { clearPendingAttachments, getPendingAttachments } from "../upload";
+import {
+  clearPendingAttachments,
+  getPendingAttachments,
+  stageFiles,
+} from "../upload";
 import { activeTab } from "../tabs";
 import {
   _debounceSave,
   clearDraft,
   loadDraft,
 } from "../composer/draft-store";
+import { renderComposer } from "../composer/composer";
 
 export function updateChannelSelect() {
   /* Channel select removed -- using sidebar selection instead */
 }
 
+/* sendMessage is invoked by renderComposer's onSubmit as well as by
+ * legacy entry points (mobile Safari send-button path etc.). Pulls
+ * attachments from upload.ts's pending tray (the Chat surface owns
+ * pendingAttachments — the Overview popup and Reply composer have
+ * their own per-surface stores so this module is unchanged by the
+ * unification). */
 export function sendMessage() {
   var input = document.getElementById("msg-input");
   /* In multi-select mode (globalThis as any).currentChannel is null; fall back to lastActiveChannel
@@ -76,9 +87,7 @@ export function sendMessage() {
   }
 }
 
-/* Auto-resize textarea as content grows + persist draft per channel.
- *
- * Drafts are stored in localStorage (not sessionStorage anymore —
+/* Drafts are stored in localStorage (not sessionStorage anymore —
  * msg#16324 ywatanabe: deploys / Cmd-R / reloads were clobbering
  * in-progress messages). The draft-store module handles the
  * per-(surface,target) keying, 24h stale-cutoff, and private-mode
@@ -122,9 +131,69 @@ export function restoreDraftForCurrentChannel() {
   } catch (_) {}
 }
 window.restoreDraftForCurrentChannel = restoreDraftForCurrentChannel;
+
+/* SSoT composer — adopts the existing dashboard.html .input-bar DOM by
+ * selector rather than re-rendering so every legacy ID (#msg-input,
+ * #msg-send, #msg-attach, #msg-webcam, #msg-sketch, #msg-voice,
+ * #msg-voice-lang, #file-input, #pending-attachments) remains in place
+ * for voice-input.ts / upload.ts / webcam.ts / sketch.ts / etc.
+ *
+ * Several Chat features DON'T come from renderComposer because upload.ts
+ * already binds them globally on module load (Ctrl+U file picker,
+ * msg-input drop, paste handler), webcam.ts owns the camera button,
+ * sketch.ts owns the sketch button, and voice-input.ts owns the voice
+ * chord and button. The composer owns:
+ *   - #msg-send click  → sendMessage via onSubmit
+ *   - plain-Enter / Shift+Enter semantics
+ *   - auto-resize up to 200px
+ *   - tab-aware focus hint
+ * The parity matrix in the PR body documents this split. */
+var _chatComposer = (function () {
+  var inputBar = document.querySelector(".input-bar");
+  var msgInput = document.getElementById("msg-input");
+  if (!inputBar || !msgInput) return null;
+  inputBar.setAttribute("data-composer-surface", "chat");
+  return renderComposer(inputBar as HTMLElement, {
+    surface: "chat",
+    adoptRoot: inputBar as HTMLElement,
+    adoptSelectors: {
+      input: "#msg-input",
+      sendBtn: "#msg-send",
+    },
+    stageFiles: function (files) {
+      return stageFiles(files);
+    },
+    features: {
+      mention: false /* mention.ts already calls initMentionAutocomplete(#msg-input) */,
+      paste: false /* upload.ts owns msg-input paste */,
+      dragDrop: false /* upload.ts owns msg-input drop */,
+      attach: false /* upload.ts owns #msg-attach click + #file-input change */,
+      camera: false /* webcam.ts owns #msg-webcam click */,
+      sketch: false /* sketch.ts owns #msg-sketch click */,
+      voice: false /* voice-input.ts owns #msg-voice click */,
+      sendButton: true,
+      cmdEnterSubmit: true,
+      shiftEnterNewline: true,
+      autoResize: true,
+      tabAwareFocus: true,
+      /* voice-input.ts installs a global capture-phase Alt/Ctrl+Enter
+       * handler that fires for the Chat surface; the composer must
+       * not also handle it or the mic toggles twice. */
+      localVoiceChord: false,
+    },
+    maxResizePx: 200,
+    onSubmit: function (_payload) {
+      sendMessage();
+    },
+  });
+})();
+
+/* Persist draft on every input, debounced at 300ms via draft-store.
+ * Kept as a separate listener from the composer's internal autoresize
+ * because draft persistence is Chat-specific on this codepath (the
+ * Overview popup + thread reply own their own debounced-save wiring
+ * in their respective modules). */
 document.getElementById("msg-input").addEventListener("input", function () {
-  this.style.height = "auto";
-  this.style.height = Math.min(this.scrollHeight, 200) + "px";
   _debounceSave("chat", _draftTarget(), this.value);
 });
 restoreDraftForCurrentChannel();
@@ -305,37 +374,3 @@ document.addEventListener("click", function (e) {
     });
   });
 })();
-
-document.getElementById("msg-send").addEventListener("click", function (e) {
-  e.preventDefault();
-  /* On mobile Safari, tapping the send button blurs the textarea before
-   * the click handler fires, which can dismiss the keyboard and cause
-   * unexpected scrolling. We call sendMessage synchronously here. */
-  sendMessage();
-  /* Re-focus the textarea so the keyboard stays open on mobile */
-  document.getElementById("msg-input").focus();
-});
-document.getElementById("msg-input").addEventListener("keydown", function (e) {
-  /* Ctrl+U / Cmd+U → trigger file upload picker (msg#9877) */
-  var isMac = /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
-  if ((isMac ? e.metaKey : e.ctrlKey) && e.key === "u") {
-    e.preventDefault();
-    var fi = document.getElementById("file-input");
-    if (fi) fi.click();
-    return;
-  }
-  if (e.key === "Enter") {
-    var dd = document.getElementById("mention-dropdown");
-    if (dd && dd.classList.contains("visible")) return;
-    /* todo#332 v2: Alt+Enter is reserved for voice toggle (see voice-input.js).
-     * Shift+Enter remains the newline shortcut. Plain Enter sends. */
-    if (e.shiftKey) return;
-    if (e.altKey) {
-      /* Voice toggle handled by voice-input.js global handler — just prevent default */
-      e.preventDefault();
-      return;
-    }
-    e.preventDefault();
-    sendMessage();
-  }
-});

--- a/hub/frontend/src/composer/composer-attach.ts
+++ b/hub/frontend/src/composer/composer-attach.ts
@@ -1,0 +1,137 @@
+// @ts-nocheck
+/* composer/composer-attach.ts — attach-button / camera / sketch / voice
+ * wiring for the SSoT composer. Each surface supplies its own file-input
+ * element (Chat reuses the static #file-input; Overview + Reply create
+ * one inline) plus optional callbacks for webcam / sketch / voice.
+ *
+ * Delegation targets:
+ *   - attach  : click() the provided <input type="file"> element
+ *   - camera  : openWebcam() from webcam.ts (global msg-webcam button wire
+ *               still exists for the Chat surface; the composer's own
+ *               button additionally invokes openWebcam() directly)
+ *   - sketch  : openSketch() from sketch.ts. Surfaces can pass an
+ *               `onSketchOpen` hook to set a per-surface flag
+ *               (threads/panel.ts sets `_threadSketchActive`).
+ *   - voice   : window.toggleVoiceInput() from voice-input.ts — but first
+ *               focus the composer's textarea so _toggleVoice's target
+ *               resolution picks it up. This replaces three identical
+ *               copies of the same four-line block (Chat inherits via
+ *               voice-input's generic handler; Overview + Reply both had
+ *               their own inline copies).
+ *
+ * `wireAttachButtons(opts)` is a single call the composer makes after
+ * it has rendered its action row. Returns a disposer that removes all
+ * listeners — used by surfaces that rebuild their composer on open
+ * (Overview popup, thread panel). */
+
+import { openSketch } from "../sketch";
+import { openWebcam } from "../webcam";
+
+export interface AttachWireOpts {
+  input: HTMLTextAreaElement;
+  fileInput?: HTMLInputElement | null;
+  attachBtn?: HTMLElement | null;
+  cameraBtn?: HTMLElement | null;
+  sketchBtn?: HTMLElement | null;
+  voiceBtn?: HTMLElement | null;
+  onAttach?: () => void;
+  onCamera?: () => void;
+  onSketchOpen?: () => void;
+  onVoiceToggle?: () => void;
+  /* Consumed by file-input change: each surface stages files into its own
+   * attachment store. When omitted, the surface is responsible for binding
+   * file-input.change itself. */
+  stageFiles?: (files: File[]) => void | Promise<void>;
+}
+
+export function wireAttachButtons(opts: AttachWireOpts): () => void {
+  var disposers: Array<() => void> = [];
+
+  function bind(el, ev, fn) {
+    if (!el) return;
+    el.addEventListener(ev, fn);
+    disposers.push(function () {
+      el.removeEventListener(ev, fn);
+    });
+  }
+
+  if (opts.attachBtn && opts.fileInput) {
+    bind(opts.attachBtn, "click", function () {
+      if (typeof opts.onAttach === "function") {
+        try {
+          opts.onAttach();
+        } catch (_) {}
+      }
+      opts.fileInput.click();
+    });
+  }
+
+  if (opts.fileInput && typeof opts.stageFiles === "function") {
+    bind(opts.fileInput, "change", function () {
+      var files = Array.prototype.slice.call(opts.fileInput.files || []);
+      opts.stageFiles(files);
+      opts.fileInput.value = "";
+    });
+  }
+
+  if (opts.cameraBtn) {
+    bind(opts.cameraBtn, "click", function () {
+      if (typeof opts.onCamera === "function") {
+        try {
+          opts.onCamera();
+        } catch (_) {}
+      }
+      if (typeof openWebcam === "function") {
+        try {
+          openWebcam();
+        } catch (_) {}
+      }
+    });
+  }
+
+  if (opts.sketchBtn) {
+    bind(opts.sketchBtn, "click", function () {
+      if (typeof opts.onSketchOpen === "function") {
+        try {
+          opts.onSketchOpen();
+        } catch (_) {}
+      }
+      if (typeof openSketch === "function") {
+        try {
+          openSketch();
+        } catch (_) {}
+      }
+    });
+  }
+
+  if (opts.voiceBtn) {
+    bind(opts.voiceBtn, "click", function () {
+      /* Focus the textarea first so voice-input.ts's _toggleVoice target
+       * resolution picks this composer's input (critical for Overview /
+       * Reply surfaces where the Chat msg-input would otherwise win). */
+      try {
+        opts.input && opts.input.focus();
+      } catch (_) {}
+      if (typeof opts.onVoiceToggle === "function") {
+        try {
+          opts.onVoiceToggle();
+        } catch (_) {}
+        return;
+      }
+      if (typeof (window as any).toggleVoiceInput === "function") {
+        try {
+          (window as any).toggleVoiceInput();
+        } catch (_) {}
+      }
+    });
+  }
+
+  return function dispose() {
+    while (disposers.length) {
+      var d = disposers.pop();
+      try {
+        d();
+      } catch (_) {}
+    }
+  };
+}

--- a/hub/frontend/src/composer/composer-mention.ts
+++ b/hub/frontend/src/composer/composer-mention.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+/* composer/composer-mention.ts — adapter that wires the existing
+ * mention.ts autocomplete (cachedAgentNames + SPECIAL_MENTIONS + the
+ * single shared #mention-dropdown) to any textarea belonging to a
+ * composer surface.
+ *
+ * Why a thin wrapper: mention.ts already does the lookup, rendering,
+ * and keyboard navigation. Threads and the group-compose modal used
+ * to call `initMentionAutocomplete` directly (threads/panel.ts does
+ * today); the graph-compose popup didn't call it at all (feature gap
+ * #311). The composer SSoT hides that inconsistency behind a single
+ * `wireComposerMention(input)` call site.
+ *
+ * `isMentionDropdownOpen()` is exposed so the composer's keydown /
+ * submit logic can defer to the dropdown when it's the active
+ * target (plain Enter = pick mention, not send). Mirrors the check
+ * Chat + Reply composers already performed inline. */
+
+import {
+  handleMentionKeydown,
+  initMentionAutocomplete,
+  mentionDropdown,
+  mentionSelectedIndex,
+} from "../mention";
+
+export function wireComposerMention(input: HTMLElement): void {
+  if (!input) return;
+  if (typeof initMentionAutocomplete === "function") {
+    initMentionAutocomplete(input);
+  }
+}
+
+export function isMentionDropdownOpen(): boolean {
+  return !!(
+    mentionDropdown &&
+    mentionDropdown.classList &&
+    mentionDropdown.classList.contains("visible") &&
+    mentionSelectedIndex >= 0
+  );
+}
+
+/* Re-export for call sites that previously imported from mention.ts
+ * directly; keeps the composer module self-contained. */
+export { handleMentionKeydown, mentionDropdown, mentionSelectedIndex };

--- a/hub/frontend/src/composer/composer-paste.test.mjs
+++ b/hub/frontend/src/composer/composer-paste.test.mjs
@@ -1,0 +1,134 @@
+/* composer/composer-paste.test.mjs — node-runner for the paste helpers.
+ *
+ * Matches the style of draft-store.test.mjs (no vitest/jest in this
+ * repo; run via `node hub/frontend/src/composer/composer-paste.test.mjs`).
+ *
+ * Covers:
+ *   - _collectPastedImages dedups by (name|size|type|lastModified)
+ *   - _collectPastedImages ignores non-image MIME types
+ *   - _collectPastedImages falls through to cd.items when cd.files is empty
+ *
+ * The real composer-paste.ts pulls in `../upload` at module load (for
+ * _pastedTextShouldAttach / _buildPastedTextFile), which in turn touches
+ * DOM. Unit tests therefore re-implement only the pure dedup helper
+ * against the same spec — the DOM-wiring path is typecheck- and
+ * build-verified separately.
+ */
+
+function _collectPastedImages(cd) {
+  var collected = [];
+  var seen = new Set();
+  function pushUnique(f) {
+    if (!f || !f.type || f.type.indexOf("image/") !== 0) return;
+    var key =
+      f.name + "|" + f.size + "|" + f.type + "|" + (f.lastModified || 0);
+    if (seen.has(key)) return;
+    seen.add(key);
+    collected.push(f);
+  }
+  if (!cd) return collected;
+  var fileList = cd.files;
+  if (fileList && fileList.length) {
+    for (var i = 0; i < fileList.length; i++) pushUnique(fileList[i]);
+  } else if (cd.items) {
+    for (var j = 0; j < cd.items.length; j++) {
+      var it = cd.items[j];
+      if (it && it.type && it.type.indexOf("image/") === 0) {
+        pushUnique(it.getAsFile());
+      }
+    }
+  }
+  return collected;
+}
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`FAIL ${name}: ${e.message}`);
+    failed++;
+  }
+}
+function assertEq(a, b, msg) {
+  if (a !== b) {
+    throw new Error(`${msg || "expected"}: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+function mkFile(name, size, type, lastModified) {
+  return { name: name, size: size, type: type, lastModified: lastModified || 0 };
+}
+
+test("returns empty for null clipboard data", () => {
+  assertEq(_collectPastedImages(null).length, 0);
+});
+
+test("returns empty for empty files + items", () => {
+  assertEq(_collectPastedImages({ files: [], items: [] }).length, 0);
+});
+
+test("collects a single image from cd.files", () => {
+  var cd = { files: [mkFile("a.png", 100, "image/png")] };
+  var out = _collectPastedImages(cd);
+  assertEq(out.length, 1);
+  assertEq(out[0].name, "a.png");
+});
+
+test("ignores non-image MIME in cd.files", () => {
+  var cd = {
+    files: [
+      mkFile("a.png", 100, "image/png"),
+      mkFile("b.txt", 50, "text/plain"),
+    ],
+  };
+  var out = _collectPastedImages(cd);
+  assertEq(out.length, 1);
+  assertEq(out[0].name, "a.png");
+});
+
+test("dedups by (name|size|type|lastModified)", () => {
+  var a1 = mkFile("a.png", 100, "image/png", 1);
+  var a2 = mkFile("a.png", 100, "image/png", 1);
+  var cd = { files: [a1, a2] };
+  assertEq(_collectPastedImages(cd).length, 1);
+});
+
+test("does NOT dedup when lastModified differs", () => {
+  var cd = {
+    files: [
+      mkFile("a.png", 100, "image/png", 1),
+      mkFile("a.png", 100, "image/png", 2),
+    ],
+  };
+  assertEq(_collectPastedImages(cd).length, 2);
+});
+
+test("falls through to cd.items when cd.files is empty", () => {
+  var file = mkFile("c.jpg", 200, "image/jpeg");
+  var cd = {
+    files: [],
+    items: [{ type: "image/jpeg", getAsFile: () => file }],
+  };
+  var out = _collectPastedImages(cd);
+  assertEq(out.length, 1);
+  assertEq(out[0].name, "c.jpg");
+});
+
+test("cd.items path also skips non-image items", () => {
+  var file = mkFile("c.jpg", 200, "image/jpeg");
+  var cd = {
+    files: [],
+    items: [
+      { type: "text/plain", getAsFile: () => mkFile("t.txt", 50, "text/plain") },
+      { type: "image/jpeg", getAsFile: () => file },
+    ],
+  };
+  assertEq(_collectPastedImages(cd).length, 1);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/hub/frontend/src/composer/composer-paste.ts
+++ b/hub/frontend/src/composer/composer-paste.ts
@@ -1,0 +1,129 @@
+// @ts-nocheck
+/* composer/composer-paste.ts — paste + drag/drop handlers for the SSoT
+ * composer. Extracted so the Chat / Overview / Reply composers share one
+ * code path instead of three near-duplicates.
+ *
+ * Each composer surface provides a `stageFiles(files)` callback via opts;
+ * this module turns raw paste / drop DOM events into a dedup'd File[] and
+ * invokes it. Does NOT know about the surface's pending-attachments tray —
+ * that stays with the surface (Chat: module-level pendingAttachments;
+ * Overview: popup-local popPending[]; Reply: window.threadPendingAttachments).
+ *
+ * Text-paste-as-file heuristic (todo#52) lives in upload.ts
+ * (_pastedTextShouldAttach / _buildPastedTextFile) and is reused here so
+ * every surface behaves identically.
+ *
+ * Paste-target guard (msg#16193): `_isTargetOnChatTab` is Chat-specific.
+ * The per-composer handler knows its own surface, so we don't need the
+ * guard here — the handler is bound to the surface's own textarea and
+ * stops propagation so the Chat-level msg-input paste handler (which
+ * still uses _isTargetOnChatTab as a safety net) won't double-fire. */
+
+import {
+  _buildPastedTextFile,
+  _pastedTextShouldAttach,
+} from "../upload";
+
+export type ComposerPasteStageFn = (files: File[]) => void | Promise<void>;
+
+/* Collect image files from a clipboard DataTransfer, dedup by
+ * (name|size|type|lastModified). Mirrors the exact dedup used in the
+ * pre-SSoT Chat + Overview paste handlers. */
+export function _collectPastedImages(cd): File[] {
+  var collected: File[] = [];
+  var seen = new Set();
+  function pushUnique(f) {
+    if (!f || !f.type || f.type.indexOf("image/") !== 0) return;
+    var key =
+      f.name + "|" + f.size + "|" + f.type + "|" + (f.lastModified || 0);
+    if (seen.has(key)) return;
+    seen.add(key);
+    collected.push(f);
+  }
+  if (!cd) return collected;
+  var fileList = cd.files;
+  if (fileList && fileList.length) {
+    for (var i = 0; i < fileList.length; i++) pushUnique(fileList[i]);
+  } else if (cd.items) {
+    for (var j = 0; j < cd.items.length; j++) {
+      var it = cd.items[j];
+      if (it && it.type && it.type.indexOf("image/") === 0) {
+        pushUnique(it.getAsFile());
+      }
+    }
+  }
+  return collected;
+}
+
+/* Install a paste handler on `input` that stages pasted images + long
+ * plain text into the surface's attachment store via `stageFiles`.
+ *
+ * Returns a disposer that removes the listener. */
+export function wireComposerPaste(
+  input: HTMLElement,
+  stageFiles: ComposerPasteStageFn,
+  opts?: { stopPropagation?: boolean },
+): () => void {
+  var stop = opts && opts.stopPropagation !== false; /* default true */
+  function handler(ev) {
+    if (stop) ev.stopPropagation();
+    var cd =
+      ev.clipboardData || (ev.originalEvent && ev.originalEvent.clipboardData);
+    if (!cd) return;
+    var collected = _collectPastedImages(cd);
+    var text = "";
+    try {
+      text = cd.getData("text/plain") || "";
+    } catch (_) {}
+    var attachText =
+      typeof _pastedTextShouldAttach === "function" &&
+      _pastedTextShouldAttach(text);
+    if (collected.length > 0 || attachText) {
+      ev.preventDefault();
+      if (attachText && typeof _buildPastedTextFile === "function") {
+        collected.push(_buildPastedTextFile(text));
+      }
+      stageFiles(collected);
+    }
+  }
+  input.addEventListener("paste", handler);
+  return function () {
+    input.removeEventListener("paste", handler);
+  };
+}
+
+/* Install drag-over / drop handlers. `host` is the outer composer
+ * element (gets .drag-over class during an active drag); `stageFiles`
+ * is called with the dropped File[]. Returns a disposer. */
+export function wireComposerDragDrop(
+  host: HTMLElement,
+  stageFiles: ComposerPasteStageFn,
+  opts?: { dragOverClass?: string },
+): () => void {
+  var cls = (opts && opts.dragOverClass) || "drag-over";
+  function onOver(ev) {
+    ev.preventDefault();
+    ev.stopPropagation();
+    host.classList.add(cls);
+  }
+  function onLeave() {
+    host.classList.remove(cls);
+  }
+  function onDrop(ev) {
+    ev.preventDefault();
+    ev.stopPropagation();
+    host.classList.remove(cls);
+    var files = ev.dataTransfer && ev.dataTransfer.files;
+    if (files && files.length) {
+      stageFiles(Array.prototype.slice.call(files));
+    }
+  }
+  host.addEventListener("dragover", onOver);
+  host.addEventListener("dragleave", onLeave);
+  host.addEventListener("drop", onDrop);
+  return function () {
+    host.removeEventListener("dragover", onOver);
+    host.removeEventListener("dragleave", onLeave);
+    host.removeEventListener("drop", onDrop);
+  };
+}

--- a/hub/frontend/src/composer/composer.ts
+++ b/hub/frontend/src/composer/composer.ts
@@ -1,0 +1,523 @@
+// @ts-nocheck
+/* composer/composer.ts — Single-Source-of-Truth message composer.
+ *
+ * Three surfaces consume this module:
+ *
+ *   1. Chat tab composer   (surface: "chat")
+ *      Host DOM already exists in dashboard.html (`.input-bar`); we
+ *      adopt it rather than re-render, so all historic IDs
+ *      (#msg-input, #msg-send, #msg-attach, #msg-webcam, #msg-sketch,
+ *      #msg-voice, #msg-voice-lang, #file-input, #pending-attachments)
+ *      keep working for voice-input.ts, upload.ts, and every other
+ *      module that still talks to those IDs.
+ *
+ *   2. Overview graph-compose popup  (surface: "overview")
+ *      Rendered on-demand anchored near a channel node. The existing
+ *      DOM uses tcc-* classes with a textarea; we create the markup
+ *      here and keep those classes for CSS compatibility.
+ *
+ *   3. Reply composer inside the thread panel  (surface: "reply")
+ *      Built when the thread panel opens. DOM used to be inlined in
+ *      threads/panel.ts; now rendered by renderComposer with a
+ *      surface-specific layout class.
+ *
+ * `renderComposer(host, opts)` returns a `ComposerInstance` with
+ * focus / setValue / getValue / destroy — the thin public API.
+ * Feature flags live on `opts.features`; each surface toggles the
+ * sub-features it wants, so Chat stays fully-featured and the smaller
+ * surfaces opt into paste / mention / attach / voice without code
+ * duplication. See PR body for the parity matrix.
+ */
+
+import {
+  wireComposerDragDrop,
+  wireComposerPaste,
+  type ComposerPasteStageFn,
+} from "./composer-paste";
+import {
+  isMentionDropdownOpen,
+  wireComposerMention,
+} from "./composer-mention";
+import {
+  wireAttachButtons,
+  type AttachWireOpts,
+} from "./composer-attach";
+
+export type ComposerSurface = "chat" | "overview" | "reply";
+
+export interface ComposerSubmitPayload {
+  text: string;
+  /* Pending attachments are OWNED by the surface (its store); this
+   * callback is a pure event — the surface is responsible for
+   * clearing its own store afterwards. */
+}
+
+export interface ComposerFeatures {
+  /* @agent / @user autocomplete (#mention-dropdown) */
+  mention?: boolean;
+  /* Cmd+V / Ctrl+V paste of images + long plain text */
+  paste?: boolean;
+  /* Drag-and-drop files onto the composer host */
+  dragDrop?: boolean;
+  /* 📎 attach button + hidden <input type="file"> */
+  attach?: boolean;
+  /* 📷 camera button → openWebcam() */
+  camera?: boolean;
+  /* ✏️ sketch button → openSketch() */
+  sketch?: boolean;
+  /* 🎤 voice button → window.toggleVoiceInput() */
+  voice?: boolean;
+  /* Send button visible in the action row */
+  sendButton?: boolean;
+  /* Cmd+Enter submits. Plain Enter also submits unless shiftEnterNewline
+   * is true AND the user held Shift. */
+  cmdEnterSubmit?: boolean;
+  /* Shift+Enter = newline (default true). When false, plain Enter
+   * submits unconditionally and Shift+Enter is a no-op. */
+  shiftEnterNewline?: boolean;
+  /* Auto-resize textarea up to maxHeight px (0 = no auto-resize). */
+  autoResize?: boolean;
+  /* Only active on the Chat tab? Guards `activeTab === "chat"` for
+   * tab-aware focus. Reply/Overview leave this false. */
+  tabAwareFocus?: boolean;
+  /* Alt/Ctrl+Enter toggles voice *locally* via the composer's keydown.
+   * Default: true — Overview + Reply need this because voice-input.ts's
+   * global chord handler explicitly skips those surfaces. Chat leaves it
+   * false: voice-input.ts fires on Chat via the global handler, and
+   * letting the composer also fire would double-toggle. */
+  localVoiceChord?: boolean;
+}
+
+export interface ComposerOpts {
+  surface: ComposerSurface;
+  /* Called when the user presses Enter / Cmd+Enter / clicks Send.
+   * Surface packages its own attachment list into the WS/REST payload. */
+  onSubmit: (p: ComposerSubmitPayload) => void;
+  /* Pass-through stage-files callback — paste / drop / file-picker all
+   * funnel through it so the surface keeps ownership of its pending
+   * attachments (Chat: upload.ts stageFiles; Overview: popup-local
+   * _stagePopFiles; Reply: _stageThreadFiles). */
+  stageFiles?: (files: File[]) => void | Promise<void>;
+  placeholder?: string;
+  features?: ComposerFeatures;
+  /* Auto-resize ceiling (default 200 for Chat, 120 for Reply, 0 for
+   * Overview's fixed-height popup textarea). */
+  maxResizePx?: number;
+  /* Chat-only: called on submit success so chat-composer can clear
+   * drafts / voice-input state. Not part of the parity contract. */
+  onAfterSubmit?: () => void;
+  /* Hooks that surfaces can plug into without owning the DOM */
+  onSketchOpen?: () => void;
+  onVoiceToggle?: () => void;
+  /* Which existing element (if any) should be adopted as the
+   * composer's root. When omitted, renderComposer creates a new
+   * .composer element inside `host`. Chat passes the existing
+   * `.input-bar` element so the static dashboard.html DOM is reused. */
+  adoptRoot?: HTMLElement;
+  /* When adoptRoot is supplied, the composer will lookup its
+   * children by these selectors instead of creating new ones.
+   * Any missing selector falls back to feature disable. */
+  adoptSelectors?: {
+    input?: string;
+    sendBtn?: string;
+    attachBtn?: string;
+    cameraBtn?: string;
+    sketchBtn?: string;
+    voiceBtn?: string;
+    voiceLangBtn?: string;
+    fileInput?: string;
+  };
+}
+
+export interface ComposerInstance {
+  root: HTMLElement;
+  input: HTMLTextAreaElement;
+  destroy: () => void;
+  focus: () => void;
+  setValue: (text: string) => void;
+  getValue: () => string;
+}
+
+const DEFAULT_FEATURES: ComposerFeatures = {
+  mention: true,
+  paste: true,
+  dragDrop: true,
+  attach: true,
+  camera: true,
+  sketch: true,
+  voice: true,
+  sendButton: true,
+  cmdEnterSubmit: true,
+  shiftEnterNewline: true,
+  autoResize: true,
+  tabAwareFocus: false,
+  localVoiceChord: true,
+};
+
+/* Build a fresh composer DOM. Used by Overview + Reply surfaces; Chat
+ * adopts the static dashboard.html markup via `adoptRoot`. */
+function _buildComposerDom(opts: ComposerOpts): {
+  root: HTMLElement;
+  input: HTMLTextAreaElement;
+  sendBtn: HTMLElement | null;
+  attachBtn: HTMLElement | null;
+  cameraBtn: HTMLElement | null;
+  sketchBtn: HTMLElement | null;
+  voiceBtn: HTMLElement | null;
+  voiceLangBtn: HTMLElement | null;
+  fileInput: HTMLInputElement | null;
+} {
+  var features = Object.assign({}, DEFAULT_FEATURES, opts.features || {});
+  var root = document.createElement("div");
+  root.className = "composer composer-surface-" + opts.surface;
+  root.setAttribute("data-composer-surface", opts.surface);
+
+  var input = document.createElement("textarea");
+  input.className = "composer-input";
+  if (opts.surface === "reply") {
+    input.id = "thread-input";
+  }
+  input.setAttribute("data-voice-input", "");
+  input.setAttribute("rows", "2");
+  input.placeholder = opts.placeholder || "Type a message…";
+  input.autocomplete = "off";
+
+  var fileInput: HTMLInputElement | null = null;
+  if (features.attach) {
+    fileInput = document.createElement("input") as HTMLInputElement;
+    fileInput.type = "file";
+    fileInput.multiple = true;
+    fileInput.style.display = "none";
+    fileInput.className = "composer-file-input";
+    if (opts.surface === "reply") {
+      fileInput.id = "thread-file-input";
+    }
+  }
+
+  var actions = document.createElement("div");
+  actions.className = "composer-actions";
+
+  var attachBtn: HTMLElement | null = null;
+  var cameraBtn: HTMLElement | null = null;
+  var sketchBtn: HTMLElement | null = null;
+  var voiceBtn: HTMLElement | null = null;
+  var voiceLangBtn: HTMLElement | null = null;
+  var sendBtn: HTMLElement | null = null;
+
+  function mkBtn(cls: string, id: string | null, title: string, emoji: string) {
+    var b = document.createElement("button");
+    b.type = "button";
+    b.className = "composer-btn " + cls;
+    if (id) b.id = id;
+    b.tabIndex = -1;
+    b.title = title;
+    b.setAttribute("aria-label", title);
+    b.textContent = emoji;
+    return b;
+  }
+
+  if (features.attach) {
+    attachBtn = mkBtn(
+      "composer-btn-attach",
+      opts.surface === "reply" ? "thread-attach-btn" : null,
+      "Attach file",
+      "\uD83D\uDCCE",
+    );
+    actions.appendChild(attachBtn);
+  }
+  if (features.camera) {
+    cameraBtn = mkBtn("composer-btn-camera", null, "Take photo", "\uD83D\uDCF7");
+    actions.appendChild(cameraBtn);
+  }
+  if (features.sketch) {
+    sketchBtn = mkBtn(
+      "composer-btn-sketch",
+      opts.surface === "reply" ? "thread-sketch-btn" : null,
+      "Draw sketch",
+      "\u270F\uFE0F",
+    );
+    actions.appendChild(sketchBtn);
+  }
+  if (features.voice) {
+    voiceBtn = mkBtn(
+      "composer-btn-voice",
+      opts.surface === "reply" ? "thread-voice-btn" : null,
+      "Voice input",
+      "\uD83C\uDFA4",
+    );
+    actions.appendChild(voiceBtn);
+    if (opts.surface === "reply") {
+      voiceLangBtn = mkBtn(
+        "composer-btn-voice-lang",
+        "thread-voice-lang-btn",
+        "Switch language (EN/JA)",
+        "EN",
+      );
+      voiceLangBtn.style.fontSize = "11px";
+      voiceLangBtn.style.padding = "2px 5px";
+      voiceLangBtn.style.opacity = "0.7";
+      actions.appendChild(voiceLangBtn);
+    }
+  }
+  if (features.sendButton) {
+    sendBtn = document.createElement("button");
+    sendBtn.type = "button";
+    sendBtn.className =
+      "composer-btn composer-btn-send " +
+      (opts.surface === "reply" ? "thread-send-btn" : "");
+    sendBtn.textContent = "Send";
+    sendBtn.title = "Send message";
+  }
+
+  root.appendChild(input);
+  if (fileInput) root.appendChild(fileInput);
+  root.appendChild(actions);
+  if (sendBtn) actions.appendChild(sendBtn);
+
+  return {
+    root: root,
+    input: input,
+    sendBtn: sendBtn,
+    attachBtn: attachBtn,
+    cameraBtn: cameraBtn,
+    sketchBtn: sketchBtn,
+    voiceBtn: voiceBtn,
+    voiceLangBtn: voiceLangBtn,
+    fileInput: fileInput,
+  };
+}
+
+function _adoptComposerDom(opts: ComposerOpts) {
+  var root = opts.adoptRoot!;
+  var sel = opts.adoptSelectors || {};
+  function q(selector: string | undefined): any {
+    if (!selector) return null;
+    return root.querySelector(selector) || document.querySelector(selector);
+  }
+  return {
+    root: root,
+    input: q(sel.input) as HTMLTextAreaElement,
+    sendBtn: q(sel.sendBtn) as HTMLElement | null,
+    attachBtn: q(sel.attachBtn) as HTMLElement | null,
+    cameraBtn: q(sel.cameraBtn) as HTMLElement | null,
+    sketchBtn: q(sel.sketchBtn) as HTMLElement | null,
+    voiceBtn: q(sel.voiceBtn) as HTMLElement | null,
+    voiceLangBtn: q(sel.voiceLangBtn) as HTMLElement | null,
+    fileInput: q(sel.fileInput) as HTMLInputElement | null,
+  };
+}
+
+export function renderComposer(
+  host: HTMLElement,
+  opts: ComposerOpts,
+): ComposerInstance {
+  if (!opts || typeof opts.onSubmit !== "function") {
+    throw new Error("renderComposer: opts.onSubmit is required");
+  }
+  var features = Object.assign({}, DEFAULT_FEATURES, opts.features || {});
+  var built = opts.adoptRoot
+    ? _adoptComposerDom(opts)
+    : _buildComposerDom(opts);
+
+  if (!built.input) {
+    throw new Error(
+      "renderComposer: no textarea found for surface " + opts.surface,
+    );
+  }
+
+  /* Always tag the root with the surface attribute so CSS selectors and
+   * debugging queries work uniformly across constructed + adopted DOMs. */
+  try {
+    built.root.setAttribute("data-composer-surface", opts.surface);
+  } catch (_) {}
+
+  /* Mount into host if we built fresh DOM. */
+  if (!opts.adoptRoot && host && built.root.parentNode !== host) {
+    host.appendChild(built.root);
+  }
+
+  var disposers: Array<() => void> = [];
+
+  /* Auto-resize */
+  var maxPx =
+    typeof opts.maxResizePx === "number"
+      ? opts.maxResizePx
+      : opts.surface === "reply"
+        ? 120
+        : 200;
+  if (features.autoResize && maxPx > 0) {
+    function resize() {
+      try {
+        (built.input as HTMLTextAreaElement).style.height = "auto";
+        (built.input as HTMLTextAreaElement).style.height =
+          Math.min(built.input.scrollHeight, maxPx) + "px";
+      } catch (_) {}
+    }
+    built.input.addEventListener("input", resize);
+    disposers.push(function () {
+      built.input.removeEventListener("input", resize);
+    });
+  }
+
+  /* Mention autocomplete */
+  if (features.mention) {
+    try {
+      wireComposerMention(built.input);
+    } catch (_) {}
+  }
+
+  /* Paste */
+  if (features.paste && typeof opts.stageFiles === "function") {
+    var pasteDispose = wireComposerPaste(built.input, opts.stageFiles);
+    disposers.push(pasteDispose);
+  }
+
+  /* Drag-drop */
+  if (features.dragDrop && typeof opts.stageFiles === "function") {
+    var dropDispose = wireComposerDragDrop(built.root, opts.stageFiles);
+    disposers.push(dropDispose);
+  }
+
+  /* Attach / camera / sketch / voice buttons */
+  if (
+    features.attach ||
+    features.camera ||
+    features.sketch ||
+    features.voice
+  ) {
+    var attachOpts: AttachWireOpts = {
+      input: built.input as HTMLTextAreaElement,
+      fileInput: built.fileInput,
+      attachBtn: features.attach ? built.attachBtn : null,
+      cameraBtn: features.camera ? built.cameraBtn : null,
+      sketchBtn: features.sketch ? built.sketchBtn : null,
+      voiceBtn: features.voice ? built.voiceBtn : null,
+      onSketchOpen: opts.onSketchOpen,
+      onVoiceToggle: opts.onVoiceToggle,
+      stageFiles: opts.stageFiles,
+    };
+    disposers.push(wireAttachButtons(attachOpts));
+  }
+
+  /* Keyboard shortcuts: Enter to submit, Shift+Enter for newline, Ctrl+U
+   * opens the file picker if one is wired. Alt/Ctrl+Enter is reserved for
+   * voice-input on all surfaces — composer just preventDefaults + delegates
+   * to the surface's onVoiceToggle hook (or window.toggleVoiceInput). */
+  function submitFromKeyboard(ev) {
+    ev.preventDefault();
+    _submit();
+  }
+  function onKeydown(ev) {
+    /* Cmd/Ctrl+U = file picker (msg#9877) */
+    var isMac = /Mac|iPhone|iPad/.test(
+      navigator.platform || navigator.userAgent,
+    );
+    if ((isMac ? ev.metaKey : ev.ctrlKey) && ev.key === "u") {
+      if (built.fileInput) {
+        ev.preventDefault();
+        built.fileInput.click();
+      }
+      return;
+    }
+    if (ev.key !== "Enter") return;
+    /* Voice toggle chords — Ctrl+Enter / Alt+Enter. Stop propagation so
+     * the global voice handler doesn't also fire. Only active when the
+     * surface opts into local voice handling; Chat defers to the
+     * voice-input.ts global handler to avoid double-toggle. */
+    if ((ev.ctrlKey || ev.altKey) && features.localVoiceChord !== false) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      try {
+        built.input.focus();
+      } catch (_) {}
+      if (typeof opts.onVoiceToggle === "function") {
+        try {
+          opts.onVoiceToggle();
+        } catch (_) {}
+      } else if (typeof (window as any).toggleVoiceInput === "function") {
+        try {
+          (window as any).toggleVoiceInput();
+        } catch (_) {}
+      }
+      return;
+    }
+    /* Even when localVoiceChord is off, Alt+Enter / Ctrl+Enter should
+     * not fall through to submit — they belong to the voice-input.ts
+     * global chord. Bail before the submit branch. */
+    if (ev.ctrlKey || ev.altKey) {
+      return;
+    }
+    /* Don't submit while the mention dropdown is showing a selection. */
+    if (features.mention && isMentionDropdownOpen()) return;
+    if (features.shiftEnterNewline !== false && ev.shiftKey) {
+      return; /* newline */
+    }
+    submitFromKeyboard(ev);
+  }
+  built.input.addEventListener("keydown", onKeydown);
+  disposers.push(function () {
+    built.input.removeEventListener("keydown", onKeydown);
+  });
+
+  /* Send button */
+  function onSendClick(ev) {
+    ev.preventDefault();
+    _submit();
+    try {
+      built.input.focus();
+    } catch (_) {}
+  }
+  if (features.sendButton && built.sendBtn) {
+    built.sendBtn.addEventListener("click", onSendClick);
+    disposers.push(function () {
+      built.sendBtn!.removeEventListener("click", onSendClick);
+    });
+  }
+
+  function _submit() {
+    var text = (built.input as HTMLTextAreaElement).value || "";
+    try {
+      opts.onSubmit({ text: text });
+    } catch (e) {
+      console.error("[composer] onSubmit error:", e);
+    }
+    if (typeof opts.onAfterSubmit === "function") {
+      try {
+        opts.onAfterSubmit();
+      } catch (_) {}
+    }
+  }
+
+  var instance: ComposerInstance = {
+    root: built.root,
+    input: built.input as HTMLTextAreaElement,
+    destroy: function () {
+      while (disposers.length) {
+        var d = disposers.pop();
+        try {
+          d!();
+        } catch (_) {}
+      }
+      /* Only remove DOM we created. Adopted DOM stays in place for the
+       * next mount / static page lifecycle. */
+      if (!opts.adoptRoot && built.root.parentNode) {
+        built.root.parentNode.removeChild(built.root);
+      }
+    },
+    focus: function () {
+      try {
+        built.input.focus();
+      } catch (_) {}
+    },
+    setValue: function (text) {
+      (built.input as HTMLTextAreaElement).value = text || "";
+      /* Manually trigger resize since we set value programmatically. */
+      built.input.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    getValue: function () {
+      return (built.input as HTMLTextAreaElement).value || "";
+    },
+  };
+
+  return instance;
+}

--- a/hub/frontend/src/index.ts
+++ b/hub/frontend/src/index.ts
@@ -43,6 +43,14 @@ import "./chat/chat-history";
 import "./chat/chat-composer";
 import "./chat/chat-actions";
 import "./mention";
+/* Composer SSoT unification (msg#16286): shared module between the
+ * Chat / Overview / Reply surfaces. Loaded after mention.ts so
+ * wireComposerMention can reach the already-initialised dropdown
+ * state. */
+import "./composer/composer-paste";
+import "./composer/composer-mention";
+import "./composer/composer-attach";
+import "./composer/composer";
 import "./settings-tab";
 import "./emoji-picker";
 import "./filter/state";

--- a/hub/frontend/src/threads/panel.ts
+++ b/hub/frontend/src/threads/panel.ts
@@ -2,8 +2,7 @@
 import { getResolvedAgentColor, getSenderIcon } from "../agent-icons";
 import { apiUrl, cleanAgentName, escapeHtml, getAgentColor, orochiHeaders, timeAgo } from "../app/utils";
 import { buildAttachmentsHtml } from "../chat/chat-attachments";
-import { initMentionAutocomplete, mentionDropdown, mentionSelectedIndex } from "../mention";
-import { openSketch } from "../sketch";
+import { renderComposer } from "../composer/composer";
 import { _linkifyThreadContent, _pushThreadUrlState, _renderThreadAttachmentTray, _stageThreadFiles } from "./state";
 import { _debounceSave, clearDraft, loadDraft } from "../composer/draft-store";
 
@@ -11,7 +10,18 @@ function _threadDraftTarget(parentId) {
   return "msg" + String(parentId);
 }
 
-/* Threading — panel open/close, replies render, send, WS handlers */
+/* Thread composer instance — created in openThreadPanel, destroyed in
+ * closeThreadPanel. Module-scoped so both paths can reference it
+ * without a DOM round-trip. */
+var _threadComposer = null;
+
+/* Threading — panel open/close, replies render, send, WS handlers.
+ * Reply composer (textarea + attach/sketch/voice/send buttons) is
+ * provided by composer.ts::renderComposer(surface: "reply") since the
+ * SSoT unification (msg#16286); this file owns the surrounding chrome
+ * (header, parent preview, replies list, pending-attachments tray)
+ * plus the thread-specific voice-lang button sync + draft-store
+ * hydration. */
 /* globals: apiUrl, orochiHeaders, escapeHtml, timeAgo, getAgentColor,
    cleanAgentName, getSenderIcon, getResolvedAgentColor,
    (globalThis as any).threadPanel, (globalThis as any).threadPanelParentId, (globalThis as any).threadPendingAttachments,
@@ -23,6 +33,10 @@ export function closeThreadPanel(opts) {
   var inputHasFocus = msgInput && document.activeElement === msgInput;
   var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
   var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
+  if (_threadComposer) {
+    try { _threadComposer.destroy(); } catch (_) {}
+    _threadComposer = null;
+  }
   if ((globalThis as any).threadPanel && (globalThis as any).threadPanel.parentNode) {
     (globalThis as any).threadPanel.parentNode.removeChild((globalThis as any).threadPanel);
   }
@@ -51,6 +65,13 @@ export async function openThreadPanel(parentId, opts) {
 
   (globalThis as any).threadPanel = document.createElement("div");
   (globalThis as any).threadPanel.className = "thread-panel";
+  /* Thread panel shell only; composer DOM (textarea, attach/sketch/voice
+   * buttons, send button, hidden file input) is built by renderComposer
+   * below and mounted into #thread-composer-slot. Legacy IDs
+   * (#thread-input, #thread-attach-btn, #thread-sketch-btn,
+   * #thread-voice-btn, #thread-voice-lang-btn, #thread-file-input,
+   * .thread-send-btn) are preserved by the surface="reply" DOM-builder
+   * in composer.ts so voice-input.ts + existing selectors keep working. */
   (globalThis as any).threadPanel.innerHTML =
     '<div class="thread-header">' +
     '<button type="button" class="thread-back" onclick="closeThreadPanel()" aria-label="Back to chat">' +
@@ -72,19 +93,7 @@ export async function openThreadPanel(parentId, opts) {
     '<div class="thread-replies" id="thread-replies"></div>' +
     '<div class="thread-input-row">' +
     '<div id="thread-pending-attachments" class="thread-pending-attachments" style="display:none"></div>' +
-    '<div class="thread-compose-row">' +
-    '<textarea id="thread-input" placeholder="Reply in thread…" rows="2"></textarea>' +
-    '<div class="thread-bottom-row">' +
-    '<div class="thread-input-actions">' +
-    '<button type="button" id="thread-attach-btn" tabindex="-1" title="Attach file (Ctrl+U)">📎</button>' +
-    '<button type="button" id="thread-sketch-btn" tabindex="-1" title="Draw sketch">✏️</button>' +
-    '<button type="button" id="thread-voice-btn" tabindex="-1" title="Voice input">🎤</button>' +
-    '<button type="button" id="thread-voice-lang-btn" tabindex="-1" title="Switch language (EN/JA)" style="font-size:11px;padding:2px 5px;opacity:0.7;">EN</button>' +
-    '<input type="file" id="thread-file-input" style="display:none" multiple>' +
-    "</div>" +
-    '<button type="button" class="thread-send-btn" onclick="sendThreadReply()">Send</button>' +
-    "</div>" +
-    "</div>" +
+    '<div class="thread-compose-row" id="thread-composer-slot"></div>' +
     "</div>";
   /* Append as flex sibling of .main inside .container (Slack-style side-by-side) */
   var container = document.querySelector(".container");
@@ -95,8 +104,54 @@ export async function openThreadPanel(parentId, opts) {
   }
 
   await loadThreadReplies(parentId);
-  var ta = document.getElementById("thread-input");
-  if (ta) {
+
+  var composerSlot = document.getElementById("thread-composer-slot");
+  (globalThis as any).threadPendingAttachments = [];
+  _renderThreadAttachmentTray();
+
+  if (composerSlot) {
+    _threadComposer = renderComposer(composerSlot as HTMLElement, {
+      surface: "reply",
+      placeholder: "Reply in thread\u2026",
+      stageFiles: function (files) {
+        return _stageThreadFiles(files);
+      },
+      onSketchOpen: function () {
+        /* openSketch() sends to currentChannel; we flag _threadSketchActive
+         * so the sketch-submit path knows to post as a thread-reply. */
+        (globalThis as any)._threadSketchActive = true;
+      },
+      features: {
+        mention: true,
+        paste: true,
+        dragDrop: false /* thread panel had no drop handler pre-SSoT; preserve current UX */,
+        attach: true,
+        camera: false /* Reply composer never had a camera button */,
+        sketch: true,
+        voice: true,
+        sendButton: true,
+        cmdEnterSubmit: true,
+        shiftEnterNewline: true,
+        autoResize: true,
+        tabAwareFocus: false,
+        /* voice-input.ts's global chord handler bails when focus is
+         * inside .thread-panel, so the composer owns Alt/Ctrl+Enter
+         * here. */
+        localVoiceChord: true,
+      },
+      maxResizePx: 120,
+      onSubmit: function () {
+        sendThreadReply();
+      },
+    });
+
+    /* Add legacy class names additively so existing .thread-* CSS still
+     * applies. */
+    var ta = _threadComposer.input;
+    ta.classList.add("thread-textarea");
+    var sendBtn = composerSlot.querySelector(".composer-btn-send");
+    if (sendBtn) sendBtn.classList.add("thread-send-btn");
+
     /* msg#16324: hydrate any persisted thread-reply draft so the user's
      * in-progress text survives page reload / deploy. Target key is
      * "msg<parentId>" per spec (orochi.draft.thread.msg12345). */
@@ -104,50 +159,20 @@ export async function openThreadPanel(parentId, opts) {
       var _saved = loadDraft("thread", _threadDraftTarget(parentId));
       if (_saved && !ta.value) {
         ta.value = _saved;
-        /* Match the auto-resize behavior used by the input handler. */
+        /* Match the auto-resize behavior used by the composer. */
         ta.style.height = "auto";
         ta.style.height = Math.min(ta.scrollHeight, 120) + "px";
       }
     } catch (_) {}
-    ta.focus();
+    try { ta.focus(); } catch (_) {}
     /* Place cursor at end of restored draft. */
     try {
       var _len = ta.value ? ta.value.length : 0;
       ta.setSelectionRange(_len, _len);
     } catch (_) {}
-    ta.addEventListener("keydown", function (e) {
-      /* Alt+Enter / Ctrl+Enter in thread: toggle voice directed at thread textarea */
-      if (e.key === "Enter" && (e.altKey || e.ctrlKey)) {
-        e.preventDefault();
-        e.stopPropagation(); /* prevent global voice handler from double-firing */
-        if (typeof window.toggleVoiceInput === "function") {
-          /* Focus thread textarea so _toggleVoice captures it as target */
-          var tIn = document.getElementById("thread-input");
-          if (tIn) tIn.focus();
-          window.toggleVoiceInput();
-        }
-        return;
-      }
-      /* Plain Enter (no modifier) sends reply */
-      if (e.key === "Enter" && !e.shiftKey) {
-        /* Don't send if mention dropdown is open and an item is selected */
-        if (
-          typeof mentionDropdown !== "undefined" &&
-          mentionDropdown &&
-          mentionDropdown.classList.contains("visible") &&
-          mentionSelectedIndex >= 0
-        ) {
-          return; /* Let handleMentionKeydown handle it */
-        }
-        e.preventDefault();
-        sendThreadReply();
-      }
-    });
-    /* Auto-resize: grow with content up to 120px; also persist the
-     * draft (debounced at 300ms via draft-store) so reload restores. */
+
+    /* Persist every keystroke (debounced at 300ms via draft-store). */
     ta.addEventListener("input", function () {
-      this.style.height = "auto";
-      this.style.height = Math.min(this.scrollHeight, 120) + "px";
       try {
         _debounceSave(
           "thread",
@@ -156,73 +181,22 @@ export async function openThreadPanel(parentId, opts) {
         );
       } catch (_) {}
     });
-    /* Enable @mention autocomplete in thread input */
-    if (typeof initMentionAutocomplete === "function") {
-      initMentionAutocomplete(ta);
+
+    /* Thread-specific voice language button: sync label with the Chat
+     * voice-lang button (voice-input.ts manages the shared state). This
+     * is the one bit of wiring the generic composer can't own because
+     * the language button is thread-only chrome. */
+    var voiceLangBtn = document.getElementById("thread-voice-lang-btn");
+    if (voiceLangBtn) {
+      var mainLangBtn = document.getElementById("msg-voice-lang");
+      if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
+      voiceLangBtn.addEventListener("click", function () {
+        if (typeof (window as any).cycleVoiceLang === "function") {
+          (window as any).cycleVoiceLang();
+          if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
+        }
+      });
     }
-    /* Ctrl+U → trigger file picker in thread panel */
-    ta.addEventListener("keydown", function (e) {
-      if ((e.ctrlKey || e.metaKey) && e.key === "u") {
-        e.preventDefault();
-        var fi = document.getElementById("thread-file-input");
-        if (fi) fi.click();
-      }
-    });
-  }
-
-  /* Wire thread action buttons */
-  (globalThis as any).threadPendingAttachments = [];
-  _renderThreadAttachmentTray();
-
-  var attachBtn = document.getElementById("thread-attach-btn");
-  var fileInput = document.getElementById("thread-file-input");
-  var sketchBtn = document.getElementById("thread-sketch-btn");
-  var voiceBtn = document.getElementById("thread-voice-btn");
-  var voiceLangBtn = document.getElementById("thread-voice-lang-btn");
-
-  if (attachBtn && fileInput) {
-    attachBtn.addEventListener("click", function () {
-      fileInput.click();
-    });
-    fileInput.addEventListener("change", function () {
-      _stageThreadFiles(Array.from(fileInput.files || []));
-      fileInput.value = "";
-    });
-  }
-
-  if (sketchBtn) {
-    sketchBtn.addEventListener("click", function () {
-      /* openSketch() sends to currentChannel; we override the callback */
-      if (typeof openSketch === "function") {
-        (globalThis as any)._threadSketchActive = true;
-        openSketch();
-      }
-    });
-  }
-
-  if (voiceBtn) {
-    /* Toggle voice into the thread textarea */
-    voiceBtn.addEventListener("click", function () {
-      if (typeof window.toggleVoiceInput === "function") {
-        /* Focus thread textarea so _toggleVoice captures it as target */
-        var tIn = document.getElementById("thread-input");
-        if (tIn) tIn.focus();
-        window.toggleVoiceInput();
-      }
-    });
-  }
-
-  if (voiceLangBtn) {
-    /* Sync button label with voice-input.js current language on open */
-    var mainLangBtn = document.getElementById("msg-voice-lang");
-    if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
-    voiceLangBtn.addEventListener("click", function () {
-      if (typeof window.cycleVoiceLang === "function") {
-        window.cycleVoiceLang();
-        /* Sync label from main lang button */
-        if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
-      }
-    });
   }
 }
 

--- a/hub/static/hub/activity-tab/compose.js
+++ b/hub/static/hub/activity-tab/compose.js
@@ -235,17 +235,9 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
   pop.id = "topo-channel-compose";
   pop.className = "topo-channel-compose";
   pop.setAttribute("data-channel", channel);
+  pop.setAttribute("data-composer-surface", "overview");
   pop.style.left = Math.max(8, clientX - 140) + "px";
   pop.style.top = Math.max(8, clientY + 12) + "px";
-  /* Minimal popup: no header, no close button, no + button, no send
-   * button. Just a textarea whose tooltip documents all the keyboard
-   * shortcuts, plus a small ▾ chevron at the bottom-right corner that
-   * reveals attach / camera / sketch / voice buttons. Enter sends, Esc
-   * closes, outside click closes. ywatanabe 2026-04-19: "make the
-   * modal minimal; no send button needed; no dm nor channel label
-   * needed; no plus button needed; not x button needed; just add a
-   * small chevron to the bottom to show other buttons; show tooltip
-   * with keyboard shortcuts even when they are not expanded to use". */
   var tccShortcuts =
     "Enter — send\n" +
     "Shift+Enter — newline\n" +
@@ -253,128 +245,23 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
     "Drop files to attach\n" +
     "Paste image/file to attach\n" +
     "Click ▾ for attach / camera / sketch / voice";
+  /* Preview slot + pending tray + composer slot + chevron. Composer DOM
+   * injected by renderComposer into .tcc-composer-slot; its action row
+   * is moved into .tcc-extras so the chevron can toggle visibility
+   * (matches pre-SSoT UX). */
   pop.innerHTML =
-    '<textarea class="tcc-input" data-voice-input rows="2" placeholder="message #' +
-    escapeHtml(channel).replace(/^#/, "") +
-    '" title="' +
-    tccShortcuts.replace(/"/g, "&quot;") +
-    '"></textarea>' +
-    '<div class="tcc-extras" style="display:none">' +
-    '<button type="button" class="tcc-x tcc-attach" title="Attach file (paste also works)">\uD83D\uDCCE</button>' +
-    '<button type="button" class="tcc-x tcc-camera" title="Camera">\uD83D\uDCF7</button>' +
-    '<button type="button" class="tcc-x tcc-sketch" title="Sketch">\u270F\uFE0F</button>' +
-    '<button type="button" class="tcc-x tcc-voice" title="Voice input">\uD83C\uDFA4</button>' +
-    "</div>" +
+    '<div class="tcc-pending" style="display:none"></div>' +
+    '<div class="tcc-composer-slot"></div>' +
     '<button type="button" class="tcc-expand" title="' +
     tccShortcuts.replace(/"/g, "&quot;") +
     '" aria-label="More options">\u25BE</button>';
   document.body.appendChild(pop);
-  var input = pop.querySelector(".tcc-input");
-  var extras = pop.querySelector(".tcc-extras");
+
+  var popTray = pop.querySelector(".tcc-pending");
+  var composerSlot = pop.querySelector(".tcc-composer-slot");
   var expandBtn = pop.querySelector(".tcc-expand");
-  /* msg#16324: restore any persisted draft + wire debounced save. */
-  try {
-    if (
-      typeof window.orochiDraftStore !== "undefined" &&
-      window.orochiDraftStore
-    ) {
-      var _saved = window.orochiDraftStore.loadDraft("overview-popup", channel);
-      if (input && _saved) input.value = _saved;
-    }
-  } catch (_) {}
-  if (input) {
-    input.addEventListener("input", function () {
-      try {
-        if (
-          typeof window.orochiDraftStore !== "undefined" &&
-          window.orochiDraftStore &&
-          typeof window.orochiDraftStore._debounceSave === "function"
-        ) {
-          window.orochiDraftStore._debounceSave(
-            "overview-popup",
-            channel,
-            input.value,
-          );
-        }
-      } catch (_) {}
-    });
-  }
-  setTimeout(function () {
-    if (input) {
-      input.focus();
-      try {
-        var _len = input.value ? input.value.length : 0;
-        input.setSelectionRange(_len, _len);
-      } catch (_) {}
-    }
-  }, 10);
 
-  /* todo#305 Task 6 (lead msg#15528): Cmd+V / ⌘V / context-menu Paste
-   * was failing on this popup. Root cause: macOS Safari does NOT focus
-   * a textarea on right-click (unlike Chrome/Firefox). A right-click on
-   * our textarea therefore left document.activeElement on whatever had
-   * focus before the popup opened (often <body> or the topology
-   * canvas), so the subsequent native "Paste" from the OS context menu
-   * fired a paste event on THAT element — not the textarea.
-   *
-   * Keyboard Cmd+V was only intermittent for the same reason: if the
-   * user clicked anywhere inside the popup that wasn't a focusable
-   * child, the textarea could lose focus and the next Cmd+V landed
-   * outside.
-   *
-   * Fix: refocus the textarea on ANY pointer interaction inside the
-   * popup (mousedown covers left + right click + middle click on all
-   * browsers), unless the target is one of the action buttons that
-   * legitimately owns focus (attach / camera / sketch / voice /
-   * expand). Also listen to `contextmenu` explicitly — belt & braces
-   * for browsers that fire contextmenu without a prior mousedown
-   * (some trackpad two-finger-tap paths on macOS). */
-  function _refocusInput(ev) {
-    if (!input) return;
-    /* Don't steal focus from action buttons. */
-    if (
-      ev.target &&
-      ev.target.closest &&
-      ev.target.closest(".tcc-x, .tcc-expand")
-    ) {
-      return;
-    }
-    /* If the user clicked directly on the textarea, the browser will
-     * focus it anyway and move the caret — don't fight that. Only
-     * refocus when the target is a non-focusable child (the popup
-     * chrome, a label, etc.) or the textarea but unfocused (e.g.
-     * right-click on macOS Safari). */
-    if (document.activeElement !== input) {
-      try {
-        input.focus();
-      } catch (_) {}
-    }
-  }
-  pop.addEventListener("mousedown", _refocusInput);
-  pop.addEventListener("contextmenu", _refocusInput);
-
-  function close() {
-    if (pop.parentNode) pop.parentNode.removeChild(pop);
-    document.removeEventListener("mousedown", outsideClick, true);
-  }
-  function outsideClick(ev) {
-    if (!pop.contains(ev.target)) close();
-  }
-  setTimeout(function () {
-    document.addEventListener("mousedown", outsideClick, true);
-  }, 50);
-
-  /* msg#16193: local-scoped pending attachments for this popup. Paste /
-   * drop stage here instead of routing to the Chat composer. */
   var popPending = [];
-  var popTray = document.createElement("div");
-  popTray.className = "tcc-pending";
-  popTray.style.display = "none";
-  if (input && input.parentNode === pop) {
-    pop.insertBefore(popTray, input);
-  } else {
-    pop.insertBefore(popTray, pop.firstChild);
-  }
 
   function _renderPopTray() {
     if (!popPending.length) {
@@ -434,7 +321,140 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
     _renderPopTray();
   }
 
+  /* Build composer via SSoT module. Mention autocomplete, paste, attach/
+   * camera/sketch/voice, keyboard shortcuts — all shared with Chat + Reply. */
+  var composerInstance =
+    typeof renderComposer === "function"
+      ? renderComposer(composerSlot, {
+          surface: "overview",
+          placeholder:
+            "message #" + String(channel || "").replace(/^#/, ""),
+          stageFiles: _stagePopFiles,
+          features: {
+            mention: true,
+            paste: true,
+            dragDrop: false,
+            attach: true,
+            camera: true,
+            sketch: true,
+            voice: true,
+            sendButton: false,
+            shiftEnterNewline: true,
+            autoResize: false,
+            cmdEnterSubmit: true,
+            tabAwareFocus: false,
+            localVoiceChord: true,
+          },
+          maxResizePx: 0,
+          onSubmit: function () {
+            send();
+          },
+        })
+      : null;
+  var input = composerInstance ? composerInstance.input : null;
+  if (input) {
+    input.classList.add("tcc-input");
+    input.title = tccShortcuts;
+    input.rows = 2;
+  }
+
+  /* Move composer action row into .tcc-extras so the chevron can toggle. */
+  var actionsRow = composerSlot.querySelector(".composer-actions");
+  var extras = document.createElement("div");
+  extras.className = "tcc-extras";
+  extras.style.display = "none";
+  if (actionsRow) extras.appendChild(actionsRow);
+  composerSlot.appendChild(extras);
+
+  var actionBtns = extras.querySelectorAll(".composer-btn");
+  actionBtns.forEach(function (b) {
+    b.classList.add("tcc-x");
+    if (b.classList.contains("composer-btn-attach")) b.classList.add("tcc-attach");
+    else if (b.classList.contains("composer-btn-camera")) b.classList.add("tcc-camera");
+    else if (b.classList.contains("composer-btn-sketch")) b.classList.add("tcc-sketch");
+    else if (b.classList.contains("composer-btn-voice")) b.classList.add("tcc-voice");
+  });
+
+  /* msg#16324: restore any persisted draft + wire debounced save. */
+  try {
+    if (
+      typeof window.orochiDraftStore !== "undefined" &&
+      window.orochiDraftStore
+    ) {
+      var _saved = window.orochiDraftStore.loadDraft("overview-popup", channel);
+      if (input && _saved) input.value = _saved;
+    }
+  } catch (_) {}
+  if (input) {
+    input.addEventListener("input", function () {
+      try {
+        if (
+          typeof window.orochiDraftStore !== "undefined" &&
+          window.orochiDraftStore &&
+          typeof window.orochiDraftStore._debounceSave === "function"
+        ) {
+          window.orochiDraftStore._debounceSave(
+            "overview-popup",
+            channel,
+            input.value,
+          );
+        }
+      } catch (_) {}
+    });
+  }
+  setTimeout(function () {
+    if (input) {
+      try {
+        input.focus();
+        var _len = input.value ? input.value.length : 0;
+        input.setSelectionRange(_len, _len);
+      } catch (_) {}
+    }
+  }, 10);
+
+  /* todo#305 Task 6 (lead msg#15528): Cmd+V / ⌘V / context-menu Paste
+   * was failing on this popup. Refocus the textarea on ANY pointer
+   * interaction inside the popup unless the target is an action button. */
+  function _refocusInput(ev) {
+    if (!input) return;
+    if (
+      ev.target &&
+      ev.target.closest &&
+      ev.target.closest(".tcc-x, .tcc-expand, .composer-btn")
+    ) {
+      return;
+    }
+    if (document.activeElement !== input) {
+      try { input.focus(); } catch (_) {}
+    }
+  }
+  pop.addEventListener("mousedown", _refocusInput);
+  pop.addEventListener("contextmenu", _refocusInput);
+
+  function close() {
+    try { if (composerInstance) composerInstance.destroy(); } catch (_) {}
+    if (pop.parentNode) pop.parentNode.removeChild(pop);
+    document.removeEventListener("mousedown", outsideClick, true);
+  }
+  function outsideClick(ev) {
+    if (!pop.contains(ev.target)) close();
+  }
+  setTimeout(function () {
+    document.addEventListener("mousedown", outsideClick, true);
+  }, 50);
+
+  /* Esc closes the popup; Enter / Shift+Enter handled by composer. */
+  if (input) {
+    input.addEventListener("keydown", function (ev) {
+      if (ev.key === "Escape") {
+        ev.preventDefault();
+        close();
+      }
+    });
+  }
+
   function send() {
+    if (!input) return;
     var text = (input.value || "").trim();
     var attachments = popPending.map(function (p) {
       return p.uploaded;
@@ -458,15 +478,11 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
         payload: payload,
       });
     }
-    /* msg#16316 / ywatanabe msg#16313: keep the popup OPEN after send so
-     * the user can keep replying without re-double-clicking the channel
-     * node. Clear the textarea + pending attachment tray, refocus the
-     * input, and leave the popup mounted. The popup still closes via
-     * Esc, outside-click, or routing to Chat (existing paths). */
+    /* msg#16316: keep popup OPEN after send; clear textarea + tray. */
     input.value = "";
     popPending.length = 0;
     _renderPopTray();
-    /* Spec msg#16324: clear the stored draft ONLY on successful send. */
+    /* msg#16324: clear the stored draft ONLY on successful send. */
     try {
       if (
         typeof window.orochiDraftStore !== "undefined" &&
@@ -476,125 +492,15 @@ function _topoOpenChannelCompose(channel, clientX, clientY) {
         window.orochiDraftStore.clearDraft("overview-popup", channel);
       }
     } catch (_) {}
-    try {
-      input.focus();
-    } catch (_) {}
+    try { input.focus(); } catch (_) {}
   }
-  input.addEventListener("keydown", function (ev) {
-    /* Voice-toggle shortcuts — same as Chat composer. Keep these BEFORE
-     * the plain-Enter branch so Ctrl+Enter / Alt+Enter don't fall through
-     * to send(). Ctrl+M and Alt+V also toggle voice. */
-    if (ev.key === "Enter" && (ev.ctrlKey || ev.altKey)) {
-      ev.preventDefault();
-      ev.stopPropagation(); /* prevent global voice handler from double-firing */
-      if (typeof window.toggleVoiceInput === "function") {
-        input.focus(); /* ensure _toggleVoice sees our textarea as active */
-        window.toggleVoiceInput();
-      }
-      return;
-    }
-    if (
-      (ev.ctrlKey && (ev.key === "m" || ev.key === "M")) ||
-      (ev.altKey && (ev.key === "v" || ev.key === "V"))
-    ) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      if (typeof window.toggleVoiceInput === "function") {
-        input.focus();
-        window.toggleVoiceInput();
-      }
-      return;
-    }
-    if (ev.key === "Enter" && !ev.shiftKey) {
-      ev.preventDefault();
-      send();
-    } else if (ev.key === "Escape") {
-      ev.preventDefault();
-      close();
-    }
-  });
-  /* Paste support — msg#16193 regression-fix: stage LOCALLY instead of
-   * routing to Chat (which flipped the user out of the Overview tab).
-   * See hub/frontend/src/activity-tab/compose.ts for the canonical
-   * source and full rationale. */
-  input.addEventListener("paste", function (ev) {
-    ev.stopPropagation();
-    var cd =
-      ev.clipboardData || (ev.originalEvent && ev.originalEvent.clipboardData);
-    if (!cd) return;
-    var collected = [];
-    var seen = new Set();
-    function pushUnique(f) {
-      if (!f || !f.type || f.type.indexOf("image/") !== 0) return;
-      var key =
-        f.name + "|" + f.size + "|" + f.type + "|" + (f.lastModified || 0);
-      if (seen.has(key)) return;
-      seen.add(key);
-      collected.push(f);
-    }
-    var fileList = cd.files;
-    if (fileList && fileList.length) {
-      for (var i = 0; i < fileList.length; i++) pushUnique(fileList[i]);
-    } else if (cd.items) {
-      for (var j = 0; j < cd.items.length; j++) {
-        var it = cd.items[j];
-        if (it && it.type && it.type.indexOf("image/") === 0) {
-          pushUnique(it.getAsFile());
-        }
-      }
-    }
-    var text = "";
-    try {
-      text = cd.getData("text/plain") || "";
-    } catch (_) {}
-    var attachText =
-      typeof _pastedTextShouldAttach === "function" &&
-      _pastedTextShouldAttach(text);
-    if (collected.length > 0 || attachText) {
-      ev.preventDefault();
-      if (attachText && typeof _buildPastedTextFile === "function") {
-        collected.push(_buildPastedTextFile(text));
-      }
-      _stagePopFiles(collected);
-    }
-  });
+
   expandBtn.addEventListener("click", function () {
     var on = extras.style.display === "none";
     extras.style.display = on ? "" : "none";
     expandBtn.textContent = on ? "\u25B4" : "\u25BE";
   });
-  /* Delegate extras — pop the channel into currentChannel so existing
-   * global helpers target the right place, then invoke them. Fallback
-   * to focusing the main composer for modes that don't have a headless
-   * API surface. */
-  function _routeToChat() {
-    if (typeof setCurrentChannel === "function") setCurrentChannel(channel);
-    if (typeof loadChannelHistory === "function") loadChannelHistory(channel);
-    var tabBtn = document.querySelector('[data-tab="chat"]');
-    if (tabBtn) tabBtn.click();
-    close();
-  }
-  pop.querySelector(".tcc-attach").addEventListener("click", function () {
-    _routeToChat();
-    if (typeof openAttachmentPicker === "function") openAttachmentPicker();
-  });
-  pop.querySelector(".tcc-camera").addEventListener("click", function () {
-    _routeToChat();
-    if (typeof openCameraCapture === "function") openCameraCapture();
-  });
-  pop.querySelector(".tcc-sketch").addEventListener("click", function () {
-    _routeToChat();
-    if (typeof openSketchPanel === "function") openSketchPanel();
-  });
-  pop.querySelector(".tcc-voice").addEventListener("click", function () {
-    /* Dictate into THIS popup's textarea — don't route to Chat.
-     * Focus the popup textarea so _toggleVoice's selector-based
-     * target resolution picks it up, then toggle. */
-    if (typeof window.toggleVoiceInput === "function") {
-      input.focus();
-      window.toggleVoiceInput();
-    }
-  });
+
   /* Drop files onto popup → stage LOCALLY (msg#16193). */
   pop.addEventListener("dragover", function (ev) {
     ev.preventDefault();

--- a/hub/static/hub/chat/chat-composer.js
+++ b/hub/static/hub/chat/chat-composer.js
@@ -1,3 +1,15 @@
+/* chat-composer.js — mirror of chat-composer.ts.
+ *
+ * Since the composer SSoT unification (feat/composer-ssot-unification)
+ * the core keydown / send / autoresize / mention wiring is owned by
+ * composer.js::renderComposer(). Chat-specific extras (draft-store
+ * hydration, blur watchdog, diagnostic blur logger, show-more toggle,
+ * mermaid raw-script toggle) remain in this file because they are not
+ * cross-surface concerns. */
+/* globals: ws, wsConnected, sendOrochiMessage, userName, currentChannel,
+   lastActiveChannel, getPendingAttachments, clearPendingAttachments,
+   stageFiles, renderComposer, activeTab, _renderMermaidIn */
+
 function updateChannelSelect() {
   /* Channel select removed -- using sidebar selection instead */
 }
@@ -52,12 +64,8 @@ function sendMessage() {
       );
     }
   } catch (_) {}
-  /* Hands-free voice dictation: if the mic is currently listening, the
-   * next recognition.result event would re-render the entire cumulative
-   * session transcript on top of the now-empty input. Tell voice-input.js
-   * to reset its baseText snapshot AND restart the recognition session
-   * so the input stays clean. ywatanabe wants to leave the mic on for
-   * continuous dictation across multiple sends (msg#6500 / msg#6504). */
+  /* Hands-free voice dictation: reset voice input baseText + restart
+   * session so the textarea stays clean across sends. */
   if (typeof window.voiceInputResetAfterSend === "function") {
     try {
       window.voiceInputResetAfterSend();
@@ -65,14 +73,6 @@ function sendMessage() {
   }
 }
 
-/* Auto-resize textarea as content grows + persist draft per channel.
- *
- * The draft is keyed by `currentChannel` so switching channels preserves
- * each channel's in-progress message. On page reload (or DOM re-render
- * accident), restoreDraftForCurrentChannel() puts the text back. We use
- * sessionStorage so drafts disappear when the tab closes — closer to a
- * "scratchpad" semantic than localStorage's "permanent" feel.
- */
 function _draftTarget() {
   try {
     return currentChannel || "__default__";
@@ -99,9 +99,50 @@ function restoreDraftForCurrentChannel() {
   } catch (_) {}
 }
 window.restoreDraftForCurrentChannel = restoreDraftForCurrentChannel;
+
+/* SSoT composer — adopts the existing dashboard.html .input-bar DOM. All
+ * per-module wiring (paste / drop / attach / camera / sketch / voice) is
+ * owned by upload.js / webcam.js / sketch.js / voice-input.js; the
+ * composer only provides keyboard shortcuts + send dispatch here. */
+(function () {
+  var inputBar = document.querySelector(".input-bar");
+  var msgInput = document.getElementById("msg-input");
+  if (!inputBar || !msgInput || typeof renderComposer !== "function") return;
+  inputBar.setAttribute("data-composer-surface", "chat");
+  renderComposer(inputBar, {
+    surface: "chat",
+    adoptRoot: inputBar,
+    adoptSelectors: {
+      input: "#msg-input",
+      sendBtn: "#msg-send",
+    },
+    stageFiles: function (files) {
+      if (typeof stageFiles === "function") return stageFiles(files);
+    },
+    features: {
+      mention: false /* mention.js already attaches handlers to #msg-input */,
+      paste: false /* upload.js owns msg-input paste */,
+      dragDrop: false /* upload.js owns msg-input drop */,
+      attach: false /* upload.js owns #msg-attach click + #file-input change */,
+      camera: false /* webcam.js owns #msg-webcam click */,
+      sketch: false /* sketch.js owns #msg-sketch click */,
+      voice: false /* voice-input.js owns #msg-voice click */,
+      sendButton: true,
+      cmdEnterSubmit: true,
+      shiftEnterNewline: true,
+      autoResize: true,
+      tabAwareFocus: true,
+      localVoiceChord: false,
+    },
+    maxResizePx: 200,
+    onSubmit: function () {
+      sendMessage();
+    },
+  });
+})();
+
+/* Persist draft on every input, debounced at 300ms via draft-store. */
 document.getElementById("msg-input").addEventListener("input", function () {
-  this.style.height = "auto";
-  this.style.height = Math.min(this.scrollHeight, 200) + "px";
   try {
     if (window.orochiDraftStore) {
       window.orochiDraftStore._debounceSave("chat", _draftTarget(), this.value);
@@ -110,15 +151,7 @@ document.getElementById("msg-input").addEventListener("input", function () {
 });
 restoreDraftForCurrentChannel();
 
-/* Diagnostic blur logger for todo#225 — captures every blur event on
- * #msg-input with timestamp, relatedTarget, and a trimmed stack trace,
- * stored in sessionStorage so a user (or mamba-verifier-mba via
- * playwright) can inspect the last N events with
- *   JSON.parse(sessionStorage.getItem("orochi-blurlog") || "[]")
- * after reproducing the bug. Async-safe (uses requestAnimationFrame to
- * also catch deferred re-blurs that happen after a synchronous
- * focus-restore). Capacity-bounded at 50 entries so it never grows
- * unbounded. Strictly diagnostic — no UI side-effect. */
+/* Diagnostic blur logger for todo#225. */
 (function () {
   var input = document.getElementById("msg-input");
   if (!input) return;
@@ -151,14 +184,12 @@ restoreDraftForCurrentChannel();
   }
   input.addEventListener("blur", function (e) {
     _logBlur("sync-blur", e);
-    /* Also check after one frame in case something defers focus theft */
     requestAnimationFrame(function () {
       if (document.activeElement !== input) {
         _logBlur("post-rAF-still-blurred", e);
       }
     });
   });
-  /* Also expose a one-shot getter for convenience */
   window.getBlurLog = function () {
     try {
       return JSON.parse(sessionStorage.getItem("orochi-blurlog") || "[]");
@@ -168,17 +199,7 @@ restoreDraftForCurrentChannel();
   };
 })();
 
-/* Focus-theft guard removed: the capture-phase mousedown delegate that
- * kept #msg-input focused when the user clicked feed buttons/links felt
- * too aggressive. Browser default focus behavior is now in effect —
- * clicks on feed elements shift focus naturally. The save→render→
- * restore pattern in the render functions still preserves mid-typing
- * state across polling re-renders; it just no longer fights user
- * clicks. */
-
-/* Show more / Show less toggle for long messages.
- * Uses delegated click on document to handle dynamically inserted buttons.
- * Replaces the previous fragile inline onclick with arguments.callee. */
+/* Show more / Show less toggle for long messages. */
 document.addEventListener("click", function (e) {
   var btn = e.target.closest(".msg-fold-btn");
   if (!btn) return;
@@ -193,8 +214,7 @@ document.addEventListener("click", function (e) {
     fullEl.style.display = "block";
     previewEl.style.display = "none";
     btn.textContent = "Show less";
-    /* Render mermaid diagrams that became visible in the expanded section */
-    _renderMermaidIn(fullEl);
+    if (typeof _renderMermaidIn === "function") _renderMermaidIn(fullEl);
   } else {
     fullEl.style.display = "none";
     previewEl.style.display = "block";
@@ -216,26 +236,12 @@ document.addEventListener("click", function (e) {
   btn.textContent = isHidden ? "Hide raw" : "Show raw";
 });
 
-/* Defensive blur watchdog (todo#225 second-order regression).
- * msg#6692: ywatanabe says focus drops *after an idle period when a
- * delayed post arrives* — i.e. NOT a click event, so the mousedown
- * delegate above can't catch it. Some async setInterval / WS-driven
- * DOM mutation is firing focus() on something else, or the textarea
- * itself is being briefly unmounted by a re-render. Rather than chase
- * every async path, install a one-shot watchdog: if #msg-input loses
- * focus AND nothing else useful (form control / link the user clicked
- * intentionally) took focus within the next paint frame, snap focus
- * straight back. The selection range is restored too so the cursor
- * lands where the user left it. We only re-focus when the textarea
- * still has user-typed content AND the focus shifted to <body> /
- * <button> / <a> — the "implicit blur" pattern — so we never fight
- * an intentional click into another textarea / input / select. */
+/* Defensive blur watchdog (todo#225 second-order regression). */
 (function () {
   var msgInput = document.getElementById("msg-input");
   if (!msgInput) return;
   msgInput.addEventListener("blur", function (e) {
     if (window.__voiceInputAllowBlur) return;
-    /* msg#16116 Item 2: never re-focus msg-input from a non-Chat tab. */
     var _activeTab =
       typeof window !== "undefined" && typeof window.activeTab === "string"
         ? window.activeTab
@@ -246,8 +252,6 @@ document.addEventListener("click", function (e) {
     var savedStart = msgInput.selectionStart || 0;
     var savedEnd = msgInput.selectionEnd || 0;
     var rt = e && e.relatedTarget;
-    /* If the user clicked into another form control on purpose, leave
-     * the focus where they put it. */
     if (rt && rt.tagName) {
       var tn = rt.tagName.toUpperCase();
       if (tn === "TEXTAREA" || tn === "INPUT" || tn === "SELECT") return;
@@ -256,15 +260,11 @@ document.addEventListener("click", function (e) {
     requestAnimationFrame(function () {
       var still = document.activeElement;
       if (still === msgInput) return;
-      /* Don't fight a real focus into another control. */
       if (still && still.tagName) {
         var stn = still.tagName.toUpperCase();
         if (stn === "TEXTAREA" || stn === "INPUT" || stn === "SELECT") return;
         if (still.isContentEditable) return;
       }
-      /* todo#315: don't snap focus back if the user is actively
-       * selecting text inside the message feed — refocusing would
-       * collapse the selection and make copy impossible. */
       try {
         var sel = window.getSelection && window.getSelection();
         if (sel && sel.toString().length > 0) {
@@ -286,37 +286,3 @@ document.addEventListener("click", function (e) {
     });
   });
 })();
-
-document.getElementById("msg-send").addEventListener("click", function (e) {
-  e.preventDefault();
-  /* On mobile Safari, tapping the send button blurs the textarea before
-   * the click handler fires, which can dismiss the keyboard and cause
-   * unexpected scrolling. We call sendMessage synchronously here. */
-  sendMessage();
-  /* Re-focus the textarea so the keyboard stays open on mobile */
-  document.getElementById("msg-input").focus();
-});
-document.getElementById("msg-input").addEventListener("keydown", function (e) {
-  /* Ctrl+U / Cmd+U → trigger file upload picker (msg#9877) */
-  var isMac = /Mac|iPhone|iPad/.test(navigator.platform || navigator.userAgent);
-  if ((isMac ? e.metaKey : e.ctrlKey) && e.key === "u") {
-    e.preventDefault();
-    var fi = document.getElementById("file-input");
-    if (fi) fi.click();
-    return;
-  }
-  if (e.key === "Enter") {
-    var dd = document.getElementById("mention-dropdown");
-    if (dd && dd.classList.contains("visible")) return;
-    /* todo#332 v2: Alt+Enter is reserved for voice toggle (see voice-input.js).
-     * Shift+Enter remains the newline shortcut. Plain Enter sends. */
-    if (e.shiftKey) return;
-    if (e.altKey) {
-      /* Voice toggle handled by voice-input.js global handler — just prevent default */
-      e.preventDefault();
-      return;
-    }
-    e.preventDefault();
-    sendMessage();
-  }
-});

--- a/hub/static/hub/composer/composer-attach.js
+++ b/hub/static/hub/composer/composer-attach.js
@@ -1,0 +1,77 @@
+/* composer/composer-attach.js — mirror of composer-attach.ts. Delegates
+ * attach/camera/sketch/voice button wiring. */
+/* globals: openSketch, openWebcam */
+
+(function () {
+  function wireAttachButtons(opts) {
+    var disposers = [];
+    function bind(el, ev, fn) {
+      if (!el) return;
+      el.addEventListener(ev, fn);
+      disposers.push(function () {
+        el.removeEventListener(ev, fn);
+      });
+    }
+
+    if (opts.attachBtn && opts.fileInput) {
+      bind(opts.attachBtn, "click", function () {
+        if (typeof opts.onAttach === "function") {
+          try { opts.onAttach(); } catch (_) {}
+        }
+        opts.fileInput.click();
+      });
+    }
+
+    if (opts.fileInput && typeof opts.stageFiles === "function") {
+      bind(opts.fileInput, "change", function () {
+        var files = Array.prototype.slice.call(opts.fileInput.files || []);
+        opts.stageFiles(files);
+        opts.fileInput.value = "";
+      });
+    }
+
+    if (opts.cameraBtn) {
+      bind(opts.cameraBtn, "click", function () {
+        if (typeof opts.onCamera === "function") {
+          try { opts.onCamera(); } catch (_) {}
+        }
+        if (typeof openWebcam === "function") {
+          try { openWebcam(); } catch (_) {}
+        }
+      });
+    }
+
+    if (opts.sketchBtn) {
+      bind(opts.sketchBtn, "click", function () {
+        if (typeof opts.onSketchOpen === "function") {
+          try { opts.onSketchOpen(); } catch (_) {}
+        }
+        if (typeof openSketch === "function") {
+          try { openSketch(); } catch (_) {}
+        }
+      });
+    }
+
+    if (opts.voiceBtn) {
+      bind(opts.voiceBtn, "click", function () {
+        try { opts.input && opts.input.focus(); } catch (_) {}
+        if (typeof opts.onVoiceToggle === "function") {
+          try { opts.onVoiceToggle(); } catch (_) {}
+          return;
+        }
+        if (typeof window.toggleVoiceInput === "function") {
+          try { window.toggleVoiceInput(); } catch (_) {}
+        }
+      });
+    }
+
+    return function dispose() {
+      while (disposers.length) {
+        var d = disposers.pop();
+        try { d(); } catch (_) {}
+      }
+    };
+  }
+
+  window.wireAttachButtons = wireAttachButtons;
+})();

--- a/hub/static/hub/composer/composer-mention.js
+++ b/hub/static/hub/composer/composer-mention.js
@@ -1,0 +1,27 @@
+/* composer/composer-mention.js — mirror of composer-mention.ts. Thin
+ * adapter around the global mention.js autocomplete for classic-script
+ * consumers. */
+/* globals: initMentionAutocomplete, mentionDropdown, mentionSelectedIndex */
+
+(function () {
+  function wireComposerMention(input) {
+    if (!input) return;
+    if (typeof initMentionAutocomplete === "function") {
+      initMentionAutocomplete(input);
+    }
+  }
+
+  function isMentionDropdownOpen() {
+    return !!(
+      typeof mentionDropdown !== "undefined" &&
+      mentionDropdown &&
+      mentionDropdown.classList &&
+      mentionDropdown.classList.contains("visible") &&
+      typeof mentionSelectedIndex !== "undefined" &&
+      mentionSelectedIndex >= 0
+    );
+  }
+
+  window.wireComposerMention = wireComposerMention;
+  window.isMentionDropdownOpen = isMentionDropdownOpen;
+})();

--- a/hub/static/hub/composer/composer-paste.js
+++ b/hub/static/hub/composer/composer-paste.js
@@ -1,0 +1,96 @@
+/* composer/composer-paste.js — paste + drag/drop handlers for the SSoT
+ * composer. Mirror of composer-paste.ts. Exposes globals for classic
+ * script consumers and also re-uses upload.js's _pastedTextShouldAttach
+ * / _buildPastedTextFile when available. */
+/* globals: _pastedTextShouldAttach, _buildPastedTextFile */
+
+(function () {
+  function _collectPastedImages(cd) {
+    var collected = [];
+    var seen = new Set();
+    function pushUnique(f) {
+      if (!f || !f.type || f.type.indexOf("image/") !== 0) return;
+      var key =
+        f.name + "|" + f.size + "|" + f.type + "|" + (f.lastModified || 0);
+      if (seen.has(key)) return;
+      seen.add(key);
+      collected.push(f);
+    }
+    if (!cd) return collected;
+    var fileList = cd.files;
+    if (fileList && fileList.length) {
+      for (var i = 0; i < fileList.length; i++) pushUnique(fileList[i]);
+    } else if (cd.items) {
+      for (var j = 0; j < cd.items.length; j++) {
+        var it = cd.items[j];
+        if (it && it.type && it.type.indexOf("image/") === 0) {
+          pushUnique(it.getAsFile());
+        }
+      }
+    }
+    return collected;
+  }
+
+  function wireComposerPaste(input, stageFiles, opts) {
+    var stop = opts && opts.stopPropagation !== false;
+    function handler(ev) {
+      if (stop) ev.stopPropagation();
+      var cd =
+        ev.clipboardData ||
+        (ev.originalEvent && ev.originalEvent.clipboardData);
+      if (!cd) return;
+      var collected = _collectPastedImages(cd);
+      var text = "";
+      try {
+        text = cd.getData("text/plain") || "";
+      } catch (_) {}
+      var attachText =
+        typeof _pastedTextShouldAttach === "function" &&
+        _pastedTextShouldAttach(text);
+      if (collected.length > 0 || attachText) {
+        ev.preventDefault();
+        if (attachText && typeof _buildPastedTextFile === "function") {
+          collected.push(_buildPastedTextFile(text));
+        }
+        stageFiles(collected);
+      }
+    }
+    input.addEventListener("paste", handler);
+    return function () {
+      input.removeEventListener("paste", handler);
+    };
+  }
+
+  function wireComposerDragDrop(host, stageFiles, opts) {
+    var cls = (opts && opts.dragOverClass) || "drag-over";
+    function onOver(ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      host.classList.add(cls);
+    }
+    function onLeave() {
+      host.classList.remove(cls);
+    }
+    function onDrop(ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      host.classList.remove(cls);
+      var files = ev.dataTransfer && ev.dataTransfer.files;
+      if (files && files.length) {
+        stageFiles(Array.prototype.slice.call(files));
+      }
+    }
+    host.addEventListener("dragover", onOver);
+    host.addEventListener("dragleave", onLeave);
+    host.addEventListener("drop", onDrop);
+    return function () {
+      host.removeEventListener("dragover", onOver);
+      host.removeEventListener("dragleave", onLeave);
+      host.removeEventListener("drop", onDrop);
+    };
+  }
+
+  window._composerCollectPastedImages = _collectPastedImages;
+  window.wireComposerPaste = wireComposerPaste;
+  window.wireComposerDragDrop = wireComposerDragDrop;
+})();

--- a/hub/static/hub/composer/composer.js
+++ b/hub/static/hub/composer/composer.js
@@ -1,0 +1,333 @@
+/* composer/composer.js — Single-Source-of-Truth message composer.
+ * Mirror of composer.ts.
+ *
+ * renderComposer(host, opts): { root, input, destroy, focus, setValue,
+ * getValue }. See composer.ts for the full architectural comment.
+ */
+/* globals: wireComposerPaste, wireComposerDragDrop, wireComposerMention,
+   isMentionDropdownOpen, wireAttachButtons */
+
+(function () {
+  var DEFAULT_FEATURES = {
+    mention: true,
+    paste: true,
+    dragDrop: true,
+    attach: true,
+    camera: true,
+    sketch: true,
+    voice: true,
+    sendButton: true,
+    cmdEnterSubmit: true,
+    shiftEnterNewline: true,
+    autoResize: true,
+    tabAwareFocus: false,
+    localVoiceChord: true,
+  };
+
+  function _buildComposerDom(opts) {
+    var features = Object.assign({}, DEFAULT_FEATURES, opts.features || {});
+    var root = document.createElement("div");
+    root.className = "composer composer-surface-" + opts.surface;
+    root.setAttribute("data-composer-surface", opts.surface);
+
+    var input = document.createElement("textarea");
+    input.className = "composer-input";
+    if (opts.surface === "reply") input.id = "thread-input";
+    input.setAttribute("data-voice-input", "");
+    input.setAttribute("rows", "2");
+    input.placeholder = opts.placeholder || "Type a message…";
+    input.autocomplete = "off";
+
+    var fileInput = null;
+    if (features.attach) {
+      fileInput = document.createElement("input");
+      fileInput.type = "file";
+      fileInput.multiple = true;
+      fileInput.style.display = "none";
+      fileInput.className = "composer-file-input";
+      if (opts.surface === "reply") fileInput.id = "thread-file-input";
+    }
+
+    var actions = document.createElement("div");
+    actions.className = "composer-actions";
+
+    var attachBtn = null,
+      cameraBtn = null,
+      sketchBtn = null,
+      voiceBtn = null,
+      voiceLangBtn = null,
+      sendBtn = null;
+
+    function mkBtn(cls, id, title, emoji) {
+      var b = document.createElement("button");
+      b.type = "button";
+      b.className = "composer-btn " + cls;
+      if (id) b.id = id;
+      b.tabIndex = -1;
+      b.title = title;
+      b.setAttribute("aria-label", title);
+      b.textContent = emoji;
+      return b;
+    }
+
+    if (features.attach) {
+      attachBtn = mkBtn(
+        "composer-btn-attach",
+        opts.surface === "reply" ? "thread-attach-btn" : null,
+        "Attach file",
+        "\uD83D\uDCCE",
+      );
+      actions.appendChild(attachBtn);
+    }
+    if (features.camera) {
+      cameraBtn = mkBtn(
+        "composer-btn-camera",
+        null,
+        "Take photo",
+        "\uD83D\uDCF7",
+      );
+      actions.appendChild(cameraBtn);
+    }
+    if (features.sketch) {
+      sketchBtn = mkBtn(
+        "composer-btn-sketch",
+        opts.surface === "reply" ? "thread-sketch-btn" : null,
+        "Draw sketch",
+        "\u270F\uFE0F",
+      );
+      actions.appendChild(sketchBtn);
+    }
+    if (features.voice) {
+      voiceBtn = mkBtn(
+        "composer-btn-voice",
+        opts.surface === "reply" ? "thread-voice-btn" : null,
+        "Voice input",
+        "\uD83C\uDFA4",
+      );
+      actions.appendChild(voiceBtn);
+      if (opts.surface === "reply") {
+        voiceLangBtn = mkBtn(
+          "composer-btn-voice-lang",
+          "thread-voice-lang-btn",
+          "Switch language (EN/JA)",
+          "EN",
+        );
+        voiceLangBtn.style.fontSize = "11px";
+        voiceLangBtn.style.padding = "2px 5px";
+        voiceLangBtn.style.opacity = "0.7";
+        actions.appendChild(voiceLangBtn);
+      }
+    }
+    if (features.sendButton) {
+      sendBtn = document.createElement("button");
+      sendBtn.type = "button";
+      sendBtn.className =
+        "composer-btn composer-btn-send " +
+        (opts.surface === "reply" ? "thread-send-btn" : "");
+      sendBtn.textContent = "Send";
+      sendBtn.title = "Send message";
+    }
+
+    root.appendChild(input);
+    if (fileInput) root.appendChild(fileInput);
+    root.appendChild(actions);
+    if (sendBtn) actions.appendChild(sendBtn);
+
+    return {
+      root: root,
+      input: input,
+      sendBtn: sendBtn,
+      attachBtn: attachBtn,
+      cameraBtn: cameraBtn,
+      sketchBtn: sketchBtn,
+      voiceBtn: voiceBtn,
+      voiceLangBtn: voiceLangBtn,
+      fileInput: fileInput,
+    };
+  }
+
+  function _adoptComposerDom(opts) {
+    var root = opts.adoptRoot;
+    var sel = opts.adoptSelectors || {};
+    function q(selector) {
+      if (!selector) return null;
+      return root.querySelector(selector) || document.querySelector(selector);
+    }
+    return {
+      root: root,
+      input: q(sel.input),
+      sendBtn: q(sel.sendBtn),
+      attachBtn: q(sel.attachBtn),
+      cameraBtn: q(sel.cameraBtn),
+      sketchBtn: q(sel.sketchBtn),
+      voiceBtn: q(sel.voiceBtn),
+      voiceLangBtn: q(sel.voiceLangBtn),
+      fileInput: q(sel.fileInput),
+    };
+  }
+
+  function renderComposer(host, opts) {
+    if (!opts || typeof opts.onSubmit !== "function") {
+      throw new Error("renderComposer: opts.onSubmit is required");
+    }
+    var features = Object.assign({}, DEFAULT_FEATURES, opts.features || {});
+    var built = opts.adoptRoot
+      ? _adoptComposerDom(opts)
+      : _buildComposerDom(opts);
+
+    if (!built.input) {
+      throw new Error(
+        "renderComposer: no textarea found for surface " + opts.surface,
+      );
+    }
+
+    try {
+      built.root.setAttribute("data-composer-surface", opts.surface);
+    } catch (_) {}
+
+    if (!opts.adoptRoot && host && built.root.parentNode !== host) {
+      host.appendChild(built.root);
+    }
+
+    var disposers = [];
+
+    var maxPx =
+      typeof opts.maxResizePx === "number"
+        ? opts.maxResizePx
+        : opts.surface === "reply"
+          ? 120
+          : 200;
+    if (features.autoResize && maxPx > 0) {
+      var resize = function () {
+        try {
+          built.input.style.height = "auto";
+          built.input.style.height =
+            Math.min(built.input.scrollHeight, maxPx) + "px";
+        } catch (_) {}
+      };
+      built.input.addEventListener("input", resize);
+      disposers.push(function () {
+        built.input.removeEventListener("input", resize);
+      });
+    }
+
+    if (features.mention) {
+      try {
+        wireComposerMention(built.input);
+      } catch (_) {}
+    }
+
+    if (features.paste && typeof opts.stageFiles === "function") {
+      disposers.push(wireComposerPaste(built.input, opts.stageFiles));
+    }
+
+    if (features.dragDrop && typeof opts.stageFiles === "function") {
+      disposers.push(wireComposerDragDrop(built.root, opts.stageFiles));
+    }
+
+    if (
+      features.attach ||
+      features.camera ||
+      features.sketch ||
+      features.voice
+    ) {
+      disposers.push(
+        wireAttachButtons({
+          input: built.input,
+          fileInput: built.fileInput,
+          attachBtn: features.attach ? built.attachBtn : null,
+          cameraBtn: features.camera ? built.cameraBtn : null,
+          sketchBtn: features.sketch ? built.sketchBtn : null,
+          voiceBtn: features.voice ? built.voiceBtn : null,
+          onSketchOpen: opts.onSketchOpen,
+          onVoiceToggle: opts.onVoiceToggle,
+          stageFiles: opts.stageFiles,
+        }),
+      );
+    }
+
+    function onKeydown(ev) {
+      var isMac = /Mac|iPhone|iPad/.test(
+        navigator.platform || navigator.userAgent,
+      );
+      if ((isMac ? ev.metaKey : ev.ctrlKey) && ev.key === "u") {
+        if (built.fileInput) {
+          ev.preventDefault();
+          built.fileInput.click();
+        }
+        return;
+      }
+      if (ev.key !== "Enter") return;
+      if ((ev.ctrlKey || ev.altKey) && features.localVoiceChord !== false) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        try { built.input.focus(); } catch (_) {}
+        if (typeof opts.onVoiceToggle === "function") {
+          try { opts.onVoiceToggle(); } catch (_) {}
+        } else if (typeof window.toggleVoiceInput === "function") {
+          try { window.toggleVoiceInput(); } catch (_) {}
+        }
+        return;
+      }
+      if (ev.ctrlKey || ev.altKey) return;
+      if (features.mention && typeof isMentionDropdownOpen === "function" && isMentionDropdownOpen()) return;
+      if (features.shiftEnterNewline !== false && ev.shiftKey) return;
+      ev.preventDefault();
+      _submit();
+    }
+    built.input.addEventListener("keydown", onKeydown);
+    disposers.push(function () {
+      built.input.removeEventListener("keydown", onKeydown);
+    });
+
+    function onSendClick(ev) {
+      ev.preventDefault();
+      _submit();
+      try { built.input.focus(); } catch (_) {}
+    }
+    if (features.sendButton && built.sendBtn) {
+      built.sendBtn.addEventListener("click", onSendClick);
+      disposers.push(function () {
+        built.sendBtn.removeEventListener("click", onSendClick);
+      });
+    }
+
+    function _submit() {
+      var text = built.input.value || "";
+      try {
+        opts.onSubmit({ text: text });
+      } catch (e) {
+        console.error("[composer] onSubmit error:", e);
+      }
+      if (typeof opts.onAfterSubmit === "function") {
+        try { opts.onAfterSubmit(); } catch (_) {}
+      }
+    }
+
+    return {
+      root: built.root,
+      input: built.input,
+      destroy: function () {
+        while (disposers.length) {
+          var d = disposers.pop();
+          try { d(); } catch (_) {}
+        }
+        if (!opts.adoptRoot && built.root.parentNode) {
+          built.root.parentNode.removeChild(built.root);
+        }
+      },
+      focus: function () {
+        try { built.input.focus(); } catch (_) {}
+      },
+      setValue: function (text) {
+        built.input.value = text || "";
+        built.input.dispatchEvent(new Event("input", { bubbles: true }));
+      },
+      getValue: function () {
+        return built.input.value || "";
+      },
+    };
+  }
+
+  window.renderComposer = renderComposer;
+})();

--- a/hub/static/hub/threads/panel.js
+++ b/hub/static/hub/threads/panel.js
@@ -1,15 +1,26 @@
-/* Threading — panel open/close, replies render, send, WS handlers */
+/* Threading — panel open/close, replies render, send, WS handlers.
+ * Reply composer (textarea + attach/sketch/voice/send buttons) is
+ * provided by composer.js::renderComposer(surface: "reply") since the
+ * SSoT unification. This file owns the surrounding chrome (header,
+ * parent preview, replies list, pending-attachments tray) plus the
+ * thread-specific voice-lang button sync + draft-store hydration. */
 /* globals: apiUrl, orochiHeaders, escapeHtml, timeAgo, getAgentColor,
-   cleanAgentName, getSenderIcon, getResolvedAgentColor,
+   cleanAgentName, getSenderIcon, getResolvedAgentColor, renderComposer,
    threadPanel, threadPanelParentId, threadPendingAttachments,
    _threadSketchActive, _renderThreadAttachmentTray, _stageThreadFiles,
    _linkifyThreadContent, _pushThreadUrlState */
+
+var _threadComposer = null;
 
 function closeThreadPanel(opts) {
   var msgInput = document.getElementById("msg-input");
   var inputHasFocus = msgInput && document.activeElement === msgInput;
   var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
   var savedEnd = inputHasFocus ? msgInput.selectionEnd : 0;
+  if (_threadComposer) {
+    try { _threadComposer.destroy(); } catch (_) {}
+    _threadComposer = null;
+  }
   if (threadPanel && threadPanel.parentNode) {
     threadPanel.parentNode.removeChild(threadPanel);
   }
@@ -59,21 +70,8 @@ async function openThreadPanel(parentId, opts) {
     '<div class="thread-replies" id="thread-replies"></div>' +
     '<div class="thread-input-row">' +
     '<div id="thread-pending-attachments" class="thread-pending-attachments" style="display:none"></div>' +
-    '<div class="thread-compose-row">' +
-    '<textarea id="thread-input" placeholder="Reply in thread…" rows="2"></textarea>' +
-    '<div class="thread-bottom-row">' +
-    '<div class="thread-input-actions">' +
-    '<button type="button" id="thread-attach-btn" tabindex="-1" title="Attach file (Ctrl+U)">📎</button>' +
-    '<button type="button" id="thread-sketch-btn" tabindex="-1" title="Draw sketch">✏️</button>' +
-    '<button type="button" id="thread-voice-btn" tabindex="-1" title="Voice input">🎤</button>' +
-    '<button type="button" id="thread-voice-lang-btn" tabindex="-1" title="Switch language (EN/JA)" style="font-size:11px;padding:2px 5px;opacity:0.7;">EN</button>' +
-    '<input type="file" id="thread-file-input" style="display:none" multiple>' +
-    "</div>" +
-    '<button type="button" class="thread-send-btn" onclick="sendThreadReply()">Send</button>' +
-    "</div>" +
-    "</div>" +
+    '<div class="thread-compose-row" id="thread-composer-slot"></div>' +
     "</div>";
-  /* Append as flex sibling of .main inside .container (Slack-style side-by-side) */
   var container = document.querySelector(".container");
   if (container) {
     container.appendChild(threadPanel);
@@ -82,8 +80,47 @@ async function openThreadPanel(parentId, opts) {
   }
 
   await loadThreadReplies(parentId);
-  var ta = document.getElementById("thread-input");
-  if (ta) {
+
+  var composerSlot = document.getElementById("thread-composer-slot");
+  threadPendingAttachments = [];
+  _renderThreadAttachmentTray();
+
+  if (composerSlot && typeof renderComposer === "function") {
+    _threadComposer = renderComposer(composerSlot, {
+      surface: "reply",
+      placeholder: "Reply in thread\u2026",
+      stageFiles: function (files) {
+        return _stageThreadFiles(files);
+      },
+      onSketchOpen: function () {
+        _threadSketchActive = true;
+      },
+      features: {
+        mention: true,
+        paste: true,
+        dragDrop: false,
+        attach: true,
+        camera: false,
+        sketch: true,
+        voice: true,
+        sendButton: true,
+        cmdEnterSubmit: true,
+        shiftEnterNewline: true,
+        autoResize: true,
+        tabAwareFocus: false,
+        localVoiceChord: true,
+      },
+      maxResizePx: 120,
+      onSubmit: function () {
+        sendThreadReply();
+      },
+    });
+
+    var ta = _threadComposer.input;
+    ta.classList.add("thread-textarea");
+    var sendBtn = composerSlot.querySelector(".composer-btn-send");
+    if (sendBtn) sendBtn.classList.add("thread-send-btn");
+
     /* msg#16324: hydrate any persisted thread-reply draft. */
     try {
       if (window.orochiDraftStore) {
@@ -98,44 +135,14 @@ async function openThreadPanel(parentId, opts) {
         }
       }
     } catch (_) {}
-    ta.focus();
+    try { ta.focus(); } catch (_) {}
     try {
       var _len = ta.value ? ta.value.length : 0;
       ta.setSelectionRange(_len, _len);
     } catch (_) {}
-    ta.addEventListener("keydown", function (e) {
-      /* Alt+Enter / Ctrl+Enter in thread: toggle voice directed at thread textarea */
-      if (e.key === "Enter" && (e.altKey || e.ctrlKey)) {
-        e.preventDefault();
-        e.stopPropagation(); /* prevent global voice handler from double-firing */
-        if (typeof window.toggleVoiceInput === "function") {
-          /* Focus thread textarea so _toggleVoice captures it as target */
-          var tIn = document.getElementById("thread-input");
-          if (tIn) tIn.focus();
-          window.toggleVoiceInput();
-        }
-        return;
-      }
-      /* Plain Enter (no modifier) sends reply */
-      if (e.key === "Enter" && !e.shiftKey) {
-        /* Don't send if mention dropdown is open and an item is selected */
-        if (
-          typeof mentionDropdown !== "undefined" &&
-          mentionDropdown &&
-          mentionDropdown.classList.contains("visible") &&
-          mentionSelectedIndex >= 0
-        ) {
-          return; /* Let handleMentionKeydown handle it */
-        }
-        e.preventDefault();
-        sendThreadReply();
-      }
-    });
-    /* Auto-resize: grow with content up to 120px; also persist the
-     * draft (debounced at 300ms via draft-store). */
+
+    /* Persist every keystroke (debounced at 300ms via draft-store). */
     ta.addEventListener("input", function () {
-      this.style.height = "auto";
-      this.style.height = Math.min(this.scrollHeight, 120) + "px";
       try {
         if (window.orochiDraftStore) {
           window.orochiDraftStore._debounceSave(
@@ -146,73 +153,19 @@ async function openThreadPanel(parentId, opts) {
         }
       } catch (_) {}
     });
-    /* Enable @mention autocomplete in thread input */
-    if (typeof initMentionAutocomplete === "function") {
-      initMentionAutocomplete(ta);
+
+    var voiceLangBtn = document.getElementById("thread-voice-lang-btn");
+    if (voiceLangBtn) {
+      var mainLangBtn = document.getElementById("msg-voice-lang");
+      if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
+      voiceLangBtn.addEventListener("click", function () {
+        if (typeof window.cycleVoiceLang === "function") {
+          window.cycleVoiceLang();
+          /* Sync label from main lang button */
+          if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
+        }
+      });
     }
-    /* Ctrl+U → trigger file picker in thread panel */
-    ta.addEventListener("keydown", function (e) {
-      if ((e.ctrlKey || e.metaKey) && e.key === "u") {
-        e.preventDefault();
-        var fi = document.getElementById("thread-file-input");
-        if (fi) fi.click();
-      }
-    });
-  }
-
-  /* Wire thread action buttons */
-  threadPendingAttachments = [];
-  _renderThreadAttachmentTray();
-
-  var attachBtn = document.getElementById("thread-attach-btn");
-  var fileInput = document.getElementById("thread-file-input");
-  var sketchBtn = document.getElementById("thread-sketch-btn");
-  var voiceBtn = document.getElementById("thread-voice-btn");
-  var voiceLangBtn = document.getElementById("thread-voice-lang-btn");
-
-  if (attachBtn && fileInput) {
-    attachBtn.addEventListener("click", function () {
-      fileInput.click();
-    });
-    fileInput.addEventListener("change", function () {
-      _stageThreadFiles(Array.from(fileInput.files || []));
-      fileInput.value = "";
-    });
-  }
-
-  if (sketchBtn) {
-    sketchBtn.addEventListener("click", function () {
-      /* openSketch() sends to currentChannel; we override the callback */
-      if (typeof openSketch === "function") {
-        _threadSketchActive = true;
-        openSketch();
-      }
-    });
-  }
-
-  if (voiceBtn) {
-    /* Toggle voice into the thread textarea */
-    voiceBtn.addEventListener("click", function () {
-      if (typeof window.toggleVoiceInput === "function") {
-        /* Focus thread textarea so _toggleVoice captures it as target */
-        var tIn = document.getElementById("thread-input");
-        if (tIn) tIn.focus();
-        window.toggleVoiceInput();
-      }
-    });
-  }
-
-  if (voiceLangBtn) {
-    /* Sync button label with voice-input.js current language on open */
-    var mainLangBtn = document.getElementById("msg-voice-lang");
-    if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
-    voiceLangBtn.addEventListener("click", function () {
-      if (typeof window.cycleVoiceLang === "function") {
-        window.cycleVoiceLang();
-        /* Sync label from main lang button */
-        if (mainLangBtn) voiceLangBtn.textContent = mainLangBtn.textContent;
-      }
-    });
   }
 }
 


### PR DESCRIPTION
## Summary

Mirrors the `renderAgentBadge` / `renderChannelBadge` SSoT pattern from PRs #285 and #311, but for the message composer. Three surfaces — Chat tab `.input-bar`, Overview graph-compose popup, thread-reply composer — now share `renderComposer(host, opts)` with per-surface feature toggles instead of hand-rolled copies of the same keydown/paste/attach wiring.

Goal: lead `#heads msg#16286`, ywatanabe msg#16276.

## Architecture

New `hub/frontend/src/composer/` (+ mirrored `hub/static/hub/composer/`):
- `composer.ts` — `renderComposer(host, opts)` returns `{ root, input, destroy, focus, setValue, getValue }`. Renders fresh DOM for Overview/Reply or adopts existing DOM (Chat's `.input-bar`) via `opts.adoptRoot` + `opts.adoptSelectors`. Adds `data-composer-surface="chat|overview|reply"` for future per-surface targeting.
- `composer-paste.ts` — paste (image dedup + long-text-as-file) and drag-drop wiring, reuses `upload.ts` helpers (`_pastedTextShouldAttach`, `_buildPastedTextFile`).
- `composer-mention.ts` — thin adapter over `mention.ts`'s `initMentionAutocomplete` + `isMentionDropdownOpen()` check for the submit path.
- `composer-attach.ts` — 📎 / 📷 / ✏️ / 🎤 button wiring, delegates to `webcam.ts::openWebcam()`, `sketch.ts::openSketch()`, `window.toggleVoiceInput()`. Hooks for per-surface onSketchOpen / onVoiceToggle.

`opts.features` toggles each sub-feature so Chat can disable composer-owned wiring that `upload.ts` / `voice-input.ts` / etc. already handle globally, while Overview + Reply turn the same features on to fill parity gaps.

## Feature parity matrix

| Feature | Chat before | Chat after | Overview before | Overview after | Reply before | Reply after |
|---|---|---|---|---|---|---|
| @agent / @user autocomplete | yes (mention.ts) | yes (unchanged) | **no** | **yes** | yes | yes |
| Paste text | yes | yes | yes (inline dedup copy) | yes (via composer-paste) | yes (native only) | yes (via composer-paste) |
| Paste image | yes | yes | yes (inline dedup copy) | yes (via composer-paste) | **no** | **yes** |
| Paste long-text-as-file | yes | yes | yes (inline) | yes (via composer-paste) | **no** | **yes** |
| Drag-drop attachments | yes | yes | yes (popup-level) | yes (popup-level, preserved) | **no** | **yes** (via composer) |
| 📎 attach | yes (upload.ts) | yes (unchanged) | yes (routed to Chat) | yes (local via stageFiles) | yes | yes |
| 📷 camera | yes (webcam.ts) | yes (unchanged) | yes (routed to Chat) | yes (local openWebcam) | no | no (opt-out) |
| ✏️ sketch | yes (sketch.ts) | yes (unchanged) | yes (routed to Chat) | yes (local openSketch) | yes | yes |
| 🎤 voice | yes (voice-input.ts) | yes (unchanged) | yes (local toggle) | yes (local toggle) | yes | yes |
| Cmd/Ctrl+Enter voice chord | yes (global handler) | yes (global handler) | yes (inline copy) | yes (composer localVoiceChord) | yes (inline copy) | yes (composer localVoiceChord) |
| Plain Enter submit | yes | yes | yes | yes | yes | yes |
| Shift+Enter newline | yes | yes | yes | yes | yes | yes |
| Cmd/Ctrl+U file picker | yes (upload.ts global) | yes (global) | no | yes (composer keydown) | yes (inline copy) | yes (composer keydown) |
| Auto-resize textarea | yes (200px) | yes (200px via composer) | no (fixed rows=2) | no (preserved) | yes (120px inline) | yes (120px via composer) |
| Per-channel draft persistence | yes (PR #330) | yes (unchanged) | yes (PR #330) | yes (unchanged) | yes (PR #330) | yes (unchanged) |
| Send button | yes (#msg-send) | yes (composer) | no (chevron+Enter) | no (preserved) | yes (.thread-send-btn) | yes (composer) |
| `data-composer-surface` attr | no | **yes** ("chat") | no | **yes** ("overview") | no | **yes** ("reply") |

Bold cells = new in this PR.

## Files added

- `hub/frontend/src/composer/composer.ts` + `.js` mirror
- `hub/frontend/src/composer/composer-paste.ts` + `.js` mirror
- `hub/frontend/src/composer/composer-mention.ts` + `.js` mirror
- `hub/frontend/src/composer/composer-attach.ts` + `.js` mirror
- `hub/frontend/src/composer/composer-paste.test.mjs` — node-runner tests (8 pass)

## Files modified

- `hub/frontend/src/index.ts` — import the new `composer/*` modules after `mention.ts`
- `hub/frontend/src/chat/chat-composer.ts` + `.js` mirror — adopt `.input-bar` via `renderComposer`; Chat-specific extras (draft hydrate, blur watchdog, show-more, mermaid toggle) stay inline
- `hub/frontend/src/activity-tab/compose.ts` + `.js` mirror — replace inline popup composer with `renderComposer(surface: "overview")`; preserve `popPending[]`, Item 15 preview, msg#16316 keep-open-on-send, msg#16324 draft-store
- `hub/frontend/src/threads/panel.ts` + `.js` mirror — replace inline thread composer with `renderComposer(surface: "reply")`; preserve legacy IDs for voice-input.ts + external selectors, thread voice-lang button sync, msg#16324 draft-store

## Don't break invariants

All of PR #293/#295/#306/#310/#311/#313/#317/#319/#323/#325/#328/#330's invariants preserved:
- msg#16193: Overview paste/drop stays local (never re-dispatches to Chat)
- msg#16116 Item 2: `_isTargetOnChatTab` guard on `upload.ts`'s global paste handler still active
- msg#16316: Overview popup stays open after send
- msg#16319: removed hover-preview has no re-entry path
- msg#16324: localStorage draft-store + `_debounceSave` / `clearDraft` / `loadDraft` wiring preserved across all three surfaces

Voice-input flow: voice-input.ts's global capture-phase Alt/Ctrl+Enter handler is still the source of truth for Chat; Overview + Reply set `localVoiceChord: true` because voice-input.ts explicitly bails on those surfaces (the `if (inCanvasCompose) return; if (inThread) return;` guards). Chat sets `localVoiceChord: false` to avoid double-toggle.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (114 modules, 753.45 kB / 171.40 kB gzip)
- [x] `node hub/frontend/src/composer/draft-store.test.mjs` → 19/19 pass
- [x] `node hub/frontend/src/composer/composer-paste.test.mjs` → 8/8 pass
- [ ] Chat: plain Enter sends, Shift+Enter newline, Cmd+Enter sends, paste image, drag-drop file, @mention autocomplete, 📎/📷/✏️/🎤 buttons, draft restored on reload
- [ ] Overview: double-click channel node → popup opens with preview, type text, paste image (stays local, tab doesn't flip), @mention autocomplete (new), Enter sends and popup stays open, Esc closes, chevron reveals action buttons
- [ ] Reply: open thread → composer mounts with draft restored, paste image (new), drag-drop file (new), Shift+Enter newline, send via button or Enter, voice-lang button syncs

## Scope deferrals

None — all three surfaces land in this PR. Further tweaks (e.g. Reply composer's camera button, if wanted, or Overview adopting a sendButton: true variant) are one-line opts changes in their respective call sites.

## Judgment calls

- **Chat disables `mention: false`.** mention.ts already runs `initMentionAutocomplete(#msg-input)` at module load. The composer adapter is idempotent but re-attaching would add duplicate listeners. Future cleanup could make mention.ts opt-in-only and have every surface go through the composer, but that's a separate refactor.
- **Chat keeps module-level paste / drop / attach / camera / sketch / voice wiring in upload.ts / webcam.ts / sketch.ts / voice-input.ts.** Moving those into the composer SSoT would be a larger blast radius (upload.ts alone is 420 lines of public API that other modules import). The SSoT currently owns the *new* per-surface wiring while the *existing* global Chat wiring stays — they're complementary, not competing.
- **JS mirrors under `hub/static/hub/`** hand-maintained per project convention even though only the Vite bundle is loaded by templates today. Matches the style of prior PRs in the composer area (#325, #328, #330).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
