### PR TITLE
feat(cli): add machine resources / todo / dispatch subcommands + convention doc (Phase 1c, msg#16477)

### DIFF
--- a/hub/tests/views/api/test_auto_dispatch_api.py
+++ b/hub/tests/views/api/test_auto_dispatch_api.py
@@ -1,0 +1,252 @@
+"""Tests for ``/api/auto-dispatch/{fire,status}/`` (Phase 1c msg#16477)."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest import mock
+
+from django.test import Client, TestCase, override_settings
+
+from hub import auto_dispatch as ad
+from hub.models import Workspace, WorkspaceToken
+from hub.registry import _agents, _connections, _lock
+
+_INMEM_CHANNELS = {
+    "default": {
+        "BACKEND": "channels.layers.InMemoryChannelLayer",
+    },
+}
+
+
+@override_settings(CHANNEL_LAYERS=_INMEM_CHANNELS)
+class AutoDispatchStatusTest(TestCase):
+    """``GET /api/auto-dispatch/status/``."""
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="ad-status-ws")
+        self.tok = WorkspaceToken.objects.create(
+            workspace=self.ws, token="wks_statustok"
+        )
+        with _lock:
+            _agents.clear()
+            _connections.clear()
+
+    def tearDown(self):
+        with _lock:
+            _agents.clear()
+            _connections.clear()
+
+    # ---- Auth ----------------------------------------------------------
+
+    def test_missing_token_returns_401(self):
+        resp = self.client.get("/api/auto-dispatch/status/")
+        self.assertEqual(resp.status_code, 401)
+        body = json.loads(resp.content)
+        self.assertIn("token", body["error"])
+
+    def test_invalid_token_returns_401(self):
+        resp = self.client.get("/api/auto-dispatch/status/?token=nope")
+        self.assertEqual(resp.status_code, 401)
+
+    # ---- Body ----------------------------------------------------------
+
+    def test_empty_registry_returns_empty_array(self):
+        resp = self.client.get(
+            f"/api/auto-dispatch/status/?token={self.tok.token}"
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(json.loads(resp.content), [])
+
+    def test_surfaces_idle_streak_and_cooldown(self):
+        now = time.time()
+        with _lock:
+            _agents["head-mba"] = {
+                "name": "head-mba",
+                "workspace_id": self.ws.id,
+                "subagent_count": 0,
+                "idle_streak": 1,
+                "auto_dispatch_last_fire_ts": now - 100,  # 100s ago
+            }
+            _agents["head-nas"] = {
+                "name": "head-nas",
+                "workspace_id": self.ws.id,
+                "subagent_count": 2,
+                "idle_streak": 0,
+                "auto_dispatch_last_fire_ts": None,
+            }
+
+        resp = self.client.get(
+            f"/api/auto-dispatch/status/?token={self.tok.token}"
+        )
+        self.assertEqual(resp.status_code, 200, resp.content)
+        rows = json.loads(resp.content)
+        names = {r["agent"] for r in rows}
+        self.assertEqual(names, {"head-mba", "head-nas"})
+        mba = next(r for r in rows if r["agent"] == "head-mba")
+        self.assertEqual(mba["idle_streak"], 1)
+        self.assertTrue(mba["cooldown_active"])
+        self.assertGreater(mba["cooldown_remaining_s"], 0)
+        self.assertEqual(mba["lane"], "infrastructure")
+        nas = next(r for r in rows if r["agent"] == "head-nas")
+        self.assertFalse(nas["cooldown_active"])
+        self.assertIsNone(nas["last_fire_at"])
+
+    def test_non_head_agents_excluded(self):
+        with _lock:
+            _agents["worker-foo"] = {
+                "name": "worker-foo",
+                "workspace_id": self.ws.id,
+                "subagent_count": 0,
+            }
+            _agents["healer-mba"] = {
+                "name": "healer-mba",
+                "workspace_id": self.ws.id,
+                "subagent_count": 0,
+            }
+        resp = self.client.get(
+            f"/api/auto-dispatch/status/?token={self.tok.token}"
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(json.loads(resp.content), [])
+
+    def test_other_workspace_agents_filtered_out(self):
+        other_ws = Workspace.objects.create(name="other")
+        with _lock:
+            _agents["head-spartan"] = {
+                "name": "head-spartan",
+                "workspace_id": other_ws.id,  # different workspace
+                "subagent_count": 0,
+            }
+        resp = self.client.get(
+            f"/api/auto-dispatch/status/?token={self.tok.token}"
+        )
+        self.assertEqual(resp.status_code, 200)
+        # head-spartan lives in other_ws, should not leak.
+        self.assertEqual(json.loads(resp.content), [])
+
+
+@override_settings(CHANNEL_LAYERS=_INMEM_CHANNELS)
+class AutoDispatchFireTest(TestCase):
+    """``POST /api/auto-dispatch/fire/``."""
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="ad-fire-ws")
+        self.tok = WorkspaceToken.objects.create(
+            workspace=self.ws, token="wks_firetok"
+        )
+        with _lock:
+            _agents.clear()
+            _connections.clear()
+
+    def tearDown(self):
+        with _lock:
+            _agents.clear()
+            _connections.clear()
+
+    def _post(self, body: dict) -> tuple[int, dict]:
+        resp = self.client.post(
+            "/api/auto-dispatch/fire/",
+            data=json.dumps(body),
+            content_type="application/json",
+        )
+        try:
+            payload = json.loads(resp.content)
+        except (json.JSONDecodeError, ValueError):
+            payload = {}
+        return resp.status_code, payload
+
+    # ---- Auth / validation --------------------------------------------
+
+    def test_missing_token_returns_401(self):
+        code, body = self._post({"head": "mba"})
+        self.assertEqual(code, 401)
+
+    def test_missing_head_returns_400(self):
+        code, body = self._post({"token": self.tok.token})
+        self.assertEqual(code, 400)
+        self.assertIn("head", body["error"])
+
+    def test_agent_not_registered_returns_404(self):
+        code, body = self._post({"token": self.tok.token, "head": "ghost"})
+        self.assertEqual(code, 404)
+
+    # ---- Happy path ----------------------------------------------------
+
+    def test_fire_arms_cooldown_on_success(self):
+        with _lock:
+            _agents["head-mba"] = {
+                "name": "head-mba",
+                "workspace_id": self.ws.id,
+                "subagent_count": 0,
+                "idle_streak": 3,
+                "auto_dispatch_last_fire_ts": None,
+            }
+        with mock.patch.object(
+            ad, "_post_dispatch_message", return_value=999
+        ), mock.patch.object(
+            ad, "_run_pick_todo", return_value=None
+        ):
+            code, body = self._post(
+                {
+                    "token": self.tok.token,
+                    "head": "mba",
+                    "reason": "operator-manual",
+                }
+            )
+        self.assertEqual(code, 200, body)
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["decision"], "fired")
+        self.assertEqual(body["message_id"], 999)
+        with _lock:
+            self.assertEqual(_agents["head-mba"]["idle_streak"], 0)
+            self.assertIsNotNone(
+                _agents["head-mba"]["auto_dispatch_last_fire_ts"]
+            )
+
+    def test_explicit_todo_overrides_pick_helper(self):
+        with _lock:
+            _agents["head-mba"] = {
+                "name": "head-mba",
+                "workspace_id": self.ws.id,
+                "subagent_count": 0,
+            }
+        captured: dict = {}
+
+        def _fake_post(agent_name, workspace_id, text, metadata):
+            captured.update(metadata)
+            return 1234
+
+        with mock.patch.object(
+            ad, "_post_dispatch_message", side_effect=_fake_post
+        ), mock.patch.object(
+            ad,
+            "_run_pick_todo",
+            side_effect=AssertionError("should not be called"),
+        ):
+            code, body = self._post(
+                {
+                    "token": self.tok.token,
+                    "head": "mba",
+                    "todo": 555,
+                    "todo_title": "custom title",
+                }
+            )
+        self.assertEqual(code, 200, body)
+        self.assertEqual(body["pick"]["number"], 555)
+        self.assertEqual(body["pick"]["title"], "custom title")
+        self.assertEqual(captured["todo_number"], 555)
+        self.assertEqual(captured["trigger"], "manual")
+
+    def test_invalid_todo_type_returns_400(self):
+        with _lock:
+            _agents["head-mba"] = {
+                "name": "head-mba",
+                "workspace_id": self.ws.id,
+            }
+        code, body = self._post(
+            {"token": self.tok.token, "head": "mba", "todo": "not-an-int"}
+        )
+        self.assertEqual(code, 400)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -117,6 +117,17 @@ urlpatterns = [
     path("api/agents/pinned/", views.api_agents_pinned, name="api-agents-pinned"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
+    # Auto-dispatch operator triggers + inspection (Phase 1c msg#16477).
+    path(
+        "api/auto-dispatch/fire/",
+        views.api_auto_dispatch_fire,
+        name="api-auto-dispatch-fire",
+    ),
+    path(
+        "api/auto-dispatch/status/",
+        views.api_auto_dispatch_status,
+        name="api-auto-dispatch-status",
+    ),
     # Admin-scoped subscribe/unsubscribe (issue #262 §9.1). Routed to a
     # dedicated view that requires the calling actor to hold the
     # workspace ``admin`` (or ``staff``) role; non-admin agents get a

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -143,6 +143,17 @@ urlpatterns = [
     ),
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/health/", views.api_agent_health, name="api-agent-health"),
+    # Auto-dispatch operator triggers + inspection (Phase 1c msg#16477).
+    path(
+        "api/auto-dispatch/fire/",
+        views.api_auto_dispatch_fire,
+        name="api-auto-dispatch-fire-bare",
+    ),
+    path(
+        "api/auto-dispatch/status/",
+        views.api_auto_dispatch_status,
+        name="api-auto-dispatch-status-bare",
+    ),
     # Per-agent single-screen detail payload (todo#420 MVP).
     path(
         "api/agents/<str:name>/detail/",

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -93,6 +93,17 @@ urlpatterns = [
     path("api/agents/kill/", views.api_agents_kill, name="api-agents-kill"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
+    # Auto-dispatch operator triggers + inspection (Phase 1c msg#16477).
+    path(
+        "api/auto-dispatch/fire/",
+        views.api_auto_dispatch_fire,
+        name="api-auto-dispatch-fire-ws",
+    ),
+    path(
+        "api/auto-dispatch/status/",
+        views.api_auto_dispatch_status,
+        name="api-auto-dispatch-status-ws",
+    ),
     # Admin-scoped subscribe/unsubscribe (issue #262 §9.1) — mounted on
     # the workspace subdomain so dashboard sessions on
     # ``<slug>.scitex-orochi.com`` can call the admin path without an

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -14,6 +14,8 @@ from hub.views.api import (  # noqa: F401
     api_agents_register,
     api_agents_registry,
     api_agents_restart,
+    api_auto_dispatch_fire,
+    api_auto_dispatch_status,
     api_channel_export,
     api_channel_members,
     api_channel_prefs,

--- a/hub/views/api/__init__.py
+++ b/hub/views/api/__init__.py
@@ -24,6 +24,10 @@ from hub.views.api._agents import (
 )
 from hub.views.api._agents_lifecycle import api_agents_kill, api_agents_restart
 from hub.views.api._agents_register import api_agents_register
+from hub.views.api._auto_dispatch import (
+    api_auto_dispatch_fire,
+    api_auto_dispatch_status,
+)
 from hub.views.api._agents_subscribe import (
     api_admin_agent_subscribe,
     api_admin_agent_unsubscribe,
@@ -68,6 +72,8 @@ __all__ = [
     "api_agents_register",
     "api_agents_registry",
     "api_agents_restart",
+    "api_auto_dispatch_fire",
+    "api_auto_dispatch_status",
     "api_channel_export",
     "api_channel_members",
     "api_channel_prefs",

--- a/hub/views/api/_auto_dispatch.py
+++ b/hub/views/api/_auto_dispatch.py
@@ -1,0 +1,280 @@
+"""``/api/auto-dispatch/{fire,status}/`` — operator-facing triggers + inspection.
+
+Companion to ``hub.auto_dispatch.check_agent_auto_dispatch`` (PR #334),
+which runs from the heartbeat hot path. These endpoints expose the
+auto-dispatch state machine to the CLI (``scitex-orochi dispatch
+{run,status}``, Phase 1c msg#16477):
+
+* ``POST /api/auto-dispatch/fire/`` — force an immediate dispatch DM to
+  the named ``head-<host>`` agent, bypassing the streak / cooldown gate.
+  Optional ``todo`` number in the body overrides the pick-helper result.
+  Token-authenticated (workspace token), same auth pattern as
+  ``api_agents_purge``.
+
+* ``GET /api/auto-dispatch/status/`` — surface per-head ``idle_streak``,
+  ``auto_dispatch_last_fire_ts`` (ISO), and derived ``cooldown_active``
+  from the in-memory ``hub.registry`` dict. Read-only. Complements the
+  machine-card resource view so operators can see "why isn't head-X
+  being dispatched?" without tailing logs.
+
+Auth: workspace token (same pattern as ``api_agents``) — the CLI already
+has the token in env, and we don't want to require a browser session for
+a fleet-coordination verb.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+
+from hub.views.api._common import (
+    JsonResponse,
+    csrf_exempt,
+    json,
+    require_GET,
+    require_http_methods,
+)
+
+log = logging.getLogger("orochi.auto_dispatch.api")
+
+
+# ---------------------------------------------------------------------------
+# Token auth helper (inlined for module self-containment)
+# ---------------------------------------------------------------------------
+
+def _resolve_workspace_from_token(request, body: dict | None = None):
+    """Validate a workspace token and return (workspace, error_json_response).
+
+    Accepts token from ?token= querystring OR JSON body.token (for POST).
+    On success returns ``(workspace, None)``; on failure ``(None, JsonResponse)``.
+
+    Unlike the subdomain-aware ``get_workspace``, this resolves the
+    workspace from the token itself so the endpoint works on the bare
+    domain, on workspace subdomains, and in test contexts with
+    ``testserver`` HTTP_HOST.
+    """
+    token = request.GET.get("token")
+    if not token and body and isinstance(body, dict):
+        token = body.get("token")
+    if not token:
+        return None, JsonResponse({"error": "token required"}, status=401)
+    from hub.models import WorkspaceToken
+
+    try:
+        row = WorkspaceToken.objects.get(token=token)
+    except WorkspaceToken.DoesNotExist:
+        return None, JsonResponse({"error": "invalid token"}, status=401)
+    return row.workspace, None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/auto-dispatch/fire/
+# ---------------------------------------------------------------------------
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def api_auto_dispatch_fire(request):
+    """Force an auto-dispatch DM to a ``head-<host>`` agent now.
+
+    Bypasses the streak/cooldown gate that the heartbeat path uses.
+    Useful for operators who want to nudge an idle head without waiting
+    for the next two heartbeats to accumulate a streak, or for testing.
+
+    Request body (JSON)::
+
+        {
+          "token":    "wks_...",     # workspace token (or ?token=)
+          "head":     "<hostname>",  # e.g. "mba" → head-mba
+          "todo":     123,           # optional; override pick-helper result
+          "reason":   "operator-manual"   # optional audit tag
+        }
+
+    Returns::
+
+        {"status":"ok","decision":"fired","message_id":N,"pick":{...}|null}
+
+    or a structured error envelope.
+    """
+    try:
+        body = json.loads(request.body or b"{}")
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "invalid json"}, status=400)
+
+    workspace, err = _resolve_workspace_from_token(request, body)
+    if err is not None:
+        return err
+
+    head = (body.get("head") or "").strip()
+    if not head:
+        return JsonResponse(
+            {"error": "field 'head' is required (e.g. 'mba' → head-mba)"}, status=400
+        )
+    agent_name = head if head.startswith("head-") else f"head-{head}"
+
+    # Use the module's internal helpers so behaviour matches the
+    # heartbeat-path dispatch. Force-fire path: skip streak/cooldown,
+    # call _run_pick_todo + _post_dispatch_message directly.
+    from hub import auto_dispatch as ad
+    from hub.registry import _agents, _lock
+
+    host = ad._head_host_from_name(agent_name)
+    if host is None:
+        return JsonResponse(
+            {"error": f"agent {agent_name} is not a head-* agent"}, status=400
+        )
+    lane = ad.LANE_FOR_HOST.get(host, "")
+
+    override_todo = body.get("todo")
+    pick = None
+    if override_todo is not None:
+        try:
+            pick = {
+                "number": int(override_todo),
+                "title": (body.get("todo_title") or "").strip()
+                or f"manual dispatch of todo#{int(override_todo)}",
+                "labels": [lane] if lane else [],
+                "reason": "operator-override",
+            }
+        except (TypeError, ValueError):
+            return JsonResponse(
+                {"error": "field 'todo' must be an integer"}, status=400
+            )
+    elif lane:
+        pick = ad._run_pick_todo(lane)
+
+    now = time.time()
+    with _lock:
+        agent = _agents.get(agent_name)
+        if agent is None:
+            return JsonResponse(
+                {
+                    "error": f"agent {agent_name} not in registry (not connected?)",
+                    "head": head,
+                },
+                status=404,
+            )
+        workspace_id = agent.get("workspace_id") or workspace.id
+        # Arm cooldown + reset streak so the heartbeat path doesn't
+        # double-fire right after this manual dispatch.
+        agent["auto_dispatch_last_fire_ts"] = now
+        agent["idle_streak"] = 0
+        streak = 0
+
+    streak_for_text = 0  # forced fire — not from a streak
+    cooldown_s = ad._cooldown_seconds()
+    text = ad._compose_dispatch_text(streak_for_text, pick, cooldown_s)
+    metadata = {
+        "kind": "auto-dispatch",
+        "agent": agent_name,
+        "lane": lane,
+        "streak": streak_for_text,
+        "todo_number": (pick or {}).get("number"),
+        "todo_title": (pick or {}).get("title"),
+        "trigger": "manual",
+        "reason": body.get("reason") or "operator-manual",
+    }
+
+    msg_id = ad._post_dispatch_message(
+        agent_name, int(workspace_id), text, metadata
+    )
+    log.info(
+        "auto_dispatch.fire: manual agent=%s lane=%s todo=%s msg=%s",
+        agent_name,
+        lane,
+        (pick or {}).get("number"),
+        msg_id,
+    )
+    return JsonResponse(
+        {
+            "status": "ok",
+            "decision": "fired",
+            "agent": agent_name,
+            "lane": lane,
+            "pick": pick,
+            "message_id": msg_id,
+            "streak": streak,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/auto-dispatch/status/
+# ---------------------------------------------------------------------------
+
+@require_GET
+def api_auto_dispatch_status(request):
+    """Per-head auto-dispatch streak + cooldown state.
+
+    Returns an array with one entry per ``head-*`` agent::
+
+        [
+          {
+            "agent": "head-mba",
+            "host":  "mba",
+            "lane":  "infrastructure",
+            "idle_streak": 0,
+            "subagent_count": 2,
+            "last_fire_ts": null,                   # unix seconds or null
+            "last_fire_at": null,                   # ISO-8601 or null
+            "cooldown_active": false,
+            "cooldown_remaining_s": 0,
+            "streak_threshold": 2,
+            "cooldown_seconds": 900
+          },
+          ...
+        ]
+
+    Read-only — does NOT mutate any state.
+    """
+    workspace, err = _resolve_workspace_from_token(request)
+    if err is not None:
+        return err
+
+    from hub import auto_dispatch as ad
+    from hub.registry import _agents, _lock
+
+    threshold = ad._streak_threshold()
+    cooldown_s = ad._cooldown_seconds()
+    now = time.time()
+
+    rows: list[dict] = []
+    with _lock:
+        for name, a in _agents.items():
+            if a.get("workspace_id") != workspace.id:
+                continue
+            host = ad._head_host_from_name(name)
+            if host is None:
+                continue
+            lane = ad.LANE_FOR_HOST.get(host, "")
+            last_fire = a.get("auto_dispatch_last_fire_ts")
+            last_fire_ts = float(last_fire) if last_fire else None
+            cooldown_active = False
+            cooldown_remaining = 0
+            if last_fire_ts is not None:
+                elapsed = now - last_fire_ts
+                if elapsed < cooldown_s:
+                    cooldown_active = True
+                    cooldown_remaining = int(max(0, cooldown_s - elapsed))
+            last_fire_at = None
+            if last_fire_ts is not None:
+                last_fire_at = datetime.fromtimestamp(
+                    last_fire_ts, tz=timezone.utc
+                ).isoformat()
+            rows.append(
+                {
+                    "agent": name,
+                    "host": host,
+                    "lane": lane,
+                    "idle_streak": int(a.get("idle_streak") or 0),
+                    "subagent_count": int(a.get("subagent_count") or 0),
+                    "last_fire_ts": last_fire_ts,
+                    "last_fire_at": last_fire_at,
+                    "cooldown_active": cooldown_active,
+                    "cooldown_remaining_s": cooldown_remaining,
+                    "streak_threshold": threshold,
+                    "cooldown_seconds": cooldown_s,
+                }
+            )
+    rows.sort(key=lambda r: r["agent"])
+    return JsonResponse(rows, safe=False)

--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -221,6 +221,13 @@ orochi.add_command(hungry_signal)
 orochi.add_command(disk)
 orochi.add_command(chrome_watchdog)
 
+# ── Fleet-coordination verbs (Phase 1c, msg#16477) ───────────
+from scitex_orochi._cli.commands.dispatch_cmd import dispatch as dispatch_group
+from scitex_orochi._cli.commands.todo_cmd import todo as todo_group
+
+orochi.add_command(todo_group)
+orochi.add_command(dispatch_group)
+
 
 def main() -> None:
     try:

--- a/src/scitex_orochi/_cli/commands/dispatch_cmd.py
+++ b/src/scitex_orochi/_cli/commands/dispatch_cmd.py
@@ -1,0 +1,246 @@
+"""``scitex-orochi dispatch {run,status}`` subcommands.
+
+Operator-side complement to the server-side auto-dispatch (PR #334).
+
+* ``dispatch run --head <host> [--todo N]`` — forces an immediate
+  auto-dispatch DM to ``head-<host>`` via the hub's
+  ``POST /api/auto-dispatch/fire/`` endpoint, bypassing the streak /
+  cooldown gate. Optional ``--todo`` overrides the pick-helper result
+  with a specific issue number.
+
+* ``dispatch status`` — GET ``/api/auto-dispatch/status/``: shows per-head
+  ``idle_streak``, ``last_fire_at`` (ISO), ``cooldown_active``, and
+  ``cooldown_remaining_s`` so the operator can see why a head is or
+  isn't being auto-dispatched right now.
+
+Auth: workspace token (env ``SCITEX_OROCHI_TOKEN`` or ``--token``), same
+as every other token-authenticated CLI verb. Hub defaults to
+``https://scitex-orochi.com``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from urllib import request as _urllib_request
+from urllib.error import HTTPError, URLError
+
+import click
+
+from ._host_ops import load_workspace_token
+
+DEFAULT_HUB = "https://scitex-orochi.com"
+
+
+@click.group("dispatch")
+def dispatch() -> None:
+    """Operator-side control of the server-side auto-dispatch (PR #334)."""
+
+
+def _resolve_token(token: str | None) -> str:
+    resolved = token or load_workspace_token()
+    if not resolved:
+        raise click.ClickException(
+            "no SCITEX_OROCHI_TOKEN (env, --token, or dotfiles secret)."
+        )
+    return resolved
+
+
+def _http_json(
+    method: str,
+    url: str,
+    token: str,
+    body: dict | None = None,
+    timeout: int = 15,
+) -> tuple[int, Any]:
+    """Tiny stdlib HTTP-JSON client. Returns (status, parsed_body|text)."""
+    sep = "&" if "?" in url else "?"
+    full_url = f"{url}{sep}token={token}"
+    data = None
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "scitex-orochi-cli/1.0",
+    }
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = _urllib_request.Request(
+        full_url, data=data, headers=headers, method=method
+    )
+    try:
+        with _urllib_request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            code = resp.status
+    except HTTPError as exc:
+        # Try to read the body so the caller sees the server's error.
+        try:
+            err_body = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_body = str(exc)
+        try:
+            return exc.code, json.loads(err_body)
+        except (json.JSONDecodeError, ValueError):
+            return exc.code, err_body
+    except URLError as exc:
+        raise click.ClickException(f"hub unreachable: {exc.reason}") from exc
+    try:
+        return code, json.loads(raw or "null")
+    except json.JSONDecodeError:
+        return code, raw
+
+
+# ---------------------------------------------------------------------------
+# dispatch run
+# ---------------------------------------------------------------------------
+
+@dispatch.command("run")
+@click.option(
+    "--head",
+    required=True,
+    help="Head host label (e.g. 'mba' → head-mba, or 'head-mba' directly).",
+)
+@click.option(
+    "--todo",
+    type=int,
+    default=None,
+    help="Specific issue number to dispatch (else the pick-helper chooses).",
+)
+@click.option(
+    "--reason",
+    default="operator-manual",
+    show_default=True,
+    help="Audit tag stored in the message metadata.",
+)
+@click.option(
+    "--hub",
+    envvar="SCITEX_OROCHI_URL",
+    default=DEFAULT_HUB,
+    show_default=True,
+    help="Hub base URL [$SCITEX_OROCHI_URL].",
+)
+@click.option(
+    "--token",
+    envvar="SCITEX_OROCHI_TOKEN",
+    default=None,
+    help="Workspace token [$SCITEX_OROCHI_TOKEN].",
+)
+@click.pass_context
+def dispatch_run(
+    ctx: click.Context,
+    head: str,
+    todo: int | None,
+    reason: str,
+    hub: str,
+    token: str | None,
+) -> None:
+    """Force an auto-dispatch DM to ``head-<host>`` now.
+
+    Bypasses the heartbeat-path streak/cooldown gate. The head's
+    ``AgentConsumer`` delivers it as a normal chat frame.
+    """
+    resolved = _resolve_token(token)
+    body: dict[str, Any] = {"head": head, "reason": reason}
+    if todo is not None:
+        body["todo"] = int(todo)
+    url = hub.rstrip("/") + "/api/auto-dispatch/fire/"
+    status_code, payload = _http_json("POST", url, resolved, body=body)
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if status_code >= 400:
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {"status": "error", "http": status_code, "body": payload},
+                    separators=(",", ":"),
+                )
+            )
+        else:
+            click.echo(f"hub returned HTTP {status_code}: {payload}", err=True)
+        sys.exit(1)
+    if as_json:
+        click.echo(json.dumps(payload, separators=(",", ":")))
+        return
+    # Human output
+    if isinstance(payload, dict):
+        click.echo(f"status:     {payload.get('status')}")
+        click.echo(f"decision:   {payload.get('decision')}")
+        click.echo(f"agent:      {payload.get('agent')}")
+        click.echo(f"lane:       {payload.get('lane')}")
+        pick = payload.get("pick") or {}
+        if pick:
+            click.echo(
+                f"pick:       #{pick.get('number')} {pick.get('title')}"
+            )
+        else:
+            click.echo("pick:       (none — head picks from own backlog)")
+        click.echo(f"message_id: {payload.get('message_id')}")
+    else:
+        click.echo(str(payload))
+
+
+# ---------------------------------------------------------------------------
+# dispatch status
+# ---------------------------------------------------------------------------
+
+@dispatch.command("status")
+@click.option(
+    "--hub",
+    envvar="SCITEX_OROCHI_URL",
+    default=DEFAULT_HUB,
+    show_default=True,
+    help="Hub base URL [$SCITEX_OROCHI_URL].",
+)
+@click.option(
+    "--token",
+    envvar="SCITEX_OROCHI_TOKEN",
+    default=None,
+    help="Workspace token [$SCITEX_OROCHI_TOKEN].",
+)
+@click.pass_context
+def dispatch_status(
+    ctx: click.Context,
+    hub: str,
+    token: str | None,
+) -> None:
+    """Show per-head auto-dispatch streak + cooldown state."""
+    resolved = _resolve_token(token)
+    url = hub.rstrip("/") + "/api/auto-dispatch/status/"
+    status_code, payload = _http_json("GET", url, resolved)
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if status_code >= 400:
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {"status": "error", "http": status_code, "body": payload},
+                    separators=(",", ":"),
+                )
+            )
+        else:
+            click.echo(f"hub returned HTTP {status_code}: {payload}", err=True)
+        sys.exit(1)
+    rows = payload if isinstance(payload, list) else []
+    if as_json:
+        click.echo(json.dumps(rows, separators=(",", ":")))
+        return
+    if not rows:
+        click.echo("no head-* agents currently registered in this workspace.")
+        return
+    click.echo(
+        f"{'agent':<28}  {'lane':<24}  {'streak':>6}  {'subagents':>9}  "
+        f"{'cooldown':>8}  last_fire_at"
+    )
+    for r in rows:
+        cd = "active" if r.get("cooldown_active") else "-"
+        if r.get("cooldown_active"):
+            cd = f"{int(r.get('cooldown_remaining_s') or 0)}s"
+        click.echo(
+            f"{str(r.get('agent', '')):<28}  "
+            f"{str(r.get('lane', '')):<24}  "
+            f"{int(r.get('idle_streak') or 0):>6}  "
+            f"{int(r.get('subagent_count') or 0):>9}  "
+            f"{cd:>8}  "
+            f"{r.get('last_fire_at') or '-'}"
+        )
+
+
+__all__ = ["dispatch"]

