### PR TITLE
test(subagent-count): lifecycle tests covering spawn -> completion -> zero transition (msg#16390)

### DIFF
--- a/hub/tests/__init__.py
+++ b/hub/tests/__init__.py
@@ -18,6 +18,7 @@ from hub.tests.consumers.test_agent_subscription import *  # noqa: F401,F403
 from hub.tests.consumers.test_dm import *  # noqa: F401,F403
 from hub.tests.consumers.test_mentions import *  # noqa: F401,F403
 from hub.tests.consumers.test_reexports import *  # noqa: F401,F403
+from hub.tests.consumers.test_subagent_count_roundtrip import *  # noqa: F401,F403
 from hub.tests.models.test_dm_schema import *  # noqa: F401,F403
 from hub.tests.models.test_identity import *  # noqa: F401,F403
 from hub.tests.models.test_messaging import *  # noqa: F401,F403

--- a/hub/tests/consumers/test_subagent_count_roundtrip.py
+++ b/hub/tests/consumers/test_subagent_count_roundtrip.py
@@ -1,0 +1,382 @@
+"""End-to-end lifecycle tests for ``subagent_count`` on the hub side.
+
+Exercises the full path a heartbeat frame takes through
+``handle_heartbeat`` → ``set_subagent_count`` → in-memory registry →
+``get_agents`` payload. Both Layer 1 (server-side auto-dispatch) and
+Layer 2 (hungry-signal DM, PR #329) depend on the hub's in-memory
+``subagent_count`` field reflecting reality within one heartbeat of the
+pane change — if the hub undercounts, auto-dispatch fires while the
+head is actually busy; if it overcounts, the head stays hungry forever.
+
+Scope: the WS heartbeat seam (``handle_heartbeat``) plus the direct
+registry setter (``set_subagent_count``). The parser-side lifecycle
+that produces the field is covered by
+``tests/test_subagent_count_lifecycle.py``. The REST register path
+(``/api/agents/register/``) round-trip is already covered by
+``hub/tests/views/api/test_agents_register.py::test_register_persists_subagent_count``;
+this module focuses on the WebSocket consumer path instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from asgiref.sync import async_to_sync
+from django.test import TestCase
+
+from hub.models import Workspace
+
+
+def _fake_consumer(agent_name: str, workspace_id: int):
+    """Minimal AgentConsumer stub capable of driving handle_heartbeat.
+
+    Mirrors the stub in ``test_agent_message_echo.py`` — bound attributes
+    the handler reads (agent_name, workspace_id, workspace_group,
+    channel_layer) plus an async-mocked ``send_json``. Persistence paths
+    are not involved in the heartbeat handler, so no ``_save_message``
+    stub is needed.
+    """
+    from hub.consumers._agent import AgentConsumer
+
+    consumer = AgentConsumer.__new__(AgentConsumer)
+    consumer.agent_name = agent_name
+    consumer.workspace_id = workspace_id
+    consumer.workspace_group = f"workspace_{workspace_id}"
+    consumer.channel_name = f"test-ch-{agent_name}"
+    consumer._registered = True
+    consumer.agent_meta = {"channels": []}
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_send = AsyncMock()
+    consumer.send_json = AsyncMock()
+    return consumer
+
+
+class SubagentCountRoundtripTest(TestCase):
+    """Heartbeat payload → registry round-trip across the full lifecycle.
+
+    Each test drives ``handle_heartbeat`` with a synthesised payload and
+    asserts the in-memory registry entry reflects the advertised count.
+    The lifecycle covered matches the parser-side parametric list:
+    spawn (0→N), partial completion (N→M<N), full completion (N→0),
+    and the stale-frame race (hub records whatever arrives; eventually
+    consistent via the next heartbeat).
+    """
+
+    def setUp(self):
+        from hub.registry import _agents, _connections, register_agent
+
+        _agents.clear()
+        _connections.clear()
+        self.ws = Workspace.objects.create(name="subagent-count-roundtrip-ws")
+
+        register_agent(
+            "head-test",
+            self.ws.id,
+            {"agent_id": "head-test", "machine": "TEST", "role": "head"},
+        )
+
+    def _send_heartbeat(self, subagent_count):
+        """Drive one heartbeat frame through ``handle_heartbeat``.
+
+        The helper builds a payload whose only meaningful field is
+        ``subagent_count`` (the metrics block is fine as ``None``s —
+        ``handle_heartbeat`` just passes them through verbatim).
+        """
+        from hub.consumers._agent_handlers import handle_heartbeat
+
+        consumer = _fake_consumer("head-test", self.ws.id)
+        frame = {
+            "type": "heartbeat",
+            "payload": {
+                "subagent_count": subagent_count,
+            },
+        }
+        async_to_sync(handle_heartbeat)(consumer, frame)
+
+    # ------------------------------------------------------------------
+    # Cold start — no heartbeat yet. The prev-preserve register_agent
+    # path defaults subagent_count to 0 so the field exists from the
+    # first call.
+    # ------------------------------------------------------------------
+
+    def test_cold_start_defaults_to_zero(self):
+        """A freshly-registered agent has ``subagent_count == 0``.
+
+        No heartbeat has arrived yet — the field must still be present
+        and equal to zero so auto-dispatch / hungry-signal doesn't
+        crash on a KeyError or treat "unknown" as "busy".
+        """
+        from hub.registry import _agents
+
+        self.assertEqual(_agents["head-test"].get("subagent_count", 0), 0)
+
+    # ------------------------------------------------------------------
+    # Layer 1 — spawn events (0 → N).
+    # ------------------------------------------------------------------
+
+    def test_heartbeat_with_one_subagent_records_one(self):
+        """One Agent in flight → registry ``subagent_count == 1``."""
+        from hub.registry import _agents
+
+        self._send_heartbeat(1)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 1)
+
+    def test_heartbeat_with_three_subagents_records_three(self):
+        """Three Agents in flight → registry ``subagent_count == 3``."""
+        from hub.registry import _agents
+
+        self._send_heartbeat(3)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 3)
+
+    def test_heartbeat_with_five_subagents_records_five(self):
+        """Large batches carry through unchanged."""
+        from hub.registry import _agents
+
+        self._send_heartbeat(5)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 5)
+
+    # ------------------------------------------------------------------
+    # Full-lifecycle transitions. The sequence (0 → 3 → 2 → 0) is the
+    # critical path — if any of these steps fail to update the registry,
+    # the dependent features misfire.
+    # ------------------------------------------------------------------
+
+    def test_full_spawn_to_zero_lifecycle(self):
+        """Full lifecycle: 0 → 1 → 0 → 3 → 2 → 0.
+
+        Each transition is an independent heartbeat. The registry must
+        reflect each step without interpolation, clamping, or memory of
+        the previous value.
+        """
+        from hub.registry import _agents
+
+        # Cold start: 0 (default)
+        self.assertEqual(_agents["head-test"].get("subagent_count", 0), 0)
+
+        # Spawn 1
+        self._send_heartbeat(1)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 1)
+
+        # That 1 finishes — back to idle
+        self._send_heartbeat(0)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 0)
+
+        # Fresh batch of 3
+        self._send_heartbeat(3)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 3)
+
+        # Partial completion: 1 of 3 returns, 2 still live
+        self._send_heartbeat(2)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 2)
+
+        # Full completion — idle again, hungry-signal counter can start
+        self._send_heartbeat(0)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 0)
+
+    def test_partial_completion_decrement(self):
+        """3 spawned, 1 finishes → hub tracks 2 (not stuck at 3)."""
+        from hub.registry import _agents
+
+        self._send_heartbeat(3)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 3)
+
+        # One of the three completes — the pane now shows
+        # "2 local agents still running" and the parser returns 2.
+        self._send_heartbeat(2)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 2)
+
+    def test_completion_clears_to_zero(self):
+        """Running → idle transition: hub reflects the zero within one tick."""
+        from hub.registry import _agents
+
+        self._send_heartbeat(4)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 4)
+
+        self._send_heartbeat(0)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 0)
+
+    # ------------------------------------------------------------------
+    # Race / stale-frame semantics. Heartbeat is eventually consistent —
+    # whatever the parser sampled is what the hub records, and the next
+    # heartbeat corrects it.
+    # ------------------------------------------------------------------
+
+    def test_stale_frame_records_stale_count(self):
+        """If the parser sampled a stale "2 local agents running" frame
+        while the batch had actually finished, the hub records 2. The
+        next heartbeat (post-redraw → 0) corrects it. Eventually
+        consistent; pin that so a future change to "smooth" transitions
+        doesn't silently swallow a stale frame.
+        """
+        from hub.registry import _agents
+
+        # Parser saw a stale status-line frame → hub records 2.
+        self._send_heartbeat(2)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 2)
+
+        # Next heartbeat arrives with the correct post-redraw count.
+        self._send_heartbeat(0)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 0)
+
+    def test_overshoot_then_correct(self):
+        """Heartbeat arrives with 5 (bogus / transient spike), next
+        heartbeat corrects to 2. Hub honours the latest value.
+        """
+        from hub.registry import _agents
+
+        self._send_heartbeat(5)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 5)
+
+        self._send_heartbeat(2)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 2)
+
+    # ------------------------------------------------------------------
+    # Payload surface — get_agents must expose the round-tripped field
+    # so the Agents-tab / hungry-signal reader sees the live value.
+    # ------------------------------------------------------------------
+
+    def test_get_agents_surfaces_current_count(self):
+        """The payload layer reflects the registry's current count.
+
+        Regression guard: without this, the dashboard + the server-side
+        auto-dispatch reader could see a stale value even though the
+        in-memory dict has the fresh one.
+        """
+        from hub.registry import get_agents
+
+        self._send_heartbeat(2)
+        payload = next(
+            a
+            for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "head-test"
+        )
+        self.assertEqual(payload["subagent_count"], 2)
+
+        self._send_heartbeat(0)
+        payload = next(
+            a
+            for a in get_agents(workspace_id=self.ws.id)
+            if a["name"] == "head-test"
+        )
+        self.assertEqual(payload["subagent_count"], 0)
+
+    # ------------------------------------------------------------------
+    # Defensive input handling — the WS heartbeat handler must not
+    # blow up on missing / malformed / negative counts. Pins the
+    # hub's "best-effort int, floor at 0" contract.
+    # ------------------------------------------------------------------
+
+    def test_heartbeat_without_subagent_count_preserves_prior(self):
+        """Heartbeat omitting ``subagent_count`` leaves the registry's
+        current value unchanged — the field is optional on the wire
+        and a heartbeat that doesn't know it should not clobber a
+        previously-recorded 3 back to 0.
+        """
+        from hub.consumers._agent_handlers import handle_heartbeat
+        from hub.registry import _agents
+
+        # Plant a known count.
+        self._send_heartbeat(3)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 3)
+
+        # Send a heartbeat that omits ``subagent_count``.
+        consumer = _fake_consumer("head-test", self.ws.id)
+        async_to_sync(handle_heartbeat)(
+            consumer, {"type": "heartbeat", "payload": {}}
+        )
+        # Prior value preserved.
+        self.assertEqual(_agents["head-test"]["subagent_count"], 3)
+
+    def test_heartbeat_with_negative_count_floors_to_zero(self):
+        """A negative count (never legal, but pathological clients
+        sometimes send one) is floored to 0 — matches the contract in
+        ``set_subagent_count`` itself.
+        """
+        from hub.registry import _agents
+
+        self._send_heartbeat(-1)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 0)
+
+        self._send_heartbeat(-99)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 0)
+
+    def test_heartbeat_with_non_int_count_is_ignored(self):
+        """Malformed ``subagent_count`` (non-coercible string) is
+        swallowed — the handler catches the ValueError and leaves the
+        prior value in place. Contract: one bad frame never corrupts
+        the registry.
+        """
+        from hub.consumers._agent_handlers import handle_heartbeat
+        from hub.registry import _agents
+
+        # Plant a known count.
+        self._send_heartbeat(2)
+        self.assertEqual(_agents["head-test"]["subagent_count"], 2)
+
+        # Send a heartbeat with a garbage count.
+        consumer = _fake_consumer("head-test", self.ws.id)
+        async_to_sync(handle_heartbeat)(
+            consumer,
+            {
+                "type": "heartbeat",
+                "payload": {"subagent_count": "banana"},
+            },
+        )
+        # Prior value preserved, no exception propagated.
+        self.assertEqual(_agents["head-test"]["subagent_count"], 2)
+
+
+class SetSubagentCountDirectTest(TestCase):
+    """Direct tests of ``set_subagent_count`` — the registry primitive.
+
+    The WS handler and the REST ``/api/agents/register/`` endpoint
+    both funnel through this setter, so pinning its behaviour guards
+    both call-sites at once.
+    """
+
+    def setUp(self):
+        from hub.registry import _agents, _connections, register_agent
+
+        _agents.clear()
+        _connections.clear()
+        self.ws = Workspace.objects.create(name="set-subagent-count-ws")
+        register_agent(
+            "head-x",
+            self.ws.id,
+            {"agent_id": "head-x", "machine": "TEST", "role": "head"},
+        )
+
+    def test_set_monotonic_sequence(self):
+        """0 → 1 → 3 → 2 → 0 round-trip."""
+        from hub.registry import _agents, set_subagent_count
+
+        for value in (0, 1, 3, 2, 0):
+            set_subagent_count("head-x", value)
+            self.assertEqual(_agents["head-x"]["subagent_count"], value)
+
+    def test_set_floors_negative_at_zero(self):
+        from hub.registry import _agents, set_subagent_count
+
+        set_subagent_count("head-x", -5)
+        self.assertEqual(_agents["head-x"]["subagent_count"], 0)
+
+    def test_set_accepts_none_as_zero(self):
+        """``None`` maps to 0 per the ``int(count or 0)`` contract."""
+        from hub.registry import _agents, set_subagent_count
+
+        # Plant a non-zero first.
+        set_subagent_count("head-x", 4)
+        self.assertEqual(_agents["head-x"]["subagent_count"], 4)
+
+        set_subagent_count("head-x", None)  # type: ignore[arg-type]
+        self.assertEqual(_agents["head-x"]["subagent_count"], 0)
+
+    def test_set_on_unknown_agent_is_noop(self):
+        """Unknown agent name is a silent no-op — the setter must not
+        create phantom registry rows. Mirrors ``update_echo_pong``'s
+        defensive behaviour.
+        """
+        from hub.registry import _agents, set_subagent_count
+
+        set_subagent_count("never-registered", 7)
+        self.assertNotIn("never-registered", _agents)

--- a/tests/test_hungry_signal_counter.py
+++ b/tests/test_hungry_signal_counter.py
@@ -200,3 +200,87 @@ def test_non_zero_clears_prior_fired_flag(tmp_path):
     s = _read_state(state_dir)
     assert s["cycles"] == 0
     assert s["fired"] == 0
+
+
+# -----------------------------------------------------------------------------
+# Lifecycle coverage (msg#16389 / msg#16390) — the hungry-signal counter must
+# track a realistic spawn → partial-completion → completion → reset sequence
+# end-to-end. The parser + hub-registry round-trips that produce the counts
+# are covered by ``tests/test_subagent_count_lifecycle.py`` +
+# ``hub/tests/consumers/test_subagent_count_roundtrip.py``; this section
+# exercises the bash state-machine's response to the full sequence.
+# -----------------------------------------------------------------------------
+
+
+def test_full_lifecycle_spawn_drain_idle_dm(tmp_path):
+    """End-to-end sequence: idle → spawn batch → drain → idle → DM.
+
+    The head starts idle (0), spawns 3 subagents (1 → 3), one finishes
+    (→ 2), all finish (→ 0), then two further idle ticks trigger the DM.
+    Pins the correctness contract: transient non-zero readings during a
+    real batch must reset the counter each time, so the DM only fires
+    after a *sustained* idle stretch past threshold.
+    """
+    state_dir = tmp_path / "state"
+
+    # Tick A — idle cold start. cycles=1.
+    r = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "counting"
+    assert _read_state(state_dir)["cycles"] == 1
+
+    # Tick B — subagent spawned (1 local agent running). Counter resets.
+    r = _invoke(tmp_path, subagent_count=1, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "noop"
+    assert _read_state(state_dir)["cycles"] == 0
+
+    # Tick C — batch ramped to 3. Still busy, counter stays at 0.
+    r = _invoke(tmp_path, subagent_count=3, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "noop"
+    assert _read_state(state_dir)["cycles"] == 0
+
+    # Tick D — partial completion (2 still running). Still non-zero.
+    r = _invoke(tmp_path, subagent_count=2, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "noop"
+    assert _read_state(state_dir)["cycles"] == 0
+
+    # Tick E — full completion. First idle tick after batch. cycles=1.
+    r = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "counting"
+    assert _read_state(state_dir)["cycles"] == 1
+
+    # Tick F — still idle. cycles=2, below threshold=3.
+    r = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "counting"
+    assert _read_state(state_dir)["cycles"] == 2
+
+    # Tick G — still idle. cycles=3 hits threshold → DM attempt.
+    r = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] in {"dm_sent", "dm_failed"}
+    assert _read_state(state_dir)["cycles"] == 3
+
+
+def test_transient_spawn_resets_counter_mid_stretch(tmp_path):
+    """A single non-zero tick mid-idle-stretch must reset the counter.
+
+    Guards against a subtle regression: if the state machine kept
+    incrementing through a brief busy interval (e.g. decremented rather
+    than reset), the DM would fire spuriously seconds after the head
+    finished a legitimate task.
+    """
+    state_dir = tmp_path / "state"
+
+    # Two idle ticks — we're one tick shy of firing at threshold=3.
+    _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=3, state_dir=state_dir)
+    _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=3, state_dir=state_dir)
+    assert _read_state(state_dir)["cycles"] == 2
+
+    # Brief busy tick — one Agent spawned + finished between ticks.
+    # Counter must reset to 0, NOT decrement by 1.
+    r = _invoke(tmp_path, subagent_count=1, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "noop"
+    assert _read_state(state_dir)["cycles"] == 0
+
+    # Back to idle. Must start over at 1 — NOT pick up where we left off.
+    r = _invoke(tmp_path, subagent_count=0, dry_run=False, threshold=3, state_dir=state_dir)
+    assert r["decision"] == "counting"
+    assert _read_state(state_dir)["cycles"] == 1

--- a/tests/test_subagent_count_lifecycle.py
+++ b/tests/test_subagent_count_lifecycle.py
@@ -1,0 +1,384 @@
+"""End-to-end lifecycle tests for ``parse_subagent_count``.
+
+Both Layer 1 (server-side auto-dispatch) and Layer 2 (hungry-signal DM,
+PR #329) depend on ``subagent_count == 0`` detection being accurate. If
+the count fails to decrement when subagents finish, auto-dispatch fires
+when the head is actually busy (false negative) or misfires when it
+shouldn't (false positive). This module pins the parser's behaviour
+across every transition the tmux pane can emit during a real subagent
+batch — spawn, ramp-up, partial completion, full completion, and the
+"marker disappears" quiet state — plus regression guards for
+false-positive chat text and multi-marker panes.
+
+The parser under test lives at
+``scripts/client/agent_meta_pkg/_pane.py::parse_subagent_count``.
+A mirror implementation lives in ``scitex-agent-container`` (separate
+repo); that one needs its own test suite there — see PR body for
+follow-up.
+
+Scope: lifecycle parser behaviour only. The hub-side round-trip (how
+``subagent_count`` travels through the heartbeat frame to the registry)
+is covered by ``hub/tests/consumers/test_subagent_count_roundtrip.py``.
+The hungry-signal counter / auto-dispatch streak logic is covered by
+``tests/test_hungry_signal_counter.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# agent_meta_pkg isn't installed into site-packages — make it importable.
+_AGENT_META_DIR = Path(__file__).resolve().parents[1] / "scripts" / "client"
+if str(_AGENT_META_DIR) not in sys.path:
+    sys.path.insert(0, str(_AGENT_META_DIR))
+
+from agent_meta_pkg._pane import parse_subagent_count  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Happy-path parametric coverage — every count / grammar variant the
+# Claude Code status line is known to emit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pane_text, expected",
+    [
+        # Singular form (1 agent, present participle)
+        ("1 local agent running", 1),
+        # Plural, small count
+        ("2 local agents running", 2),
+        ("3 local agents running", 3),
+        # Plural, larger count (stress the \d+ group)
+        ("5 local agents running", 5),
+        # "still running" variant — emitted once the batch has been
+        # alive long enough to tick the status-line refresh.
+        ("1 local agent still running", 1),
+        ("2 local agents still running", 2),
+        # Full status-line shape — leading glyph, trailing elapsed time
+        ("  ✶ 1 local agent running · 2s\n❯ ", 1),
+        ("  ✢ 5 local agents still running · 45s\n", 5),
+        # Zero — Claude Code briefly emits "0 local agents" while the
+        # batch drains. Parser must treat this as 0, not as "no marker".
+        ("0 local agents", 0),
+        ("0 local agents running", 0),
+    ],
+    ids=[
+        "singular-1",
+        "plural-2",
+        "plural-3",
+        "plural-5",
+        "singular-still",
+        "plural-still",
+        "full-status-line-1",
+        "full-status-line-5-still",
+        "zero-no-running-suffix",
+        "zero-with-running",
+    ],
+)
+def test_count_parsed_from_marker(pane_text: str, expected: int) -> None:
+    """The regex extracts the advertised integer across every known variant."""
+    assert parse_subagent_count(pane_text) == expected
+
+
+# ---------------------------------------------------------------------------
+# Zero state — marker absent / pane empty. Both must parse to 0 so the
+# heartbeat carries an authoritative 0 rather than a stale prior count.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pane_text",
+    [
+        "",  # empty pane (WS just connected, no scrollback yet)
+        "agent session active",  # no marker, normal chat output
+        "regular chat output\nnothing special here\n❯ ",  # idle prompt
+        "doing some work\n  ⎿ tool finished\n❯ ",  # finished-tool idle state
+        "0 local agents\n",  # explicit zero — covered by parametric above,
+        # but pinned here because "marker disappears" and "zero marker" are
+        # two distinct real-world transitions and both must floor at 0.
+    ],
+    ids=[
+        "empty-pane",
+        "no-marker-phrase",
+        "idle-prompt",
+        "finished-tool",
+        "zero-marker",
+    ],
+)
+def test_zero_state_parses_to_zero(pane_text: str) -> None:
+    """Empty / marker-less / explicit-zero panes all report 0."""
+    assert parse_subagent_count(pane_text) == 0
+
+
+def test_none_pane_returns_zero() -> None:
+    """A None pane (tmux capture failed) must not raise — treat as 0."""
+    # The production signature takes str, but defensive call-sites pass
+    # through whatever ``capture_pane`` returned. Pin the None-safe path.
+    assert parse_subagent_count(None) == 0  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Full spawn → run → complete lifecycle. Two distinct parses against the
+# same captured pane must yield the transition the hub expects.
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_then_completion_transition() -> None:
+    """Burst transition: 1 running, later 0 running.
+
+    The head's heartbeat loop captures the pane twice across two ticks.
+    Tick 1 captures the pane while an Agent call is in flight → parser
+    returns 1. Tick 2 captures after the Agent returned and the status
+    line cleared → parser returns 0. Both parses must be independent
+    and correct so the hub's ``subagent_count`` field tracks reality.
+    """
+    pane_tick_1 = "  ✶ 1 local agent running · 2s\n❯ "
+    pane_tick_2 = "  ⎿ Agent finished\n❯ "  # marker fully gone
+    assert parse_subagent_count(pane_tick_1) == 1
+    assert parse_subagent_count(pane_tick_2) == 0
+
+
+def test_partial_completion_transition() -> None:
+    """3 spawned, 1 finishes → pane shows "2 local agents running"."""
+    pane_tick_1 = "  ✶ 3 local agents running · 5s\n❯ "
+    pane_tick_2 = "  ✢ 2 local agents still running · 12s\n❯ "
+    pane_tick_3 = "  ⎿ Agent finished\n❯ "
+    assert parse_subagent_count(pane_tick_1) == 3
+    assert parse_subagent_count(pane_tick_2) == 2
+    assert parse_subagent_count(pane_tick_3) == 0
+
+
+def test_ramp_up_transition() -> None:
+    """Parser tracks monotonic spawn-up: 1 → 2 → 5."""
+    # Head spawns Agents one at a time across three ticks.
+    assert parse_subagent_count("  ✶ 1 local agent running · 1s\n❯ ") == 1
+    assert parse_subagent_count("  ✶ 2 local agents running · 2s\n❯ ") == 2
+    assert parse_subagent_count("  ✶ 5 local agents running · 3s\n❯ ") == 5
+
+
+def test_zero_to_one_to_zero_roundtrip() -> None:
+    """Cold-start → one Agent spawn → completion back to idle."""
+    assert parse_subagent_count("") == 0  # cold start
+    assert parse_subagent_count("1 local agent running") == 1  # spawn
+    assert parse_subagent_count("0 local agents") == 0  # wind-down
+    assert parse_subagent_count("❯ ") == 0  # marker fully gone
+
+
+# ---------------------------------------------------------------------------
+# False-positive regression guards. The current regex anchors on the
+# literal ``running`` trailer precisely to stop these from matching; pin
+# that so a future refactor that broadens the regex breaks loudly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pane_text",
+    [
+        # Chat prose mentioning the count-like phrase — the "running"
+        # trailer guards against this. Listed in msg#16389 as the
+        # canonical regression-guard case.
+        "reviewing 2 local agent names that were stale last cycle",
+        "2 local agent names are stale",
+        # Another false-positive shape — possessive construction
+        "the 4 local agent instances each report their own state",
+        # Error message citing count without the trailer
+        "error: expected 1 local agent; got 3",
+    ],
+    ids=[
+        "chat-names-are-stale",
+        "chat-names-are-stale-short",
+        "possessive-instances",
+        "error-citing-count",
+    ],
+)
+def test_false_positive_regression_guards(pane_text: str) -> None:
+    """Chat / doc / error text mentioning "local agent" without the
+    ``running`` trailer must NOT match.
+
+    The old substring regex (``(\\d+) local agent``) fired on all of
+    these and inflated ``subagent_count``. The current regex requires
+    the ``running`` trailer; pin that so the guard doesn't regress.
+    """
+    assert parse_subagent_count(pane_text) == 0
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Known false-positive: quoted docs / chat prose containing the "
+        "literal string \"N local agents running\" — e.g. a help-text "
+        "citation or a channel message quoting the marker phrase — are "
+        "matched by the current regex even though the surrounding "
+        "context makes clear they are not live status lines. A future "
+        "fix could anchor the regex to start-of-line (``^``) or require "
+        "leading whitespace + a status-line glyph (``✶`` / ``✢``). "
+        "Tracked as a follow-up; this test pins the current buggy "
+        "behaviour so the fix is visible when it lands."
+    ),
+)
+def test_quoted_marker_phrase_false_positive() -> None:
+    """Documented bug: quoted docs containing the marker phrase match.
+
+    When a chat message or help-text quotes the literal status-line
+    phrase (e.g. ``see docs: '3 local agents running' appears when...``)
+    the regex matches and the parser reports 3 even though no subagent
+    is actually running. This is a known false positive — filing a
+    follow-up issue keeps scope out of the lifecycle-test PR.
+    """
+    # Expected (correct) behaviour: quoted citation should not count.
+    pane = "see docs: '3 local agents running' appears when a batch is active"
+    assert parse_subagent_count(pane) == 0
+
+
+# ---------------------------------------------------------------------------
+# Prefix / suffix tolerance — real tmux panes are full of control codes,
+# box-drawing characters, and trailing whitespace. The marker must still
+# be found.
+# ---------------------------------------------------------------------------
+
+
+def test_leading_whitespace_tolerated() -> None:
+    """Leading spaces + glyphs don't block the match."""
+    assert parse_subagent_count("     1 local agent running") == 1
+    assert parse_subagent_count("\t\t3 local agents running") == 3
+
+
+def test_trailing_whitespace_tolerated() -> None:
+    """Trailing padding / elapsed-time suffix doesn't block the match."""
+    assert parse_subagent_count("1 local agent running · 2s") == 1
+    assert parse_subagent_count("1 local agent running   \n") == 1
+    assert parse_subagent_count("1 local agent running\r\n") == 1
+
+
+def test_newlines_and_multiline_pane() -> None:
+    """Marker embedded in a multi-line capture still resolves."""
+    pane = "\n".join([
+        "some earlier output",
+        "  ⎿ tool output",
+        "  ✶ 4 local agents running · 7s",
+        "❯ ",
+    ])
+    assert parse_subagent_count(pane) == 4
+
+
+def test_color_escape_codes_do_not_break_match() -> None:
+    """ANSI escape sequences around the marker don't consume the digit.
+
+    tmux capture-pane defaults to stripping escapes, but some call
+    sites pass raw text through; pin the tolerance so we don't
+    silently lose a match when the pipeline changes.
+    """
+    # The regex doesn't anchor to start-of-line, and the digit+literal
+    # "local agents running" is the matched run, so ESC sequences on
+    # either side are ignored.
+    pane = "\x1b[32m  ✶ 2 local agents running · 3s\x1b[0m\n"
+    assert parse_subagent_count(pane) == 2
+
+
+def test_case_insensitive_markers() -> None:
+    """Future-proofing: the regex is case-insensitive per the current
+    implementation. Pin that so a refactor doesn't drop ``re.IGNORECASE``
+    silently — there's no cost to keeping the match forgiving and the
+    hungry-signal / auto-dispatch path wants the broadest match possible.
+    """
+    assert parse_subagent_count("1 Local Agent Running") == 1
+    assert parse_subagent_count("2 LOCAL AGENTS RUNNING") == 2
+    assert parse_subagent_count("3 LOCAL AGENTS STILL RUNNING") == 3
+
+
+# ---------------------------------------------------------------------------
+# Multi-marker pane — pin first-match semantics so a future refactor
+# that changes to "last match" breaks explicitly rather than silently.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_marker_returns_first_match() -> None:
+    """Pane scrollback can contain a stale earlier marker above a newer
+    one (pane is 500 lines of history, the batch transition is shorter
+    than that). Current implementation uses ``re.search``, which returns
+    the first (top-most) match. Pin the behaviour; if a future author
+    wants last-match / latest-wins semantics they should change this
+    test in the same commit so the change is explicit.
+    """
+    pane = (
+        "  ✶ 2 local agents running\n"
+        "... later ticks ...\n"
+        "  ✢ 4 local agents still running\n"
+    )
+    assert parse_subagent_count(pane) == 2
+
+
+def test_multi_marker_stale_above_current() -> None:
+    """Realistic shape: an old fully-completed batch left
+    "0 local agents running" behind, then a new batch spawned. First
+    match wins — hub sees 0 until the old line scrolls off, at which
+    point the new count takes over. The test pins the order-sensitive
+    behaviour; whether "stale wins" is actually desirable is a separate
+    concern (see PR body for follow-up notes).
+
+    Note: only a stale "0 local agents **running**" line steals the
+    match — a bare "0 local agents" has no ``running`` trailer, so the
+    regex skips past it to the live ``N local agents running`` line
+    below. Both shapes are exercised here.
+    """
+    # Shape A: stale line still has the ``running`` trailer → first-match
+    # semantics mean the stale 0 wins.
+    pane_stale_with_running = (
+        "  ⎿ 0 local agents running\n"
+        "...\n"
+        "  ✶ 3 local agents running · 2s\n"
+    )
+    assert parse_subagent_count(pane_stale_with_running) == 0
+
+    # Shape B: stale line dropped the ``running`` trailer → the stale
+    # line fails to match and the live count wins.
+    pane_stale_without_running = (
+        "  ⎿ 0 local agents\n"
+        "...\n"
+        "  ✶ 3 local agents running · 2s\n"
+    )
+    assert parse_subagent_count(pane_stale_without_running) == 3
+
+
+# ---------------------------------------------------------------------------
+# Race conditions. Heartbeat may sample the pane mid-transition (the
+# status line is being redrawn). The parser is expected to return
+# whatever the pane says *right now*; the hub is eventually consistent
+# via the next heartbeat.
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_during_stale_frame_records_stale_count() -> None:
+    """Race: pane still shows "2 local agents running" while both have
+    actually just finished. The parser returns 2 — that's correct
+    behaviour — and the hub records 2 until the next heartbeat. The
+    contract is eventual-consistency, not mid-tick correctness.
+    """
+    # A realistic stale frame: the status-line redraw hasn't happened
+    # yet even though the Agent calls returned.
+    stale_pane = "  ✢ 2 local agents running · 8s\n  ⎿ Done\n❯ "
+    assert parse_subagent_count(stale_pane) == 2
+
+    # Next heartbeat samples the post-redraw pane → hub updates.
+    post_redraw = "  ⎿ Done\n❯ "
+    assert parse_subagent_count(post_redraw) == 0
+
+
+def test_count_never_goes_negative() -> None:
+    """Defensive: even if a pathological pane somehow contained a
+    negative sign before the digit, the regex's ``\\d+`` group can't
+    capture the sign — so the count stays non-negative. The hub's
+    ``set_subagent_count`` floors at zero as a second line of defence,
+    but we want the parser to do the right thing on its own too.
+    """
+    # ``-3 local agents running`` — the regex matches "3 local agents
+    # running" (the minus sign is not consumed by ``\\d+``), so the
+    # count is 3 not -3.
+    assert parse_subagent_count("-3 local agents running") == 3
+    assert parse_subagent_count("-1 local agent running") == 1
+    # The produced value is always a non-negative int.
+    assert parse_subagent_count("-99 local agents running") >= 0

