### PR TITLE
feat(hub): server-side auto-dispatch — hub detects idle head and pushes dispatch message (Layer 1 redesign, msg#16388)

### DIFF
--- a/hub/auto_dispatch.py
+++ b/hub/auto_dispatch.py
@@ -1,0 +1,461 @@
+"""Server-side auto-dispatch for idle ``head-*`` agents (Layer 1 redesign).
+
+Replaces the client-side ``scripts/client/auto-dispatch-probe.sh`` daemon
+(PR #320) with hub-side detection driven off the heartbeat hot path.
+
+Design (lead msg#16388, ywatanabe msg#16380)
+--------------------------------------------
+
+On every heartbeat from a ``head-<host>`` agent:
+
+1. Compare the newly written ``subagent_count`` with the prior reading
+   held in ``hub.registry._agents[<name>]``.
+2. Maintain a per-head ``idle_streak`` counter. Zero reading increments
+   the streak, any non-zero reading resets it (but the cooldown window
+   is preserved — a head that briefly forks then collapses to zero
+   should not immediately get re-dispatched).
+3. When the streak reaches ``SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD``
+   (default 2 — roughly two heartbeat cycles of stillness), fire an
+   auto-dispatch DM to the head's own DM channel with itself (the
+   canonical ``dm:agent:head-<host>|human:orochi-auto-dispatch`` lane)
+   so the head's :class:`AgentConsumer` receives it as a normal chat
+   frame and the head's Claude parses the instruction.
+4. After firing, mark the cooldown (``SCITEX_AUTO_DISPATCH_COOLDOWN_SECONDS``,
+   default 900 = 15 min). No further auto-dispatches to the same head
+   until the cooldown expires. Streak is reset on fire.
+
+Kill switch
+-----------
+
+``SCITEX_AUTO_DISPATCH_DISABLED=1`` — any value other than ``"1"`` leaves
+the feature enabled. Best-effort: any exception raised inside the auto-
+dispatch path is logged and swallowed; the heartbeat hot path must never
+fail because of auto-dispatch.
+
+State location
+--------------
+
+Streak counter and cooldown timestamp live on the in-memory agent
+entry (``_agents[name]["idle_streak"]`` / ``_agents[name]["auto_dispatch_last_fire_ts"]``),
+so they survive regular heartbeats via ``_register.register_agent``'s
+prev-preserve block (see changes there). Hub restart resets the state,
+which is acceptable — an idle head will re-trigger on the next two
+heartbeats.
+
+Todo-selection
+--------------
+
+We shell out to ``scripts/client/auto-dispatch-pick-todo.py`` as a
+subprocess rather than inlining the ``gh issue list`` logic. The helper
+is already unit-tested (PR #320 test_pick_todo.py) and has its own
+failure contract ("print null on no match, never crash"). Subprocess
+timeout = 20s — if ``gh`` is unauth or slow, auto-dispatch silently
+skips this cycle.
+
+Hooks
+-----
+
+Entry point: :func:`check_agent_auto_dispatch` — invoked from
+``hub/registry/_heartbeat.py::update_heartbeat`` after the quota
+pressure check. Only fires for agents whose name starts with
+``head-`` — non-head agents (workers, managers, healers) are skipped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("orochi.auto_dispatch")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Lane label per head host. Source of truth: lead msg#15975 /
+# auto-dispatch-probe.sh. Kept in sync.
+LANE_FOR_HOST: dict[str, str] = {
+    "mba": "infrastructure",
+    "nas": "hub-admin",
+    "spartan": "specialized-domain",
+    "ywata-note-win": "specialized-wsl-access",
+}
+
+# Sender name used when the hub writes the auto-dispatch message into a
+# head's DM channel. Kept distinct from ``orochi-quota-watch`` so any
+# future audit / filter can tell the two sources apart.
+AUTO_DISPATCH_SENDER = "orochi-auto-dispatch"
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer env var with a fallback."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _streak_threshold() -> int:
+    """How many consecutive zero-subagent-count readings before firing."""
+    return max(_env_int("SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD", 2), 1)
+
+
+def _cooldown_seconds() -> int:
+    """Per-head minimum gap between auto-dispatches, in seconds."""
+    return max(_env_int("SCITEX_AUTO_DISPATCH_COOLDOWN_SECONDS", 900), 0)
+
+
+def _is_disabled() -> bool:
+    """Kill switch. Any value except exactly ``"1"`` is "enabled"."""
+    return os.environ.get("SCITEX_AUTO_DISPATCH_DISABLED", "0") == "1"
+
+
+def _head_host_from_name(agent_name: str) -> Optional[str]:
+    """Extract ``mba`` from ``head-mba``. Returns None for non-head agents."""
+    if not agent_name or not agent_name.startswith("head-"):
+        return None
+    host = agent_name[len("head-") :]
+    return host or None
+
+
+# ---------------------------------------------------------------------------
+# Todo selection (subprocess to auto-dispatch-pick-todo.py)
+# ---------------------------------------------------------------------------
+
+_PICK_HELPER_LOCK = threading.Lock()
+_PICK_HELPER_PATH: Optional[Path] = None
+
+
+def _pick_helper_path() -> Optional[Path]:
+    """Locate ``scripts/client/auto-dispatch-pick-todo.py`` once and cache it.
+
+    The hub process runs from the repo root so a relative ``scripts/``
+    path is the canonical location. Operators can override via
+    ``SCITEX_AUTO_DISPATCH_PICK_HELPER`` (absolute path).
+    """
+    global _PICK_HELPER_PATH
+    with _PICK_HELPER_LOCK:
+        if _PICK_HELPER_PATH is not None:
+            return _PICK_HELPER_PATH if _PICK_HELPER_PATH.exists() else None
+        override = os.environ.get("SCITEX_AUTO_DISPATCH_PICK_HELPER")
+        if override:
+            candidate = Path(override)
+        else:
+            # hub/auto_dispatch.py → repo root is parents[1].
+            candidate = Path(__file__).resolve().parents[1] / "scripts" / "client" / "auto-dispatch-pick-todo.py"
+        _PICK_HELPER_PATH = candidate
+        return candidate if candidate.exists() else None
+
+
+def _run_pick_todo(lane: str, timeout_s: int = 20) -> Optional[dict]:
+    """Invoke the pick-todo helper and return the chosen issue dict or None.
+
+    Swallows all exceptions — auto-dispatch must never raise into the
+    heartbeat hot path. A missing helper, missing ``gh``, ``gh`` unauth,
+    or helper timeout all result in ``None`` (no dispatch this cycle).
+    """
+    path = _pick_helper_path()
+    if path is None:
+        log.debug("auto_dispatch: pick helper not found at expected path")
+        return None
+    try:
+        proc = subprocess.run(
+            ["python3", str(path), "--lane", lane],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    out = (proc.stdout or "").strip()
+    if not out or out == "null":
+        return None
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    # Minimal sanity: must have integer number and non-empty title.
+    if not data.get("number") or not data.get("title"):
+        return None
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Message composition + DM fan-out
+# ---------------------------------------------------------------------------
+
+
+def _compose_dispatch_text(streak: int, pick: Optional[dict], cooldown_s: int) -> str:
+    """Build the Claude-visible instruction text.
+
+    Shape matches the spec in lead msg#16388. When no todo matches the
+    lane we still fire (the stillness itself is the signal); the head's
+    Claude can then choose what to do from its own backlog / context.
+    """
+    cooldown_min = max(cooldown_s // 60, 1)
+    if pick is None:
+        candidate = "no open todo matched this lane — pick from your own backlog"
+    else:
+        title = (pick.get("title") or "").strip()
+        candidate = f"todo#{pick['number']} — {title} — pick and fork a subagent for it"
+    return (
+        f"[auto-dispatch] you have been idle for {streak} cycles. "
+        f"Pick a high-priority todo from your lane and fork a subagent immediately. "
+        f"Candidate: {candidate}. "
+        f"Cooldown: no further auto-dispatches for {cooldown_min}min."
+    )
+
+
+def _canonical_auto_dispatch_dm_name(agent_name: str) -> str:
+    """Build the canonical DM channel name for hub → head auto-dispatch.
+
+    Uses ``agent:head-<host>`` for the head principal and
+    ``human:orochi-auto-dispatch`` for the hub-synth sender. Names are
+    sorted to match ``_dm_canonical_name``.
+    """
+    agent_key = f"agent:{agent_name}"
+    sender_key = f"human:{AUTO_DISPATCH_SENDER}"
+    keys = sorted([agent_key, sender_key])
+    return "dm:" + "|".join(keys)
+
+
+def _post_dispatch_message(agent_name: str, workspace_id: int, text: str, metadata: dict) -> Optional[int]:
+    """Persist + broadcast the dispatch DM. Returns the new Message.id or None.
+
+    Mirrors the fan-out shape in ``hub.mentions.expand_mentions_and_notify``:
+
+      1. Ensure a sender ``User`` row (``orochi-auto-dispatch``) + a
+         ``WorkspaceMember`` row for the workspace.
+      2. Lazy-create the DM channel via ``_ensure_dm_channel``.
+      3. Insert a :class:`Message` with ``metadata["kind"]="auto-dispatch"``.
+      4. ``group_send`` on the DM channel group so the head's
+         ``AgentConsumer`` delivers it live as a chat frame.
+
+    Best-effort at every step — any failure is logged and returns None.
+    """
+    try:
+        from asgiref.sync import async_to_sync
+        from channels.layers import get_channel_layer
+        from django.contrib.auth.models import User
+
+        from hub.consumers import _sanitize_group
+        from hub.models import Message, Workspace, WorkspaceMember
+        from hub.views.api._dms import _ensure_dm_channel
+
+        try:
+            workspace = Workspace.objects.get(id=workspace_id)
+        except Workspace.DoesNotExist:
+            log.warning("auto_dispatch: workspace %s missing — skip", workspace_id)
+            return None
+
+        # Ensure the hub-synth sender user + workspace membership exist.
+        sender_user, _ = User.objects.get_or_create(
+            username=AUTO_DISPATCH_SENDER,
+            defaults={
+                "email": f"{AUTO_DISPATCH_SENDER}@agents.orochi.local",
+                "is_active": True,
+            },
+        )
+        WorkspaceMember.objects.get_or_create(
+            user=sender_user,
+            workspace=workspace,
+            defaults={"role": "member"},
+        )
+
+        dm_name = _canonical_auto_dispatch_dm_name(agent_name)
+        dm_channel = _ensure_dm_channel(workspace, dm_name)
+        if dm_channel is None:
+            log.warning("auto_dispatch: could not resolve DM channel %s", dm_name)
+            return None
+
+        dm_msg = Message.objects.create(
+            workspace=workspace,
+            channel=dm_channel,
+            sender=AUTO_DISPATCH_SENDER,
+            sender_type="agent",
+            content=text,
+            metadata=metadata,
+        )
+
+        # Broadcast so any already-connected AgentConsumer delivers it
+        # as a normal chat.message frame immediately.
+        layer = get_channel_layer()
+        if layer is not None:
+            group = _sanitize_group(f"channel_{workspace.id}_{dm_name}")
+            try:
+                async_to_sync(layer.group_send)(
+                    group,
+                    {
+                        "type": "chat.message",
+                        "id": dm_msg.id,
+                        "sender": AUTO_DISPATCH_SENDER,
+                        "sender_type": "agent",
+                        "channel": dm_name,
+                        "kind": "dm",
+                        "text": text,
+                        "ts": dm_msg.ts.isoformat(),
+                        "metadata": metadata,
+                    },
+                )
+            except Exception:
+                log.exception("auto_dispatch: group_send failed for %s", dm_name)
+
+        return dm_msg.id
+    except Exception:
+        log.exception("auto_dispatch: _post_dispatch_message failed for %s", agent_name)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Streak / cooldown state machine (pure-ish; reads + writes registry)
+# ---------------------------------------------------------------------------
+
+
+def _update_streak_locked(agent: dict, subagent_count: int) -> int:
+    """Increment / reset the idle streak on ``agent`` and return new value.
+
+    Called while holding ``hub.registry._lock`` from :func:`check_agent_auto_dispatch`.
+    """
+    prev_streak = int(agent.get("idle_streak") or 0)
+    if subagent_count == 0:
+        new_streak = prev_streak + 1
+    else:
+        new_streak = 0
+    agent["idle_streak"] = new_streak
+    return new_streak
+
+
+def _cooldown_active_locked(agent: dict, now: float, cooldown_s: int) -> bool:
+    """Return True if the per-head cooldown window hasn't expired yet."""
+    last_fire = agent.get("auto_dispatch_last_fire_ts")
+    if not last_fire:
+        return False
+    try:
+        elapsed = now - float(last_fire)
+    except (TypeError, ValueError):
+        return False
+    return elapsed < cooldown_s
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def check_agent_auto_dispatch(agent_name: str) -> Optional[dict]:
+    """Run the auto-dispatch state machine for one agent, based on registry state.
+
+    Called from ``hub/registry/_heartbeat.py::update_heartbeat`` on the
+    heartbeat hot path. Returns a dict summarizing what happened (for
+    observability / tests), or ``None`` when nothing fired.
+
+    Best-effort — any exception is logged and swallowed. The heartbeat
+    path must never fail because of auto-dispatch.
+    """
+    try:
+        if _is_disabled():
+            return None
+
+        host = _head_host_from_name(agent_name)
+        if host is None:
+            return None
+        lane = LANE_FOR_HOST.get(host)
+        if not lane:
+            return None
+
+        # Deferred import to avoid a circular: hub.registry is the caller.
+        from hub.registry import _agents, _lock
+
+        threshold = _streak_threshold()
+        cooldown_s = _cooldown_seconds()
+        now = time.time()
+
+        with _lock:
+            agent = _agents.get(agent_name)
+            if not agent:
+                return None
+            subagent_count = int(agent.get("subagent_count") or 0)
+            streak = _update_streak_locked(agent, subagent_count)
+            if subagent_count > 0:
+                return {"decision": "reset", "streak": 0}
+            if streak < threshold:
+                return {"decision": "streak_increment", "streak": streak}
+            if _cooldown_active_locked(agent, now, cooldown_s):
+                return {"decision": "cooldown_skip", "streak": streak}
+            workspace_id = agent.get("workspace_id")
+            # Arm cooldown + reset streak optimistically so a reentrant
+            # call (unlikely but possible under asgiref) doesn't fire twice.
+            agent["auto_dispatch_last_fire_ts"] = now
+            agent["idle_streak"] = 0
+
+        # Everything below runs without the registry lock.
+        if workspace_id is None:
+            log.warning("auto_dispatch: %s has no workspace_id — skip", agent_name)
+            return {"decision": "no_workspace", "streak": streak}
+
+        pick = _run_pick_todo(lane)
+        text = _compose_dispatch_text(streak, pick, cooldown_s)
+        metadata = {
+            "kind": "auto-dispatch",
+            "agent": agent_name,
+            "lane": lane,
+            "streak": streak,
+            "todo_number": (pick or {}).get("number"),
+            "todo_title": (pick or {}).get("title"),
+        }
+        msg_id = _post_dispatch_message(agent_name, int(workspace_id), text, metadata)
+        log.info(
+            "auto_dispatch: fired agent=%s lane=%s streak=%d todo=%s msg=%s",
+            agent_name,
+            lane,
+            streak,
+            (pick or {}).get("number"),
+            msg_id,
+        )
+        return {
+            "decision": "fired",
+            "streak": streak,
+            "lane": lane,
+            "pick": pick,
+            "message_id": msg_id,
+        }
+    except Exception:
+        log.exception("auto_dispatch: check_agent_auto_dispatch failed for %s", agent_name)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_auto_dispatch_state_for_tests(agent_name: Optional[str] = None) -> None:
+    """Clear per-agent streak / cooldown state. Test-only utility.
+
+    ``None`` clears every head-* entry; a specific name clears just that
+    one.
+    """
+    from hub.registry import _agents, _lock
+
+    with _lock:
+        targets = (
+            [agent_name] if agent_name is not None else list(_agents.keys())
+        )
+        for name in targets:
+            a = _agents.get(name)
+            if not a:
+                continue
+            a.pop("idle_streak", None)
+            a.pop("auto_dispatch_last_fire_ts", None)

--- a/hub/registry/_heartbeat.py
+++ b/hub/registry/_heartbeat.py
@@ -155,6 +155,13 @@ def update_heartbeat(name: str, metrics: dict | None = None) -> None:
     message to ``#progress`` / ``#escalation`` / ``#ywatanabe`` when a
     window crosses the warn / escalate bands. Best-effort — the check
     never raises into the heartbeat hot path.
+
+    msg#16388: after quota pressure, run the auto-dispatch state machine
+    for ``head-*`` agents. ``check_agent_auto_dispatch()`` reads
+    ``subagent_count`` (just written by the heartbeat handler via
+    ``set_subagent_count``) and maintains a per-head idle streak + 15min
+    cooldown, firing a DM when a head stalls for N consecutive zero
+    readings. Also best-effort.
     """
     with _lock:
         if name in _agents:
@@ -173,6 +180,16 @@ def update_heartbeat(name: str, metrics: dict | None = None) -> None:
             from hub.quota_watch import check_agent_quota_pressure
 
             check_agent_quota_pressure(name)
+        except Exception:  # pragma: no cover — defense in depth
+            pass
+
+        # msg#16388 Layer 1 redesign — server-side auto-dispatch hook.
+        # Only fires for ``head-*`` agents (internal name prefix check).
+        # Deferred import to avoid a circular through hub.registry.
+        try:
+            from hub.auto_dispatch import check_agent_auto_dispatch
+
+            check_agent_auto_dispatch(name)
         except Exception:  # pragma: no cover — defense in depth
             pass
 

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -326,6 +326,13 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
             # re-post warn / escalate on every poll (spam regression).
             "quota_state_5h": prev.get("quota_state_5h") or "ok",
             "quota_state_7d": prev.get("quota_state_7d") or "ok",
+            # msg#16388 — server-side auto-dispatch streak + cooldown state.
+            # Owned by ``hub.auto_dispatch.check_agent_auto_dispatch``. Same
+            # prev-preserve pattern as quota_state_*: without it every
+            # heartbeat would reset the streak to 0 and the firing
+            # condition (N consecutive zero readings) could never be met.
+            "idle_streak": prev.get("idle_streak") or 0,
+            "auto_dispatch_last_fire_ts": prev.get("auto_dispatch_last_fire_ts"),
             "mcp_servers": (
                 list(info.get("mcp_servers"))
                 if isinstance(info.get("mcp_servers"), (list, tuple))

--- a/hub/tests/test_auto_dispatch.py
+++ b/hub/tests/test_auto_dispatch.py
@@ -1,0 +1,436 @@
+"""Tests for server-side auto-dispatch (msg#16388, Layer 1 redesign).
+
+Covers three layers:
+
+  1. :func:`_update_streak_locked` + :func:`_cooldown_active_locked` —
+     pure streak/cooldown state primitives.
+  2. :func:`_compose_dispatch_text` + :func:`_canonical_auto_dispatch_dm_name` —
+     message shape + DM channel naming.
+  3. :func:`check_agent_auto_dispatch` — end-to-end: streak reaches
+     threshold, DM channel lazy-created, auto-dispatch Message row
+     inserted with ``metadata["kind"]="auto-dispatch"``, cooldown arms.
+
+Todo selection is mocked in these tests — the real helper hits ``gh``
+and is exercised in ``test_pick_todo.py`` (PR #320). Here we assert
+the fan-out path, not the gh-backed pick.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from hub import auto_dispatch as ad
+from hub.auto_dispatch import (
+    AUTO_DISPATCH_SENDER,
+    LANE_FOR_HOST,
+    _canonical_auto_dispatch_dm_name,
+    _compose_dispatch_text,
+    _cooldown_active_locked,
+    _cooldown_seconds,
+    _head_host_from_name,
+    _reset_auto_dispatch_state_for_tests,
+    _streak_threshold,
+    _update_streak_locked,
+    check_agent_auto_dispatch,
+)
+from hub.models import Channel, Message, Workspace
+from hub.registry import _agents, _lock, register_agent, update_heartbeat
+
+_INMEM_CHANNELS = {
+    "default": {
+        "BACKEND": "channels.layers.InMemoryChannelLayer",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure primitives
+# ---------------------------------------------------------------------------
+
+
+class StreakPrimitivesTest(TestCase):
+    """``_update_streak_locked`` and ``_cooldown_active_locked``."""
+
+    def test_zero_reading_increments_streak(self):
+        agent = {}
+        self.assertEqual(_update_streak_locked(agent, 0), 1)
+        self.assertEqual(_update_streak_locked(agent, 0), 2)
+        self.assertEqual(_update_streak_locked(agent, 0), 3)
+
+    def test_nonzero_reading_resets_streak(self):
+        agent = {"idle_streak": 5}
+        self.assertEqual(_update_streak_locked(agent, 2), 0)
+        self.assertEqual(agent["idle_streak"], 0)
+
+    def test_streak_survives_on_missing_prev(self):
+        # First-ever observation with no prev streak stored: treat as 0.
+        agent = {}
+        self.assertEqual(_update_streak_locked(agent, 0), 1)
+
+    def test_cooldown_inactive_when_never_fired(self):
+        agent = {}
+        self.assertFalse(_cooldown_active_locked(agent, now=1000.0, cooldown_s=900))
+
+    def test_cooldown_active_inside_window(self):
+        agent = {"auto_dispatch_last_fire_ts": 1000.0}
+        # 500s elapsed, cooldown 900 — still active.
+        self.assertTrue(_cooldown_active_locked(agent, now=1500.0, cooldown_s=900))
+
+    def test_cooldown_expired_outside_window(self):
+        agent = {"auto_dispatch_last_fire_ts": 1000.0}
+        # 901s elapsed — expired.
+        self.assertFalse(_cooldown_active_locked(agent, now=1901.0, cooldown_s=900))
+
+    def test_cooldown_bad_ts_treated_as_inactive(self):
+        agent = {"auto_dispatch_last_fire_ts": "garbage"}
+        self.assertFalse(_cooldown_active_locked(agent, now=1000.0, cooldown_s=900))
+
+
+class HeadHostExtractTest(TestCase):
+    def test_head_host(self):
+        self.assertEqual(_head_host_from_name("head-mba"), "mba")
+        self.assertEqual(_head_host_from_name("head-ywata-note-win"), "ywata-note-win")
+
+    def test_non_head_returns_none(self):
+        self.assertIsNone(_head_host_from_name("worker-foo"))
+        self.assertIsNone(_head_host_from_name("healer-mba"))
+        self.assertIsNone(_head_host_from_name(""))
+        self.assertIsNone(_head_host_from_name("head-"))
+
+
+class LaneMappingTest(TestCase):
+    """Spec lane-to-label mapping (lead msg#15975, reaffirmed msg#16388)."""
+
+    def test_all_four_heads_mapped(self):
+        self.assertEqual(LANE_FOR_HOST["mba"], "infrastructure")
+        self.assertEqual(LANE_FOR_HOST["nas"], "hub-admin")
+        self.assertEqual(LANE_FOR_HOST["spartan"], "specialized-domain")
+        self.assertEqual(LANE_FOR_HOST["ywata-note-win"], "specialized-wsl-access")
+
+
+class EnvConfigTest(TestCase):
+    def test_streak_threshold_default(self):
+        with mock.patch.dict("os.environ", {}, clear=False):
+            if "SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD" in __import__("os").environ:
+                del __import__("os").environ["SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD"]
+            self.assertEqual(_streak_threshold(), 2)
+
+    def test_streak_threshold_env_override(self):
+        with mock.patch.dict("os.environ", {"SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD": "5"}):
+            self.assertEqual(_streak_threshold(), 5)
+
+    def test_streak_threshold_min_one(self):
+        with mock.patch.dict("os.environ", {"SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD": "0"}):
+            # ``max(..., 1)`` floors the threshold at 1 so the state
+            # machine can't be accidentally disabled by a bad config.
+            self.assertEqual(_streak_threshold(), 1)
+
+    def test_cooldown_default(self):
+        with mock.patch.dict("os.environ", {}, clear=False):
+            if "SCITEX_AUTO_DISPATCH_COOLDOWN_SECONDS" in __import__("os").environ:
+                del __import__("os").environ["SCITEX_AUTO_DISPATCH_COOLDOWN_SECONDS"]
+            self.assertEqual(_cooldown_seconds(), 900)
+
+    def test_cooldown_env_override(self):
+        with mock.patch.dict("os.environ", {"SCITEX_AUTO_DISPATCH_COOLDOWN_SECONDS": "120"}):
+            self.assertEqual(_cooldown_seconds(), 120)
+
+
+# ---------------------------------------------------------------------------
+# 2. Message composition + DM naming
+# ---------------------------------------------------------------------------
+
+
+class ComposeTextTest(TestCase):
+    def test_text_with_pick(self):
+        pick = {"number": 42, "title": "migrate foo to bar"}
+        out = _compose_dispatch_text(streak=2, pick=pick, cooldown_s=900)
+        self.assertIn("[auto-dispatch]", out)
+        self.assertIn("idle for 2 cycles", out)
+        self.assertIn("todo#42", out)
+        self.assertIn("migrate foo to bar", out)
+        self.assertIn("15min", out)
+
+    def test_text_without_pick(self):
+        out = _compose_dispatch_text(streak=3, pick=None, cooldown_s=900)
+        self.assertIn("[auto-dispatch]", out)
+        self.assertIn("no open todo matched", out)
+
+    def test_cooldown_minutes_from_seconds(self):
+        out = _compose_dispatch_text(streak=2, pick=None, cooldown_s=60)
+        self.assertIn("1min", out)
+
+
+class DmNameTest(TestCase):
+    def test_canonical_dm_name_for_head(self):
+        # Sorted lexically: ``agent:head-mba`` < ``human:orochi-auto-dispatch``.
+        name = _canonical_auto_dispatch_dm_name("head-mba")
+        self.assertEqual(name, "dm:agent:head-mba|human:orochi-auto-dispatch")
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end via check_agent_auto_dispatch
+# ---------------------------------------------------------------------------
+
+
+@override_settings(CHANNEL_LAYERS=_INMEM_CHANNELS)
+class CheckAgentAutoDispatchTest(TestCase):
+    """Integration: heartbeat → streak → fire → DM message row."""
+
+    def setUp(self):
+        # Fresh registry slot for head-mba.
+        self.agent_name = "head-mba"
+        with _lock:
+            _agents.pop(self.agent_name, None)
+        self.ws = Workspace.objects.create(name="auto-dispatch-e2e-ws")
+        register_agent(self.agent_name, self.ws.id, {"role": "head"})
+        _reset_auto_dispatch_state_for_tests(self.agent_name)
+
+    def tearDown(self):
+        with _lock:
+            _agents.pop(self.agent_name, None)
+
+    def _set_subagent_count(self, count: int) -> None:
+        """Mirror what ``set_subagent_count`` does — write directly."""
+        with _lock:
+            a = _agents.get(self.agent_name)
+            if a is not None:
+                a["subagent_count"] = count
+
+    def test_streak_not_fired_below_threshold(self):
+        # Threshold default 2 — a single zero reading must NOT fire.
+        self._set_subagent_count(0)
+        with mock.patch.object(ad, "_run_pick_todo", return_value=None) as pick_m:
+            res = check_agent_auto_dispatch(self.agent_name)
+        self.assertEqual(res["decision"], "streak_increment")
+        self.assertEqual(res["streak"], 1)
+        pick_m.assert_not_called()
+        # No DM message yet.
+        self.assertFalse(
+            Message.objects.filter(
+                channel__name=_canonical_auto_dispatch_dm_name(self.agent_name)
+            ).exists()
+        )
+
+    def test_fires_on_second_consecutive_zero(self):
+        pick = {"number": 17, "title": "clean up stale fixtures"}
+        self._set_subagent_count(0)
+        with mock.patch.object(ad, "_run_pick_todo", return_value=pick):
+            r1 = check_agent_auto_dispatch(self.agent_name)
+            self.assertEqual(r1["decision"], "streak_increment")
+            r2 = check_agent_auto_dispatch(self.agent_name)
+        self.assertEqual(r2["decision"], "fired")
+        self.assertEqual(r2["streak"], 2)
+        self.assertEqual(r2["pick"], pick)
+
+        # DM channel must exist with kind=DM.
+        dm_name = _canonical_auto_dispatch_dm_name(self.agent_name)
+        ch = Channel.objects.get(workspace=self.ws, name=dm_name)
+        self.assertEqual(ch.kind, Channel.KIND_DM)
+
+        # One Message with the auto-dispatch metadata.
+        msgs = list(Message.objects.filter(channel=ch))
+        self.assertEqual(len(msgs), 1)
+        m = msgs[0]
+        self.assertEqual(m.sender, AUTO_DISPATCH_SENDER)
+        self.assertEqual(m.metadata.get("kind"), "auto-dispatch")
+        self.assertEqual(m.metadata.get("agent"), self.agent_name)
+        self.assertEqual(m.metadata.get("lane"), "infrastructure")
+        self.assertEqual(m.metadata.get("todo_number"), 17)
+        self.assertIn("todo#17", m.content)
+
+    def test_nonzero_resets_streak(self):
+        self._set_subagent_count(0)
+        with mock.patch.object(ad, "_run_pick_todo", return_value=None):
+            check_agent_auto_dispatch(self.agent_name)  # streak=1
+            self._set_subagent_count(2)
+            r = check_agent_auto_dispatch(self.agent_name)
+        self.assertEqual(r["decision"], "reset")
+        with _lock:
+            self.assertEqual(_agents[self.agent_name].get("idle_streak"), 0)
+
+    def test_cooldown_suppresses_second_fire(self):
+        pick = {"number": 17, "title": "X"}
+        self._set_subagent_count(0)
+        with mock.patch.object(ad, "_run_pick_todo", return_value=pick):
+            # Two consecutive zeros → fire.
+            check_agent_auto_dispatch(self.agent_name)
+            r2 = check_agent_auto_dispatch(self.agent_name)
+            self.assertEqual(r2["decision"], "fired")
+
+            # Keep pushing zeros — streak re-accumulates from 0 (reset
+            # post-fire), but the cooldown gate blocks any new fire.
+            # Need another two increments to reach threshold.
+            check_agent_auto_dispatch(self.agent_name)  # streak=1
+            r_cool = check_agent_auto_dispatch(self.agent_name)  # streak=2
+        self.assertEqual(r_cool["decision"], "cooldown_skip")
+        # Only one DM still.
+        dm_name = _canonical_auto_dispatch_dm_name(self.agent_name)
+        ch = Channel.objects.get(workspace=self.ws, name=dm_name)
+        self.assertEqual(Message.objects.filter(channel=ch).count(), 1)
+
+    def test_cooldown_expires_and_refires(self):
+        pick = {"number": 17, "title": "X"}
+        self._set_subagent_count(0)
+        with mock.patch.object(ad, "_run_pick_todo", return_value=pick):
+            check_agent_auto_dispatch(self.agent_name)
+            check_agent_auto_dispatch(self.agent_name)  # fires, arms cooldown
+
+            # Artificially expire the cooldown by rewinding last-fire ts.
+            with _lock:
+                _agents[self.agent_name]["auto_dispatch_last_fire_ts"] = (
+                    time.time() - 10_000
+                )
+
+            # Re-build streak then fire again.
+            check_agent_auto_dispatch(self.agent_name)  # streak=1
+            r = check_agent_auto_dispatch(self.agent_name)  # streak=2 → fire
+        self.assertEqual(r["decision"], "fired")
+        dm_name = _canonical_auto_dispatch_dm_name(self.agent_name)
+        ch = Channel.objects.get(workspace=self.ws, name=dm_name)
+        self.assertEqual(Message.objects.filter(channel=ch).count(), 2)
+
+    def test_kill_switch_disables(self):
+        self._set_subagent_count(0)
+        with mock.patch.dict(
+            "os.environ", {"SCITEX_AUTO_DISPATCH_DISABLED": "1"}
+        ), mock.patch.object(ad, "_run_pick_todo", return_value=None) as pick_m:
+            r1 = check_agent_auto_dispatch(self.agent_name)
+            r2 = check_agent_auto_dispatch(self.agent_name)
+        self.assertIsNone(r1)
+        self.assertIsNone(r2)
+        pick_m.assert_not_called()
+
+    def test_non_head_agent_skipped(self):
+        # Register a non-head and verify the auto-dispatch is a no-op.
+        worker_name = "worker-bee"
+        with _lock:
+            _agents.pop(worker_name, None)
+        register_agent(worker_name, self.ws.id, {"role": "worker"})
+        try:
+            with _lock:
+                _agents[worker_name]["subagent_count"] = 0
+            r = check_agent_auto_dispatch(worker_name)
+            self.assertIsNone(r)
+        finally:
+            with _lock:
+                _agents.pop(worker_name, None)
+
+    def test_fires_without_pick_still_dms(self):
+        # Picker returns None (e.g. gh unauth) — we still fire so the
+        # stillness signal reaches the head. The message text mentions
+        # no concrete todo.
+        self._set_subagent_count(0)
+        with mock.patch.object(ad, "_run_pick_todo", return_value=None):
+            check_agent_auto_dispatch(self.agent_name)
+            r = check_agent_auto_dispatch(self.agent_name)
+        self.assertEqual(r["decision"], "fired")
+        dm_name = _canonical_auto_dispatch_dm_name(self.agent_name)
+        msgs = list(Message.objects.filter(channel__name=dm_name))
+        self.assertEqual(len(msgs), 1)
+        self.assertIn("no open todo matched", msgs[0].content)
+
+
+# ---------------------------------------------------------------------------
+# 4. Heartbeat integration
+# ---------------------------------------------------------------------------
+
+
+@override_settings(CHANNEL_LAYERS=_INMEM_CHANNELS)
+class HeartbeatIntegrationTest(TestCase):
+    """Wire test: ``update_heartbeat`` calls through to auto-dispatch."""
+
+    def setUp(self):
+        self.agent_name = "head-mba"
+        with _lock:
+            _agents.pop(self.agent_name, None)
+        self.ws = Workspace.objects.create(name="auto-dispatch-hb-ws")
+        register_agent(self.agent_name, self.ws.id, {"role": "head"})
+        _reset_auto_dispatch_state_for_tests(self.agent_name)
+
+    def tearDown(self):
+        with _lock:
+            _agents.pop(self.agent_name, None)
+
+    def test_heartbeat_invokes_auto_dispatch(self):
+        with _lock:
+            _agents[self.agent_name]["subagent_count"] = 0
+        with mock.patch.object(
+            ad, "check_agent_auto_dispatch", wraps=ad.check_agent_auto_dispatch
+        ) as spy:
+            update_heartbeat(self.agent_name)
+            update_heartbeat(self.agent_name)
+        # The hook fires once per heartbeat.
+        self.assertEqual(spy.call_count, 2)
+
+    def test_two_heartbeats_with_zero_trigger_fire(self):
+        with mock.patch.object(
+            ad, "_run_pick_todo", return_value={"number": 9, "title": "fix foo"}
+        ):
+            # Two heartbeats while subagent_count is 0 → fire.
+            with _lock:
+                _agents[self.agent_name]["subagent_count"] = 0
+            update_heartbeat(self.agent_name)
+            with _lock:
+                _agents[self.agent_name]["subagent_count"] = 0
+            update_heartbeat(self.agent_name)
+        dm_name = _canonical_auto_dispatch_dm_name(self.agent_name)
+        msgs = list(Message.objects.filter(channel__name=dm_name))
+        self.assertEqual(len(msgs), 1)
+
+
+# ---------------------------------------------------------------------------
+# 5. _run_pick_todo — subprocess contract (no network)
+# ---------------------------------------------------------------------------
+
+
+class RunPickTodoContractTest(TestCase):
+    """``_run_pick_todo`` must never raise and must return ``None`` on junk."""
+
+    def test_timeout_returns_none(self):
+        import subprocess as _sp
+
+        # ``_run_pick_todo`` only catches specific, expected subprocess
+        # failure modes (Timeout / FileNotFoundError / OSError); other
+        # exceptions propagate to the caller (``check_agent_auto_dispatch``
+        # wraps the whole thing in its own broad except). We pin the
+        # contract for the timeout path here.
+        with mock.patch("subprocess.run", side_effect=_sp.TimeoutExpired(cmd="x", timeout=1)), \
+             mock.patch.object(ad, "_pick_helper_path", return_value=__import__("pathlib").Path(__file__)):
+            self.assertIsNone(ad._run_pick_todo("infrastructure"))
+        with mock.patch("subprocess.run", side_effect=FileNotFoundError("no gh")), \
+             mock.patch.object(ad, "_pick_helper_path", return_value=__import__("pathlib").Path(__file__)):
+            self.assertIsNone(ad._run_pick_todo("infrastructure"))
+
+    def test_null_stdout_returns_none(self):
+        proc = mock.MagicMock(stdout="null\n", returncode=0)
+        with mock.patch("subprocess.run", return_value=proc), mock.patch.object(
+            ad, "_pick_helper_path", return_value=__import__("pathlib").Path(__file__)
+        ):
+            self.assertIsNone(ad._run_pick_todo("infrastructure"))
+
+    def test_malformed_json_returns_none(self):
+        proc = mock.MagicMock(stdout="not-json", returncode=0)
+        with mock.patch("subprocess.run", return_value=proc), mock.patch.object(
+            ad, "_pick_helper_path", return_value=__import__("pathlib").Path(__file__)
+        ):
+            self.assertIsNone(ad._run_pick_todo("infrastructure"))
+
+    def test_missing_helper_returns_none(self):
+        with mock.patch.object(ad, "_pick_helper_path", return_value=None):
+            self.assertIsNone(ad._run_pick_todo("infrastructure"))
+
+    def test_well_formed_dict_passes_through(self):
+        proc = mock.MagicMock(
+            stdout='{"number":7,"title":"fix it","labels":[],"reason":"x"}\n',
+            returncode=0,
+        )
+        with mock.patch("subprocess.run", return_value=proc), mock.patch.object(
+            ad, "_pick_helper_path", return_value=__import__("pathlib").Path(__file__)
+        ):
+            got = ad._run_pick_todo("infrastructure")
+        self.assertEqual(got["number"], 7)
+        self.assertEqual(got["title"], "fix it")

--- a/scripts/client/auto-dispatch-probe.sh
+++ b/scripts/client/auto-dispatch-probe.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 # auto-dispatch-probe.sh — auto-dispatch daemon: "idle = forbidden" enforced by code
 # -----------------------------------------------------------------------------
+# >>> DEPRECATED (msg#16388 / ywatanabe msg#16380) <<<
+#
+# Layer 1 auto-dispatch moved from this per-host client probe to a
+# server-side hook in the hub. On every heartbeat the hub now:
+#   * maintains an idle-streak counter per head in its in-memory registry
+#   * after N consecutive zero-subagent-count readings (default 2), DMs
+#     the head with an auto-dispatch instruction that Claude parses
+#   * enforces a 15-min per-head cooldown
+#
+# See ``hub/auto_dispatch.py`` + the ``check_agent_auto_dispatch`` hook
+# in ``hub/registry/_heartbeat.py::update_heartbeat``.
+#
+# This script is kept in-tree so hosts where the server-side mechanism
+# is unavailable (stale hub, local dev, emergency manual dispatch) can
+# still run the probe. A follow-up PR may delete it after burn-in. To
+# explicitly run it in the interim, pass ``--yes`` — the installer
+# warns you not to enable the scheduler alongside server-side dispatch.
+#
+# To migrate: ``./scripts/client/install-auto-dispatch-probe.sh --uninstall``
+# once your hub is on a version carrying the server-side hook.
+# -----------------------------------------------------------------------------
 # Problem statement (lead msg#15975, ywatanabe msg#15971)
 #   Rules-based discipline failed. The fleet keeps dropping to
 #   ``subagent_count == 0`` on individual heads (2026-04-20: head-mba hit 0

--- a/scripts/client/install-auto-dispatch-probe.sh
+++ b/scripts/client/install-auto-dispatch-probe.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # install-auto-dispatch-probe.sh
 #
+# >>> DEPRECATED (msg#16388) <<<
+# Layer 1 auto-dispatch moved to a hub server-side hook. The installer
+# still works for emergency/local use but prints a warning banner. To
+# uninstall on hosts that already track a hub carrying the server-side
+# dispatcher, run ``./install-auto-dispatch-probe.sh --uninstall``.
+#
 # Installer for the auto-dispatch probe scheduler — enforces "idle =
 # forbidden" on each head by code instead of memory/rules.
 #
@@ -45,10 +51,32 @@ while [ $# -gt 0 ]; do
         --dry-run-only) mode="--dry-run"; shift ;;
         --yes)          mode="--yes"; shift ;;
         -h|--help)
-            sed -n '2,25p' "$0"; exit 0 ;;
+            sed -n '2,32p' "$0"; exit 0 ;;
         *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
+
+# Deprecation banner — print before any action so operators running
+# `install-auto-dispatch-probe.sh` interactively see it. Installs still
+# proceed (for hosts whose hub hasn't rolled out the server-side hook
+# yet); uninstalls are encouraged once the hub deploy lands.
+if [ "$action" = "install" ]; then
+    cat >&2 <<'EOF'
+===============================================================================
+WARNING: auto-dispatch-probe.sh is DEPRECATED (msg#16388).
+
+Layer 1 auto-dispatch moved to a hub server-side hook. The hub now
+detects idle heads from the heartbeat stream and DMs them directly.
+
+If your hub is already running the new build, UNINSTALL this probe:
+  ./scripts/client/install-auto-dispatch-probe.sh --uninstall
+
+If you still want to install (local dev / emergency fallback), proceed
+— the probe is kept in-tree for exactly that reason. It will be
+deleted in a follow-up PR after server-side burn-in.
+===============================================================================
+EOF
+fi
 
 OS="$(uname -s)"
 


### PR DESCRIPTION
## Summary

Replaces the client-side Layer 1 auto-dispatch probe (PR #320) with a hub server-side hook. On every heartbeat from a `head-*` agent, the hub tracks an idle-streak counter in its in-memory registry and, after N consecutive `subagent_count == 0` readings (default 2, roughly 2 heartbeat cycles), DMs the head with an auto-dispatch instruction that Claude parses as a chat frame and acts on. Per-head 15-min cooldown prevents spam; streak resets on any non-zero reading.

Directive: lead msg#16388 / ywatanabe msg#16380.

## What is new

- **`hub/auto_dispatch.py`** — streak + cooldown state machine, DM fan-out. Reuses `hub.views.api._dms._ensure_dm_channel` + the same `chat.message` group_send shape as `hub.mentions`. Message carries `metadata["kind"]="auto-dispatch"` + lane + todo number.
- **`hub/registry/_heartbeat.py`** — new `check_agent_auto_dispatch` hook after the quota-pressure check in `update_heartbeat`. Best-effort: exceptions logged, heartbeat hot path never fails.
- **`hub/registry/_register.py`** — prev-preserve for `idle_streak` and `auto_dispatch_last_fire_ts` across re-registers (same pattern as `quota_state_5h`).
- **`hub/tests/test_auto_dispatch.py`** — 34 unit + integration tests.

## Todo selection

We shell out to `scripts/client/auto-dispatch-pick-todo.py` (already unit-tested under PR #320) via subprocess rather than inlining the `gh issue list` logic. 20s timeout bounds slow `gh`. On any failure (missing helper, `gh` unauth, JSON parse error) the hub still fires the dispatch DM (the stillness signal itself is the point) but omits a concrete todo number from the message text.

## Config

| Env var | Default | Purpose |
|---|---|---|
| `SCITEX_AUTO_DISPATCH_DISABLED` | `0` | Kill switch — any other value disables |
| `SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD` | `2` | Consecutive zero readings before firing (floor 1) |
| `SCITEX_AUTO_DISPATCH_COOLDOWN_SECONDS` | `900` | Per-head minimum gap (15 min) |
| `SCITEX_AUTO_DISPATCH_PICK_HELPER` | — | Override path to the pick-todo script |

## Lane-to-label (reaffirmed from PR #320)

| Host | Label |
|---|---|
| mba | infrastructure |
| nas | hub-admin |
| spartan | specialized-domain |
| ywata-note-win | specialized-wsl-access |

## Client-side deprecation

`scripts/client/auto-dispatch-probe.sh` and its installer remain in the tree with a `DEPRECATED` header + warning banner — operators on hubs that predate this rollout can still run them locally. A follow-up PR will delete after burn-in.

## Does not break

- PR #318 `sac_status` heartbeat forward — auto-dispatch reads only `subagent_count`, which arrives unchanged via the terse-key path.
- PR #314 mention-push fanout — reuses the same `_ensure_dm_channel` + `chat.message` group_send primitives; distinct `metadata["kind"]` marker keeps the two message streams separable.
- PR #329 Layer 2 hungry-signal — orthogonal to this, stays as-is.

## Cross-coordination with PR #314 mention-push

Both features now lazy-create DM channels and broadcast on the `chat.message` group. The code paths intentionally stay separate (distinct metadata markers, distinct senders: `orochi-auto-dispatch` vs the user own `@mention` sender) — the shared infrastructure is the two public helpers `_ensure_dm_channel` and `_sanitize_group`. A shared fanout helper would accrete too many branches today; a post-merge refactor could extract a common "post DM + broadcast" helper if a third consumer appears.

## Test plan

- [x] Unit: streak counter — zero increments, nonzero resets
- [x] Unit: cooldown window — active, expired, malformed timestamp
- [x] Unit: env-var overrides for threshold + cooldown
- [x] Unit: non-head agents are skipped
- [x] Unit: subprocess contract (missing helper, timeout, malformed JSON, well-formed passthrough)
- [x] Integration: two consecutive zero readings trigger a DM Message row with `metadata["kind"]="auto-dispatch"` on the canonical DM channel
- [x] Integration: nonzero reading resets streak, DM not sent
- [x] Integration: after fire, cooldown suppresses re-fire; artificial cooldown expiry allows re-fire
- [x] Integration: kill switch `SCITEX_AUTO_DISPATCH_DISABLED=1` short-circuits all paths
- [x] Integration: `update_heartbeat` invokes the hook

All 34 new tests pass; adjacent suites (registry, consumers, mentions, quota_watch, agents_register) = 209/209 green. Pre-existing failures elsewhere (`hub.tests.test_auth`, `test_push.PushFanoutTest`) are unrelated (missing `pywebpush` module, auth-backend oauth config) and also fail on `origin/develop` before these changes.

## Judgment calls

1. **What if the head Claude session is mid-stream when the auto-dispatch arrives?** The DM is posted via the same `chat.message` group_send path as any user-typed DM, which `AgentConsumer.handle_dm` queues onto the WS and ultimately hands to the head Claude as a chat frame. Claude MCP-client + harness already serialize inbound chat frames — the dispatch simply joins the end of the head inbox. Worst case, it is processed after the current turn completes; it is never dropped. The 15-min cooldown prevents a second "you are idle" message while the first is still being acted on.
2. **Fire when no todo matches?** Yes — the stillness signal itself is the point. The head Claude can fall back to its own backlog / context. Alternative (suppress fire when picker returns null) would mean a silent hub during a transient `gh auth` outage — worse.
3. **Streak threshold floor at 1, not 0.** `SCITEX_AUTO_DISPATCH_STREAK_THRESHOLD=0` via env would disable the state machine by accident (every reading fires immediately). Clamping at 1 keeps "one zero reading = fire" intentional.

Generated with Claude Code (https://claude.com/claude-code).
