### PR TITLE
fix(ui/reply): restore paste support in Reply composer (msg#16527)

### DIFF
--- a/hub/frontend/src/composer/composer-paste.ts
+++ b/hub/frontend/src/composer/composer-paste.ts
@@ -7,7 +7,9 @@
  * this module turns raw paste / drop DOM events into a dedup'd File[] and
  * invokes it. Does NOT know about the surface's pending-attachments tray —
  * that stays with the surface (Chat: module-level pendingAttachments;
- * Overview: popup-local popPending[]; Reply: window.threadPendingAttachments).
+ * Overview: popup-local popPending[]; Reply: threads/state.ts module-level
+ * threadPendingAttachments, accessed via getThreadPendingAttachments() /
+ * resetThreadPendingAttachments() — msg#16527).
  *
  * Text-paste-as-file heuristic (todo#52) lives in upload.ts
  * (_pastedTextShouldAttach / _buildPastedTextFile) and is reused here so

--- a/hub/frontend/src/threads/panel.ts
+++ b/hub/frontend/src/threads/panel.ts
@@ -3,7 +3,14 @@ import { getResolvedAgentColor, getSenderIcon } from "../agent-icons";
 import { apiUrl, cleanAgentName, escapeHtml, getAgentColor, orochiHeaders, timeAgo } from "../app/utils";
 import { buildAttachmentsHtml } from "../chat/chat-attachments";
 import { renderComposer } from "../composer/composer";
-import { _linkifyThreadContent, _pushThreadUrlState, _renderThreadAttachmentTray, _stageThreadFiles } from "./state";
+import {
+  _linkifyThreadContent,
+  _pushThreadUrlState,
+  _renderThreadAttachmentTray,
+  _stageThreadFiles,
+  getThreadPendingAttachments,
+  resetThreadPendingAttachments,
+} from "./state";
 import { _debounceSave, clearDraft, loadDraft } from "../composer/draft-store";
 
 function _threadDraftTarget(parentId) {
@@ -24,8 +31,9 @@ var _threadComposer = null;
  * hydration. */
 /* globals: apiUrl, orochiHeaders, escapeHtml, timeAgo, getAgentColor,
    cleanAgentName, getSenderIcon, getResolvedAgentColor,
-   (globalThis as any).threadPanel, (globalThis as any).threadPanelParentId, (globalThis as any).threadPendingAttachments,
+   (globalThis as any).threadPanel, (globalThis as any).threadPanelParentId,
    (globalThis as any)._threadSketchActive, _renderThreadAttachmentTray, _stageThreadFiles,
+   getThreadPendingAttachments, resetThreadPendingAttachments,
    _linkifyThreadContent, _pushThreadUrlState */
 
 export function closeThreadPanel(opts) {
@@ -106,7 +114,11 @@ export async function openThreadPanel(parentId, opts) {
   await loadThreadReplies(parentId);
 
   var composerSlot = document.getElementById("thread-composer-slot");
-  (globalThis as any).threadPendingAttachments = [];
+  /* msg#16527: clear the shared pending-attachments array IN PLACE. Do
+   * NOT reassign `(globalThis as any).threadPendingAttachments` — under
+   * ES modules that would orphan state.ts's module-local reference, so
+   * pasted / dropped images would never reach sendThreadReply. */
+  resetThreadPendingAttachments();
   _renderThreadAttachmentTray();
 
   if (composerSlot) {
@@ -331,7 +343,12 @@ export async function sendThreadReply() {
   var ta = document.getElementById("thread-input");
   if (!ta) return;
   var text = ta.value.trim();
-  var attachments = (globalThis as any).threadPendingAttachments
+  /* msg#16527: read from the shared SSoT accessor, not
+   * `(globalThis as any).threadPendingAttachments`. The globalThis
+   * mirror falls out of sync across ES-module boundaries every time
+   * panel.ts reassigned it, so pasted / dropped images sat in
+   * state.ts's local array but were missed by the send payload. */
+  var attachments = getThreadPendingAttachments()
     .filter(function (p) {
       return p.uploaded;
     })
@@ -347,8 +364,9 @@ export async function sendThreadReply() {
       window.voiceInputResetAfterSend();
     } catch (_) {}
   }
-  /* Clear thread attachment tray */
-  (globalThis as any).threadPendingAttachments = [];
+  /* Clear thread attachment tray — in-place mutate so the state.ts
+   * module-local reference stays authoritative. */
+  resetThreadPendingAttachments();
   _renderThreadAttachmentTray();
   try {
     var res = await fetch(apiUrl("/api/threads/"), {

--- a/hub/frontend/src/threads/state.ts
+++ b/hub/frontend/src/threads/state.ts
@@ -8,9 +8,31 @@ import { closeThreadPanel, openThreadPanel } from "./panel";
 var threadPanel = null;
 var threadPanelParentId = null;
 
-/* Thread-local pending attachments (separate from main composer pendingAttachments) */
+/* Thread-local pending attachments (separate from main composer
+ * pendingAttachments). This is the single source of truth — paste,
+ * drop, and file-picker all push here via _stageThreadFiles; the send
+ * path (threads/panel.ts::sendThreadReply) reads via
+ * getThreadPendingAttachments(); panel open/close + send clear via
+ * resetThreadPendingAttachments(). Previously panel.ts reassigned
+ * `(globalThis as any).threadPendingAttachments = []`, which broke the
+ * reference shared with this module under ES modules — pasted images
+ * were staged here but never picked up by the send path, so the Reply
+ * composer "lost" pasted attachments (msg#16527). */
 var threadPendingAttachments = [];
 var _threadSketchActive = false;
+
+/* Accessor + resetter so cross-module consumers never need to reassign
+ * the array reference (which would break this module's writers). */
+export function getThreadPendingAttachments() {
+  return threadPendingAttachments;
+}
+
+export function resetThreadPendingAttachments() {
+  /* Mutate in place so any existing reference (including the legacy
+   * globalThis mirror at the bottom of this file) stays pointing at
+   * the live array. */
+  threadPendingAttachments.length = 0;
+}
 
 export function _renderThreadAttachmentTray() {
   var tray = document.getElementById("thread-pending-attachments");

--- a/hub/static/hub/threads/panel.js
+++ b/hub/static/hub/threads/panel.js
@@ -6,8 +6,9 @@
  * thread-specific voice-lang button sync + draft-store hydration. */
 /* globals: apiUrl, orochiHeaders, escapeHtml, timeAgo, getAgentColor,
    cleanAgentName, getSenderIcon, getResolvedAgentColor, renderComposer,
-   threadPanel, threadPanelParentId, threadPendingAttachments,
+   threadPanel, threadPanelParentId,
    _threadSketchActive, _renderThreadAttachmentTray, _stageThreadFiles,
+   getThreadPendingAttachments, resetThreadPendingAttachments,
    _linkifyThreadContent, _pushThreadUrlState */
 
 var _threadComposer = null;
@@ -82,7 +83,8 @@ async function openThreadPanel(parentId, opts) {
   await loadThreadReplies(parentId);
 
   var composerSlot = document.getElementById("thread-composer-slot");
-  threadPendingAttachments = [];
+  /* msg#16527: clear IN PLACE so the shared reference stays authoritative. */
+  resetThreadPendingAttachments();
   _renderThreadAttachmentTray();
 
   if (composerSlot && typeof renderComposer === "function") {
@@ -300,7 +302,11 @@ async function sendThreadReply() {
   var ta = document.getElementById("thread-input");
   if (!ta) return;
   var text = ta.value.trim();
-  var attachments = threadPendingAttachments
+  /* msg#16527: read via the shared accessor so the mirror stays
+   * aligned with threads/state — panel.js used to reassign
+   * threadPendingAttachments on every open, which the ES-module build
+   * cannot do across module boundaries. */
+  var attachments = getThreadPendingAttachments()
     .filter(function (p) {
       return p.uploaded;
     })
@@ -316,8 +322,8 @@ async function sendThreadReply() {
       window.voiceInputResetAfterSend();
     } catch (_) {}
   }
-  /* Clear thread attachment tray */
-  threadPendingAttachments = [];
+  /* Clear thread attachment tray — in-place mutate (msg#16527). */
+  resetThreadPendingAttachments();
   _renderThreadAttachmentTray();
   try {
     var res = await fetch(apiUrl("/api/threads/"), {

--- a/hub/static/hub/threads/state.js
+++ b/hub/static/hub/threads/state.js
@@ -4,9 +4,23 @@
 var threadPanel = null;
 var threadPanelParentId = null;
 
-/* Thread-local pending attachments (separate from main composer pendingAttachments) */
+/* Thread-local pending attachments (separate from main composer
+ * pendingAttachments). Classic-script siblings share this global by
+ * name; the ES-module build accesses it through the
+ * getThreadPendingAttachments / resetThreadPendingAttachments helpers
+ * defined below (msg#16527 — panel.js previously reassigned
+ * threadPendingAttachments = [], which orphaned the shared reference
+ * under ES modules). */
 var threadPendingAttachments = [];
 var _threadSketchActive = false;
+
+function getThreadPendingAttachments() {
+  return threadPendingAttachments;
+}
+
+function resetThreadPendingAttachments() {
+  threadPendingAttachments.length = 0;
+}
 
 function _renderThreadAttachmentTray() {
   var tray = document.getElementById("thread-pending-attachments");


### PR DESCRIPTION
## Summary

Restores Cmd+V / Ctrl+V image paste in the thread Reply composer. Root cause: ES-module scope mismatch introduced by PR #332.

## Root cause

PR #332 wired `features.paste: true` on the Reply composer, and paste staged files into `threads/state.ts`'s module-level `threadPendingAttachments` via `_stageThreadFiles`. But the send path in `threads/panel.ts` read/reset `(globalThis as any).threadPendingAttachments` — which, under the ES-module build, is a one-shot snapshot of state.ts's local. Every `openThreadPanel` did `(globalThis as any).threadPendingAttachments = []`, orphaning state.ts's reference.

Net effect: user pastes → thumbnail appears in tray → click Send → payload goes out with `attachments: []`. User reads as "paste doesn't work".

The classic-script mirror (`hub/static/hub/threads/*.js`) doesn't trip this because all siblings share a true top-level global; only the ES-module bundle does.

## Fix

- Promote `threads/state.ts` to SSoT for pending thread attachments.
- Expose `getThreadPendingAttachments()` / `resetThreadPendingAttachments()` helpers (in-place mutation).
- `panel.ts` reads via accessor and clears in-place instead of reassigning `globalThis`.
- Classic-script `.js` mirrors receive the matching helpers so grep-across-tree stays aligned with the TS spec.

## Files touched

- `hub/frontend/src/threads/state.ts`
- `hub/frontend/src/threads/panel.ts`
- `hub/frontend/src/composer/composer-paste.ts` (comment only)
- `hub/static/hub/threads/state.js` (mirror)
- `hub/static/hub/threads/panel.js` (mirror)

## Preserved invariants

- PR #325 / msg#16193 — Reply paste still stages LOCALLY and never flips the user into Chat; composer-paste's stopPropagation still shields `msg-input`'s `_isTargetOnChatTab` listener from double-firing.
- Chat and Overview composers: untouched.
- Backend `api_threads` already accepts `attachments` — no backend change.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (748 kB bundle)
- [x] `node composer-paste.test.mjs` — 8/8 PASS
- [x] `node draft-store.test.mjs` — 19/19 PASS
- [ ] Manual: open thread panel → Cmd+V image → thumbnail shows in tray → click Send → reply lands with image attached
- [ ] Manual: paste in Reply does NOT flip user into Chat tab
- [ ] Manual: Chat + Overview paste unchanged
