### PR TITLE
feat(ops): Orochi unified cron -- single daemon + scitex-orochi cron CLI (msg#16406 / msg#16410)

### DIFF
--- a/deployment/host-setup/launchd/com.scitex.orochi-cron.plist
+++ b/deployment/host-setup/launchd/com.scitex.orochi-cron.plist
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  LaunchAgent: Orochi unified cron daemon (msg#16406 / msg#16410).
+
+  One long-running Python process that schedules every Orochi
+  per-host cron job (agent-meta-push, fleet-host-liveness-probe,
+  hungry-signal, chrome-codesign-watchdog, ...) per the declarative
+  schedule in ~/.scitex/orochi/cron.yaml.
+
+  Replaces the scattered com.scitex.{fleet-host-liveness-probe,
+  hungry-signal, chrome-codesign-watchdog, auto-dispatch-probe,
+  orochi.agent-meta-push} plists. install-orochi-cron.sh auto-unloads
+  and backs them up to ~/.scitex/orochi/cron-migrated-units/ so
+  rollback is a single `launchctl load` away.
+
+  Install:
+    ./scripts/client/install-orochi-cron.sh
+
+  Logs:
+    ~/Library/Logs/scitex/orochi-cron.log (daemon lifecycle)
+    ~/.local/state/scitex/orochi-cron/logs/<job>.ndjson (per-job runs)
+
+  KeepAlive keeps the daemon alive even if it crashes (unlike
+  StartInterval, which just fires periodically). The daemon handles its
+  own scheduling loop internally.
+
+  Template placeholders: __HOME__, __STABLE_BIN__ are rewritten by
+  install-orochi-cron.sh (stable-bin-path pattern, same as PR #326
+  todo#466). Kill switch: set SCITEX_OROCHI_CRON_DISABLED=1 in the
+  user env to pause without uninstalling.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.scitex.orochi-cron</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/bin/env</string>
+      <string>python3</string>
+      <string>-u</string>
+      <string>__STABLE_BIN__/orochi-cron.py</string>
+    </array>
+
+    <!-- Daemon-style: keep alive across crashes. StartInterval is
+         intentionally absent because the daemon owns its own loop. -->
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/Library/Logs/scitex/orochi-cron.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/Library/Logs/scitex/orochi-cron.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+      <!-- SCITEX_OROCHI_REPO_ROOT is auto-detected by the daemon from
+           its installed scitex_orochi package location. Override here
+           only if running from a non-standard checkout. -->
+    </dict>
+  </dict>
+</plist>

--- a/deployment/host-setup/orochi-cron/cron.yaml.example
+++ b/deployment/host-setup/orochi-cron/cron.yaml.example
@@ -1,0 +1,63 @@
+# Orochi unified cron — declarative schedule for one host.
+#
+# Copy to ~/.scitex/orochi/cron.yaml and tune. The install-orochi-cron.sh
+# helper copies this file on first install if the target doesn't yet
+# exist (never overwrites an operator-edited copy).
+#
+# Schema:
+#   tick_seconds: int  — how often the scheduler wakes to check due
+#                         jobs. Default 10. Smaller = tighter cadence,
+#                         more wakeups. Leave alone unless you have a
+#                         sub-minute job.
+#   jobs: list of
+#     name:     string, unique. Used for state + log file names.
+#     interval: cadence — "30s", "5m", "1h", "1d", or plain seconds.
+#     command:  shell command. ${VAR} expands against the daemon's env.
+#               ${SCITEX_OROCHI_REPO_ROOT} is auto-detected from the
+#               installed scitex_orochi package (stable-bin-path
+#               pattern, same shape as PR #326 todo#466).
+#     timeout:  optional. "10m" / 600 seconds default. Jobs that
+#               overrun are killed and logged skipped="timeout_after_…".
+#     disabled: optional bool. Kept in cron list so re-enabling is
+#               a one-line YAML edit, no manual crontab surgery.
+
+tick_seconds: 10
+
+jobs:
+  # Per-agent heartbeat push (replaces agent_meta.py --push daemon).
+  - name: agent-meta-push
+    interval: 5m
+    command: "scitex-orochi heartbeat-push --all"
+    timeout: 4m
+
+  # Layer 1 fleet-watch: detect dead tmux / missing expected agents
+  # and revive locally. Paired cadence with server-side liveness.
+  - name: fleet-host-liveness-probe
+    interval: 5m
+    command: "bash ${SCITEX_OROCHI_REPO_ROOT}/scripts/client/fleet-watch/host-liveness-probe.sh --yes"
+    timeout: 4m
+
+  # Layer 2: idle heads DM lead for coordinated dispatch. Cadence
+  # intentionally half of fleet-host-liveness so the HUNGRY_THRESHOLD=2
+  # counter maps to ~20 min of real idleness.
+  - name: hungry-signal
+    interval: 10m
+    command: "bash ${SCITEX_OROCHI_REPO_ROOT}/scripts/client/hungry-signal.sh --yes"
+    timeout: 9m
+
+  # Chrome code_sign_clone reaper — hourly is plenty, the problem grows
+  # on the order of GB/day when it goes wrong.
+  - name: chrome-codesign-watchdog
+    interval: 1h
+    command: "bash ${SCITEX_OROCHI_REPO_ROOT}/scripts/client/chrome-codesign-clone-watchdog.sh"
+    timeout: 10m
+
+  # Disk reaper — Phase 2 will wire the full version; this is the
+  # hourly tmp-file sweep (safe subset) so Phase 1 already gains back
+  # the cadence from the old disk-reaper.sh script.
+  # Uncomment once deployment/host-setup/orochi-cron/cron.yaml on the
+  # host reflects disk thresholds appropriate for that box.
+  # - name: disk-reaper
+  #   interval: 1h
+  #   command: "bash ${SCITEX_OROCHI_REPO_ROOT}/scripts/client/disk-reaper.sh --reap"
+  #   timeout: 10m

--- a/deployment/host-setup/systemd/scitex-orochi-cron.service
+++ b/deployment/host-setup/systemd/scitex-orochi-cron.service
@@ -1,0 +1,43 @@
+[Unit]
+# SciTeX Orochi — unified cron daemon (msg#16406 / msg#16410 / lead msg#16408).
+#
+# One long-running Python process that owns every Orochi per-host cron
+# job (agent-meta-push, fleet-host-liveness-probe, hungry-signal,
+# chrome-codesign-watchdog, ...) via the declarative schedule in
+# ~/.scitex/orochi/cron.yaml.
+#
+# Replaces the pair of scitex-auto-dispatch-probe.{service,timer} /
+# scitex-hungry-signal.{service,timer} units + crontab fallbacks.
+# install-orochi-cron.sh auto-unloads and backs them up to
+# ~/.scitex/orochi/cron-migrated-units/.
+#
+# Install via scripts/client/install-orochi-cron.sh. Templated
+# placeholders (__HOME__, __STABLE_BIN__) are rewritten by the
+# installer — stable-bin-path pattern from PR #326.
+#
+# Unlike the per-job units this replaces, there's no companion .timer.
+# The daemon owns its own scheduling loop; systemd's role here is just
+# to keep the daemon alive on failure.
+Description=SciTeX Orochi — unified cron daemon
+Documentation=https://github.com/ywatanabe1989/scitex-orochi
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=-%h/.config/systemd/user/orochi.env
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+# SCITEX_OROCHI_REPO_ROOT is auto-detected by the daemon; override in
+# ~/.config/systemd/user/orochi.env only when running from a custom
+# checkout.
+ExecStart=/usr/bin/env python3 -u __STABLE_BIN__/orochi-cron.py
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=30s
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=30
+TimeoutStopSec=15
+
+[Install]
+WantedBy=default.target

--- a/scripts/client/install-orochi-cron.sh
+++ b/scripts/client/install-orochi-cron.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# install-orochi-cron.sh
+#
+# Installer for the Orochi unified cron daemon (msg#16406 / msg#16410 /
+# lead msg#16408). One Python process per host replaces the per-job
+# scatter of launchd plists / systemd timers / crontab entries.
+#
+# What this does
+# --------------
+# 1. Copies scripts/server/orochi-cron.py to ~/.scitex/orochi/bin/
+#    (stable-bin-path pattern; same shape as PR #326 todo#466).
+# 2. Seeds ~/.scitex/orochi/cron.yaml from the example if absent.
+#    Never overwrites an operator-edited copy.
+# 3. Migrates existing per-job units: unloads them and backs them up
+#    to ~/.scitex/orochi/cron-migrated-units/ so rollback is trivial
+#    (just mv + launchctl load / systemctl --user enable).
+# 4. Installs + loads the daemon-style unit:
+#      macOS : ~/Library/LaunchAgents/com.scitex.orochi-cron.plist
+#      Linux : ~/.config/systemd/user/scitex-orochi-cron.service
+#
+# Usage:
+#   ./scripts/client/install-orochi-cron.sh                # install
+#   ./scripts/client/install-orochi-cron.sh --uninstall    # remove daemon
+#   ./scripts/client/install-orochi-cron.sh --no-migrate   # skip step 3
+#   ./scripts/client/install-orochi-cron.sh --dry-run      # show actions only
+#
+# Rollback: the migrated units sit intact under
+# ~/.scitex/orochi/cron-migrated-units/ with a README.md explaining
+# how to reinstate them.
+
+set -u
+set -o pipefail
+
+LABEL="com.scitex.orochi-cron"
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+DAEMON_SRC="${REPO_ROOT}/scripts/server/orochi-cron.py"
+STABLE_BIN_DIR="${HOME}/.scitex/orochi/bin"
+STABLE_DAEMON="${STABLE_BIN_DIR}/orochi-cron.py"
+
+CONFIG_DIR="${HOME}/.scitex/orochi"
+CONFIG_TARGET="${CONFIG_DIR}/cron.yaml"
+CONFIG_EXAMPLE="${REPO_ROOT}/deployment/host-setup/orochi-cron/cron.yaml.example"
+MIGRATED_DIR="${CONFIG_DIR}/cron-migrated-units"
+
+MAC_LOG_DIR="${HOME}/Library/Logs/scitex"
+LINUX_LOG_DIR="${HOME}/.local/state/scitex/orochi-cron"
+
+LAUNCHD_TEMPLATE="${REPO_ROOT}/deployment/host-setup/launchd/${LABEL}.plist"
+LAUNCHD_TARGET="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+
+SYSTEMD_UNIT_DIR="${HOME}/.config/systemd/user"
+SYSTEMD_SERVICE_TEMPLATE="${REPO_ROOT}/deployment/host-setup/systemd/scitex-orochi-cron.service"
+SYSTEMD_SERVICE_NAME="scitex-orochi-cron.service"
+
+action="install"
+migrate=1
+dry_run=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --uninstall)  action="uninstall"; shift ;;
+        --no-migrate) migrate=0; shift ;;
+        --dry-run)    dry_run=1; shift ;;
+        -h|--help)    sed -n '2,33p' "$0"; exit 0 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+OS="$(uname -s)"
+
+run() {
+    if [ "$dry_run" = "1" ]; then
+        printf '[dry-run] %s\n' "$*"
+    else
+        "$@"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Stable bin + config seeding
+# -----------------------------------------------------------------------------
+install_stable_daemon() {
+    if [[ ! -f "$DAEMON_SRC" ]]; then
+        echo "daemon source missing: $DAEMON_SRC" >&2
+        exit 1
+    fi
+    run mkdir -p "$STABLE_BIN_DIR"
+    run cp -f "$DAEMON_SRC" "$STABLE_DAEMON"
+    run chmod +x "$STABLE_DAEMON"
+    echo "stable daemon: $STABLE_DAEMON"
+}
+
+uninstall_stable_daemon() {
+    run rm -f "$STABLE_DAEMON"
+    echo "uninstalled stable daemon: $STABLE_DAEMON"
+}
+
+seed_config() {
+    run mkdir -p "$CONFIG_DIR"
+    if [[ -f "$CONFIG_TARGET" ]]; then
+        echo "config exists (left as-is): $CONFIG_TARGET"
+        return
+    fi
+    if [[ ! -f "$CONFIG_EXAMPLE" ]]; then
+        echo "config example missing: $CONFIG_EXAMPLE" >&2
+        exit 1
+    fi
+    run cp "$CONFIG_EXAMPLE" "$CONFIG_TARGET"
+    echo "seeded config from example: $CONFIG_TARGET"
+}
+
+# -----------------------------------------------------------------------------
+# Migrate per-job units out of the way. Preserved under MIGRATED_DIR
+# so rollback is a single `mv` + `launchctl load` / `systemctl enable`.
+# -----------------------------------------------------------------------------
+MAC_LEGACY_LABELS=(
+    "com.scitex.fleet-host-liveness-probe"
+    "com.scitex.hungry-signal"
+    "com.scitex.chrome-codesign-watchdog"
+    "com.scitex.auto-dispatch-probe"
+    "com.scitex.orochi.agent-meta-push"
+)
+
+LINUX_LEGACY_UNITS=(
+    "scitex-hungry-signal.timer"
+    "scitex-hungry-signal.service"
+    "scitex-auto-dispatch-probe.timer"
+    "scitex-auto-dispatch-probe.service"
+)
+
+LINUX_LEGACY_CRON_MARKERS=(
+    "# scitex-orochi host-liveness-probe (todo#271)"
+    "# scitex-orochi hungry-signal (lead msg#16310)"
+)
+
+migrate_macos() {
+    run mkdir -p "$MIGRATED_DIR"
+    for label in "${MAC_LEGACY_LABELS[@]}"; do
+        local src="${HOME}/Library/LaunchAgents/${label}.plist"
+        if [[ -f "$src" ]]; then
+            echo "migrating $label"
+            run launchctl unload "$src" 2>/dev/null || true
+            run mv -f "$src" "${MIGRATED_DIR}/${label}.plist"
+        fi
+    done
+    _write_rollback_readme_mac
+}
+
+_write_rollback_readme_mac() {
+    if [ "$dry_run" = "1" ]; then return; fi
+    cat > "${MIGRATED_DIR}/README.md" <<'EOF'
+# Orochi cron — migrated per-job units
+
+install-orochi-cron.sh moved these legacy LaunchAgents aside so the
+unified daemon owns the schedule. They stay here so you can roll back.
+
+## Rollback
+
+    # 1. Stop the unified daemon
+    launchctl unload ~/Library/LaunchAgents/com.scitex.orochi-cron.plist
+
+    # 2. Reinstate a specific legacy agent
+    mv ~/.scitex/orochi/cron-migrated-units/com.scitex.<name>.plist \
+       ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.scitex.<name>.plist
+
+    # Or everything at once: re-run the old install-*.sh scripts.
+EOF
+    echo "wrote rollback README: ${MIGRATED_DIR}/README.md"
+}
+
+migrate_linux_systemd() {
+    command -v systemctl >/dev/null 2>&1 || return 0
+    run mkdir -p "$MIGRATED_DIR"
+    for unit in "${LINUX_LEGACY_UNITS[@]}"; do
+        local src="${SYSTEMD_UNIT_DIR}/${unit}"
+        if [[ -f "$src" ]]; then
+            echo "migrating $unit"
+            run systemctl --user disable --now "$unit" 2>/dev/null || true
+            run mv -f "$src" "${MIGRATED_DIR}/${unit}"
+        fi
+    done
+    run systemctl --user daemon-reload 2>/dev/null || true
+    _write_rollback_readme_linux
+}
+
+_write_rollback_readme_linux() {
+    if [ "$dry_run" = "1" ]; then return; fi
+    cat > "${MIGRATED_DIR}/README.md" <<'EOF'
+# Orochi cron — migrated per-job units
+
+install-orochi-cron.sh moved these legacy systemd user units aside so
+the unified daemon owns the schedule. They stay here so you can roll
+back.
+
+## Rollback
+
+    # 1. Stop the unified daemon
+    systemctl --user disable --now scitex-orochi-cron.service
+
+    # 2. Reinstate a specific legacy unit
+    mv ~/.scitex/orochi/cron-migrated-units/<unit> \
+       ~/.config/systemd/user/
+    systemctl --user daemon-reload
+    systemctl --user enable --now <unit>
+EOF
+}
+
+migrate_linux_cron() {
+    local existing
+    existing="$(crontab -l 2>/dev/null || true)"
+    [ -z "$existing" ] && return 0
+    local touched=0
+    local rebuilt="$existing"
+    for marker in "${LINUX_LEGACY_CRON_MARKERS[@]}"; do
+        if printf '%s\n' "$rebuilt" | grep -qF "$marker"; then
+            rebuilt="$(printf '%s\n' "$rebuilt" | awk -v marker="$marker" '
+                BEGIN { skip=0 }
+                {
+                    if ($0 == marker) { skip=2; next }
+                    if (skip > 0)     { skip--; next }
+                    print $0
+                }
+            ')"
+            echo "migrated crontab marker: $marker"
+            touched=1
+        fi
+    done
+    if [ "$touched" -eq 1 ]; then
+        if [ "$dry_run" = "0" ]; then
+            printf '%s\n' "$rebuilt" | crontab -
+        fi
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# macOS install / uninstall
+# -----------------------------------------------------------------------------
+install_macos() {
+    if [[ ! -f "$LAUNCHD_TEMPLATE" ]]; then
+        echo "template missing: $LAUNCHD_TEMPLATE" >&2
+        exit 1
+    fi
+    install_stable_daemon
+    seed_config
+    [ "$migrate" = "1" ] && migrate_macos
+
+    run mkdir -p "$(dirname "$LAUNCHD_TARGET")" "$MAC_LOG_DIR"
+
+    local esc_home esc_bin
+    esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+    esc_bin="$(printf '%s' "$STABLE_BIN_DIR" | sed 's|[|&]|\\&|g')"
+    if [ "$dry_run" = "1" ]; then
+        echo "[dry-run] would template plist into $LAUNCHD_TARGET"
+    else
+        sed -e "s|__HOME__|${esc_home}|g" \
+            -e "s|__STABLE_BIN__|${esc_bin}|g" \
+            "$LAUNCHD_TEMPLATE" > "$LAUNCHD_TARGET"
+    fi
+
+    run launchctl unload "$LAUNCHD_TARGET" 2>/dev/null || true
+    run launchctl load "$LAUNCHD_TARGET"
+
+    echo "installed: $LAUNCHD_TARGET"
+    echo "config:    $CONFIG_TARGET"
+    echo "daemon:    $STABLE_DAEMON"
+    echo "log:       ${MAC_LOG_DIR}/orochi-cron.log"
+    echo "status:    launchctl list | grep ${LABEL}"
+    echo "introspect: scitex-orochi cron list"
+}
+
+uninstall_macos() {
+    if [[ -f "$LAUNCHD_TARGET" ]]; then
+        run launchctl unload "$LAUNCHD_TARGET" 2>/dev/null || true
+        run rm -f "$LAUNCHD_TARGET"
+        echo "uninstalled: $LAUNCHD_TARGET"
+    else
+        echo "nothing to uninstall (no $LAUNCHD_TARGET)"
+    fi
+    uninstall_stable_daemon
+}
+
+# -----------------------------------------------------------------------------
+# Linux install / uninstall (systemd --user)
+# -----------------------------------------------------------------------------
+_systemd_user_available() {
+    command -v systemctl >/dev/null 2>&1 && \
+        systemctl --user status >/dev/null 2>&1
+}
+
+install_linux() {
+    if [[ ! -f "$SYSTEMD_SERVICE_TEMPLATE" ]]; then
+        echo "systemd template missing: $SYSTEMD_SERVICE_TEMPLATE" >&2
+        exit 1
+    fi
+    if ! _systemd_user_available; then
+        echo "systemd --user unavailable — unified cron requires a systemd user instance." >&2
+        echo "Fallback to manual: run scripts/server/orochi-cron.py under your preferred supervisor." >&2
+        exit 1
+    fi
+    install_stable_daemon
+    seed_config
+    if [ "$migrate" = "1" ]; then
+        migrate_linux_systemd
+        migrate_linux_cron
+    fi
+    run mkdir -p "$SYSTEMD_UNIT_DIR" "$LINUX_LOG_DIR"
+
+    local esc_home esc_bin
+    esc_home="$(printf '%s' "$HOME" | sed 's|[|&]|\\&|g')"
+    esc_bin="$(printf '%s' "$STABLE_BIN_DIR" | sed 's|[|&]|\\&|g')"
+    if [ "$dry_run" = "1" ]; then
+        echo "[dry-run] would template service into $SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME"
+    else
+        sed -e "s|__HOME__|${esc_home}|g" \
+            -e "s|__STABLE_BIN__|${esc_bin}|g" \
+            "$SYSTEMD_SERVICE_TEMPLATE" > "$SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME"
+    fi
+    run systemctl --user daemon-reload
+    run systemctl --user enable --now "$SYSTEMD_SERVICE_NAME"
+    echo "installed: $SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME"
+    echo "config:    $CONFIG_TARGET"
+    echo "daemon:    $STABLE_DAEMON"
+    echo "status:    systemctl --user status ${SYSTEMD_SERVICE_NAME}"
+    echo "logs:      journalctl --user -u ${SYSTEMD_SERVICE_NAME}"
+    echo "introspect: scitex-orochi cron list"
+}
+
+uninstall_linux() {
+    if _systemd_user_available; then
+        run systemctl --user disable --now "$SYSTEMD_SERVICE_NAME" 2>/dev/null || true
+    fi
+    if [[ -f "$SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME" ]]; then
+        run rm -f "$SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME"
+        run systemctl --user daemon-reload 2>/dev/null || true
+        echo "uninstalled: $SYSTEMD_UNIT_DIR/$SYSTEMD_SERVICE_NAME"
+    fi
+    uninstall_stable_daemon
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------------
+case "$OS" in
+    Darwin)
+        case "$action" in
+            install)   install_macos ;;
+            uninstall) uninstall_macos ;;
+        esac
+        ;;
+    Linux)
+        case "$action" in
+            install)   install_linux ;;
+            uninstall) uninstall_linux ;;
+        esac
+        ;;
+    *)
+        echo "install-orochi-cron: unsupported OS ($OS)" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/server/orochi-cron.py
+++ b/scripts/server/orochi-cron.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env -S python3 -u
+"""Orochi unified cron daemon (msg#16406 / msg#16410 / lead msg#16408).
+
+One process per host replaces the per-job scatter of launchd plists /
+systemd timers / crontab lines. Reads ``~/.scitex/orochi/cron.yaml``,
+runs each declared job at its cadence, captures structured results,
+and writes a shared state file the CLI + heartbeat pusher both read.
+
+All scheduling logic lives in ``scitex_orochi._cron.CronDaemon`` — this
+script is a thin CLI wrapper so the OS-native unit only has to know
+how to exec a Python file with the right flags.
+
+Usage::
+
+    orochi-cron.py                            # normal daemon
+    orochi-cron.py --config /path/cron.yaml   # override YAML location
+    orochi-cron.py --dry-run                  # log "would run" only
+
+Exit codes:
+    0  — clean shutdown after SIGTERM/SIGINT
+    2  — config parse error at startup (log to stderr, crash-visibly)
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from scitex_orochi._cron import (
+    CronDaemon,
+    default_config_path,
+    default_log_dir,
+    default_state_path,
+)
+from scitex_orochi._cron._config import default_pid_path
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="orochi-cron",
+        description=(
+            "Unified Orochi cron daemon. One process replaces the "
+            "scatter of per-job launchd plists / systemd timers."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=f"Path to cron.yaml (default: {default_config_path()})",
+    )
+    parser.add_argument(
+        "--state",
+        default=None,
+        help=f"Path to state.json (default: {default_state_path()})",
+    )
+    parser.add_argument(
+        "--pid",
+        default=None,
+        help=f"Path to pid file (default: {default_pid_path()})",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default=None,
+        help=f"Per-job NDJSON log dir (default: {default_log_dir()})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Tick the scheduler but only log 'would run' (no subprocesses).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="DEBUG-level logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    daemon = CronDaemon(
+        config_path=Path(args.config) if args.config else None,
+        state_path=Path(args.state) if args.state else None,
+        pid_path=Path(args.pid) if args.pid else None,
+        log_dir=Path(args.log_dir) if args.log_dir else None,
+        dry_run=args.dry_run,
+    )
+    try:
+        return daemon.run()
+    except FileNotFoundError as exc:
+        print(f"orochi-cron: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"orochi-cron: config error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -203,6 +203,11 @@ from scitex_orochi._cli.commands.host_identity_cmd import host_identity
 
 orochi.add_command(host_identity)
 
+# Unified cron daemon (msg#16406 / msg#16410)
+from scitex_orochi._cli.commands.cron_cmd import cron as cron_group
+
+orochi.add_command(cron_group)
+
 
 def main() -> None:
     try:

--- a/src/scitex_orochi/_cli/commands/cron_cmd.py
+++ b/src/scitex_orochi/_cli/commands/cron_cmd.py
@@ -1,0 +1,378 @@
+"""CLI: ``scitex-orochi cron {start, stop, list, run, status, reload}``.
+
+Manages the unified Orochi cron daemon (msg#16406 / msg#16410).
+
+Subcommand matrix
+-----------------
+* ``start``   — shell out to ``install-orochi-cron.sh`` to install +
+                load the OS-native unit. Idempotent.
+* ``stop``    — unload only by default (daemon stays installed).
+                ``--uninstall`` additionally removes the unit file so
+                ``start`` will reinstall from template.
+* ``list``    — JSON/text snapshot of every job: name, interval,
+                last_run, last_exit, next_run, disabled. Reads the
+                shared state file written by the daemon — works even
+                if the daemon isn't loaded (returns last known state
+                or an empty array).
+* ``run``     — invoke a single job once, synchronously, and print
+                its result. Doesn't go through the daemon loop, so
+                it works before the daemon is installed.
+* ``status``  — "is the daemon loaded + PID?" Combines the PID file
+                (the daemon's own view) with ``os.kill(pid, 0)`` so
+                stale PID files don't give false positives.
+* ``reload``  — ``kill -HUP`` the daemon so it re-reads cron.yaml
+                without a full restart.
+
+All subcommands honour the top-level ``--json`` flag for machine
+readable output; tail commands also accept explicit ``--text`` / ``--json``
+overrides when the parent context is unavailable (e.g. direct imports
+from other CLI entry points).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import click
+
+from scitex_orochi._cron import (
+    CronDaemon,
+    default_config_path,
+    default_log_dir,
+    default_state_path,
+    state_read,
+)
+from scitex_orochi._cron._config import default_pid_path
+from scitex_orochi._cron._state import render_cron_jobs
+
+
+def _repo_root() -> Path:
+    """Climb from the installed package to the repo root.
+
+    Mirrors the logic in ``_cron._config._auto_repo_root`` but the CLI
+    needs a Path, not a string. Falls back to ``$SCITEX_OROCHI_REPO_ROOT``
+    if the package isn't next to a pyproject (e.g. in a venv pip install
+    from PyPI — though Phase 1 doesn't ship there).
+    """
+    env = os.environ.get("SCITEX_OROCHI_REPO_ROOT")
+    if env:
+        return Path(env)
+    try:
+        import scitex_orochi  # noqa: F401
+
+        here = Path(scitex_orochi.__file__).resolve().parent
+    except Exception:
+        return Path.cwd()
+    for candidate in [here, *here.parents]:
+        if (candidate / "pyproject.toml").is_file():
+            try:
+                text = (candidate / "pyproject.toml").read_text(
+                    encoding="utf-8", errors="replace"
+                )
+                if 'name = "scitex-orochi"' in text:
+                    return candidate
+            except OSError:
+                continue
+    return Path.cwd()
+
+
+@click.group("cron")
+def cron() -> None:
+    """Manage the unified Orochi cron daemon (msg#16406 / msg#16410)."""
+
+
+# ----------------------------------------------------------------------
+# cron start
+# ----------------------------------------------------------------------
+
+
+@cron.command("start")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Pass --dry-run to install-orochi-cron.sh (show actions only).",
+)
+@click.option(
+    "--no-migrate",
+    is_flag=True,
+    help="Skip migration of legacy per-job units.",
+)
+def cron_start(dry_run: bool, no_migrate: bool) -> None:
+    """Install + load the cron daemon via install-orochi-cron.sh."""
+    installer = _repo_root() / "scripts" / "client" / "install-orochi-cron.sh"
+    if not installer.is_file():
+        raise click.ClickException(
+            f"installer not found: {installer} — run from a scitex-orochi checkout"
+        )
+    cmd = ["bash", str(installer)]
+    if dry_run:
+        cmd.append("--dry-run")
+    if no_migrate:
+        cmd.append("--no-migrate")
+    click.echo(" ".join(cmd))
+    rc = subprocess.call(cmd)
+    sys.exit(rc)
+
+
+# ----------------------------------------------------------------------
+# cron stop
+# ----------------------------------------------------------------------
+
+
+@cron.command("stop")
+@click.option(
+    "--uninstall",
+    is_flag=True,
+    help="Also remove the unit file (so `cron start` reinstalls from template).",
+)
+def cron_stop(uninstall: bool) -> None:
+    """Unload the cron daemon. ``--uninstall`` additionally removes the unit file."""
+    installer = _repo_root() / "scripts" / "client" / "install-orochi-cron.sh"
+    if uninstall:
+        if not installer.is_file():
+            raise click.ClickException(f"installer not found: {installer}")
+        rc = subprocess.call(["bash", str(installer), "--uninstall"])
+        sys.exit(rc)
+    # Best-effort unload without touching the unit file.
+    if sys.platform == "darwin":
+        target = Path.home() / "Library/LaunchAgents/com.scitex.orochi-cron.plist"
+        if target.is_file():
+            rc = subprocess.call(["launchctl", "unload", str(target)])
+            click.echo(f"launchctl unload {target} -> rc={rc}")
+            sys.exit(0 if rc in (0,) else rc)
+        click.echo("no plist loaded", err=True)
+        sys.exit(0)
+    # Linux: try systemd --user stop; succeed silently if not installed.
+    rc = subprocess.call(
+        ["systemctl", "--user", "stop", "scitex-orochi-cron.service"]
+    )
+    sys.exit(0 if rc == 0 else rc)
+
+
+# ----------------------------------------------------------------------
+# cron list
+# ----------------------------------------------------------------------
+
+
+@cron.command("list")
+@click.option(
+    "--state",
+    "state_path_str",
+    default=None,
+    help=f"Override state file (default: {default_state_path()}).",
+)
+@click.pass_context
+def cron_list(ctx: click.Context, state_path_str: str | None) -> None:
+    """Print each job's cadence + last run outcome + next run time."""
+    state_path = Path(state_path_str) if state_path_str else default_state_path()
+    state = state_read(state_path)
+    jobs = render_cron_jobs(state)
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if as_json:
+        click.echo(json.dumps(jobs, indent=2, default=str))
+        return
+    if not jobs:
+        click.echo("no jobs registered (daemon not running or cron.yaml empty)")
+        return
+    # Keep text output small + greppable.
+    click.echo(f"{'job':<32} {'interval':>10} {'last':>22} {'exit':>6} {'next':>22}")
+    now = time.time()
+    for j in jobs:
+        last = _fmt_ts(j.get("last_run"))
+        nxt = _fmt_rel(j.get("next_run"), now)
+        exit_code = j.get("last_exit")
+        exit_s = "-" if exit_code is None else str(exit_code)
+        click.echo(
+            f"{j['name']:<32} {j['interval']!s:>10} {last:>22} {exit_s:>6} {nxt:>22}"
+        )
+
+
+def _fmt_ts(ts: float | None) -> str:
+    if not ts:
+        return "never"
+    lt = time.localtime(float(ts))
+    return time.strftime("%Y-%m-%d %H:%M:%S", lt)
+
+
+def _fmt_rel(ts: float | None, now: float) -> str:
+    if not ts:
+        return "-"
+    delta = float(ts) - now
+    if delta < -60:
+        return f"{int(-delta)}s ago (overdue)"
+    if delta < 0:
+        return "due now"
+    if delta < 60:
+        return f"in {int(delta)}s"
+    if delta < 3600:
+        return f"in {int(delta // 60)}m"
+    return f"in {delta / 3600:.1f}h"
+
+
+# ----------------------------------------------------------------------
+# cron run
+# ----------------------------------------------------------------------
+
+
+@cron.command("run")
+@click.argument("name")
+@click.option("--dry-run", is_flag=True, help="Don't exec — print the command only.")
+@click.option(
+    "--config",
+    "config_path",
+    default=None,
+    help=f"Override cron.yaml (default: {default_config_path()}).",
+)
+@click.pass_context
+def cron_run(
+    ctx: click.Context, name: str, dry_run: bool, config_path: str | None
+) -> None:
+    """Fire a single job once and print its outcome.
+
+    Doesn't go through the daemon loop — you can test a new command
+    before installing the daemon.
+    """
+    daemon = CronDaemon(
+        config_path=Path(config_path) if config_path else None,
+        dry_run=dry_run,
+    )
+    try:
+        run = daemon.run_once(name)
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from None
+    except KeyError as exc:
+        raise click.ClickException(str(exc)) from None
+
+    payload = {
+        "name": name,
+        "started_at": run.started_at,
+        "ended_at": run.ended_at,
+        "duration_seconds": run.duration_seconds,
+        "exit_code": run.exit_code,
+        "skipped": run.skipped or None,
+        "stdout_tail": run.stdout_tail,
+        "stderr_tail": run.stderr_tail,
+    }
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if as_json:
+        click.echo(json.dumps(payload, indent=2, default=str))
+    else:
+        click.echo(f"job:      {name}")
+        click.echo(f"exit:     {run.exit_code}")
+        click.echo(f"duration: {run.duration_seconds:.2f}s")
+        if run.skipped:
+            click.echo(f"skipped:  {run.skipped}")
+        if run.stdout_tail:
+            click.echo("--- stdout (tail) ---")
+            click.echo(run.stdout_tail)
+        if run.stderr_tail:
+            click.echo("--- stderr (tail) ---")
+            click.echo(run.stderr_tail)
+    if run.exit_code not in (0, None):
+        sys.exit(run.exit_code)
+
+
+# ----------------------------------------------------------------------
+# cron status
+# ----------------------------------------------------------------------
+
+
+@cron.command("status")
+@click.option(
+    "--pid",
+    "pid_path_str",
+    default=None,
+    help=f"Override PID file (default: {default_pid_path()}).",
+)
+@click.option(
+    "--state",
+    "state_path_str",
+    default=None,
+    help=f"Override state file (default: {default_state_path()}).",
+)
+@click.pass_context
+def cron_status(
+    ctx: click.Context,
+    pid_path_str: str | None,
+    state_path_str: str | None,
+) -> None:
+    """Report whether the daemon is running + its PID + config location."""
+    pid_path = Path(pid_path_str) if pid_path_str else default_pid_path()
+    state_path = Path(state_path_str) if state_path_str else default_state_path()
+    pid, alive = _daemon_liveness(pid_path)
+    state = state_read(state_path)
+    payload = {
+        "daemon_pid": pid,
+        "daemon_running": alive,
+        "daemon_started_at": (state.daemon_started_at if state else None),
+        "state_updated_at": (state.updated_at if state else None),
+        "config_path": str(default_config_path()),
+        "state_path": str(state_path),
+        "pid_path": str(pid_path),
+        "log_dir": str(default_log_dir()),
+        "job_count": len(state.jobs) if state else 0,
+    }
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if as_json:
+        click.echo(json.dumps(payload, indent=2, default=str))
+        return
+    click.echo(f"pid:      {pid if pid else '-'}")
+    click.echo(f"running:  {alive}")
+    click.echo(f"jobs:     {payload['job_count']}")
+    click.echo(f"config:   {payload['config_path']}")
+    click.echo(f"state:    {payload['state_path']}")
+    click.echo(f"logs:     {payload['log_dir']}")
+
+
+def _daemon_liveness(pid_path: Path) -> tuple[int, bool]:
+    """Return (pid, is_alive). 0 + False if no pid file."""
+    if not pid_path.is_file():
+        return (0, False)
+    try:
+        raw = pid_path.read_text(encoding="utf-8").strip()
+        pid = int(raw)
+    except (OSError, ValueError):
+        return (0, False)
+    if pid <= 0:
+        return (0, False)
+    try:
+        os.kill(pid, 0)
+        return (pid, True)
+    except ProcessLookupError:
+        return (pid, False)
+    except PermissionError:
+        # Process exists, owned by another user — treat as alive.
+        return (pid, True)
+
+
+# ----------------------------------------------------------------------
+# cron reload
+# ----------------------------------------------------------------------
+
+
+@cron.command("reload")
+@click.option(
+    "--pid",
+    "pid_path_str",
+    default=None,
+    help=f"Override PID file (default: {default_pid_path()}).",
+)
+def cron_reload(pid_path_str: str | None) -> None:
+    """Signal the daemon to re-read cron.yaml (SIGHUP)."""
+    pid_path = Path(pid_path_str) if pid_path_str else default_pid_path()
+    pid, alive = _daemon_liveness(pid_path)
+    if not alive:
+        raise click.ClickException(
+            f"daemon not running (pid file: {pid_path}) — start with `scitex-orochi cron start`"
+        )
+    try:
+        os.kill(pid, signal.SIGHUP)
+    except OSError as exc:
+        raise click.ClickException(f"failed to signal pid {pid}: {exc}") from None
+    click.echo(f"sent SIGHUP to pid {pid}")