--- a/src/scitex_orochi/_cli/commands/machine_cmd.py
+++ b/src/scitex_orochi/_cli/commands/machine_cmd.py
@@ -1,16 +1,21 @@
-"""``scitex-orochi machine heartbeat {send,status}`` subcommands.
+"""``scitex-orochi machine {heartbeat,resources} ...`` subcommands.
 
-``send``  — drop-in for ``scripts/client/agent_meta.py --push --once``.
-            Enumerate local tmux/screen agent sessions, collect their
-            metadata via ``agent_meta_pkg`` (the real implementation
-            already lives in the repo), and POST each entry to the
-            Orochi hub's ``/api/agents/register/`` endpoint.
+``heartbeat send``    — drop-in for ``scripts/client/agent_meta.py --push --once``.
+                       Enumerate local tmux/screen agent sessions, collect their
+                       metadata via ``agent_meta_pkg`` (the real implementation
+                       already lives in the repo), and POST each entry to the
+                       Orochi hub's ``/api/agents/register/`` endpoint.
 
-``status`` — GET the hub agents registry and print this host's canonical
-            payload (``head-<hostname>``) as JSON. Used as a lightweight
-            smoke test in lieu of the dashboard.
+``heartbeat status``  — GET the hub agents registry and print this host's canonical
+                       payload (``head-<hostname>``) as JSON. Used as a lightweight
+                       smoke test in lieu of the dashboard.
 
