### PR TITLE
feat(cli): Phase 1d Step B — noun dispatcher skeleton (11 empty groups, no verbs yet)

### DIFF
--- a/src/scitex_orochi/_cli/_help_availability.py
+++ b/src/scitex_orochi/_cli/_help_availability.py
@@ -109,6 +109,18 @@ DEFAULT_PROBE_MAP: Mapping[str, ProbeKind] = {
     "serve": ProbeKind.HUB,
     "setup-push": ProbeKind.HUB,
     "doctor": ProbeKind.HUB,
+    # Phase 1d Step B: new empty noun dispatchers (plan §2 / PR #337).
+    # Verbs land in Step C; these entries make the top-level `--help`
+    # annotate the new groups with `(Available Now)` from day one.
+    "channel": ProbeKind.HUB,
+    "workspace": ProbeKind.HUB,
+    "invite": ProbeKind.HUB,
+    "message": ProbeKind.HUB,
+    "push": ProbeKind.HUB,
+    "server": ProbeKind.HUB,
+    "auth": ProbeKind.HUB,
+    "hook": ProbeKind.HUB,
+    "system": ProbeKind.HUB,
     # Local daemon-dependent commands
     "cron": ProbeKind.LOCAL_DAEMON,
     "chrome-watchdog": ProbeKind.LOCAL_DAEMON,
@@ -120,6 +132,9 @@ DEFAULT_PROBE_MAP: Mapping[str, ProbeKind] = {
     "launch": ProbeKind.PURE_LOCAL,
     "deploy": ProbeKind.PURE_LOCAL,
     "stop": ProbeKind.PURE_LOCAL,
+    # Phase 1d Step B: `config` is pure-local (config init writes local
+    # state only) — keep the suffix off to avoid false positives.
+    "config": ProbeKind.PURE_LOCAL,
     # Flat keeper `mcp start` is pure-local (stdio server startup): no
     # suffix added to keep external mcp.json contracts noise-free.
     "mcp": ProbeKind.PURE_LOCAL,

--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -234,10 +234,46 @@ from scitex_orochi._cli.commands.mcp_cmd import mcp as mcp_group
 
 orochi.add_command(mcp_group)
 
+# ── Phase 1d Step B: noun dispatcher skeleton (plan §2, PR #337) ───
+# Empty click groups for every canonical top-level noun. Verbs move
+# under them in Step C — Step B only wires the dispatchers themselves
+# so that `scitex-orochi <noun> --help` is well-formed *before* any
+# rename and so nested help can already annotate reachability.
+#
+# The legacy flat verbs (`list-agents`, `send`, `create-workspace`,
+# `serve`, `doctor`, `init`, `login`, `deploy`, `report`, …) stay
+# registered and functional in Step B; they are migrated and aliased
+# off in Step C.
+from scitex_orochi._cli.commands.agent_cmd import agent as agent_group
+from scitex_orochi._cli.commands.auth_cmd import auth as auth_group
+from scitex_orochi._cli.commands.channel_cmd import channel as channel_group
+from scitex_orochi._cli.commands.config_cmd import config as config_group
+from scitex_orochi._cli.commands.hook_cmd import hook as hook_group
+from scitex_orochi._cli.commands.invite_cmd import invite as invite_group
+from scitex_orochi._cli.commands.message_cmd import message as message_group
+from scitex_orochi._cli.commands.push_cmd import push as push_group
+from scitex_orochi._cli.commands.server_cmd import server as server_group
+from scitex_orochi._cli.commands.system_cmd import system as system_group
+from scitex_orochi._cli.commands.workspace_cmd import workspace as workspace_group
+
+orochi.add_command(agent_group)
+orochi.add_command(auth_group)
+orochi.add_command(channel_group)
+orochi.add_command(config_group)
+orochi.add_command(hook_group)
+orochi.add_command(invite_group)
+orochi.add_command(message_group)
+orochi.add_command(push_group)
+orochi.add_command(server_group)
+orochi.add_command(system_group)
+orochi.add_command(workspace_group)
+
 # ── Phase 1d Step A: (Available Now) help-suffix layer ───────
 # Annotates `--help` output of the top-level group with a quiet
 # "(Available Now)" next to each reachable subcommand. See plan §9
-# (PR #337). Top-level only in this PR; nested groups land in Step B.
+# (PR #337). Top-level was Step A; Step B extends the probe map to
+# cover the new noun groups and applies the same decorator to each
+# of them (so Step C's nested verbs inherit it for free).
 from scitex_orochi._cli._help_availability import annotate_help_with_availability
 
 annotate_help_with_availability(orochi)

--- a/src/scitex_orochi/_cli/commands/agent_cmd/__init__.py
+++ b/src/scitex_orochi/_cli/commands/agent_cmd/__init__.py
@@ -14,13 +14,45 @@ Launch flow:
   4. Run setup-workspace.sh to prepare workspace
   5. Start screen session with claude
   6. After delay, press Enter to confirm dev channel dialog
+
+Phase 1d Step B additionally exposes an empty ``agent`` click group — the
+noun dispatcher that will host ``agent launch/restart/status/stop/list/
+fleet-list`` once Step C migrates the existing flat verbs. The group is
+deliberately empty in Step B; it co-exists with the legacy flat commands.
 """
 
 from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
 
 from ._launch import agent_launch
 from ._restart import agent_restart
 from ._status import agent_status
 from ._stop import agent_stop
 
-__all__ = ["agent_launch", "agent_restart", "agent_status", "agent_stop"]
+
+# ── Phase 1d Step B: empty noun dispatcher ─────────────────────────────
+# No verbs are registered under this group in Step B. Step C migrates
+# the flat ``agent-launch / agent-restart / agent-stop / agent-status``
+# commands and introduces ``agent list / agent fleet-list``.
+@click.group(
+    "agent",
+    short_help="Agent lifecycle and fleet view",
+    help="Agent lifecycle and fleet view (launch, restart, stop, status, list).",
+)
+def agent() -> None:
+    """Agent-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(agent)
+
+
+__all__ = [
+    "agent",
+    "agent_launch",
+    "agent_restart",
+    "agent_status",
+    "agent_stop",
+]

--- a/src/scitex_orochi/_cli/commands/auth_cmd.py
+++ b/src/scitex_orochi/_cli/commands/auth_cmd.py
@@ -1,0 +1,29 @@
+"""``scitex-orochi auth`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verb (``auth login``, replacing top-level
+``login``) moves here in Step C. Step B only ensures ``scitex-orochi
+auth --help`` works and the group appears in top-level help with an
+``(Available Now)`` suffix when the hub is reachable.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "auth",
+    short_help="Credential / session management",
+    help="Credential / session management (login).",
+)
+def auth() -> None:
+    """Auth-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(auth)

--- a/src/scitex_orochi/_cli/commands/channel_cmd.py
+++ b/src/scitex_orochi/_cli/commands/channel_cmd.py
@@ -1,0 +1,32 @@
+"""``scitex-orochi channel`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verbs (``channel list``, ``channel join``,
+``channel history``, ``channel members``) move here in Step C. Step B
+only ensures ``scitex-orochi channel --help`` works and the group is
+visible in top-level help with an ``(Available Now)`` suffix when the
+hub is reachable.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "channel",
+    short_help="Channel membership and history",
+    help="Channel membership and history (list, join, history, members).",
+)
+def channel() -> None:
+    """Channel-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+# Annotate nested help so Step C's verbs will render with the
+# ``(Available Now)`` suffix as soon as they are registered.
+annotate_help_with_availability(channel)

--- a/src/scitex_orochi/_cli/commands/config_cmd.py
+++ b/src/scitex_orochi/_cli/commands/config_cmd.py
@@ -1,0 +1,30 @@
+"""``scitex-orochi config`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verb (``config init``, replacing top-level
+``init``) moves here in Step C. Step B only ensures ``scitex-orochi
+config --help`` works. ``config`` is pure-local so no ``(Available
+Now)`` suffix is ever shown — its backing operations write local
+state only.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "config",
+    short_help="Local scitex-orochi config",
+    help="Local scitex-orochi config (init).",
+)
+def config() -> None:
+    """Config-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(config)

--- a/src/scitex_orochi/_cli/commands/hook_cmd.py
+++ b/src/scitex_orochi/_cli/commands/hook_cmd.py
@@ -1,0 +1,30 @@
+"""``scitex-orochi hook`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verbs (``hook report activity``, ``hook report
+stuck``, ``hook report heartbeat``) move here in Step C. Step B only
+ensures ``scitex-orochi hook --help`` works and the group appears in
+top-level help with an ``(Available Now)`` suffix when the hub is
+reachable.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "hook",
+    short_help="Claude Code / framework hook reports",
+    help="Claude Code / framework hook reports (report activity/stuck/heartbeat).",
+)
+def hook() -> None:
+    """Hook-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(hook)

--- a/src/scitex_orochi/_cli/commands/invite_cmd.py
+++ b/src/scitex_orochi/_cli/commands/invite_cmd.py
@@ -1,0 +1,29 @@
+"""``scitex-orochi invite`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verbs (``invite create``, ``invite list``)
+move here in Step C. Step B only ensures ``scitex-orochi invite --help``
+works and the group appears in top-level help with an ``(Available
+Now)`` suffix when the hub is reachable.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "invite",
+    short_help="Workspace invite codes",
+    help="Workspace invite codes (create, list).",
+)
+def invite() -> None:
+    """Invite-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(invite)

--- a/src/scitex_orochi/_cli/commands/message_cmd.py
+++ b/src/scitex_orochi/_cli/commands/message_cmd.py
@@ -1,0 +1,30 @@
+"""``scitex-orochi message`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verbs (``message send``, ``message listen``,
+``message react add``, ``message react remove``) move here in Step C.
+Step B only ensures ``scitex-orochi message --help`` works and the
+group appears in top-level help with an ``(Available Now)`` suffix
+when the hub is reachable.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "message",
+    short_help="Send, listen, and react to messages",
+    help="Send, listen, and react to messages (send, listen, react add/remove).",
+)
+def message() -> None:
+    """Message-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(message)

--- a/src/scitex_orochi/_cli/commands/push_cmd.py
+++ b/src/scitex_orochi/_cli/commands/push_cmd.py
@@ -1,0 +1,29 @@
+"""``scitex-orochi push`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verbs (``push setup``, ``push send``) move
+here in Step C. Step B only ensures ``scitex-orochi push --help``
+works and the group appears in top-level help with an ``(Available
+Now)`` suffix when the hub is reachable.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "push",
+    short_help="APNs / push-notification plumbing",
+    help="APNs / push-notification plumbing (setup, send).",
+)
+def push() -> None:
+    """Push-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(push)

--- a/src/scitex_orochi/_cli/commands/server_cmd.py
+++ b/src/scitex_orochi/_cli/commands/server_cmd.py
@@ -1,4 +1,11 @@
-"""CLI commands: serve, vapid-generate."""
+"""CLI commands: serve, vapid-generate.
+
+Phase 1d Step B additionally exposes an empty ``server`` click group —
+the noun dispatcher that will host ``server start/status/deploy`` once
+Step C migrates the flat ``serve`` / top-level ``deploy`` verbs. The
+group is deliberately empty in Step B; it co-exists with the legacy
+flat commands.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +13,24 @@ import json
 
 import click
 
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
 from scitex_orochi._cli._helpers import EXAMPLES_HEADER
+
+
+# ── Phase 1d Step B: empty noun dispatcher ─────────────────────────────
+# No verbs are registered under this group in Step B. Step C migrates
+# the flat ``serve`` / ``deploy`` commands into
+# ``server start / server status / server deploy``.
+@click.group(
+    "server",
+    short_help="Hub server lifecycle",
+    help="Hub server lifecycle (start, status, deploy).",
+)
+def server() -> None:
+    """Server-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(server)
 
 
 # ── serve ───────────────────────────────────────────────────────

--- a/src/scitex_orochi/_cli/commands/system_cmd.py
+++ b/src/scitex_orochi/_cli/commands/system_cmd.py
@@ -1,0 +1,29 @@
+"""``scitex-orochi system`` — empty noun group (Phase 1d Step B).
+
+Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
+deliberately empty — the verb (``system doctor``, replacing top-level
+``doctor``) moves here in Step C. Step B only ensures ``scitex-orochi
+system --help`` works and the group appears in top-level help with an
+``(Available Now)`` suffix when the hub is reachable.
+
+See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
+for the full noun-group registry.
+"""
+
+from __future__ import annotations
+
+import click
+
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
+
+
+@click.group(
+    "system",
+    short_help="Host-side self-diagnosis",
+    help="Host-side self-diagnosis (doctor).",
+)
+def system() -> None:
+    """System-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(system)

--- a/src/scitex_orochi/_cli/commands/workspace_cmd.py
+++ b/src/scitex_orochi/_cli/commands/workspace_cmd.py
@@ -1,4 +1,10 @@
-"""CLI commands: workspace management (create, delete, list, invites)."""
+"""CLI commands: workspace management (create, delete, list, invites).
+
+Phase 1d Step B additionally exposes an empty ``workspace`` click group —
+the noun dispatcher that will host ``workspace create/delete/list`` once
+Step C migrates the flat verbs. The group is deliberately empty in
+Step B; it co-exists with the legacy flat commands.
+"""
 
 from __future__ import annotations
 
@@ -10,7 +16,25 @@ import urllib.request
 
 import click
 
+from scitex_orochi._cli._help_availability import annotate_help_with_availability
 from scitex_orochi._cli._helpers import EXAMPLES_HEADER
+
+
+# ── Phase 1d Step B: empty noun dispatcher ─────────────────────────────
+# No verbs are registered under this group in Step B. Step C migrates
+# the flat ``create-workspace / delete-workspace / list-workspaces``
+# commands into ``workspace create / delete / list``.
+@click.group(
+    "workspace",
+    short_help="Manage workspaces",
+    help="Manage workspaces (create, delete, list).",
+)
+def workspace() -> None:
+    """Workspace-scoped verbs. Subcommands populate in Phase 1d Step C."""
+
+
+annotate_help_with_availability(workspace)
+
 
 # ── HTTP helper ───────────────────────────────────────────────────
 

--- a/tests/cli/test_help_availability.py
+++ b/tests/cli/test_help_availability.py
@@ -261,3 +261,109 @@ def test_default_probe_map_covers_all_registered_top_level_commands() -> None:
     assert "agent" in hub_or_daemon_names
     assert "cron" in hub_or_daemon_names
     assert bogus  # keeps variables used; suppresses ruff unused-var
+
+
+# ---------------------------------------------------------------------------
+# Step B — new noun dispatchers participate in (Available Now) annotation.
+# ---------------------------------------------------------------------------
+
+
+# Nouns that depend on the hub (entry in DEFAULT_PROBE_MAP is HUB). Suffix
+# must appear when the hub is reachable, must NOT appear when it is not.
+STEP_B_HUB_NOUNS: list[str] = [
+    "agent",
+    "auth",
+    "channel",
+    "hook",
+    "invite",
+    "message",
+    "push",
+    "server",
+    "system",
+    "workspace",
+]
+
+
+# Nouns that are PURE_LOCAL and must NEVER show the suffix. `config` is the
+# only new Step B noun in this bucket (config init writes local state only).
+STEP_B_PURE_LOCAL_NOUNS: list[str] = ["config"]
+
+
+@pytest.mark.parametrize("noun", STEP_B_HUB_NOUNS)
+def test_step_b_noun_suffix_present_when_hub_reachable(noun: str) -> None:
+    """Each Step B hub-backed noun group gets `(Available Now)` next to
+    its short-help when the hub probe succeeds."""
+    from scitex_orochi._cli._main import orochi
+
+    runner = CliRunner()
+    with patch.object(ha, "probe_hub", return_value=True), patch.object(
+        ha, "probe_local_daemon", return_value=True
+    ):
+        result = runner.invoke(orochi, ["--help"], obj={"host": "h", "port": 9559})
+
+    assert result.exit_code == 0, result.output
+    line = next(
+        (
+            ln
+            for ln in result.output.splitlines()
+            if ln.lstrip().startswith(noun + " ")
+        ),
+        "",
+    )
+    assert AVAILABLE_SUFFIX in line, (
+        f"expected {AVAILABLE_SUFFIX} on {noun!r} line when hub reachable; "
+        f"got line {line!r}\nfull output:\n{result.output}"
+    )
+
+
+@pytest.mark.parametrize("noun", STEP_B_HUB_NOUNS)
+def test_step_b_noun_suffix_absent_when_hub_unreachable(noun: str) -> None:
+    """Each Step B hub-backed noun group drops the suffix when the hub
+    probe fails."""
+    from scitex_orochi._cli._main import orochi
+
+    runner = CliRunner()
+    with patch.object(ha, "probe_hub", return_value=False), patch.object(
+        ha, "probe_local_daemon", return_value=False
+    ):
+        result = runner.invoke(orochi, ["--help"], obj={"host": "h", "port": 9559})
+
+    assert result.exit_code == 0, result.output
+    line = next(
+        (
+            ln
+            for ln in result.output.splitlines()
+            if ln.lstrip().startswith(noun + " ")
+        ),
+        "",
+    )
+    assert AVAILABLE_SUFFIX not in line, (
+        f"{noun!r} must NOT show the suffix when hub is unreachable; "
+        f"got line {line!r}"
+    )
+
+
+@pytest.mark.parametrize("noun", STEP_B_PURE_LOCAL_NOUNS)
+def test_step_b_pure_local_noun_never_annotated(noun: str) -> None:
+    """PURE_LOCAL Step B nouns never show the suffix, even with both
+    probes green."""
+    from scitex_orochi._cli._main import orochi
+
+    runner = CliRunner()
+    with patch.object(ha, "probe_hub", return_value=True), patch.object(
+        ha, "probe_local_daemon", return_value=True
+    ):
+        result = runner.invoke(orochi, ["--help"], obj={"host": "h", "port": 9559})
+
+    assert result.exit_code == 0, result.output
+    line = next(
+        (
+            ln
+            for ln in result.output.splitlines()
+            if ln.lstrip().startswith(noun + " ")
+        ),
+        "",
+    )
+    assert AVAILABLE_SUFFIX not in line, (
+        f"pure-local {noun!r} must never show {AVAILABLE_SUFFIX}; got {line!r}"
+    )

--- a/tests/cli/test_noun_dispatchers_skeleton.py
+++ b/tests/cli/test_noun_dispatchers_skeleton.py
@@ -1,0 +1,165 @@
+"""Tests for the Phase 1d Step B noun dispatcher skeleton.
+
+Plan PR #337 §2 / Step B scope:
+
+* 11 new empty noun groups (``agent``, ``channel``, ``workspace``,
+  ``invite``, ``message``, ``push``, ``server``, ``config``, ``system``,
+  ``auth``, ``hook``) are registered under the top-level ``scitex-orochi``
+  click group.
+* Each new group's ``--help`` must succeed with exit 0, must print the
+  group's short-help, and must NOT have any subcommands yet — Step C
+  adds the verbs.
+* Each new group's class must be annotated by
+  :func:`annotate_help_with_availability` (the decorator is a no-op on
+  empty groups today, but the attribute check protects Step C from
+  regressing: nested help needs the annotated class already in place
+  the moment a verb lands).
+* The pre-existing flat verbs (``list-agents``, ``send``,
+  ``create-workspace``, ``serve``, ``doctor``, ``init``, ``login``,
+  ``deploy``, ``report``, …) must still be registered unchanged —
+  Step B is additive only.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._help_availability import (
+    AvailabilityAnnotatedGroup,
+)
+from scitex_orochi._cli._main import orochi
+
+NEW_NOUNS: list[str] = [
+    "agent",
+    "auth",
+    "channel",
+    "config",
+    "hook",
+    "invite",
+    "message",
+    "push",
+    "server",
+    "system",
+    "workspace",
+]
+
+
+#: Legacy flat commands that must remain registered in Step B. Step C
+#: will migrate / alias them; Step B touches none of them.
+LEGACY_FLAT_COMMANDS: list[str] = [
+    "agent-launch",
+    "agent-restart",
+    "agent-status",
+    "agent-stop",
+    "create-invite",
+    "create-workspace",
+    "delete-workspace",
+    "deploy",
+    "doctor",
+    "fleet",
+    "heartbeat-push",
+    "init",
+    "join",
+    "launch",
+    "list-agents",
+    "list-channels",
+    "list-invites",
+    "list-members",
+    "list-workspaces",
+    "listen",
+    "login",
+    "report",
+    "send",
+    "serve",
+    "setup-push",
+    "show-history",
+    "show-status",
+    "stop",
+]
+
+
+# ---------------------------------------------------------------------------
+# Registration: every new noun is a click group hanging off the root.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("noun", NEW_NOUNS)
+def test_noun_group_is_registered(noun: str) -> None:
+    """Every Phase 1d Step B noun group is present on the top-level group."""
+    assert noun in orochi.commands, (
+        f"noun group {noun!r} missing from scitex-orochi root "
+        f"(plan PR #337 §2 / Step B)"
+    )
+    cmd = orochi.commands[noun]
+    assert isinstance(cmd, click.Group), (
+        f"{noun!r} must be a click.Group — got {type(cmd).__name__}"
+    )
+
+
+@pytest.mark.parametrize("noun", NEW_NOUNS)
+def test_noun_group_has_no_verbs_yet(noun: str) -> None:
+    """Step B scope: empty groups only. Verbs land in Step C."""
+    group = orochi.commands[noun]
+    assert isinstance(group, click.Group)
+    assert dict(group.commands) == {}, (
+        f"{noun!r} must be empty in Step B; found verbs: "
+        f"{sorted(group.commands.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# `<noun> --help` renders cleanly with exit 0.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("noun", NEW_NOUNS)
+def test_noun_help_runs_cleanly(noun: str) -> None:
+    """``scitex-orochi <noun> --help`` succeeds and prints usage / help."""
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, [noun, "--help"], obj={"host": "127.0.0.1", "port": 9559}
+    )
+    assert result.exit_code == 0, (
+        f"{noun} --help exited {result.exit_code}\n"
+        f"stderr/stdout:\n{result.output}\n"
+        f"exception: {result.exception!r}"
+    )
+    # Click always prints "Usage: ..." on --help; that's a safe canary.
+    assert "Usage:" in result.output, (
+        f"{noun} --help did not print a Usage line; got:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Availability annotation: each new group's class is the annotated variant,
+# so nested subcommands (arriving in Step C) inherit the `(Available Now)`
+# rendering without a second wiring step.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("noun", NEW_NOUNS)
+def test_noun_group_is_availability_annotated(noun: str) -> None:
+    """Each Step B noun group has been passed through
+    :func:`annotate_help_with_availability` so Step C's nested verbs get
+    the suffix treatment automatically."""
+    group = orochi.commands[noun]
+    assert isinstance(group, AvailabilityAnnotatedGroup), (
+        f"{noun!r} must be annotated by annotate_help_with_availability; "
+        f"got class {type(group).__name__}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Legacy commands stay registered (Step B is additive only).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", LEGACY_FLAT_COMMANDS)
+def test_legacy_flat_command_still_registered(name: str) -> None:
+    """Step B must not remove / rename any flat command — Step C handles that."""
+    assert name in orochi.commands, (
+        f"legacy flat command {name!r} disappeared in Step B; "
+        f"registration should be unchanged"
+    )


### PR DESCRIPTION
## Summary

Phase 1d **Step B** of the CLI noun-verb refactor (plan PR #337, Step A = merged #341). Lays the **noun dispatcher skeleton** before any verb-rename work in Step C. Strictly additive: **11 new empty click groups, zero verb moves, zero aliases, every legacy flat command still registered unchanged.**

- New noun groups: `agent`, `auth`, `channel`, `config`, `hook`, `invite`, `message`, `push`, `server`, `system`, `workspace`.
- Each group is wrapped by `annotate_help_with_availability` so Step C's nested verbs inherit the `(Available Now)` suffix without a second wiring step.
- `DEFAULT_PROBE_MAP` gains HUB entries for the 10 hub-backed nouns; `config` is PURE_LOCAL (config init writes local state only — no false-positive suffix).

## Files

New:
- `src/scitex_orochi/_cli/commands/{auth,channel,config,hook,invite,message,push,system}_cmd.py` (8 files)
- `tests/cli/test_noun_dispatchers_skeleton.py` (72 new tests)

Modified:
- `src/scitex_orochi/_cli/_main.py` — register all 11 groups
- `src/scitex_orochi/_cli/_help_availability.py` — extend `DEFAULT_PROBE_MAP`
- `src/scitex_orochi/_cli/commands/agent_cmd/__init__.py` — add empty `agent` group alongside existing `agent_launch/_restart/_stop/_status` flat commands
- `src/scitex_orochi/_cli/commands/workspace_cmd.py` — add empty `workspace` group alongside existing flat verbs
- `src/scitex_orochi/_cli/commands/server_cmd.py` — add empty `server` group alongside existing flat `serve`
- `tests/cli/test_help_availability.py` — +20 tests for new noun suffix behaviour

## Scope guardrails

Per the task brief:
- No verbs registered under new groups (that is Step C).
- No rename / removal of any existing command — flat style keeps working.
- No alias redirects.
- No touch to `hub/frontend/`, `ts-migration-v2`, or backend Python outside `src/scitex_orochi/_cli/`.

## Test plan

- [x] `tests/cli/test_noun_dispatchers_skeleton.py` — 72 tests: each new noun is registered, is a `click.Group`, has zero sub-commands, its `--help` exits 0 with a `Usage:` line, is wrapped by `AvailabilityAnnotatedGroup`, and every legacy flat command is still registered.
- [x] `tests/cli/test_help_availability.py` (+20) — for each new hub-backed noun: suffix appears iff hub reachable, is absent when unreachable; for `config`: suffix never appears.
- [x] Full repo suite: **402 passed, 1 skipped, 1 xfailed** (Step A baseline + 92 new Step B tests).
- [x] Ruff clean on `src/scitex_orochi/_cli/` and `tests/cli/`.
- [x] `scitex-orochi --help`, `scitex-orochi --help-recursive`, and each `scitex-orochi <noun> --help` render cleanly.

## Next step

Step C: migrate the legacy flat verbs into these dispatchers, wire the `hard_rename_error` plumbing from `_cli/_deprecation.py` (Step A) on every renamed command, and alias-free hard-error at call time per the Q1 policy in `convention-cli.md`.

Target branch: `develop`.

Generated with [Claude Code](https://claude.com/claude-code)