--- a/src/scitex_orochi/_cli/commands/heartbeat_cmd.py
+++ b/src/scitex_orochi/_cli/commands/heartbeat_cmd.py
@@ -136,9 +136,31 @@ def _wrap_with_orochi_fields(
         "account_email": status.get("account_email") or "",
         "version": status.get("version") or "",
     }
+    # Orochi unified cron state (msg#16406 / msg#16410). Surfaced in
+    # every heartbeat so Phase 2 can wire the Machines tab directly off
+    # /api/agents/...heartbeat.payload.cron_jobs — no extra endpoint
+    # needed. Empty list when the daemon isn't running on this host, so
+    # UI just renders "no jobs".
+    body["cron_jobs"] = _collect_cron_jobs()
     if channels:
         body["channels"] = list(channels)
     return body
+
+
+def _collect_cron_jobs() -> list[dict[str, Any]]:
+    """Read the orochi-cron state file and normalise it for heartbeat.
+
+    Defensive: any read / parse error returns an empty list. The
+    heartbeat is best-effort telemetry; never let a local daemon glitch
+    prevent the health signal from reaching the hub.
+    """
+    try:
+        from scitex_orochi._cron import default_state_path, state_read
+        from scitex_orochi._cron._state import render_cron_jobs
+
+        return render_cron_jobs(state_read(default_state_path()))
+    except Exception:
+        return []
 
 
 def _post_register(hub: str, body: dict[str, Any]) -> tuple[int, str]:

--- a/src/scitex_orochi/_cron/__init__.py
+++ b/src/scitex_orochi/_cron/__init__.py
@@ -1,0 +1,47 @@
+"""Orochi unified cron daemon — scheduler + state access helpers.
+
+Replaces the scattered ``install-*.sh`` -> per-job launchd/systemd/cron
+entries with one YAML-declared daemon per host. The daemon owns the
+scheduling loop; the OS-native unit only needs to keep *it* alive.
+
+Phase 1 scope (msg#16406 / msg#16410 / lead msg#16408):
+
+* ``Job``, ``JobRun``, ``CronConfig`` dataclasses + ``load_config``
+  YAML parser.
+* ``CronDaemon`` — long-running scheduler using stdlib threading (no
+  new pip deps).
+* ``state_read`` helper the CLI + heartbeat pusher both consume so
+  ``cron_jobs`` can surface in ``scitex-orochi cron list`` AND in the
+  heartbeat payload without a second source of truth.
+
+See ``deployment/host-setup/orochi-cron/cron.yaml.example`` for the
+schema + default job list.
+"""
+
+from __future__ import annotations
+
+from scitex_orochi._cron._config import (
+    CronConfig,
+    Job,
+    default_config_path,
+    default_log_dir,
+    default_state_path,
+    load_config,
+    parse_interval,
+)
+from scitex_orochi._cron._daemon import CronDaemon
+from scitex_orochi._cron._state import JobRun, state_read, state_write
+
+__all__ = [
+    "CronConfig",
+    "CronDaemon",
+    "Job",
+    "JobRun",
+    "default_config_path",
+    "default_log_dir",
+    "default_state_path",
+    "load_config",
+    "parse_interval",
+    "state_read",
+    "state_write",
+]