-Both commands emit NDJSON on stdout and human-readable progress on
+``resources show``    — Snapshot local CPU / RAM / Storage / GPU in the
+                       ``N cores`` / ``N/M GB`` / ``N/M TB`` format that the
+                       Machines tab renders (PR #327 parity, ywatanabe msg#16215).
+                       Reads via ``agent_meta_pkg._metrics.collect_machine_metrics``.
+
+All commands emit NDJSON on stdout and human-readable progress on
 stderr when ``--verbose``.
 """
 
@@ -206,6 +211,144 @@ def heartbeat_status(
         click.echo(json.dumps(payload, indent=2, sort_keys=False))
     else:
         click.echo(json.dumps(payload, separators=(",", ":")))
+
+
+# ---------------------------------------------------------------------------
+# machine resources show
+# ---------------------------------------------------------------------------
+
+@machine.group("resources")
+def resources() -> None:
+    """Local host resource snapshot (CPU / RAM / Storage / GPU)."""
+
+
+def _import_metrics():
+    """Return ``collect_machine_metrics`` from ``agent_meta_pkg._metrics``.
+
+    Same bootstrapping dance as ``_import_agent_meta_pkg`` above: falls
+    back to prepending ``scripts/client`` to ``sys.path`` so non-installed
+    checkouts work.
+    """
+    try:
+        from agent_meta_pkg._metrics import (  # type: ignore[import-not-found]
+            collect_machine_metrics,
+        )
+
+        return collect_machine_metrics
+    except ImportError:
+        pass
+    from ._host_ops import _repo_root_candidate  # local import to avoid cycle
+
+    scripts_client = _repo_root_candidate() / "scripts" / "client"
+    if scripts_client.is_dir() and str(scripts_client) not in sys.path:
+        sys.path.insert(0, str(scripts_client))
+    try:
+        from agent_meta_pkg._metrics import (  # type: ignore[import-not-found]
+            collect_machine_metrics,
+        )
+
+        return collect_machine_metrics
+    except ImportError as exc:  # pragma: no cover - defensive
+        raise click.ClickException(
+            "agent_meta_pkg._metrics not importable — ensure you're in a "
+            "repo checkout or set SCITEX_OROCHI_REPO_ROOT."
+        ) from exc
+
+
+def _fmt_cores(n: int | None) -> str:
+    if not n:
+        return "-"
+    return f"{int(n)} cores"
+
+
+def _fmt_gb_ratio(used_mb: int | None, total_mb: int | None) -> str:
+    if not used_mb or not total_mb:
+        return "-"
+    used_gb = float(used_mb) / 1024.0
+    total_gb = float(total_mb) / 1024.0
+    return f"{used_gb:.1f}/{total_gb:.1f} GB"
+
+
+def _fmt_tb_ratio(used_mb: int | None, total_mb: int | None) -> str:
+    if not used_mb or not total_mb:
+        return "-"
+    used_tb = float(used_mb) / 1024.0 / 1024.0
+    total_tb = float(total_mb) / 1024.0 / 1024.0
+    return f"{used_tb:.2f}/{total_tb:.2f} TB"
+
+
+def _fmt_gpu(gpus: list[dict]) -> str:
+    if not gpus:
+        return "n/a"
+    used = sum(float(g.get("memory_used_mb") or 0) for g in gpus)
+    total = sum(float(g.get("memory_total_mb") or 0) for g in gpus)
+    if total <= 0:
+        return f"{len(gpus)}x"
+    used_gb = used / 1024.0
+    total_gb = total / 1024.0
+    return f"{len(gpus)}x — VRAM {used_gb:.1f}/{total_gb:.1f} GB"
+
+
+@resources.command("show")
+@click.option(
+    "--pretty",
+    is_flag=True,
+    help="Pretty-print the JSON (default: single-line NDJSON).",
+)
+@click.pass_context
+def resources_show(ctx: click.Context, pretty: bool) -> None:
+    """Print this host's resource snapshot (matches Machines-tab display).
+
+    Emits the shape::
+
+        {
+          "host": "<shortname>",
+          "display": {
+            "cpu": "N cores",
+            "ram": "N/M GB",
+            "storage": "N/M TB",
+            "gpu":  "N x — VRAM N/M GB"   # or "n/a"
+          },
+          "raw": { ...full metrics dict... }
+        }
+
+    ``--json`` (top-level) or ``--pretty`` honoured. Human output prints
+    the four lines in a compact key:value format so operators can eyeball
+    the values without piping through jq.
+    """
+    collect = _import_metrics()
+    try:
+        metrics = collect()
+    except Exception as exc:  # noqa: BLE001 - must degrade
+        raise click.ClickException(f"collect_machine_metrics failed: {exc}") from exc
+
+    display = {
+        "cpu": _fmt_cores(metrics.get("cpu_count")),
+        "ram": _fmt_gb_ratio(metrics.get("mem_used_mb"), metrics.get("mem_total_mb")),
+        "storage": _fmt_tb_ratio(
+            metrics.get("disk_used_mb"), metrics.get("disk_total_mb")
+        ),
+        "gpu": _fmt_gpu(metrics.get("gpus") or []),
+    }
+    payload = {
+        "host": resolve_self_host(),
+        "display": display,
+        "raw": metrics,
+    }
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if as_json or pretty:
+        click.echo(
+            json.dumps(payload, indent=2 if pretty else None, default=str)
+            if pretty
+            else json.dumps(payload, separators=(",", ":"), default=str)
+        )
+        return
+    # Human output — the four Machines-tab lines.
+    click.echo(f"host:    {payload['host']}")
+    click.echo(f"CPU:     {display['cpu']}")
+    click.echo(f"RAM:     {display['ram']}")
+    click.echo(f"Storage: {display['storage']}")
+    click.echo(f"GPU:     {display['gpu']}")
 
 
 __all__ = ["machine"]

--- a/src/scitex_orochi/_cli/commands/todo_cmd.py
+++ b/src/scitex_orochi/_cli/commands/todo_cmd.py
@@ -1,0 +1,412 @@
+"""``scitex-orochi todo {list,next,triage}`` subcommands.
+
+Operator-facing wrappers around the ``gh issue list --repo
+ywatanabe1989/todo`` fleet workflow that the server-side auto-dispatch
+and the client-side probe share. Mirrors ``scripts/client/
+auto-dispatch-pick-todo.py`` (PR #320) but exposes three verbs:
+
+``list``   — JSON list of open high-priority todos (optionally lane-filtered).
+``next``   — Single recommendation for the given lane; null if nothing
+             matches (the classic "pick one" path; same logic as
+             auto-dispatch-pick-todo.py).
+``triage`` — Classifier: score every open todo on staleness, lane fit,
+             claimed-by-PR, and assignee presence. ``--json`` honoured.
+
+Data source: ``gh issue list`` + ``gh pr list`` against
+``ywatanabe1989/todo``. The ``pick`` core logic is re-imported from
+``scripts/client/auto-dispatch-pick-todo.py`` so any behavioural fix
+there propagates here without duplication.
+
+Per ywatanabe msg#16477: fill the operator UX gap so that a head
+doesn't need to hand-roll ``gh issue list --label high-priority --label
+infrastructure`` to see the same list auto-dispatch sees.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from typing import Any
+
+import click
+
+from ._host_ops import _repo_root_candidate
+
+TODO_REPO_DEFAULT = os.environ.get("SCITEX_TODO_REPO", "ywatanabe1989/todo")
+
+
+# ---------------------------------------------------------------------------
+# Pick-helper import (reuse the pure-function core from PR #320)
+# ---------------------------------------------------------------------------
+
+def _import_pick_helper() -> Any:
+    """Load ``auto-dispatch-pick-todo.py`` as a module and return it.
+
+    Falls back to prepending ``scripts/client`` to sys.path — consistent
+    with how ``machine_cmd._import_agent_meta_pkg`` bootstraps.
+
+    The file is hyphenated (not a valid module name) so we load it via
+    ``importlib.util.spec_from_file_location`` keyed to the underscored
+    stem. Result is cached in module globals to avoid the exec cost on
+    every CLI invocation.
+    """
+    global _PICK_MOD_CACHE
+    cached = globals().get("_PICK_MOD_CACHE")
+    if cached is not None:
+        return cached
+    import importlib.util
+
+    helper = _repo_root_candidate() / "scripts" / "client" / "auto-dispatch-pick-todo.py"
+    if not helper.is_file():
+        raise click.ClickException(
+            f"pick-helper not found at {helper} — set SCITEX_OROCHI_REPO_ROOT "
+            "or run from a scitex-orochi checkout."
+        )
+    spec = importlib.util.spec_from_file_location(
+        "auto_dispatch_pick_todo", helper
+    )
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise click.ClickException(f"could not load helper spec from {helper}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    globals()["_PICK_MOD_CACHE"] = mod
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# gh shell-out (shared between list/next/triage)
+# ---------------------------------------------------------------------------
+
+def _gh_json(args: list[str], timeout: int = 20) -> list[dict]:
+    """Run ``gh <args>`` and parse stdout as JSON array.
+
+    Returns ``[]`` on any failure (missing gh, non-zero exit, bad JSON)
+    — the command should degrade gracefully for operators without gh
+    auth (they'll just see an empty result).
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _fetch_open_todos(repo: str, limit: int = 100) -> list[dict]:
+    """All open high-priority todos in the repo, flattened to dicts."""
+    return _gh_json(
+        [
+            "issue", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--label", "high-priority",
+            "--json", "number,title,labels,assignees,updatedAt,createdAt",
+            "--limit", str(limit),
+        ]
+    )
+
+
+def _fetch_open_prs(repo: str, limit: int = 100) -> list[dict]:
+    """All open PRs in the repo — title + body only (used for claim filter)."""
+    return _gh_json(
+        [
+            "pr", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--json", "title,body",
+            "--limit", str(limit),
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scoring (for `triage`)
+# ---------------------------------------------------------------------------
+
+def _staleness_score(updated_at: str | None, now_iso: float) -> float:
+    """0.0 (just updated) .. 1.0 (untouched > 30 days). Best-effort."""
+    if not updated_at:
+        return 0.0
+    try:
+        # gh emits RFC3339 strings. Fall back to a naïve parse.
+        from datetime import datetime
+
+        ts = datetime.fromisoformat(updated_at.rstrip("Z")).timestamp()
+    except (ValueError, TypeError):
+        return 0.0
+    delta_days = max(0.0, (now_iso - ts) / 86400.0)
+    return min(1.0, delta_days / 30.0)
+
+
+def _score_issue(
+    issue: dict,
+    lane: str | None,
+    claimed: set[int],
+    now_ts: float,
+) -> dict:
+    """Return the issue dict augmented with a ``score`` + ``score_reason`` field.
+
+    Score components (all in [0,1], summed):
+      * staleness (up to +1.0)
+      * lane fit (+1.0 if label present when lane given; 0 otherwise — or
+        not penalised if ``lane`` is ``None``)
+      * unclaimed (+0.5 if no PR refers to it)
+      * unassigned (+0.5 if no human assignee)
+
+    Higher score = better pick. Operator can re-rank by any column of
+    the JSON output.
+    """
+    labels = {
+        (lab.get("name") or "").strip() for lab in (issue.get("labels") or [])
+    }
+    assignees = issue.get("assignees") or []
+    num = int(issue.get("number") or 0)
+    staleness = _staleness_score(issue.get("updatedAt"), now_ts)
+    lane_fit = 0.0
+    if lane is None:
+        lane_fit = 0.0  # neutral when no lane filter
+    elif lane in labels:
+        lane_fit = 1.0
+    unclaimed = 0.5 if num not in claimed else 0.0
+    unassigned = 0.5 if not assignees else 0.0
+    score = round(staleness + lane_fit + unclaimed + unassigned, 3)
+    reason_parts = []
+    if lane is not None:
+        reason_parts.append(f"lane={'fit' if lane_fit else 'miss'}")
+    reason_parts.append(f"stale={staleness:.2f}")
+    if num in claimed:
+        reason_parts.append("claimed")
+    if assignees:
+        reason_parts.append("assigned")
+    return {
+        "number": num,
+        "title": issue.get("title") or "",
+        "labels": sorted(labels),
+        "assignees": [a.get("login") or "" for a in assignees],
+        "updated_at": issue.get("updatedAt"),
+        "claimed_by_pr": num in claimed,
+        "score": score,
+        "score_reason": ";".join(reason_parts),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Click group
+# ---------------------------------------------------------------------------
+
+@click.group("todo")
+def todo() -> None:
+    """Fleet todo queue — list / next / triage (PR #320 core reused)."""
+
+
+# ---------------------------------------------------------------------------
+# todo list
+# ---------------------------------------------------------------------------
+
+@todo.command("list")
+@click.option(
+    "--lane",
+    default=None,
+    help="Label name to filter on (e.g. infrastructure, hub-admin). "
+    "Omit to see every open high-priority todo.",
+)
+@click.option(
+    "--repo",
+    default=TODO_REPO_DEFAULT,
+    show_default=True,
+    help="Todo repo [$SCITEX_TODO_REPO].",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=100,
+    show_default=True,
+    help="Max issues to fetch.",
+)
+@click.pass_context
+def todo_list(
+    ctx: click.Context,
+    lane: str | None,
+    repo: str,
+    limit: int,
+) -> None:
+    """List open high-priority todos (optionally lane-filtered)."""
+    issues = _fetch_open_todos(repo, limit=limit)
+    if lane is not None:
+        issues = [
+            i
+            for i in issues
+            if lane in {(lab.get("name") or "").strip() for lab in (i.get("labels") or [])}
+        ]
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    # Default output is JSON array of the essentials.
+    slim = [
+        {
+            "number": int(i.get("number") or 0),
+            "title": i.get("title") or "",
+            "labels": sorted(
+                (lab.get("name") or "") for lab in (i.get("labels") or [])
+            ),
+            "assignees": [a.get("login") or "" for a in (i.get("assignees") or [])],
+            "updated_at": i.get("updatedAt"),
+        }
+        for i in issues
+    ]
+    if as_json:
+        click.echo(json.dumps(slim, indent=2))
+        return
+    if not slim:
+        click.echo("no open high-priority todos matching this filter.")
+        return
+    click.echo(f"{'#':>5}  {'labels':<40}  {'title':<60}")
+    for row in slim:
+        labels_s = ",".join(row["labels"])[:38]
+        title_s = row["title"][:58]
+        click.echo(f"{row['number']:>5}  {labels_s:<40}  {title_s:<60}")
+
+
+# ---------------------------------------------------------------------------
+# todo next
+# ---------------------------------------------------------------------------
+
+@todo.command("next")
+@click.option(
+    "--lane",
+    required=True,
+    help="Label to filter on (e.g. infrastructure, hub-admin). "
+    "Required — ``next`` is the 'pick one' path and needs a lane.",
+)
+@click.option(
+    "--repo",
+    default=TODO_REPO_DEFAULT,
+    show_default=True,
+    help="Todo repo [$SCITEX_TODO_REPO].",
+)
+@click.option(
+    "--exclude",
+    default="",
+    help="Comma-sep issue numbers to skip (cooldown list).",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=50,
+    show_default=True,
+    help="Max issues to fetch before picking.",
+)
+@click.pass_context
+def todo_next(
+    ctx: click.Context,
+    lane: str,
+    repo: str,
+    exclude: str,
+    limit: int,
+) -> None:
+    """Pick the next todo for ``--lane`` (auto-dispatch-pick-todo.py parity).
+
+    Exits non-zero when nothing matches (so cron / subshells can branch).
+    """
+    extra: list[int] = []
+    for tok in (exclude or "").split(","):
+        tok = tok.strip()
+        if tok.isdigit():
+            extra.append(int(tok))
+
+    issues = _fetch_open_todos(repo, limit=limit)
+    prs = _fetch_open_prs(repo, limit=100)
+
+    pick_mod = _import_pick_helper()
+    pick = pick_mod.pick_todo(issues, prs, lane, extra)
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if pick is None:
+        if as_json:
+            click.echo("null")
+        else:
+            click.echo("no unclaimed todo matched this lane.", err=True)
+        sys.exit(1)
+    if as_json:
+        click.echo(json.dumps(pick, indent=2))
+    else:
+        click.echo(f"#{pick['number']}  {pick['title']}")
+        click.echo(f"  labels: {','.join(pick['labels'])}")
+        click.echo(f"  reason: {pick['reason']}")
+
+
+# ---------------------------------------------------------------------------
+# todo triage
+# ---------------------------------------------------------------------------
+
+@todo.command("triage")
+@click.option(
+    "--lane",
+    default=None,
+    help="Label to weight lane-fit against. Omit for lane-agnostic scoring.",
+)
+@click.option(
+    "--repo",
+    default=TODO_REPO_DEFAULT,
+    show_default=True,
+    help="Todo repo [$SCITEX_TODO_REPO].",
+)
+@click.option(
+    "--limit",
+    type=int,
+    default=100,
+    show_default=True,
+    help="Max issues to fetch.",
+)
+@click.pass_context
+def todo_triage(
+    ctx: click.Context,
+    lane: str | None,
+    repo: str,
+    limit: int,
+) -> None:
+    """Score every open todo on staleness + lane-fit + claimed + assigned.
+
+    Output is a JSON array sorted by descending score. Use ``--json`` for
+    machine-readable output; the human form is a ranked table.
+    """
+    issues = _fetch_open_todos(repo, limit=limit)
+    prs = _fetch_open_prs(repo, limit=100)
+
+    pick_mod = _import_pick_helper()
+    claimed = pick_mod.claimed_numbers_from_prs(prs)
+    now_ts = time.time()
+
+    scored = [_score_issue(i, lane, claimed, now_ts) for i in issues]
+    scored.sort(key=lambda row: row["score"], reverse=True)
+
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+    if as_json:
+        click.echo(json.dumps(scored, indent=2))
+        return
+    if not scored:
+        click.echo("no open high-priority todos to triage.")
+        return
+    click.echo(
+        f"{'score':>6}  {'#':>5}  {'reason':<40}  {'title':<60}"
+    )
+    for row in scored:
+        title_s = row["title"][:58]
+        reason_s = row["score_reason"][:38]
+        click.echo(
+            f"{row['score']:>6.2f}  {row['number']:>5}  {reason_s:<40}  {title_s:<60}"
+        )
+
+
+__all__ = ["todo"]

--- a/src/scitex_orochi/_skills/scitex-orochi/convention-cli.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/convention-cli.md
@@ -9,22 +9,88 @@ These conventions apply to all CLI tools built within the SciTeX ecosystem and O
 
 ## Command Structure
 
-### Verb-Noun Pattern (Preferred)
+### Canonical shape: `scitex-orochi <noun> <verb>` (House style)
+
+As of Phase 1b/1c (PR #336 + #337, msg#16414 / msg#16477), every new
+scitex-orochi subcommand MUST be exposed as a `<noun> <verb>` pair —
+click group = noun, command = verb. This is the SAME style scitex-dev
+uses and what we are migrating the whole fleet toward.
+
 ```bash
-scitex-orochi list-agents          # verb-noun, hyphenated
-scitex-orochi show-history #general
-scitex-orochi send-message #general "hi"
+scitex-orochi machine heartbeat send         # noun=machine, verb=heartbeat send
+scitex-orochi machine resources show         # resource snapshot for this host
+scitex-orochi cron start                     # unified cron daemon
+scitex-orochi host-liveness probe            # fleet-watch probe
+scitex-orochi hungry-signal check            # idle→lead ping
+scitex-orochi disk pressure-probe            # df-based alert
+scitex-orochi chrome-watchdog check          # kernel_task CPU escape hatch
+scitex-orochi todo list --lane infrastructure
+scitex-orochi todo next --lane hub-admin
+scitex-orochi todo triage --lane hub-admin --json
+scitex-orochi dispatch run --head mba --todo 123
+scitex-orochi dispatch status
 ```
 
-### Subcommand Hierarchy (For grouped operations)
-```bash
-scitex-dev skills list             # noun → verb
-scitex-dev skills export
-scitex-dev mcp start
-scitex-dev mcp doctor
-```
+### Complete subcommand-group registry (as of Phase 1c)
 
-Pick one style per package and stay consistent. Existing scitex-orochi uses verb-noun for top-level CLI; scitex-dev uses subcommands.
+1. **`machine`** — host-level operations
+   * `machine heartbeat {send,status}` — push agent metadata / inspect registry
+   * `machine resources show` — CPU / RAM / Storage / GPU snapshot (matches Machines tab)
+2. **`host-liveness`** — fleet-watch host reachability probe
+   * `host-liveness probe`
+3. **`hungry-signal`** — Layer 2 idle-head → lead ping
+   * `hungry-signal check`
+4. **`disk`** — host disk hygiene
+   * `disk reaper-dry-run` — cache/sticker dir cleanup
+   * `disk pressure-probe` — NDJSON alert pipeline
+5. **`chrome-watchdog`** — macOS kernel_task CPU escape hatch
+   * `chrome-watchdog check`
+6. **`cron`** — unified Orochi cron daemon (msg#16406 / #16410)
+   * `cron start|stop|list|run|status|reload`
+7. **`todo`** — fleet todo queue (PR #320 helper reused)
+   * `todo list [--lane LABEL]`
+   * `todo next --lane LABEL` — pick-one path
+   * `todo triage [--lane LABEL]` — scored ranking
+8. **`dispatch`** — operator-side auto-dispatch control
+   * `dispatch run --head HOST [--todo N]` — force-fire
+   * `dispatch status` — per-head streak / cooldown table
+9. **`host-identity`** — local-vs-remote resolver (read-only)
+
+Legacy top-level verb-noun commands (`list-agents`, `show-history`,
+`send-message`, etc.) are kept for backwards compatibility but are
+**deprecated for new additions** — reach for a `<noun> <verb>`
+group instead. When a legacy verb-noun command is logically part of
+an existing group, the acceptable migration path is: (a) add the
+`<noun> <verb>` form, (b) keep the old alias as a thin shim, (c)
+mark the shim deprecated in `--help`.
+
+### Why this shape
+
+* Groups keep the `--help` tree navigable. `scitex-orochi machine --help`
+  lists every host-level verb without polluting the top level.
+* Subcommand-level monkeypatching (the PR #336 test pattern) is
+  cleaner when the verb is the last path component.
+* The shell wrappers (`scripts/client/*.sh`) become trivial
+  `exec scitex-orochi <noun> <verb> "$@"` shims — one idiom, no
+  per-script flag handling.
+
+### Deprecated: legacy per-script shell-call convention
+
+Before Phase 1b (PR #336), each host-side concern lived in its own
+bash script under `scripts/client/` with hand-rolled flag parsing,
+inconsistent exit codes, and no unit tests. That convention is now
+deprecated:
+
+* **Do NOT** add new bash-only scripts for host-side operations.
+  Implement the logic as a click subcommand under an existing or
+  new `<noun>` group; if a shell-callable entry point is needed
+  (launchd / systemd / cron), write a three-line wrapper that
+  `exec`s `scitex-orochi <noun> <verb> "$@"`.
+* **Do NOT** add new flags directly to existing legacy bash scripts.
+  Port the script to a click subcommand first, then add the flag.
+* **Do NOT** invent new top-level verb-noun entries (`scitex-orochi
+  foo-bar-baz`). Put them inside an existing group or propose a new
+  group in the PR description.
 
 ## Standard Flags (All Commands)
 

--- a/tests/cli/test_dispatch_cmd.py
+++ b/tests/cli/test_dispatch_cmd.py
@@ -1,0 +1,182 @@
+"""Tests for ``scitex-orochi dispatch {run,status}`` (Phase 1c msg#16477)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._main import orochi
+from scitex_orochi._cli.commands import dispatch_cmd as dc
+
+
+def test_dispatch_group_registered() -> None:
+    assert "dispatch" in orochi.commands
+    d = orochi.commands["dispatch"]
+    assert set(d.commands.keys()) == {"run", "status"}  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# dispatch run
+# ---------------------------------------------------------------------------
+
+def test_run_requires_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``dispatch run`` without ``--head`` fails fast."""
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["dispatch", "run"], obj={})
+    assert result.exit_code != 0
+    assert "head" in (result.output + str(result.exception or ""))
+
+
+def test_run_posts_to_hub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`dispatch run` POSTs to /api/auto-dispatch/fire/ and prints the response."""
+    calls: dict = {}
+
+    def fake_http(method, url, token, body=None, timeout=15):
+        calls["method"] = method
+        calls["url"] = url
+        calls["token"] = token
+        calls["body"] = body
+        return 200, {
+            "status": "ok",
+            "decision": "fired",
+            "agent": "head-mba",
+            "lane": "infrastructure",
+            "pick": {"number": 777, "title": "hello"},
+            "message_id": 42,
+        }
+
+    monkeypatch.setattr(dc, "_http_json", fake_http)
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["dispatch", "run", "--head", "mba", "--todo", "777"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    assert calls["method"] == "POST"
+    assert calls["url"].endswith("/api/auto-dispatch/fire/")
+    assert calls["body"] == {
+        "head": "mba",
+        "reason": "operator-manual",
+        "todo": 777,
+    }
+    assert "decision:   fired" in result.output
+    assert "#777" in result.output
+
+
+def test_run_json_passthrough(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--json` emits the hub payload verbatim on stdout."""
+    def fake_http(method, url, token, body=None, timeout=15):
+        return 200, {"status": "ok", "decision": "fired", "message_id": 1}
+
+    monkeypatch.setattr(dc, "_http_json", fake_http)
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["--json", "dispatch", "run", "--head", "nas"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["decision"] == "fired"
+
+
+def test_run_propagates_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-2xx → exit 1 with the body surfaced."""
+    def fake_http(method, url, token, body=None, timeout=15):
+        return 404, {"error": "agent head-nope not in registry"}
+
+    monkeypatch.setattr(dc, "_http_json", fake_http)
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["dispatch", "run", "--head", "nope"], obj={}
+    )
+    assert result.exit_code == 1
+    assert "404" in result.output or "not in registry" in result.output
+
+
+def test_run_missing_token_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No token anywhere → ClickException."""
+    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
+    monkeypatch.setattr(dc, "load_workspace_token", lambda: None)
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["dispatch", "run", "--head", "mba"], obj={}
+    )
+    assert result.exit_code != 0
+    assert "SCITEX_OROCHI_TOKEN" in (result.output + str(result.exception or ""))
+
+
+# ---------------------------------------------------------------------------
+# dispatch status
+# ---------------------------------------------------------------------------
+
+def test_status_human(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default output prints a table with one row per head."""
+    rows = [
+        {
+            "agent": "head-mba",
+            "host": "mba",
+            "lane": "infrastructure",
+            "idle_streak": 1,
+            "subagent_count": 0,
+            "last_fire_ts": None,
+            "last_fire_at": None,
+            "cooldown_active": False,
+            "cooldown_remaining_s": 0,
+            "streak_threshold": 2,
+            "cooldown_seconds": 900,
+        },
+        {
+            "agent": "head-nas",
+            "host": "nas",
+            "lane": "hub-admin",
+            "idle_streak": 0,
+            "subagent_count": 3,
+            "last_fire_ts": 1_700_000_000.0,
+            "last_fire_at": "2023-11-14T22:13:20+00:00",
+            "cooldown_active": True,
+            "cooldown_remaining_s": 300,
+            "streak_threshold": 2,
+            "cooldown_seconds": 900,
+        },
+    ]
+
+    monkeypatch.setattr(dc, "_http_json", lambda *a, **kw: (200, rows))
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["dispatch", "status"], obj={})
+    assert result.exit_code == 0, result.output
+    assert "head-mba" in result.output
+    assert "head-nas" in result.output
+    # cooldown_remaining rendered as "300s" on the nas row
+    assert "300s" in result.output
+
+
+def test_status_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--json` emits the array verbatim."""
+    rows = [{"agent": "head-mba", "idle_streak": 0, "subagent_count": 1}]
+    monkeypatch.setattr(dc, "_http_json", lambda *a, **kw: (200, rows))
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["--json", "dispatch", "status"], obj={})
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert isinstance(payload, list)
+    assert payload[0]["agent"] == "head-mba"
+
+
+def test_status_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty list prints the human-friendly no-heads notice."""
+    monkeypatch.setattr(dc, "_http_json", lambda *a, **kw: (200, []))
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["dispatch", "status"], obj={})
+    assert result.exit_code == 0
+    assert "no head-*" in result.output

--- a/tests/cli/test_machine_resources_cmd.py
+++ b/tests/cli/test_machine_resources_cmd.py
@@ -1,0 +1,119 @@
+"""Tests for ``scitex-orochi machine resources show`` (Phase 1c msg#16477)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._main import orochi
+from scitex_orochi._cli.commands import machine_cmd
+
+
+def test_resources_group_registered() -> None:
+    """``machine resources show`` must be wired into the group tree."""
+    assert "machine" in orochi.commands
+    machine = orochi.commands["machine"]
+    assert "resources" in machine.commands  # type: ignore[attr-defined]
+    res = machine.commands["resources"]  # type: ignore[attr-defined]
+    assert set(res.commands.keys()) == {"show"}
+
+
+def _fake_metrics() -> dict:
+    """Canonical metrics dict shape used in the Machines tab."""
+    return {
+        "cpu_count": 8,
+        "cpu_model": "Apple M1",
+        "mem_used_mb": 12 * 1024,
+        "mem_total_mb": 16 * 1024,
+        "mem_free_mb": 4 * 1024,
+        "mem_used_percent": 75.0,
+        "disk_used_mb": 500 * 1024,          # 0.49 TB
+        "disk_total_mb": 2 * 1024 * 1024,    # 2 TB
+        "disk_used_percent": 24.4,
+        "gpus": [],
+        "load_avg_1m": 1.0,
+        "load_avg_5m": 1.0,
+        "load_avg_15m": 1.0,
+    }
+
+
+def test_resources_show_human_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default output prints the four Machines-tab lines."""
+    monkeypatch.setattr(machine_cmd, "_import_metrics", lambda: _fake_metrics)
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["machine", "resources", "show"], obj={})
+    assert result.exit_code == 0, result.output
+    assert "CPU:     8 cores" in result.output
+    assert "RAM:     12.0/16.0 GB" in result.output
+    assert "Storage: 0.49/2.00 TB" in result.output
+    assert "GPU:     n/a" in result.output
+
+
+def test_resources_show_json_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--json`` honours the top-level flag and includes display + raw."""
+    monkeypatch.setattr(machine_cmd, "_import_metrics", lambda: _fake_metrics)
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["--json", "machine", "resources", "show"], obj={}
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["display"]["cpu"] == "8 cores"
+    assert payload["display"]["ram"] == "12.0/16.0 GB"
+    assert payload["display"]["storage"] == "0.49/2.00 TB"
+    assert payload["display"]["gpu"] == "n/a"
+    # raw metrics must round-trip unmodified
+    assert payload["raw"]["cpu_count"] == 8
+    assert payload["raw"]["mem_total_mb"] == 16 * 1024
+
+
+def test_resources_show_with_gpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GPU summary line is built from the per-GPU list."""
+    metrics = _fake_metrics()
+    metrics["gpus"] = [
+        {"name": "A100", "utilization_percent": 50.0,
+         "memory_used_mb": 10 * 1024, "memory_total_mb": 40 * 1024},
+        {"name": "A100", "utilization_percent": 0.0,
+         "memory_used_mb": 0, "memory_total_mb": 40 * 1024},
+    ]
+    monkeypatch.setattr(machine_cmd, "_import_metrics", lambda: lambda: metrics)
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["machine", "resources", "show"], obj={})
+    assert result.exit_code == 0, result.output
+    # 2 GPUs, 10/80 GB VRAM total.
+    assert "GPU:     2x — VRAM 10.0/80.0 GB" in result.output
+
+
+def test_resources_show_pretty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--pretty`` emits indented JSON even without top-level ``--json``."""
+    monkeypatch.setattr(machine_cmd, "_import_metrics", lambda: _fake_metrics)
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["machine", "resources", "show", "--pretty"], obj={}
+    )
+    assert result.exit_code == 0
+    # Two-space indent is the tell.
+    assert '\n  "display"' in result.output or '"display":' in result.output
+
+
+def test_resources_show_missing_mb_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the producer can't read some metrics, display is ``-``, not 'None'."""
+    metrics = {
+        "cpu_count": None,
+        "mem_used_mb": None,
+        "mem_total_mb": None,
+        "disk_used_mb": None,
+        "disk_total_mb": None,
+        "gpus": [],
+    }
+    monkeypatch.setattr(machine_cmd, "_import_metrics", lambda: lambda: metrics)
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["machine", "resources", "show"], obj={})
+    assert result.exit_code == 0, result.output
+    assert "CPU:     -" in result.output
+    assert "RAM:     -" in result.output
+    assert "Storage: -" in result.output

--- a/tests/cli/test_todo_cmd.py
+++ b/tests/cli/test_todo_cmd.py
@@ -1,0 +1,201 @@
+"""Tests for ``scitex-orochi todo {list,next,triage}`` (Phase 1c msg#16477)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._main import orochi
+from scitex_orochi._cli.commands import todo_cmd
+
+
+def test_todo_group_registered() -> None:
+    assert "todo" in orochi.commands
+    td = orochi.commands["todo"]
+    assert set(td.commands.keys()) == {"list", "next", "triage"}  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# todo list
+# ---------------------------------------------------------------------------
+
+def _issue(n: int, title: str, labels=(), assignees=(), updated="2026-04-01T00:00:00Z"):
+    return {
+        "number": n,
+        "title": title,
+        "labels": [{"name": lab} for lab in labels],
+        "assignees": [{"login": a} for a in assignees],
+        "updatedAt": updated,
+    }
+
+
+def test_list_human_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unfiltered ``todo list`` prints every open todo as a table."""
+    issues = [
+        _issue(101, "wire X", labels=["high-priority", "infrastructure"]),
+        _issue(102, "fix Y", labels=["high-priority", "hub-admin"]),
+    ]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["todo", "list"], obj={})
+    assert result.exit_code == 0, result.output
+    assert "101" in result.output and "wire X" in result.output
+    assert "102" in result.output and "fix Y" in result.output
+
+
+def test_list_lane_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--lane` filters by exact label match."""
+    issues = [
+        _issue(101, "wire X", labels=["high-priority", "infrastructure"]),
+        _issue(102, "fix Y", labels=["high-priority", "hub-admin"]),
+    ]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["todo", "list", "--lane", "hub-admin"], obj={}
+    )
+    assert result.exit_code == 0
+    assert "102" in result.output
+    assert "101" not in result.output
+
+
+def test_list_json_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--json` returns the slim array shape."""
+    issues = [_issue(101, "wire X", labels=["high-priority", "infrastructure"])]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["--json", "todo", "list"], obj={})
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert payload[0]["number"] == 101
+    assert "infrastructure" in payload[0]["labels"]
+
+
+# ---------------------------------------------------------------------------
+# todo next
+# ---------------------------------------------------------------------------
+
+def test_next_picks_unclaimed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Picks first unclaimed lane-matching issue."""
+    issues = [
+        _issue(201, "already claimed", labels=["high-priority", "infrastructure"]),
+        _issue(202, "fresh pick", labels=["high-priority", "infrastructure"]),
+    ]
+    # open PR claims todo 201 via "closes #201" in body
+    prs = [{"title": "feat: x", "body": "closes #201"}]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    monkeypatch.setattr(todo_cmd, "_fetch_open_prs", lambda *a, **kw: prs)
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["--json", "todo", "next", "--lane", "infrastructure"], obj={}
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["number"] == 202
+    assert "lane=infrastructure" in payload["reason"]
+
+
+def test_next_exits_1_when_nothing_matches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty lane → exit 1 with ``null`` on stdout when --json."""
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: [])
+    monkeypatch.setattr(todo_cmd, "_fetch_open_prs", lambda *a, **kw: [])
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["--json", "todo", "next", "--lane", "infrastructure"], obj={}
+    )
+    assert result.exit_code == 1
+    assert "null" in result.output
+
+
+def test_next_requires_lane() -> None:
+    """``--lane`` is a required option."""
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["todo", "next"], obj={})
+    # Click click.UsageError → exit code 2
+    assert result.exit_code != 0
+    assert "lane" in (result.output + (str(result.exception or "")))
+
+
+def test_next_respects_exclude(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--exclude list skips the named issue numbers."""
+    issues = [
+        _issue(301, "first", labels=["high-priority", "infrastructure"]),
+        _issue(302, "second", labels=["high-priority", "infrastructure"]),
+    ]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    monkeypatch.setattr(todo_cmd, "_fetch_open_prs", lambda *a, **kw: [])
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["--json", "todo", "next", "--lane", "infrastructure", "--exclude", "301"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["number"] == 302
+
+
+# ---------------------------------------------------------------------------
+# todo triage
+# ---------------------------------------------------------------------------
+
+def test_triage_json_ranked(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Triage output is a list sorted by score desc."""
+    issues = [
+        _issue(401, "ready", labels=["high-priority", "infrastructure"]),
+        _issue(402, "assigned", labels=["high-priority", "infrastructure"],
+               assignees=["alice"]),
+    ]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    monkeypatch.setattr(todo_cmd, "_fetch_open_prs", lambda *a, **kw: [])
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["--json", "todo", "triage", "--lane", "infrastructure"], obj={}
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    # ready must rank above assigned (higher score — unassigned + unclaimed)
+    assert payload[0]["number"] == 401
+    assert payload[0]["score"] >= payload[1]["score"]
+    # each row has score_reason + claimed_by_pr fields
+    assert "score_reason" in payload[0]
+    assert payload[0]["claimed_by_pr"] is False
+
+
+def test_triage_lane_fit_weighs_score(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lane-matching issues outrank non-lane issues when --lane given."""
+    issues = [
+        _issue(501, "off-lane", labels=["high-priority", "specialized-domain"]),
+        _issue(502, "in-lane", labels=["high-priority", "infrastructure"]),
+    ]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    monkeypatch.setattr(todo_cmd, "_fetch_open_prs", lambda *a, **kw: [])
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["--json", "todo", "triage", "--lane", "infrastructure"],
+        obj={},
+    )
+    payload = json.loads(result.output)
+    # top row must be the lane-matching one
+    assert payload[0]["number"] == 502
+
+
+def test_triage_without_lane(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No --lane → lane_fit is neutral; output still ordered by score."""
+    issues = [_issue(601, "x", labels=["high-priority"])]
+    monkeypatch.setattr(todo_cmd, "_fetch_open_todos", lambda *a, **kw: issues)
+    monkeypatch.setattr(todo_cmd, "_fetch_open_prs", lambda *a, **kw: [])
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["--json", "todo", "triage"], obj={})
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload[0]["number"] == 601


### PR DESCRIPTION
## Summary

Phase 1c follow-up to PR #336 (msg#16477). Adds the three
fleet-coordination subcommand groups that the full operator UX
needs now that the `scitex-orochi <noun> <verb>` tree is the
house style:

- **`machine resources show`** - CPU / RAM / Storage / GPU
  snapshot in the `N cores` / `N/M GB` / `N/M TB` shape the
  Machines tab renders (PR #327 / msg#16215 parity). Reads via
  `agent_meta_pkg._metrics.collect_machine_metrics`.
- **`todo list|next|triage`** - wraps
  `gh issue list --repo ywatanabe1989/todo` with the same lane +
  already-claimed + audit-review filters that auto-dispatch uses.
  `next` reuses the pure-function core from PR #320's
  `auto-dispatch-pick-todo.py` (no duplication). `triage` scores
  every open todo on staleness + lane fit + unclaimed +
  unassigned. `--json` honoured throughout.
- **`dispatch run|status`** - operator-side complement to PR #334's
  server-side auto-dispatch. `run --head <host> [--todo N]`
  force-fires a dispatch DM via the new hub API (bypasses the
  streak/cooldown gate). `status` surfaces per-head `idle_streak`,
  `last_fire_at`, `cooldown_active`, and `cooldown_remaining_s`.

New hub endpoints (needed for `dispatch`):

- `POST /api/auto-dispatch/fire/` - force-fire; token-auth
  resolves workspace from the token (works on bare domain,
  subdomain, and `testserver` test contexts alike).
- `GET /api/auto-dispatch/status/` - per-head streak + cooldown
  snapshot (read-only).

Wired into `hub/urls.py`, `hub/urls_bare.py`, and
`hub/urls_workspace.py` so they're reachable from every Host
header the middleware currently routes.

`src/scitex_orochi/_skills/scitex-orochi/convention-cli.md` updated
to declare `scitex-orochi <noun> <verb>` the canonical CLI shape,
enumerate the 9 subcommand groups that exist today, and deprecate
the legacy per-script shell-call convention.

## Test plan

- [x] `pytest tests/cli/` - 60 pass (26 new in
      `test_machine_resources_cmd.py`, `test_todo_cmd.py`,
      `test_dispatch_cmd.py`).
- [x] `pytest tests/ -m "not llm_eval"` - 286 pass, 1 xfailed (no
      regressions vs `origin/develop`).
- [x] `manage.py test hub.tests.views.api.test_auto_dispatch_api
      hub.tests.test_auto_dispatch` - 46 pass (12 new Django
      TestCases cover the new endpoints' auth / 400 / 404 /
      happy-path envelopes + registry side-effects).
- [x] `ruff check src/ tests/` clean.
- [x] `scitex-orochi machine resources show` smoke-tested on
      mba locally (prints 4 lines for host/CPU/RAM/Storage/GPU).
- [x] `scitex-orochi todo --help`, `scitex-orochi dispatch --help`
      render cleanly.

## Constraints honoured

- `ts-migration-v2` - untouched.
- `hub/frontend/` - untouched.
- No new legacy bash scripts - all new verbs are click
  subcommands under `<noun>` groups per the convention doc.
- `auto-dispatch-pick-todo.py` pure-function core re-used
  (imported by `todo_cmd.py`), no duplication.

Generated with [Claude Code](https://claude.com/claude-code)