--- a/tests/test_subagent_count_lifecycle.py
+++ b/tests/test_subagent_count_lifecycle.py
@@ -37,7 +37,6 @@ if str(_AGENT_META_DIR) not in sys.path:
 
 from agent_meta_pkg._pane import parse_subagent_count  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Happy-path parametric coverage — every count / grammar variant the
 # Claude Code status line is known to emit.


### PR DESCRIPTION
## Summary

Both Layer 1 (server-side auto-dispatch, in flight as `feat/auto-dispatch-server-side-push`) and Layer 2 (hungry-signal DM, shipped in #329) depend on `subagent_count == 0` detection being accurate. If the count fails to decrement when subagents finish, auto-dispatch fires while the head is actually busy (false negative) or misfires when it should not (false positive). This PR pins the full lifecycle across three seams:

- **Pane parser** (`parse_subagent_count` in `scripts/client/agent_meta_pkg/_pane.py`) — parametric coverage across every known status-line variant plus transition scenarios.
- **Hub heartbeat round-trip** (`handle_heartbeat` -> `set_subagent_count` -> `_agents` registry) — end-to-end frame replay.
- **Hungry-signal state machine** (`scripts/client/hungry-signal.sh`) — full spawn -> drain -> idle -> DM sequence.

## Test files added

| File | New cases | Purpose |
|------|-----------|---------|
| `tests/test_subagent_count_lifecycle.py` | 33 + 1 xfail | Parser lifecycle, false-positive guards, race semantics |
| `hub/tests/consumers/test_subagent_count_roundtrip.py` | 17 | Heartbeat -> registry round-trip, defensive input handling |
| `tests/test_hungry_signal_counter.py` | +2 | Full spawn/drain/idle/DM lifecycle + transient-spawn reset |

**Total: 52 new test cases, 1 documented xfail.**

### Coverage detail

- **Parser lifecycle** — spawn (0 -> 1/2/3/5), ramp-up (1 -> 2 -> 5), partial completion (3 -> 2), full completion (N -> 0), zero-state variants (empty pane, no marker, idle prompt, finished-tool, explicit `0 local agents`), None-safe.
- **Grammar variants** — singular/plural, `still running`, full status-line with glyph + elapsed time.
- **False-positive regression guards** — chat prose (`2 local agent names are stale`), possessive (`4 local agent instances`), error text (`expected 1 local agent; got 3`) all parse to 0.
- **Tolerance** — leading whitespace, trailing padding / elapsed-time suffix, multi-line capture, ANSI color escapes, case-insensitivity.
- **Multi-marker semantics** — first-match wins (pinned so future refactors are explicit); stale-above-current scenarios.
- **Race semantics** — heartbeat arrives mid-transition with stale frame, next heartbeat corrects (eventual consistency).
- **Hub round-trip** — full 0 -> 1 -> 0 -> 3 -> 2 -> 0 sequence via `handle_heartbeat` against a fake consumer; `get_agents` payload surfaces the current value; defensive handling (missing field preserves prior, negative floors at 0, non-coercible string is ignored, unknown agent is no-op).
- **Hungry-signal state machine** — end-to-end idle -> spawn (1) -> ramp (3) -> partial-drain (2) -> full-drain (0) -> sustained-idle -> DM; transient-busy-mid-idle-stretch resets the counter rather than decrementing.

## Test-revealed bug (follow-up, not fixed inline)

The lifecycle exercise uncovered one false positive in the current regex:

> Quoted docs / chat prose containing the literal string `"N local agents running"` — e.g. a help-text citation or a `#progress` channel message quoting the marker phrase — match the regex even though the surrounding context makes clear they are not live status lines.

Example: `see docs: '3 local agents running' appears when a batch is active` -> parser returns 3, should return 0.

**Root cause:** the regex only anchors on the `running` trailer, not on start-of-line / a status-line glyph (`✶` / `✢`).

**Fix options:** anchor to `^`, or require leading whitespace + a status-line glyph. Both need coordination with the scitex-agent-container mirror parser, so filing separately.

**How it is surfaced here:** `@pytest.mark.xfail(strict=True)` on `test_quoted_marker_phrase_false_positive` — a future fix will flip it to green and the `strict=True` means the xpass is a loud failure if someone tightens the regex without removing the marker.

Follow-up issue to file after this PR merges: `parser: regex over-matches quoted marker phrase in chat / doc text`. Severity is low (chat rarely quotes the literal marker string) but should be cleaned up before it bites Layer 1 in production.

## Scope boundaries (respected)

- No production-code changes; tests only.
- No streak-counter tests for Layer 1 — that logic has not landed on `develop` yet and is owned by the in-flight `feat/auto-dispatch-server-side-push` PR. This PR stays upstream of firing logic.
- `ts-migration-v2` untouched.
- `hub/frontend/` and `hub/static/hub/` untouched.
- Mirror parser in `scitex-agent-container` (separate repo) needs its own PR with equivalent coverage — noted as follow-up.

## Test plan

- [x] `pytest tests/test_subagent_count_lifecycle.py tests/test_subagent_count_parse.py tests/test_hungry_signal_counter.py` — 49 passed, 1 xfailed locally on mba.
- [x] `python manage.py test hub.tests.SubagentCountRoundtripTest hub.tests.SetSubagentCountDirectTest` — 17 passed locally.
- [ ] CI green on the full matrix.

## Context

- Prompted by ywatanabe msg#16389 (quoted in worker-progress msg#16390).
- Parser-under-test landed in PR #318 with rebase scope onto current develop.
- Layer 2 (hungry-signal) shipped in PR #329 — its real-behaviour tests are complementary; lifecycle extension appended to the existing file rather than a new one.

Generated with [Claude Code](https://claude.com/claude-code)