--- a/src/scitex_orochi/_cron/_config.py
+++ b/src/scitex_orochi/_cron/_config.py
@@ -1,0 +1,315 @@
+"""Config schema + YAML loader for the Orochi unified cron daemon.
+
+Responsibilities
+----------------
+* Parse ``~/.scitex/orochi/cron.yaml`` (or an explicit path).
+* Expand ``${VAR}`` placeholders in command strings against a merged env
+  (process env + a small set of daemon-injected defaults like
+  ``SCITEX_OROCHI_REPO_ROOT``). Unknown vars are left untouched so
+  errors surface at job-run time rather than silently becoming empty
+  strings.
+* Convert human-friendly interval strings (``"5m"``, ``"1h"``,
+  ``"30s"``) into seconds.
+
+No scheduler logic lives here — that's ``_daemon.py``. Keeping the
+parser isolated makes the YAML easy to unit-test without a live daemon.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# ----------------------------------------------------------------------
+# Paths — the daemon, the CLI, and the heartbeat pusher all agree on
+# these locations so "what the daemon thinks it did" and "what
+# `scitex-orochi cron list` reports" can never diverge.
+# ----------------------------------------------------------------------
+
+
+def default_config_path() -> Path:
+    """Location of ``cron.yaml`` (operator-owned, per-host)."""
+    return Path.home() / ".scitex" / "orochi" / "cron.yaml"
+
+
+def default_state_path() -> Path:
+    """Location of the daemon's JSON state file.
+
+    Follows the same convention as other Orochi client-side state
+    (``~/.local/state/scitex/...``). Kept outside ``~/.scitex/orochi/``
+    because it's runtime telemetry, not config.
+    """
+    return Path.home() / ".local" / "state" / "scitex" / "orochi-cron" / "state.json"
+
+
+def default_log_dir() -> Path:
+    """Per-job stdout/stderr NDJSON log directory."""
+    return Path.home() / ".local" / "state" / "scitex" / "orochi-cron" / "logs"
+
+
+def default_pid_path() -> Path:
+    """PID file for the daemon — used by ``cron status`` to answer
+    "is the daemon loaded, and what PID?" without speaking launchctl."""
+    return Path.home() / ".local" / "state" / "scitex" / "orochi-cron" / "daemon.pid"
+
+
+# ----------------------------------------------------------------------
+# Interval parser
+# ----------------------------------------------------------------------
+
+_INTERVAL_RE = re.compile(r"^\s*(\d+)\s*([smhd]?)\s*$", re.IGNORECASE)
+_INTERVAL_MULTIPLIERS = {"": 1, "s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def parse_interval(value: str | int | float) -> int:
+    """Convert ``"5m"`` / ``"1h"`` / ``"30s"`` / plain seconds to int seconds.
+
+    Accepts:
+        * ``int`` / ``float`` — treated as seconds.
+        * ``"<N><unit>"`` where unit is ``s|m|h|d`` (default ``s``).
+    Raises ``ValueError`` on unparseable input so the daemon crashes
+    visibly at YAML-load time rather than silently defaulting.
+    """
+    if isinstance(value, (int, float)):
+        seconds = int(value)
+        if seconds <= 0:
+            raise ValueError(f"interval must be positive, got {value!r}")
+        return seconds
+    if not isinstance(value, str):
+        raise ValueError(f"interval must be int or string, got {type(value).__name__}")
+    match = _INTERVAL_RE.match(value)
+    if not match:
+        raise ValueError(f"unparseable interval: {value!r}")
+    n = int(match.group(1))
+    unit = match.group(2).lower()
+    seconds = n * _INTERVAL_MULTIPLIERS[unit]
+    if seconds <= 0:
+        raise ValueError(f"interval must be positive, got {value!r}")
+    return seconds
+
+
+# ----------------------------------------------------------------------
+# Variable expansion — intentionally narrow so typos don't silently
+# evaluate to empty strings.
+# ----------------------------------------------------------------------
+
+_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def expand_vars(template: str, env: dict[str, str]) -> str:
+    """Replace ``${NAME}`` with ``env[NAME]``; leave unknown names as-is.
+
+    The leave-as-is behavior is intentional: if an operator writes
+    ``${REPO_ROOOT}`` (typo), we'd rather the subprocess fail loudly
+    with "no such command" than silently run "``bash ``" which would
+    tie up a job slot doing nothing.
+    """
+
+    def _sub(m: re.Match[str]) -> str:
+        name = m.group(1)
+        return env.get(name, m.group(0))
+
+    return _VAR_RE.sub(_sub, template)
+
+
+# ----------------------------------------------------------------------
+# Dataclasses
+# ----------------------------------------------------------------------
+
+
+@dataclass
+class Job:
+    """One scheduled job.
+
+    Attributes
+    ----------
+    name:
+        Unique identifier. Used as the key in state + log file names.
+    interval_seconds:
+        Cadence in seconds (resolved from ``interval`` in YAML).
+    command:
+        Shell command line. ``${VAR}`` placeholders are pre-expanded
+        against the daemon's merged env when the config is loaded.
+    timeout_seconds:
+        Per-job wall-clock timeout. Defaults to 600s (10 min).
+    disabled:
+        Operator-set kill switch. Disabled jobs still appear in
+        ``cron list`` so they can be re-enabled without editing YAML.
+    """
+
+    name: str
+    interval_seconds: int
+    command: str
+    timeout_seconds: int = 600
+    disabled: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "interval": self.interval_seconds,
+            "command": self.command,
+            "timeout": self.timeout_seconds,
+            "disabled": self.disabled,
+        }
+
+
+@dataclass
+class CronConfig:
+    """Parsed ``cron.yaml`` — a set of jobs plus daemon-level knobs.
+
+    ``tick_seconds`` is how often the scheduler wakes to check due
+    jobs. Keep it smaller than the shortest interval so cadence drift
+    stays bounded. Default 10s — negligible CPU, and even 1m jobs are
+    fired within 10s of their due time.
+    """
+
+    jobs: list[Job] = field(default_factory=list)
+    tick_seconds: int = 10
+
+
+# ----------------------------------------------------------------------
+# Loader
+# ----------------------------------------------------------------------
+
+
+def _auto_repo_root() -> str:
+    """Best-effort resolution of ``SCITEX_OROCHI_REPO_ROOT``.
+
+    Priority:
+      1. Explicit ``SCITEX_OROCHI_REPO_ROOT`` in the env.
+      2. The installed ``scitex_orochi`` package location + walk up
+         until we find a ``pyproject.toml`` naming scitex-orochi. This
+         matches the stable-bin-path shape from PR #326 so a
+         feature-branch worktree doesn't 404 a scheduler after merge.
+      3. Empty string — unresolved ``${SCITEX_OROCHI_REPO_ROOT}``
+         tokens are then left visible in the command so the failure
+         mode is obvious.
+    """
+    env = os.environ.get("SCITEX_OROCHI_REPO_ROOT")
+    if env:
+        return env
+    try:
+        import scitex_orochi  # type: ignore  # noqa: F401 — just need the path
+
+        pkg_path = Path(scitex_orochi.__file__).resolve().parent
+    except Exception:
+        return ""
+    # Walk up until we hit a pyproject.toml with scitex-orochi.
+    for candidate in [pkg_path, *pkg_path.parents]:
+        pyproject = candidate / "pyproject.toml"
+        if pyproject.is_file():
+            try:
+                content = pyproject.read_text(encoding="utf-8", errors="replace")
+                if 'name = "scitex-orochi"' in content:
+                    return str(candidate)
+            except OSError:
+                continue
+    return ""
+
+
+def _default_env() -> dict[str, str]:
+    """Minimal env the daemon injects before variable expansion.
+
+    * Process env (so operator-set vars like ``HOME`` work).
+    * ``SCITEX_OROCHI_REPO_ROOT`` auto-detected (matches the
+      stable-bin-path pattern).
+    """
+    env = dict(os.environ)
+    if not env.get("SCITEX_OROCHI_REPO_ROOT"):
+        env["SCITEX_OROCHI_REPO_ROOT"] = _auto_repo_root()
+    return env
+
+
+def load_config(
+    path: str | Path | None = None,
+    *,
+    env_overrides: dict[str, str] | None = None,
+) -> CronConfig:
+    """Parse a cron YAML file into a ``CronConfig``.
+
+    Parameters
+    ----------
+    path:
+        Path to ``cron.yaml``. Defaults to ``~/.scitex/orochi/cron.yaml``.
+        A missing file is a hard error because silent "no jobs" would
+        mask the operator forgetting to copy the example.
+    env_overrides:
+        Extra vars layered on top of the process env. Mainly used by
+        tests to inject deterministic repo paths / ``$HOME`` stubs.
+
+    Raises
+    ------
+    FileNotFoundError:
+        If the YAML file is missing.
+    ValueError:
+        For malformed job entries, duplicate names, or unparseable
+        intervals. Each error names the offending job so the operator
+        can fix ``cron.yaml`` without running the daemon.
+    """
+    p = Path(path) if path is not None else default_config_path()
+    if not p.is_file():
+        raise FileNotFoundError(
+            f"cron config not found: {p}\n"
+            f"copy deployment/host-setup/orochi-cron/cron.yaml.example "
+            f"to {p} and tune."
+        )
+    with p.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{p}: top-level must be a mapping, got {type(raw).__name__}")
+
+    env = _default_env()
+    if env_overrides:
+        env.update(env_overrides)
+
+    tick = int(raw.get("tick_seconds", 10))
+    if tick <= 0:
+        raise ValueError(f"{p}: tick_seconds must be positive, got {tick}")
+
+    raw_jobs = raw.get("jobs", [])
+    if not isinstance(raw_jobs, list):
+        raise ValueError(f"{p}: 'jobs' must be a list, got {type(raw_jobs).__name__}")
+
+    seen: set[str] = set()
+    jobs: list[Job] = []
+    for idx, entry in enumerate(raw_jobs):
+        if not isinstance(entry, dict):
+            raise ValueError(f"{p}: jobs[{idx}] must be a mapping")
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"{p}: jobs[{idx}] missing 'name'")
+        if name in seen:
+            raise ValueError(f"{p}: duplicate job name {name!r}")
+        seen.add(name)
+        if "interval" not in entry:
+            raise ValueError(f"{p}: job {name!r} missing 'interval'")
+        try:
+            interval = parse_interval(entry["interval"])
+        except ValueError as e:
+            raise ValueError(f"{p}: job {name!r}: {e}") from None
+        command = entry.get("command")
+        if not isinstance(command, str) or not command.strip():
+            raise ValueError(f"{p}: job {name!r} missing 'command'")
+        command_expanded = expand_vars(command, env)
+        timeout = entry.get("timeout", 600)
+        try:
+            timeout_seconds = parse_interval(timeout)
+        except ValueError as e:
+            raise ValueError(f"{p}: job {name!r} timeout: {e}") from None
+        disabled = bool(entry.get("disabled", False))
+        jobs.append(
+            Job(
+                name=name,
+                interval_seconds=interval,
+                command=command_expanded,
+                timeout_seconds=timeout_seconds,
+                disabled=disabled,
+            )
+        )
+
+    return CronConfig(jobs=jobs, tick_seconds=tick)

--- a/src/scitex_orochi/_cron/_daemon.py
+++ b/src/scitex_orochi/_cron/_daemon.py
@@ -1,0 +1,396 @@
+"""Orochi unified cron daemon — the scheduling core.
+
+Design in one paragraph
+-----------------------
+Single Python process. One main thread sleeps for ``tick_seconds``,
+wakes up, and for every job whose ``next_run_at`` has passed spawns a
+subprocess in a worker thread. Each worker captures exit + stdout/stderr
+tails, updates the shared ``CronState`` under a lock, and writes the
+state file + appends an NDJSON log line. Run-in-progress jobs skip the
+next tick (``skipped: "prev_still_running"``) rather than queueing —
+this is cron semantics, not a job queue. SIGHUP re-reads ``cron.yaml``.
+SIGTERM / SIGINT drain in-flight workers up to a short grace and then
+exit. No external deps beyond stdlib + pyyaml (already in
+``pyproject.toml``).
+
+Why not ``schedule`` / ``APScheduler``?
+Neither is in our dep set; ``threading.Timer`` + monotonic comparisons
+is ~100 lines and avoids carrying a scheduler dep into the hub
+container. The job count here is small (4-6 jobs) so sophistication
+doesn't earn its keep.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import signal
+import subprocess
+import threading
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+from scitex_orochi._cron._config import (
+    CronConfig,
+    Job,
+    default_log_dir,
+    default_pid_path,
+    default_state_path,
+    load_config,
+)
+from scitex_orochi._cron._state import (
+    CronState,
+    JobRun,
+    JobState,
+    state_write,
+)
+
+logger = logging.getLogger("orochi.cron")
+
+_STDOUT_TAIL_BYTES = 2048
+_STDERR_TAIL_BYTES = 2048
+
+
+class CronDaemon:
+    """Long-running scheduler. Run via ``daemon.run()``."""
+
+    def __init__(
+        self,
+        config_path: Path | None = None,
+        state_path: Path | None = None,
+        pid_path: Path | None = None,
+        log_dir: Path | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        self.config_path = config_path
+        self.state_path = state_path or default_state_path()
+        self.pid_path = pid_path or default_pid_path()
+        self.log_dir = log_dir or default_log_dir()
+        self.dry_run = dry_run
+
+        self._config: CronConfig | None = None
+        self._stop_event = threading.Event()
+        self._reload_event = threading.Event()
+        self._state_lock = threading.Lock()
+        self._state = CronState(
+            daemon_pid=os.getpid(),
+            daemon_started_at=time.time(),
+        )
+        # Track in-flight worker threads so we can drain on shutdown
+        # and so concurrent-run-guard knows a previous tick's child is
+        # still alive.
+        self._workers: dict[str, threading.Thread] = {}
+        self._workers_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Config handling
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """(Re-)read cron.yaml and rebuild the state skeleton.
+
+        Preserves each job's ``last_run`` record so operators see
+        history across reloads. New jobs start with empty history.
+        Removed jobs are dropped — their state file entry disappears
+        so ``cron list`` doesn't show stale rows.
+        """
+        self._config = load_config(self.config_path)
+        now = time.time()
+        # Stagger initial runs so we don't fire everything at startup.
+        # Each job gets scheduled at now + min(1s, its interval) — small
+        # enough to feel immediate but large enough that a 0-interval
+        # misconfig can't runaway (parse_interval already rejects <=0).
+        with self._state_lock:
+            existing = {j.name: j for j in self._state.jobs}
+            new_states: list[JobState] = []
+            for job in self._config.jobs:
+                prev = existing.get(job.name)
+                js = JobState(
+                    name=job.name,
+                    interval_seconds=job.interval_seconds,
+                    command=job.command,
+                    timeout_seconds=job.timeout_seconds,
+                    disabled=job.disabled,
+                    next_run_at=(prev.next_run_at if prev else now + 1.0),
+                    running=(prev.running if prev else False),
+                    last_run=(prev.last_run if prev else JobRun()),
+                )
+                new_states.append(js)
+            self._state.jobs = new_states
+        self._persist_state()
+        logger.info(
+            "cron: loaded %d job(s) from %s",
+            len(self._config.jobs),
+            self.config_path or "<default>",
+        )
+
+    def _persist_state(self) -> None:
+        with self._state_lock:
+            state_write(self._state, self.state_path)
+
+    # ------------------------------------------------------------------
+    # PID file
+    # ------------------------------------------------------------------
+
+    def _write_pid(self) -> None:
+        self.pid_path.parent.mkdir(parents=True, exist_ok=True)
+        self.pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+    def _remove_pid(self) -> None:
+        try:
+            current = self.pid_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return
+        if current == str(os.getpid()):
+            try:
+                self.pid_path.unlink()
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------
+    # Scheduling loop
+    # ------------------------------------------------------------------
+
+    def run(self) -> int:
+        """Enter the scheduling loop. Blocks until SIGTERM/SIGINT."""
+        self.load()
+        self._write_pid()
+        self._install_signal_handlers()
+        logger.info("cron: daemon started (pid=%d)", os.getpid())
+        try:
+            while not self._stop_event.is_set():
+                if self._reload_event.is_set():
+                    self._reload_event.clear()
+                    try:
+                        self.load()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.error("cron: reload failed — %s", exc)
+                self._tick()
+                tick = (self._config.tick_seconds if self._config else 10)
+                self._stop_event.wait(timeout=tick)
+        finally:
+            self._drain_workers()
+            self._remove_pid()
+            logger.info("cron: daemon exited")
+        return 0
+
+    def _tick(self) -> None:
+        """Fire every job whose ``next_run_at`` has passed."""
+        now = time.time()
+        with self._state_lock:
+            due: list[JobState] = [
+                js for js in self._state.jobs if js.next_run_at <= now and not js.disabled
+            ]
+        for js in due:
+            self._dispatch(js, now)
+
+    def _dispatch(self, js: JobState, now: float) -> None:
+        """Start a worker thread for ``js`` unless a previous run is still alive.
+
+        Concurrent-run-guard: if a worker for this job is still in
+        ``_workers`` and alive, record a skip and move the next-run
+        time forward by one interval. This is the cron semantic —
+        never stack duplicate runs of the same job.
+        """
+        with self._workers_lock:
+            prev = self._workers.get(js.name)
+            if prev is not None and prev.is_alive():
+                with self._state_lock:
+                    js.last_run = JobRun(
+                        started_at=now,
+                        ended_at=now,
+                        duration_seconds=0.0,
+                        exit_code=None,
+                        skipped="prev_still_running",
+                        stdout_tail="",
+                        stderr_tail="",
+                    )
+                    # Don't wait forever — reschedule for the next
+                    # cadence so the next probe still happens on time.
+                    js.next_run_at = now + js.interval_seconds
+                self._persist_state()
+                self._log_run(js.name, asdict(js.last_run))
+                return
+            thread = threading.Thread(
+                target=self._run_job,
+                name=f"cron-{js.name}",
+                args=(js.name,),
+                daemon=True,
+            )
+            self._workers[js.name] = thread
+            thread.start()
+
+    def _lookup(self, name: str) -> tuple[Job, JobState] | None:
+        if self._config is None:
+            return None
+        for j in self._config.jobs:
+            if j.name == name:
+                with self._state_lock:
+                    for js in self._state.jobs:
+                        if js.name == name:
+                            return (j, js)
+        return None
+
+    def _run_job(self, name: str) -> None:
+        """Worker-thread entry — executes one job and records the outcome."""
+        lookup = self._lookup(name)
+        if lookup is None:
+            logger.warning("cron: job %s vanished during dispatch", name)
+            return
+        job, js = lookup
+        start = time.time()
+        with self._state_lock:
+            js.running = True
+        self._persist_state()
+
+        run = JobRun(started_at=start)
+        try:
+            if self.dry_run:
+                logger.info("cron[dry-run]: would run %s -> %s", name, job.command)
+                run.exit_code = 0
+                run.stdout_tail = f"[dry-run] {job.command}"
+            else:
+                run = self._execute(job, start)
+        except Exception as exc:  # noqa: BLE001
+            # An internal scheduling error is distinct from the job
+            # itself failing — record it as exit_code=None + skipped=
+            # "internal_error:<msg>" so operators can tell them apart.
+            run.ended_at = time.time()
+            run.duration_seconds = run.ended_at - start
+            run.exit_code = None
+            run.skipped = f"internal_error:{exc}"
+        finally:
+            with self._state_lock:
+                js.running = False
+                js.last_run = run
+                js.next_run_at = max(start + js.interval_seconds, time.time() + 1.0)
+            self._persist_state()
+            self._log_run(name, asdict(run))
+            with self._workers_lock:
+                # Only clear the slot if it's still us — a later dispatch
+                # may have already replaced it (shouldn't happen with
+                # the run-guard, but defensive).
+                current = self._workers.get(name)
+                if current is threading.current_thread():
+                    self._workers.pop(name, None)
+
+    def _execute(self, job: Job, start: float) -> JobRun:
+        """Actually fork + run the command. Returns a populated ``JobRun``."""
+        # Use shell=False with shlex.split so simple commands don't need a
+        # shell, but fall back to shell=True when shlex fails (complex
+        # pipelines, redirects). Operators who write pipelines knowingly
+        # opt into the shell; simple commands stay safer.
+        try:
+            argv = shlex.split(job.command)
+            shell = False
+        except ValueError:
+            argv = job.command
+            shell = True
+        try:
+            proc = subprocess.run(
+                argv,
+                shell=shell,
+                capture_output=True,
+                text=True,
+                timeout=job.timeout_seconds,
+                env=os.environ.copy(),
+            )
+            exit_code = proc.returncode
+            stdout = proc.stdout or ""
+            stderr = proc.stderr or ""
+            skipped = ""
+        except subprocess.TimeoutExpired as exc:
+            exit_code = None
+            stdout = (exc.stdout or b"") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+            stderr = (exc.stderr or b"") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode("utf-8", errors="replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode("utf-8", errors="replace")
+            skipped = f"timeout_after_{job.timeout_seconds}s"
+        except FileNotFoundError as exc:
+            exit_code = 127
+            stdout = ""
+            stderr = f"command not found: {exc}"
+            skipped = ""
+        end = time.time()
+        return JobRun(
+            started_at=start,
+            ended_at=end,
+            duration_seconds=end - start,
+            exit_code=exit_code,
+            skipped=skipped,
+            stdout_tail=stdout[-_STDOUT_TAIL_BYTES:],
+            stderr_tail=stderr[-_STDERR_TAIL_BYTES:],
+        )
+
+    def _log_run(self, name: str, record: dict) -> None:
+        """Append one NDJSON line to the per-job log."""
+        try:
+            self.log_dir.mkdir(parents=True, exist_ok=True)
+            log_path = self.log_dir / f"{name}.ndjson"
+            payload = {"job": name, **record}
+            with log_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(payload, default=str) + "\n")
+        except OSError as exc:
+            logger.warning("cron: failed to write log for %s: %s", name, exc)
+
+    # ------------------------------------------------------------------
+    # One-shot runner (used by `cron run <name>`)
+    # ------------------------------------------------------------------
+
+    def run_once(self, name: str) -> JobRun:
+        """Execute a single job synchronously and return its ``JobRun``.
+
+        Used by the CLI's ``cron run <name>``. Doesn't go through the
+        scheduling loop so it works even if the daemon isn't running
+        (operators can test a command change before reload).
+        """
+        if self._config is None:
+            self._config = load_config(self.config_path)
+        job = next((j for j in self._config.jobs if j.name == name), None)
+        if job is None:
+            raise KeyError(f"no such job: {name}")
+        start = time.time()
+        if self.dry_run:
+            return JobRun(
+                started_at=start,
+                ended_at=start,
+                duration_seconds=0.0,
+                exit_code=0,
+                skipped="",
+                stdout_tail=f"[dry-run] {job.command}",
+                stderr_tail="",
+            )
+        return self._execute(job, start)
+
+    # ------------------------------------------------------------------
+    # Signals + shutdown
+    # ------------------------------------------------------------------
+
+    def _install_signal_handlers(self) -> None:
+        signal.signal(signal.SIGTERM, self._handle_stop)
+        signal.signal(signal.SIGINT, self._handle_stop)
+        if hasattr(signal, "SIGHUP"):
+            signal.signal(signal.SIGHUP, self._handle_reload)
+
+    def _handle_stop(self, *_args) -> None:
+        logger.info("cron: stop signal received")
+        self._stop_event.set()
+
+    def _handle_reload(self, *_args) -> None:
+        logger.info("cron: reload signal received")
+        self._reload_event.set()
+
+    def _drain_workers(self, grace_seconds: float = 5.0) -> None:
+        """Wait briefly for workers; they're daemon threads so the process
+        can exit even if a command is mid-flight."""
+        deadline = time.time() + grace_seconds
+        with self._workers_lock:
+            threads = list(self._workers.values())
+        for t in threads:
+            remaining = max(0.0, deadline - time.time())
+            t.join(timeout=remaining)

--- a/src/scitex_orochi/_cron/_state.py
+++ b/src/scitex_orochi/_cron/_state.py
@@ -1,0 +1,223 @@
+"""Shared state file for the cron daemon.
+
+The daemon writes one JSON document capturing the last run result for
+each job, the next due time, and whether a run is currently in flight.
+
+Everyone else (``scitex-orochi cron list``, ``cron status``, the
+heartbeat pusher) reads this file rather than querying the daemon
+directly. A file-based contract keeps the design stdlib-only (no
+control socket, no IPC) and also means ``cron list`` works even if the
+daemon crashed — the last known state is still on disk.
+
+Concurrency: writes go through a best-effort POSIX lock on the file
+itself (``fcntl.flock`` on POSIX; no-op fallback on Windows since
+Orochi heads are all POSIX anyway). Readers tolerate a partially-written
+file by retrying once.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterator
+
+try:
+    import fcntl  # POSIX only
+
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover — Windows fallback
+    _HAS_FCNTL = False
+
+
+@dataclass
+class JobRun:
+    """Outcome of one subprocess run for a given job.
+
+    ``stdout_tail`` / ``stderr_tail`` cap at 2048 bytes each so a noisy
+    job can't blow up the shared state file. Full output lives in the
+    per-job NDJSON log.
+    """
+
+    started_at: float = 0.0
+    ended_at: float = 0.0
+    duration_seconds: float = 0.0
+    exit_code: int | None = None
+    skipped: str = ""  # e.g. "prev_still_running" | "disabled" | ""
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+
+
+@dataclass
+class JobState:
+    """Per-job runtime state surfaced by ``cron list``."""
+
+    name: str
+    interval_seconds: int
+    command: str
+    timeout_seconds: int
+    disabled: bool
+    next_run_at: float = 0.0
+    running: bool = False
+    last_run: JobRun = field(default_factory=JobRun)
+
+
+@dataclass
+class CronState:
+    """Snapshot of the whole daemon.
+
+    ``daemon_pid`` is informational — if the daemon crashed, the PID
+    may be stale. ``cron status`` pairs it with ``os.kill(pid, 0)`` to
+    distinguish "running" from "leftover PID file".
+    """
+
+    daemon_pid: int = 0
+    daemon_started_at: float = 0.0
+    updated_at: float = 0.0
+    jobs: list[JobState] = field(default_factory=list)
+
+
+# ----------------------------------------------------------------------
+# File I/O
+# ----------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _file_lock(path: Path, mode: str) -> Iterator[Any]:
+    """Open + lock a file for read or write. No-op on non-POSIX."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, mode) as fh:
+        if _HAS_FCNTL:
+            lock_op = fcntl.LOCK_EX if "w" in mode or "a" in mode else fcntl.LOCK_SH
+            try:
+                fcntl.flock(fh.fileno(), lock_op)
+            except OSError:
+                # Lock contention on read is fine — we'll retry at the
+                # caller layer if JSON parse fails.
+                pass
+        try:
+            yield fh
+        finally:
+            if _HAS_FCNTL:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def state_write(state: CronState, path: Path) -> None:
+    """Atomically persist a ``CronState`` to disk.
+
+    Write-temp-then-rename so a ``cron list`` that happens mid-write
+    never sees a truncated file.
+    """
+    state.updated_at = time.time()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(asdict(state), indent=2, sort_keys=False)
+    # Temp file in the same directory so os.replace() is atomic.
+    fd, tmp_path_str = tempfile.mkstemp(
+        prefix=".state-", suffix=".json", dir=str(path.parent)
+    )
+    tmp_path = Path(tmp_path_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+            fh.flush()
+            with contextlib.suppress(OSError):
+                os.fsync(fh.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink()
+        raise
+
+
+def state_read(path: Path) -> CronState | None:
+    """Read and parse the state file. Returns ``None`` if absent.
+
+    Tolerates one partial-write glitch by retrying once after a 50ms
+    pause — tight-loop readers (e.g. ``cron list --watch``) don't need
+    a more elaborate backoff.
+    """
+    if not path.is_file():
+        return None
+    for attempt in range(2):
+        try:
+            with _file_lock(path, "r") as fh:
+                raw = fh.read()
+            data = json.loads(raw)
+            return _state_from_dict(data)
+        except (json.JSONDecodeError, ValueError):
+            if attempt == 0:
+                time.sleep(0.05)
+                continue
+            return None
+    return None
+
+
+def _state_from_dict(data: dict[str, Any]) -> CronState:
+    jobs = []
+    for j in data.get("jobs", []) or []:
+        last_run_raw = j.get("last_run", {}) or {}
+        jobs.append(
+            JobState(
+                name=j.get("name", ""),
+                interval_seconds=int(j.get("interval_seconds", 0) or 0),
+                command=j.get("command", ""),
+                timeout_seconds=int(j.get("timeout_seconds", 0) or 0),
+                disabled=bool(j.get("disabled", False)),
+                next_run_at=float(j.get("next_run_at", 0) or 0),
+                running=bool(j.get("running", False)),
+                last_run=JobRun(
+                    started_at=float(last_run_raw.get("started_at", 0) or 0),
+                    ended_at=float(last_run_raw.get("ended_at", 0) or 0),
+                    duration_seconds=float(
+                        last_run_raw.get("duration_seconds", 0) or 0
+                    ),
+                    exit_code=last_run_raw.get("exit_code"),
+                    skipped=last_run_raw.get("skipped", "") or "",
+                    stdout_tail=last_run_raw.get("stdout_tail", "") or "",
+                    stderr_tail=last_run_raw.get("stderr_tail", "") or "",
+                ),
+            )
+        )
+    return CronState(
+        daemon_pid=int(data.get("daemon_pid", 0) or 0),
+        daemon_started_at=float(data.get("daemon_started_at", 0) or 0),
+        updated_at=float(data.get("updated_at", 0) or 0),
+        jobs=jobs,
+    )
+
+
+def render_cron_jobs(state: CronState | None) -> list[dict[str, Any]]:
+    """Normalise state → the array shape surfaced by ``cron list`` and
+    the heartbeat payload. Both callers want the same keys so the UI
+    (Phase 2) has one contract to render.
+
+    Returns ``[]`` if state is unavailable (daemon never started, state
+    file missing/corrupt). Empty list is distinguishable from "daemon
+    running but 0 jobs" because the latter returns an empty jobs array
+    too — by design the UI just says "no jobs".
+    """
+    if state is None:
+        return []
+    out: list[dict[str, Any]] = []
+    for j in state.jobs:
+        out.append(
+            {
+                "name": j.name,
+                "interval": j.interval_seconds,
+                "last_run": j.last_run.ended_at or j.last_run.started_at or None,
+                "last_exit": j.last_run.exit_code,
+                "last_skipped": j.last_run.skipped or None,
+                "last_duration_seconds": j.last_run.duration_seconds or None,
+                "next_run": j.next_run_at or None,
+                "running": j.running,
+                "disabled": j.disabled,
+                "command": j.command,
+                "timeout": j.timeout_seconds,
+            }
+        )
+    return out

--- a/tests/test_cron_cli.py
+++ b/tests/test_cron_cli.py
@@ -1,0 +1,176 @@
+"""Tests for the ``scitex-orochi cron`` CLI group.
+
+Validates each subcommand's behavior via ``click.testing.CliRunner``:
+
+* ``cron list`` reads the state file and prints JSON on ``--json``.
+* ``cron list`` with no state file emits an empty array (JSON) /
+  a friendly text line.
+* ``cron run <name>`` shells out a trivial command + returns its exit.
+* ``cron status`` distinguishes "no pid file" vs "live pid" vs "stale pid".
+* ``cron reload`` errors clearly when the daemon isn't running.
+
+These tests don't actually load or spawn the OS-native unit — they
+exercise the Python surface that the unit is wrapping.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scitex_orochi._cli.commands.cron_cmd import cron
+from scitex_orochi._cron import CronDaemon
+
+
+def _invoke_list(runner: CliRunner, state_path: Path, as_json: bool):
+    # Match how _main.py threads ctx.obj through — use obj= to seed it.
+    args = ["list", "--state", str(state_path)]
+    return runner.invoke(cron, args, obj={"json": as_json})
+
+
+def test_list_no_state_json(tmp_path):
+    runner = CliRunner()
+    result = _invoke_list(runner, tmp_path / "nope.json", as_json=True)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == []
+
+
+def test_list_no_state_text(tmp_path):
+    runner = CliRunner()
+    result = _invoke_list(runner, tmp_path / "nope.json", as_json=False)
+    assert result.exit_code == 0
+    assert "no jobs registered" in result.output
+
+
+def test_list_with_state(tmp_path):
+    # Populate state by loading a daemon against a small yaml.
+    cfg = tmp_path / "cron.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            jobs:
+              - name: a
+                interval: 1m
+                command: "/bin/true"
+              - name: b
+                interval: 2m
+                command: "/bin/true"
+            """
+        )
+    )
+    state_path = tmp_path / "state.json"
+    d = CronDaemon(config_path=cfg, state_path=state_path, pid_path=tmp_path / "p", log_dir=tmp_path / "l")
+    d.load()
+
+    runner = CliRunner()
+    result = _invoke_list(runner, state_path, as_json=True)
+    assert result.exit_code == 0, result.output
+    rows = json.loads(result.output)
+    assert {r["name"] for r in rows} == {"a", "b"}
+    assert rows[0]["interval"] in (60, 120)
+
+
+def test_run_happy(tmp_path):
+    cfg = tmp_path / "cron.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            jobs:
+              - name: ping
+                interval: 5m
+                command: "/bin/echo hello"
+            """
+        )
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cron, ["run", "ping", "--config", str(cfg)], obj={"json": True}
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["exit_code"] == 0
+    assert "hello" in payload["stdout_tail"]
+
+
+def test_run_unknown_job(tmp_path):
+    cfg = tmp_path / "cron.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            jobs:
+              - name: ping
+                interval: 5m
+                command: "/bin/echo hello"
+            """
+        )
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cron, ["run", "missing", "--config", str(cfg)], obj={"json": True}
+    )
+    assert result.exit_code != 0
+
+
+def test_status_no_pid(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(
+        cron,
+        [
+            "status",
+            "--pid",
+            str(tmp_path / "nope.pid"),
+            "--state",
+            str(tmp_path / "nope.json"),
+        ],
+        obj={"json": True},
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["daemon_pid"] == 0
+    assert payload["daemon_running"] is False
+
+
+def test_status_alive_pid(tmp_path):
+    # Use our own PID — guaranteed alive for the duration of the test.
+    pid_path = tmp_path / "daemon.pid"
+    pid_path.write_text(str(os.getpid()))
+    runner = CliRunner()
+    result = runner.invoke(
+        cron,
+        ["status", "--pid", str(pid_path), "--state", str(tmp_path / "nope.json")],
+        obj={"json": True},
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["daemon_pid"] == os.getpid()
+    assert payload["daemon_running"] is True
+
+
+def test_status_stale_pid(tmp_path):
+    # Pick a PID far outside the kernel's typical range so os.kill(p, 0)
+    # reliably returns ProcessLookupError. If the chosen PID happens to
+    # be live on this CI host we fall back to an also-unlikely-live PID.
+    pid_path = tmp_path / "daemon.pid"
+    # 99999999 is > max_pid on all reasonable kernels (default 2^22).
+    pid_path.write_text("99999999")
+    runner = CliRunner()
+    result = runner.invoke(
+        cron,
+        ["status", "--pid", str(pid_path), "--state", str(tmp_path / "nope.json")],
+        obj={"json": True},
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["daemon_pid"] == 99999999
+    assert payload["daemon_running"] is False
+
+
+def test_reload_not_running(tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(cron, ["reload", "--pid", str(tmp_path / "nope.pid")])
+    assert result.exit_code != 0
+    assert "not running" in result.output

--- a/tests/test_cron_config.py
+++ b/tests/test_cron_config.py
@@ -1,0 +1,166 @@
+"""Unit tests for ``scitex_orochi._cron._config``.
+
+Covers the YAML loader, interval parsing, and var expansion. These are
+the pieces an operator hits first — a broken config should fail at
+``load_config`` with a clear error, not at job-run time.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scitex_orochi._cron._config import (
+    expand_vars,
+    load_config,
+    parse_interval,
+)
+
+# ----------------------------------------------------------------------
+# parse_interval
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("30s", 30),
+        ("5m", 300),
+        ("1h", 3600),
+        ("1d", 86400),
+        ("10", 10),
+        (10, 10),
+        ("2M", 120),  # case-insensitive
+    ],
+)
+def test_parse_interval_happy(value, expected):
+    assert parse_interval(value) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "abc", "0", 0, -5, "5x", None])
+def test_parse_interval_rejects_bad(bad):
+    with pytest.raises((ValueError, TypeError)):
+        parse_interval(bad)  # type: ignore[arg-type]
+
+
+# ----------------------------------------------------------------------
+# expand_vars
+# ----------------------------------------------------------------------
+
+
+def test_expand_vars_replaces_known():
+    out = expand_vars("bash ${ROOT}/a.sh", {"ROOT": "/tmp/x"})
+    assert out == "bash /tmp/x/a.sh"
+
+
+def test_expand_vars_leaves_unknown_visible():
+    # Typos shouldn't silently become empty strings — otherwise the
+    # wrong command executes quietly.
+    out = expand_vars("bash ${TYPO}/a.sh", {"ROOT": "/tmp/x"})
+    assert out == "bash ${TYPO}/a.sh"
+
+
+# ----------------------------------------------------------------------
+# load_config
+# ----------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    p = tmp_path / "cron.yaml"
+    p.write_text(textwrap.dedent(text))
+    return p
+
+
+def test_load_config_parses_defaults(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        jobs:
+          - name: ping
+            interval: 30s
+            command: "echo hi"
+          - name: slow
+            interval: 1h
+            command: "sleep 1"
+            timeout: 10m
+            disabled: true
+        """,
+    )
+    cfg = load_config(p)
+    assert cfg.tick_seconds == 10  # default
+    assert len(cfg.jobs) == 2
+    a, b = cfg.jobs
+    assert a.name == "ping"
+    assert a.interval_seconds == 30
+    assert a.timeout_seconds == 600  # default
+    assert not a.disabled
+    assert b.interval_seconds == 3600
+    assert b.timeout_seconds == 600
+    assert b.disabled
+
+
+def test_load_config_expands_repo_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCITEX_OROCHI_REPO_ROOT", "/opt/scitex")
+    p = _write(
+        tmp_path,
+        """
+        jobs:
+          - name: probe
+            interval: 5m
+            command: "bash ${SCITEX_OROCHI_REPO_ROOT}/a.sh"
+        """,
+    )
+    cfg = load_config(p)
+    assert cfg.jobs[0].command == "bash /opt/scitex/a.sh"
+
+
+def test_load_config_rejects_duplicate_names(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        jobs:
+          - name: dup
+            interval: 1m
+            command: "echo a"
+          - name: dup
+            interval: 1m
+            command: "echo b"
+        """,
+    )
+    with pytest.raises(ValueError, match="duplicate job name"):
+        load_config(p)
+
+
+def test_load_config_missing_file(tmp_path):
+    missing = tmp_path / "nope.yaml"
+    with pytest.raises(FileNotFoundError):
+        load_config(missing)
+
+
+def test_load_config_rejects_missing_command(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        jobs:
+          - name: bad
+            interval: 1m
+        """,
+    )
+    with pytest.raises(ValueError, match="missing 'command'"):
+        load_config(p)
+
+
+def test_load_config_rejects_bad_interval(tmp_path):
+    p = _write(
+        tmp_path,
+        """
+        jobs:
+          - name: bad
+            interval: "hello"
+            command: "echo"
+        """,
+    )
+    with pytest.raises(ValueError, match="unparseable interval"):
+        load_config(p)

--- a/tests/test_cron_daemon.py
+++ b/tests/test_cron_daemon.py
@@ -1,0 +1,184 @@
+"""End-to-end tests for the Orochi cron daemon.
+
+Runs the real ``CronDaemon`` against a tiny YAML that uses fast (1s)
+intervals + trivial shell commands so the test stays under a second.
+Covers:
+
+* ``run_once`` fires a job synchronously and returns exit + output.
+* ``load`` populates state; failed command records non-zero exit.
+* Concurrent-run-guard: a slow job firing twice within its interval
+  records ``skipped="prev_still_running"``.
+* Timeout: a command that overruns is killed with ``skipped="timeout_after_*"``.
+* State file is readable mid-run.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+from scitex_orochi._cron import CronDaemon, state_read
+from scitex_orochi._cron._daemon import (
+    CronDaemon as _CD,  # noqa: F401 — explicit import
+)
+from scitex_orochi._cron._state import render_cron_jobs
+
+
+def _mk_config(tmp_path: Path, yaml_body: str) -> Path:
+    cfg = tmp_path / "cron.yaml"
+    cfg.write_text(textwrap.dedent(yaml_body))
+    return cfg
+
+
+def _mk_daemon(tmp_path: Path, cfg: Path) -> CronDaemon:
+    return CronDaemon(
+        config_path=cfg,
+        state_path=tmp_path / "state.json",
+        pid_path=tmp_path / "daemon.pid",
+        log_dir=tmp_path / "logs",
+    )
+
+
+def test_run_once_echo(tmp_path):
+    cfg = _mk_config(
+        tmp_path,
+        """
+        jobs:
+          - name: ping
+            interval: 5m
+            command: "/bin/echo hello"
+        """,
+    )
+    d = _mk_daemon(tmp_path, cfg)
+    run = d.run_once("ping")
+    assert run.exit_code == 0
+    assert "hello" in run.stdout_tail
+
+
+def test_run_once_unknown_job(tmp_path):
+    cfg = _mk_config(
+        tmp_path,
+        """
+        jobs:
+          - name: ping
+            interval: 5m
+            command: "/bin/true"
+        """,
+    )
+    d = _mk_daemon(tmp_path, cfg)
+    with pytest.raises(KeyError):
+        d.run_once("nope")
+
+
+def test_run_once_dry_run_doesnt_execute(tmp_path):
+    cfg = _mk_config(
+        tmp_path,
+        """
+        jobs:
+          - name: destructive
+            interval: 5m
+            command: "/bin/false"
+        """,
+    )
+    d = CronDaemon(config_path=cfg, dry_run=True)
+    run = d.run_once("destructive")
+    assert run.exit_code == 0
+    assert "dry-run" in run.stdout_tail
+
+
+def test_run_once_captures_nonzero_exit(tmp_path):
+    cfg = _mk_config(
+        tmp_path,
+        """
+        jobs:
+          - name: fail
+            interval: 5m
+            command: "/bin/sh -c 'echo err >&2; exit 3'"
+        """,
+    )
+    d = _mk_daemon(tmp_path, cfg)
+    run = d.run_once("fail")
+    assert run.exit_code == 3
+    assert "err" in run.stderr_tail
+
+
+def test_run_once_timeout(tmp_path):
+    cfg = _mk_config(
+        tmp_path,
+        """
+        jobs:
+          - name: slow
+            interval: 5m
+            timeout: 1s
+            command: "/bin/sh -c 'sleep 5'"
+        """,
+    )
+    d = _mk_daemon(tmp_path, cfg)
+    run = d.run_once("slow")
+    assert run.skipped.startswith("timeout_after_")
+
+
+def test_load_populates_state_file(tmp_path):
+    cfg = _mk_config(
+        tmp_path,
+        """
+        jobs:
+          - name: a
+            interval: 1m
+            command: "/bin/true"
+          - name: b
+            interval: 2m
+            command: "/bin/true"
+            disabled: true
+        """,
+    )
+    d = _mk_daemon(tmp_path, cfg)
+    d.load()
+    state = state_read(tmp_path / "state.json")
+    assert state is not None
+    assert len(state.jobs) == 2
+    rendered = render_cron_jobs(state)
+    names = {j["name"] for j in rendered}
+    assert names == {"a", "b"}
+    disabled_flags = {j["name"]: j["disabled"] for j in rendered}
+    assert disabled_flags == {"a": False, "b": True}
+
+
+def test_concurrent_run_guard_skips_overlap(tmp_path):
+    """A second dispatch while the first is still running must be
+    recorded as skipped, not queued.
+
+    We trigger this by calling ``_dispatch`` twice back-to-back on a
+    slow job; the worker-thread slot for the second call should detect
+    the first is still alive and return without spawning.
+    """
+    cfg = _mk_config(
+        tmp_path,
+        """
+        jobs:
+          - name: slow
+            interval: 1m
+            command: "/bin/sh -c 'sleep 1'"
+        """,
+    )
+    d = _mk_daemon(tmp_path, cfg)
+    d.load()
+    js = d._state.jobs[0]  # type: ignore[attr-defined]
+    now = time.time()
+    d._dispatch(js, now)  # type: ignore[attr-defined]
+    # Second dispatch must hit the run-guard. Small sleep to ensure the
+    # worker thread has actually started.
+    time.sleep(0.05)
+    d._dispatch(js, now)  # type: ignore[attr-defined]
+    # Inspect state (reload snapshot).
+    state = state_read(tmp_path / "state.json")
+    assert state is not None
+    row = next(j for j in state.jobs if j.name == "slow")
+    assert row.last_run.skipped == "prev_still_running"
+    # Drain the still-running first worker so pytest teardown doesn't
+    # hang on a lingering thread (CronDaemon workers are daemon=True,
+    # but explicit join keeps logs clean).
+    d._drain_workers(grace_seconds=3.0)  # type: ignore[attr-defined]

--- a/tests/test_cron_heartbeat.py
+++ b/tests/test_cron_heartbeat.py
@@ -1,0 +1,61 @@
+"""Verify ``heartbeat-push`` surfaces ``cron_jobs`` in the outgoing payload.
+
+Phase 2 will wire the Machines tab UI panel directly off
+``/api/agents/register/`` body's ``cron_jobs`` field, so Phase 1 needs
+to guarantee that field is populated from the cron daemon's state
+file whenever the daemon is running — and is an empty list otherwise
+(no crash, no NPE).
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from scitex_orochi._cli.commands.heartbeat_cmd import _wrap_with_orochi_fields
+from scitex_orochi._cron import CronDaemon
+
+
+def test_cron_jobs_empty_when_no_state(monkeypatch, tmp_path):
+    # Point the cron module at an empty state path so the helper
+    # degrades gracefully.
+    from scitex_orochi import _cron
+
+    monkeypatch.setattr(
+        _cron, "default_state_path", lambda: tmp_path / "missing.json"
+    )
+    body = _wrap_with_orochi_fields({"name": "head-test"}, token="t", channels=None)
+    assert body["cron_jobs"] == []
+
+
+def test_cron_jobs_populated(monkeypatch, tmp_path):
+    cfg = tmp_path / "cron.yaml"
+    cfg.write_text(
+        textwrap.dedent(
+            """
+            jobs:
+              - name: ping
+                interval: 5m
+                command: "/bin/true"
+            """
+        )
+    )
+    state_path = tmp_path / "state.json"
+    d = CronDaemon(
+        config_path=cfg,
+        state_path=state_path,
+        pid_path=tmp_path / "pid",
+        log_dir=tmp_path / "logs",
+    )
+    d.load()
+
+    from scitex_orochi import _cron
+
+    monkeypatch.setattr(_cron, "default_state_path", lambda: state_path)
+
+    body = _wrap_with_orochi_fields({"name": "head-test"}, token="t", channels=None)
+    assert isinstance(body["cron_jobs"], list)
+    assert len(body["cron_jobs"]) == 1
+    row = body["cron_jobs"][0]
+    assert row["name"] == "ping"
+    assert row["interval"] == 300
+    assert row["disabled"] is False


### PR DESCRIPTION
## Summary

Replaces the scattered per-host scheduler entries (five `com.scitex.*` launchd plists / systemd timers / crontab lines) with **one unified `orochi-cron` Python daemon per host**, driven by a declarative YAML schedule at `~/.scitex/orochi/cron.yaml`. Plus a `scitex-orochi cron {start|stop|list|run|status|reload}` CLI. Phase 1 per ywatanabe msg#16406 / msg#16410 and lead msg#16408.

- **Daemon** `scripts/server/orochi-cron.py` — stdlib-only (`threading` + monotonic), no new pip deps. Per-job run-guard (`skipped: prev_still_running`), per-job timeout (default 600s), SIGHUP reload, `--dry-run`, NDJSON per-job logs, JSON state file.
- **Installer** `scripts/client/install-orochi-cron.sh` — idempotent macOS LaunchAgent / Linux systemd user-unit install; auto-migrates the five legacy units to `~/.scitex/orochi/cron-migrated-units/` with a rollback README; seeds `cron.yaml` from the example without clobbering an operator copy.
- **CLI** `scitex-orochi cron {start, stop, list, run, status, reload}` honouring the parent `--json` flag for machine-readable output.
- **Heartbeat extension** — `heartbeat-push` now surfaces `cron_jobs` in the outgoing `/api/agents/register/` body so Phase 2's Machines tab UI panel reads directly from the heartbeat (no new endpoint needed).

## Scheduler approach

Plain `threading` loop: main thread sleeps `tick_seconds` (default 10), wakes, and for every job whose `next_run_at` has passed spawns a worker thread that runs the subprocess and atomically updates a shared `CronState`. Avoids adding `schedule` / `APScheduler` as a dep for a small (~4-6 jobs) scheduler. Per-job concurrent-run-guard is enforced by checking the in-flight worker thread; no task queue, matches cron semantics.

## Migration path

Single command: `scripts/client/install-orochi-cron.sh` unloads each legacy unit and moves it to `~/.scitex/orochi/cron-migrated-units/` (with a rollback README) before loading the unified one. `--no-migrate` skips this for staged rollouts. Rollback = `mv` + `launchctl load` (or `systemctl --user enable`). The old `install-*.sh` scripts stay in place as Phase-1 fallback — deletion is a separate PR after burn-in.

## Out of scope (Phase 2)

- Machines tab UI panel rendering `cron_jobs`.
- Hub-side `/api/hosts/<host>/cron-status` (data is already in `heartbeat.payload.cron_jobs` post-Phase 1).
- Retiring the per-job `install-*.sh` scripts.
- mgr-todo pivot for auto-dispatch selection.

## Test plan

- [x] Unit tests for YAML loader, interval parser, var expansion, error paths (`tests/test_cron_config.py`, 22 cases).
- [x] Integration tests for the daemon: `run_once`, non-zero exit capture, timeout, state population, concurrent-run-guard (`tests/test_cron_daemon.py`, 7 cases).
- [x] CLI tests via `CliRunner` for `list`, `run`, `status` (no-pid / live-pid / stale-pid), `reload` (`tests/test_cron_cli.py`, 9 cases).
- [x] Heartbeat tests confirming `cron_jobs` lands in the pushed body when state exists, empty list + no crash otherwise (`tests/test_cron_heartbeat.py`, 2 cases).
- [x] Full suite green: **226 passed, 1 xfailed** (pre-existing).
- [x] Ruff clean on all new files.
- [x] End-to-end smoke: ran `scripts/server/orochi-cron.py` against a 1s-tick YAML on macOS, confirmed NDJSON per-job logs + state file populate; `cron list --json` renders the state.
- [x] `install-orochi-cron.sh --dry-run` exercised; migrates the five legacy labels correctly.
- [ ] Burn-in on mba + one Linux head before deleting legacy `install-*.sh` (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
