### PR TITLE
feat(cli): Phase 1d Step C — move verbs under nouns + hard-error rename redirects (plan PR #337)

### DIFF
--- a/src/scitex_orochi/_cli/_deprecation.py
+++ b/src/scitex_orochi/_cli/_deprecation.py
@@ -33,6 +33,7 @@ __all__ = [
     "SOFT_TTL_S",
     "is_opted_out",
     "hard_rename_error",
+    "make_rename_stub",
     "soft_notice",
     "reset_soft_notice_state",
 ]
@@ -131,6 +132,53 @@ def hard_rename_error(
     )
     print(msg, file=out)
     exit_fn(exit_code)
+
+
+def make_rename_stub(old_name: str, new_name: str):
+    """Return a click.Command that fires :func:`hard_rename_error` when invoked.
+
+    Used by the top-level ``_main.py`` to replace legacy flat commands
+    whose body has been migrated under a noun group (Phase 1d Step C, plan
+    PR #337). The stub:
+
+    * accepts arbitrary extra args (so users who run
+      ``scitex-orochi list-agents --json`` still see the rename error,
+      not a click usage error that would confuse them further);
+    * prints the canonical one-liner to stderr and exits ``2`` unchanged;
+    * exposes a short help string mentioning the new form, so
+      ``scitex-orochi --help`` readers see the redirect target.
+
+    The stub is deliberately a ``click.Command`` (not a group) — any
+    former subcommand path (e.g. ``scitex-orochi deploy stable``) is
+    swallowed by ``UNPROCESSED`` and the user still gets the rename
+    error. This is simpler than enumerating every old sub-verb and is
+    correct per the plan: the old path is dead, not re-routed.
+    """
+    import click as _click
+
+    short_help = f"Renamed -- use `scitex-orochi {new_name}`."
+
+    @_click.command(
+        old_name,
+        short_help=short_help,
+        help=(
+            f"Renamed. Use `scitex-orochi {new_name}` instead. This stub "
+            f"exists only to give a clear error message; invoking it "
+            f"exits non-zero."
+        ),
+        # Accept any extra args so users who ran the old form with its
+        # old options still hit the rename error (not a click parse error).
+        context_settings={
+            "ignore_unknown_options": True,
+            "allow_extra_args": True,
+            "help_option_names": ["-h", "--help"],
+        },
+    )
+    @_click.argument("_args", nargs=-1, type=_click.UNPROCESSED)
+    def _stub(_args):  # pragma: no cover - exercised via tests
+        hard_rename_error(old_name, new_name)
+
+    return _stub
 
 
 def soft_notice(

--- a/src/scitex_orochi/_cli/_help_availability.py
+++ b/src/scitex_orochi/_cli/_help_availability.py
@@ -77,64 +77,69 @@ class ProbeKind(enum.Enum):
 # ---------------------------------------------------------------------------
 
 DEFAULT_PROBE_MAP: Mapping[str, ProbeKind] = {
-    # Hub-dependent verbs/groups (talk to the Orochi server or Django API)
+    # ── Phase 1d Step C: canonical noun groups (plan §2 / PR #337). ──
+    # The noun dispatchers are hub-dependent wherever their verbs talk
+    # to the hub (agent, auth, channel, hook, invite, message, push,
+    # server, system, workspace). ``config`` stays pure-local — its only
+    # verb (``config init``) writes a local YAML.
     "agent": ProbeKind.HUB,
-    "agent-launch": ProbeKind.HUB,
-    "agent-restart": ProbeKind.HUB,
-    "agent-status": ProbeKind.HUB,
-    "agent-stop": ProbeKind.HUB,
-    "list-agents": ProbeKind.HUB,
-    "list-channels": ProbeKind.HUB,
-    "list-members": ProbeKind.HUB,
-    "list-workspaces": ProbeKind.HUB,
-    "list-invites": ProbeKind.HUB,
-    "show-status": ProbeKind.HUB,
-    "show-history": ProbeKind.HUB,
-    "send": ProbeKind.HUB,
-    "listen": ProbeKind.HUB,
-    "join": ProbeKind.HUB,
-    "login": ProbeKind.HUB,
-    "fleet": ProbeKind.HUB,
-    "create-workspace": ProbeKind.HUB,
-    "delete-workspace": ProbeKind.HUB,
-    "create-invite": ProbeKind.HUB,
-    "report": ProbeKind.HUB,
-    "heartbeat-push": ProbeKind.HUB,
+    "auth": ProbeKind.HUB,
+    "channel": ProbeKind.HUB,
+    "hook": ProbeKind.HUB,
+    "invite": ProbeKind.HUB,
+    "message": ProbeKind.HUB,
+    "push": ProbeKind.HUB,
+    "server": ProbeKind.HUB,
+    "system": ProbeKind.HUB,
+    "workspace": ProbeKind.HUB,
+    "config": ProbeKind.PURE_LOCAL,
+    # ── Phase 1d Step C: flat rename stubs (hard-error). ──
+    # The stubs do not talk to the hub; they print-and-exit. Mark them
+    # pure-local so no probe runs and no ``(Available Now)`` suffix is
+    # rendered next to a command that will deterministically fail. This
+    # avoids misleading operators who glance at ``--help``.
+    "agent-launch": ProbeKind.PURE_LOCAL,
+    "agent-restart": ProbeKind.PURE_LOCAL,
+    "agent-status": ProbeKind.PURE_LOCAL,
+    "agent-stop": ProbeKind.PURE_LOCAL,
+    "list-agents": ProbeKind.PURE_LOCAL,
+    "list-channels": ProbeKind.PURE_LOCAL,
+    "list-members": ProbeKind.PURE_LOCAL,
+    "list-workspaces": ProbeKind.PURE_LOCAL,
+    "list-invites": ProbeKind.PURE_LOCAL,
+    "show-status": ProbeKind.PURE_LOCAL,
+    "show-history": ProbeKind.PURE_LOCAL,
+    "send": ProbeKind.PURE_LOCAL,
+    "listen": ProbeKind.PURE_LOCAL,
+    "join": ProbeKind.PURE_LOCAL,
+    "login": ProbeKind.PURE_LOCAL,
+    "fleet": ProbeKind.PURE_LOCAL,
+    "create-workspace": ProbeKind.PURE_LOCAL,
+    "delete-workspace": ProbeKind.PURE_LOCAL,
+    "create-invite": ProbeKind.PURE_LOCAL,
+    "report": ProbeKind.PURE_LOCAL,
+    "heartbeat-push": ProbeKind.PURE_LOCAL,
+    "serve": ProbeKind.PURE_LOCAL,
+    "setup-push": ProbeKind.PURE_LOCAL,
+    "doctor": ProbeKind.PURE_LOCAL,
+    "init": ProbeKind.PURE_LOCAL,
+    "launch": ProbeKind.PURE_LOCAL,
+    "deploy": ProbeKind.PURE_LOCAL,
+    "stop": ProbeKind.PURE_LOCAL,
+    # ── Other hub-dependent top-level commands (not renamed). ──
     "machine": ProbeKind.HUB,
     "host-liveness": ProbeKind.HUB,
     "hungry-signal": ProbeKind.HUB,
     "dispatch": ProbeKind.HUB,
     "todo": ProbeKind.HUB,
     "host-identity": ProbeKind.HUB,
-    "serve": ProbeKind.HUB,
-    "setup-push": ProbeKind.HUB,
-    "doctor": ProbeKind.HUB,
-    # Phase 1d Step B: new empty noun dispatchers (plan §2 / PR #337).
-    # Verbs land in Step C; these entries make the top-level `--help`
-    # annotate the new groups with `(Available Now)` from day one.
-    "channel": ProbeKind.HUB,
-    "workspace": ProbeKind.HUB,
-    "invite": ProbeKind.HUB,
-    "message": ProbeKind.HUB,
-    "push": ProbeKind.HUB,
-    "server": ProbeKind.HUB,
-    "auth": ProbeKind.HUB,
-    "hook": ProbeKind.HUB,
-    "system": ProbeKind.HUB,
-    # Local daemon-dependent commands
+    # ── Local daemon-dependent commands. ──
     "cron": ProbeKind.LOCAL_DAEMON,
     "chrome-watchdog": ProbeKind.LOCAL_DAEMON,
     "disk": ProbeKind.LOCAL_DAEMON,
-    # Pure-local commands: omit suffix entirely
+    # ── Flat keepers (Q5): docs / skills / mcp stay flat. ──
     "docs": ProbeKind.PURE_LOCAL,
     "skills": ProbeKind.PURE_LOCAL,
-    "init": ProbeKind.PURE_LOCAL,
-    "launch": ProbeKind.PURE_LOCAL,
-    "deploy": ProbeKind.PURE_LOCAL,
-    "stop": ProbeKind.PURE_LOCAL,
-    # Phase 1d Step B: `config` is pure-local (config init writes local
-    # state only) — keep the suffix off to avoid false positives.
-    "config": ProbeKind.PURE_LOCAL,
     # Flat keeper `mcp start` is pure-local (stdio server startup): no
     # suffix added to keep external mcp.json contracts noise-free.
     "mcp": ProbeKind.PURE_LOCAL,

--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -112,89 +112,68 @@ def orochi(
 
 
 # ── Register subcommands ────────────────────────────────────────
-from scitex_orochi._cli.commands.agent_cmd import (
-    agent_launch,
-    agent_restart,
-    agent_status,
-    agent_stop,
-)
-from scitex_orochi._cli.commands.deploy_cmd import deploy
+# Phase 1d Step C (plan PR #337 §2, Q1 decision): flat command names
+# are now hard-error stubs that tell the user the new form. The verb
+# bodies live under the noun dispatchers below.
+from scitex_orochi._cli._deprecation import make_rename_stub
 from scitex_orochi._cli.commands.docs_cmd import docs
-from scitex_orochi._cli.commands.doctor_cmd import doctor_cmd
-from scitex_orochi._cli.commands.fleet_cmd import fleet
-from scitex_orochi._cli.commands.init_cmd import init_cmd
-from scitex_orochi._cli.commands.launch_cmd import launch
-from scitex_orochi._cli.commands.messaging_cmd import join, listen, login, send
-from scitex_orochi._cli.commands.query_cmd import (
-    list_agents,
-    list_channels,
-    list_members,
-    show_history,
-    show_status,
-)
-from scitex_orochi._cli.commands.report_cmd import report
-from scitex_orochi._cli.commands.server_cmd import serve, setup_push
 from scitex_orochi._cli.commands.skills_cmd import skills
 
-# Agent lifecycle (direct screen-based management)
-orochi.add_command(agent_launch)
-orochi.add_command(agent_restart)
-orochi.add_command(agent_stop)
-orochi.add_command(agent_status)
+# Rename table (plan §2). Each tuple is (old_flat_name, new_noun_verb).
+# The stub accepts any trailing args so users who still run the old
+# form with its old flags still hit the rename error rather than a
+# confusing click parse failure.
+_RENAMES: list[tuple[str, str]] = [
+    # Agent lifecycle
+    ("agent-launch", "agent launch"),
+    ("agent-restart", "agent restart"),
+    ("agent-status", "agent status"),
+    ("agent-stop", "agent stop"),
+    ("list-agents", "agent list"),
+    ("fleet", "agent fleet-list"),
+    # Flat `launch` (group with master/head/all) and flat `stop` both
+    # mapped to the agent-lifecycle nouns per plan §2 (ambiguous-stop
+    # resolution: implementation targets fleet agents).
+    ("launch", "agent launch"),
+    ("stop", "agent stop"),
+    # Messaging
+    ("send", "message send"),
+    ("listen", "message listen"),
+    # Channels
+    ("show-history", "channel history"),
+    ("join", "channel join"),
+    ("list-channels", "channel list"),
+    ("list-members", "channel members"),
+    # Invites
+    ("create-invite", "invite create"),
+    ("list-invites", "invite list"),
+    # Workspaces
+    ("create-workspace", "workspace create"),
+    ("delete-workspace", "workspace delete"),
+    ("list-workspaces", "workspace list"),
+    # Server
+    ("show-status", "server status"),
+    ("serve", "server start"),
+    ("deploy", "server deploy"),
+    # Push
+    ("setup-push", "push setup"),
+    # Config
+    ("init", "config init"),
+    # System
+    ("doctor", "system doctor"),
+    # Auth
+    ("login", "auth login"),
+    # Machine (Q1 rename, even though `machine heartbeat send` already
+    # exists from PR #336 — the flat form still needs a hard error).
+    ("heartbeat-push", "machine heartbeat send"),
+    # Hook
+    ("report", "hook report"),
+]
 
-# Fleet
-orochi.add_command(fleet)
+for _old, _new in _RENAMES:
+    orochi.add_command(make_rename_stub(_old, _new))
 
-# Messaging
-orochi.add_command(send)
-orochi.add_command(listen)
-orochi.add_command(login)
-orochi.add_command(join)
-
-# Queries
-orochi.add_command(list_agents)
-orochi.add_command(show_status)
-orochi.add_command(list_channels)
-orochi.add_command(list_members)
-orochi.add_command(show_history)
-
-# Server
-orochi.add_command(serve)
-orochi.add_command(doctor_cmd)
-orochi.add_command(setup_push)
-
-from scitex_orochi._cli.commands.stop_cmd import stop as stop_cmd
-
-# Deployment (legacy agent-container based)
-orochi.add_command(init_cmd)
-orochi.add_command(launch)
-orochi.add_command(deploy)
-orochi.add_command(stop_cmd)
-
-# Workspace
-from scitex_orochi._cli.commands.workspace_cmd import (
-    create_invite,
-    create_workspace,
-    delete_workspace,
-    list_invites,
-    list_workspaces,
-)
-
-orochi.add_command(create_workspace)
-orochi.add_command(delete_workspace)
-orochi.add_command(list_workspaces)
-orochi.add_command(create_invite)
-orochi.add_command(list_invites)
-
-# Hook-driven liveness reporting (#143)
-orochi.add_command(report)
-
-# Non-agentic heartbeat pusher (consumes scitex-agent-container CLI)
-from scitex_orochi._cli.commands.heartbeat_cmd import heartbeat_push
-
-orochi.add_command(heartbeat_push)
-
-# Integration
+# Flat keepers (Q5): docs and skills stay flat, no rename.
 orochi.add_command(docs)
 orochi.add_command(skills)
 
@@ -234,16 +213,10 @@ from scitex_orochi._cli.commands.mcp_cmd import mcp as mcp_group
 
 orochi.add_command(mcp_group)
 
-# ── Phase 1d Step B: noun dispatcher skeleton (plan §2, PR #337) ───
-# Empty click groups for every canonical top-level noun. Verbs move
-# under them in Step C — Step B only wires the dispatchers themselves
-# so that `scitex-orochi <noun> --help` is well-formed *before* any
-# rename and so nested help can already annotate reachability.
-#
-# The legacy flat verbs (`list-agents`, `send`, `create-workspace`,
-# `serve`, `doctor`, `init`, `login`, `deploy`, `report`, …) stay
-# registered and functional in Step B; they are migrated and aliased
-# off in Step C.
+# ── Phase 1d Step C: noun dispatchers with migrated verbs (plan §2, PR #337) ─
+# Click groups for every canonical top-level noun. Verbs have been
+# migrated under them (Step C). Flat legacy verbs now hard-error via
+# the rename table above.
 from scitex_orochi._cli.commands.agent_cmd import agent as agent_group
 from scitex_orochi._cli.commands.auth_cmd import auth as auth_group
 from scitex_orochi._cli.commands.channel_cmd import channel as channel_group

--- a/src/scitex_orochi/_cli/commands/agent_cmd/__init__.py
+++ b/src/scitex_orochi/_cli/commands/agent_cmd/__init__.py
@@ -1,4 +1,4 @@
-"""CLI commands: scitex-orochi {launch,restart,stop,status} for agent lifecycle.
+"""CLI commands: scitex-orochi agent {launch,restart,stop,status,list,fleet-list}.
 
 Direct agent lifecycle management using agent definitions from
 ~/.scitex/orochi/agents/<name>/.  Each agent directory may contain:
@@ -15,10 +15,10 @@ Launch flow:
   5. Start screen session with claude
   6. After delay, press Enter to confirm dev channel dialog
 
-Phase 1d Step B additionally exposes an empty ``agent`` click group — the
-noun dispatcher that will host ``agent launch/restart/status/stop/list/
-fleet-list`` once Step C migrates the existing flat verbs. The group is
-deliberately empty in Step B; it co-exists with the legacy flat commands.
+Phase 1d Step C (plan PR #337): the nested verbs ``agent launch /
+restart / stop / status / list / fleet-list`` live here. The flat
+legacy commands (``agent-launch``, ``list-agents``, ``fleet``, etc.)
+are stubbed in ``_main.py`` to return ``hard_rename_error``.
 """
 
 from __future__ import annotations
@@ -33,18 +33,38 @@ from ._status import agent_status
 from ._stop import agent_stop
 
 
-# ── Phase 1d Step B: empty noun dispatcher ─────────────────────────────
-# No verbs are registered under this group in Step B. Step C migrates
-# the flat ``agent-launch / agent-restart / agent-stop / agent-status``
-# commands and introduces ``agent list / agent fleet-list``.
+# ── Phase 1d Step C: noun dispatcher with migrated verbs ───────────────
 @click.group(
     "agent",
     short_help="Agent lifecycle and fleet view",
-    help="Agent lifecycle and fleet view (launch, restart, stop, status, list).",
+    help="Agent lifecycle and fleet view (launch, restart, stop, status, list, fleet-list).",
 )
 def agent() -> None:
-    """Agent-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Agent-scoped verbs (Phase 1d Step C)."""
 
+
+# Register the four original lifecycle verbs under short names.
+# The command functions were declared with click names like
+# ``agent-launch``; we re-expose them as ``launch`` etc. under the
+# group by passing an explicit ``name=`` to ``add_command``.
+agent.add_command(agent_launch, name="launch")
+agent.add_command(agent_restart, name="restart")
+agent.add_command(agent_stop, name="stop")
+agent.add_command(agent_status, name="status")
+
+# Deferred imports to avoid circular import (query_cmd / fleet_cmd
+# both pull helpers that may import agent_cmd transitively).
+
+
+def _register_list_and_fleet() -> None:
+    from scitex_orochi._cli.commands.fleet_cmd import fleet
+    from scitex_orochi._cli.commands.query_cmd import list_agents
+
+    agent.add_command(list_agents, name="list")
+    agent.add_command(fleet, name="fleet-list")
+
+
+_register_list_and_fleet()
 
 annotate_help_with_availability(agent)
 

--- a/src/scitex_orochi/_cli/commands/auth_cmd.py
+++ b/src/scitex_orochi/_cli/commands/auth_cmd.py
@@ -1,13 +1,11 @@
-"""``scitex-orochi auth`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi auth {login}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verb (``auth login``, replacing top-level
-``login``) moves here in Step C. Step B only ensures ``scitex-orochi
-auth --help`` works and the group appears in top-level help with an
-``(Available Now)`` suffix when the hub is reachable.
+The verb body lives in ``messaging_cmd.py`` (historical wiring — the
+flat command was plain ``login``). We re-expose it under the ``auth``
+noun group with a short name.
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+The old flat spelling (``login``) is stubbed in ``_main.py`` to emit
+``hard_rename_error`` (plan PR #337 §2, Q1 decision).
 """
 
 from __future__ import annotations
@@ -23,7 +21,11 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
     help="Credential / session management (login).",
 )
 def auth() -> None:
-    """Auth-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Auth-scoped verbs (Phase 1d Step C)."""
 
+
+from scitex_orochi._cli.commands.messaging_cmd import login as _login  # noqa: E402
+
+auth.add_command(_login, name="login")
 
 annotate_help_with_availability(auth)

--- a/src/scitex_orochi/_cli/commands/channel_cmd.py
+++ b/src/scitex_orochi/_cli/commands/channel_cmd.py
@@ -1,15 +1,16 @@
-"""``scitex-orochi channel`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi channel {list,join,history,members}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verbs (``channel list``, ``channel join``,
-``channel history``, ``channel members``) move here in Step C. Step B
-only ensures ``scitex-orochi channel --help`` works and the group is
-visible in top-level help with an ``(Available Now)`` suffix when the
-hub is reachable.
+The underlying verb bodies still live in ``query_cmd.py`` and
+``messaging_cmd.py`` — this module just re-exposes them under the
+``channel`` noun group with short names.
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+The old flat spellings (``list-channels``, ``join``, ``show-history``,
+``list-members``) are stubbed in ``_main.py`` to emit
+``hard_rename_error`` (plan PR #337 §2, Q1 decision).
 """
+# ruff: noqa: E402
+# (E402 is ignored file-wide so the noun-group decorator can run before
+# the deferred verb imports below — the pattern mirrors ``_main.py``.)
 
 from __future__ import annotations
 
@@ -24,9 +25,20 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
     help="Channel membership and history (list, join, history, members).",
 )
 def channel() -> None:
-    """Channel-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Channel-scoped verbs (Phase 1d Step C)."""
 
 
-# Annotate nested help so Step C's verbs will render with the
-# ``(Available Now)`` suffix as soon as they are registered.
+# Deferred registrations — ``query_cmd`` / ``messaging_cmd`` import
+# lightweight helpers only, so we can pull them at module-import time
+# without a cycle.
+from scitex_orochi._cli.commands.messaging_cmd import join as _join
+from scitex_orochi._cli.commands.query_cmd import list_channels as _list_channels
+from scitex_orochi._cli.commands.query_cmd import list_members as _list_members
+from scitex_orochi._cli.commands.query_cmd import show_history as _show_history
+
+channel.add_command(_list_channels, name="list")
+channel.add_command(_join, name="join")
+channel.add_command(_show_history, name="history")
+channel.add_command(_list_members, name="members")
+
 annotate_help_with_availability(channel)

--- a/src/scitex_orochi/_cli/commands/config_cmd.py
+++ b/src/scitex_orochi/_cli/commands/config_cmd.py
@@ -1,14 +1,11 @@
-"""``scitex-orochi config`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi config {init}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verb (``config init``, replacing top-level
-``init``) moves here in Step C. Step B only ensures ``scitex-orochi
-config --help`` works. ``config`` is pure-local so no ``(Available
-Now)`` suffix is ever shown — its backing operations write local
-state only.
+The verb body lives in ``init_cmd.py`` (the flat command was plain
+``init``). We re-expose it under the ``config`` noun group with a short
+name.
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+The old flat spelling (``init``) is stubbed in ``_main.py`` to emit
+``hard_rename_error`` (plan PR #337 §2, Q1 decision).
 """
 
 from __future__ import annotations
@@ -24,7 +21,11 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
     help="Local scitex-orochi config (init).",
 )
 def config() -> None:
-    """Config-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Config-scoped verbs (Phase 1d Step C)."""
 
+
+from scitex_orochi._cli.commands.init_cmd import init_cmd as _init_cmd  # noqa: E402
+
+config.add_command(_init_cmd, name="init")
 
 annotate_help_with_availability(config)

--- a/src/scitex_orochi/_cli/commands/hook_cmd.py
+++ b/src/scitex_orochi/_cli/commands/hook_cmd.py
@@ -1,14 +1,13 @@
-"""``scitex-orochi hook`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi hook {report ...}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verbs (``hook report activity``, ``hook report
-stuck``, ``hook report heartbeat``) move here in Step C. Step B only
-ensures ``scitex-orochi hook --help`` works and the group appears in
-top-level help with an ``(Available Now)`` suffix when the hub is
-reachable.
+The verb bodies live in ``report_cmd.py`` as a nested click group
+(``report activity`` / ``report stuck`` / ``report heartbeat``). The
+entire group moves under ``hook`` wholesale so those three verbs are
+reachable as ``scitex-orochi hook report activity`` / ``stuck`` /
+``heartbeat``.
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+The old flat spelling (``report …``) is stubbed in ``_main.py`` to
+emit ``hard_rename_error`` (plan PR #337 §2, Q1 decision).
 """
 
 from __future__ import annotations
@@ -24,7 +23,11 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
     help="Claude Code / framework hook reports (report activity/stuck/heartbeat).",
 )
 def hook() -> None:
-    """Hook-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Hook-scoped verbs (Phase 1d Step C)."""
 
+
+from scitex_orochi._cli.commands.report_cmd import report as _report_group  # noqa: E402
+
+hook.add_command(_report_group, name="report")
 
 annotate_help_with_availability(hook)

--- a/src/scitex_orochi/_cli/commands/invite_cmd.py
+++ b/src/scitex_orochi/_cli/commands/invite_cmd.py
@@ -1,14 +1,15 @@
-"""``scitex-orochi invite`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi invite {create,list}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verbs (``invite create``, ``invite list``)
-move here in Step C. Step B only ensures ``scitex-orochi invite --help``
-works and the group appears in top-level help with an ``(Available
-Now)`` suffix when the hub is reachable.
+The verb bodies live in ``workspace_cmd.py`` (historical wiring — the
+original flat commands were ``create-invite`` / ``list-invites`` which
+are workspace-scoped operations). We re-expose them under the
+``invite`` noun group with short names.
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+The old flat spellings (``create-invite``, ``list-invites``) are
+stubbed in ``_main.py`` to emit ``hard_rename_error`` (plan PR #337
+§2, Q1 decision).
 """
+# ruff: noqa: E402
 
 from __future__ import annotations
 
@@ -23,7 +24,13 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
     help="Workspace invite codes (create, list).",
 )
 def invite() -> None:
-    """Invite-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Invite-scoped verbs (Phase 1d Step C)."""
 
+
+from scitex_orochi._cli.commands.workspace_cmd import create_invite as _create_invite
+from scitex_orochi._cli.commands.workspace_cmd import list_invites as _list_invites
+
+invite.add_command(_create_invite, name="create")
+invite.add_command(_list_invites, name="list")
 
 annotate_help_with_availability(invite)

--- a/src/scitex_orochi/_cli/commands/message_cmd.py
+++ b/src/scitex_orochi/_cli/commands/message_cmd.py
@@ -1,15 +1,15 @@
-"""``scitex-orochi message`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi message {send,listen}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verbs (``message send``, ``message listen``,
-``message react add``, ``message react remove``) move here in Step C.
-Step B only ensures ``scitex-orochi message --help`` works and the
-group appears in top-level help with an ``(Available Now)`` suffix
-when the hub is reachable.
+The underlying verb bodies still live in ``messaging_cmd.py`` — this
+module just re-exposes them under the ``message`` noun group with short
+names. ``react add/remove`` remain future work (plan §2 lists them in
+the noun registry; no flat verb to migrate).
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+The old flat spellings (``send``, ``listen``) are stubbed in
+``_main.py`` to emit ``hard_rename_error`` (plan PR #337 §2, Q1
+decision).
 """
+# ruff: noqa: E402
 
 from __future__ import annotations
 
@@ -20,11 +20,17 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
 
 @click.group(
     "message",
-    short_help="Send, listen, and react to messages",
-    help="Send, listen, and react to messages (send, listen, react add/remove).",
+    short_help="Send and listen to messages",
+    help="Send and listen to messages (send, listen).",
 )
 def message() -> None:
-    """Message-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Message-scoped verbs (Phase 1d Step C)."""
 
+
+from scitex_orochi._cli.commands.messaging_cmd import listen as _listen
+from scitex_orochi._cli.commands.messaging_cmd import send as _send
+
+message.add_command(_send, name="send")
+message.add_command(_listen, name="listen")
 
 annotate_help_with_availability(message)

--- a/src/scitex_orochi/_cli/commands/push_cmd.py
+++ b/src/scitex_orochi/_cli/commands/push_cmd.py
@@ -1,14 +1,16 @@
-"""``scitex-orochi push`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi push {setup}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verbs (``push setup``, ``push send``) move
-here in Step C. Step B only ensures ``scitex-orochi push --help``
-works and the group appears in top-level help with an ``(Available
-Now)`` suffix when the hub is reachable.
+The verb body lives in ``server_cmd.py`` (historical wiring — the flat
+command was ``setup-push``). We re-expose it under the ``push`` noun
+group with a short name.
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+``push send`` is listed in the plan noun registry but has no flat
+predecessor to migrate; that's Phase 2 work.
+
+The old flat spelling (``setup-push``) is stubbed in ``_main.py`` to
+emit ``hard_rename_error`` (plan PR #337 §2, Q1 decision).
 """
+# ruff: noqa: E402
 
 from __future__ import annotations
 
@@ -19,11 +21,15 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
 
 @click.group(
     "push",
-    short_help="APNs / push-notification plumbing",
-    help="APNs / push-notification plumbing (setup, send).",
+    short_help="Push-notification plumbing",
+    help="Push-notification plumbing (setup).",
 )
 def push() -> None:
-    """Push-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Push-scoped verbs (Phase 1d Step C)."""
 
+
+from scitex_orochi._cli.commands.server_cmd import setup_push as _setup_push
+
+push.add_command(_setup_push, name="setup")
 
 annotate_help_with_availability(push)

--- a/src/scitex_orochi/_cli/commands/server_cmd.py
+++ b/src/scitex_orochi/_cli/commands/server_cmd.py
@@ -1,11 +1,14 @@
 """CLI commands: serve, vapid-generate.
 
-Phase 1d Step B additionally exposes an empty ``server`` click group —
-the noun dispatcher that will host ``server start/status/deploy`` once
-Step C migrates the flat ``serve`` / top-level ``deploy`` verbs. The
-group is deliberately empty in Step B; it co-exists with the legacy
-flat commands.
+Phase 1d Step C (plan PR #337): the ``server`` noun group now hosts
+``start`` (= former ``serve``), ``status`` (= former ``show-status``)
+and ``deploy`` (= former flat ``deploy`` group). The flat legacy verbs
+are stubbed in ``_main.py``.
 """
+# ruff: noqa: E402
+# (E402 ignored file-wide so the bottom-of-file verb registrations can
+# import from sibling modules without the isort-style reordering that
+# breaks the click.Group → add_command invariant.)
 
 from __future__ import annotations
 
@@ -17,20 +20,17 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
 from scitex_orochi._cli._helpers import EXAMPLES_HEADER
 
 
-# ── Phase 1d Step B: empty noun dispatcher ─────────────────────────────
-# No verbs are registered under this group in Step B. Step C migrates
-# the flat ``serve`` / ``deploy`` commands into
-# ``server start / server status / server deploy``.
+# ── Phase 1d Step C: noun dispatcher with migrated verbs ───────────────
 @click.group(
     "server",
     short_help="Hub server lifecycle",
     help="Hub server lifecycle (start, status, deploy).",
 )
 def server() -> None:
-    """Server-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Server-scoped verbs (Phase 1d Step C)."""
 
 
-annotate_help_with_availability(server)
+# Verbs registered at bottom of file after their definitions.
 
 
 # ── serve ───────────────────────────────────────────────────────
@@ -128,3 +128,18 @@ def setup_push(output: str | None, force: bool, as_json: bool, dry_run: bool) ->
     else:
         click.echo(f"VAPID keys generated and saved to {path}")
         click.echo(f"Public key: {keys['public_key']}")
+
+
+# ── Phase 1d Step C: register verbs under the noun group ───────────────
+# ``server start`` (was flat ``serve``), ``server status`` (was flat
+# ``show-status``), ``server deploy`` (was flat ``deploy`` group with
+# stable/dev/status subcommands — the whole group moves under ``server``
+# wholesale).
+from scitex_orochi._cli.commands.deploy_cmd import deploy as _deploy_group
+from scitex_orochi._cli.commands.query_cmd import show_status as _show_status
+
+server.add_command(serve, name="start")
+server.add_command(_show_status, name="status")
+server.add_command(_deploy_group, name="deploy")
+
+annotate_help_with_availability(server)

--- a/src/scitex_orochi/_cli/commands/system_cmd.py
+++ b/src/scitex_orochi/_cli/commands/system_cmd.py
@@ -1,14 +1,15 @@
-"""``scitex-orochi system`` — empty noun group (Phase 1d Step B).
+"""``scitex-orochi system {doctor}`` (Phase 1d Step C).
 
-Step B (PR plan §2 / #337) lays the dispatcher skeleton. This group is
-deliberately empty — the verb (``system doctor``, replacing top-level
-``doctor``) moves here in Step C. Step B only ensures ``scitex-orochi
-system --help`` works and the group appears in top-level help with an
-``(Available Now)`` suffix when the hub is reachable.
+The verb body lives in ``doctor_cmd.py`` (the flat command was plain
+``doctor``). We re-expose it under the ``system`` noun group with a
+short name.
 
-See ``src/scitex_orochi/_skills/scitex-orochi/convention-cli.md`` §1.1
-for the full noun-group registry.
+The old flat spelling (``doctor``) is stubbed in ``_main.py`` to emit
+``hard_rename_error`` (plan PR #337 §2, Q1 decision).
 """
+# ruff: noqa: E402
+# (E402 is ignored file-wide so the noun-group decorator can run before
+# the deferred verb imports below — the pattern mirrors ``_main.py``.)
 
 from __future__ import annotations
 
@@ -23,7 +24,11 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
     help="Host-side self-diagnosis (doctor).",
 )
 def system() -> None:
-    """System-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """System-scoped verbs (Phase 1d Step C)."""
 
+
+from scitex_orochi._cli.commands.doctor_cmd import doctor_cmd as _doctor_cmd
+
+system.add_command(_doctor_cmd, name="doctor")
 
 annotate_help_with_availability(system)

--- a/src/scitex_orochi/_cli/commands/workspace_cmd.py
+++ b/src/scitex_orochi/_cli/commands/workspace_cmd.py
@@ -1,9 +1,9 @@
 """CLI commands: workspace management (create, delete, list, invites).
 
-Phase 1d Step B additionally exposes an empty ``workspace`` click group —
-the noun dispatcher that will host ``workspace create/delete/list`` once
-Step C migrates the flat verbs. The group is deliberately empty in
-Step B; it co-exists with the legacy flat commands.
+Phase 1d Step C (plan PR #337): the ``workspace`` noun group now hosts
+``create / delete / list``, and the separate ``invite`` noun group
+hosts ``create / list`` (registered in ``invite_cmd.py``). The flat
+legacy verbs are stubbed in ``_main.py``.
 """
 
 from __future__ import annotations
@@ -20,20 +20,19 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
 from scitex_orochi._cli._helpers import EXAMPLES_HEADER
 
 
-# ── Phase 1d Step B: empty noun dispatcher ─────────────────────────────
-# No verbs are registered under this group in Step B. Step C migrates
-# the flat ``create-workspace / delete-workspace / list-workspaces``
-# commands into ``workspace create / delete / list``.
+# ── Phase 1d Step C: noun dispatcher with migrated verbs ───────────────
 @click.group(
     "workspace",
     short_help="Manage workspaces",
     help="Manage workspaces (create, delete, list).",
 )
 def workspace() -> None:
-    """Workspace-scoped verbs. Subcommands populate in Phase 1d Step C."""
+    """Workspace-scoped verbs (Phase 1d Step C)."""
 
 
-annotate_help_with_availability(workspace)
+# Verbs registered at the bottom of this file, after their flat
+# definitions, so we do not add_command before the command object
+# exists.
 
 
 # ── HTTP helper ───────────────────────────────────────────────────
@@ -320,3 +319,13 @@ def list_invites(ctx: click.Context, workspace_id: str, as_json: bool) -> None:
             max_u = inv.get("max_uses", 0)
             uses_str = f"{uses}/{max_u}" if max_u else f"{uses}/unlimited"
             click.echo(f"  {code}  role={inv_role}  uses={uses_str}")
+
+
+# ── Phase 1d Step C: register verbs under the noun groups ──────────────
+# ``workspace create / delete / list`` — the flat ``create-workspace`` /
+# ``delete-workspace`` / ``list-workspaces`` stubs live in ``_main.py``.
+workspace.add_command(create_workspace, name="create")
+workspace.add_command(delete_workspace, name="delete")
+workspace.add_command(list_workspaces, name="list")
+
+annotate_help_with_availability(workspace)

--- a/tests/cli/test_deprecation_helper.py
+++ b/tests/cli/test_deprecation_helper.py
@@ -126,3 +126,87 @@ def test_reset_soft_notice_state_allows_reemit() -> None:
     assert dep.soft_notice("cmd", "x", stream=buf1) is True
     dep.reset_soft_notice_state()
     assert dep.soft_notice("cmd", "x", stream=buf2) is True
+
+
+# ---------------------------------------------------------------------------
+# make_rename_stub — Phase 1d Step C factory (plan PR #337 §2)
+# ---------------------------------------------------------------------------
+
+
+def test_make_rename_stub_returns_click_command() -> None:
+    """``make_rename_stub`` produces a click.Command usable with add_command."""
+    import click
+
+    stub = dep.make_rename_stub("list-agents", "agent list")
+    assert isinstance(stub, click.Command)
+    assert stub.name == "list-agents"
+
+
+def test_make_rename_stub_emits_hard_error_when_invoked() -> None:
+    """Invoking the stub via CliRunner exits non-zero with the canonical
+    rename message."""
+    import click
+    from click.testing import CliRunner
+
+    stub = dep.make_rename_stub("list-agents", "agent list")
+
+    @click.group()
+    def root() -> None:
+        pass
+
+    root.add_command(stub)
+
+    runner = CliRunner()
+    result = runner.invoke(root, ["list-agents"])
+    assert result.exit_code == 2, (
+        f"stub must exit 2; got {result.exit_code}\n{result.output!r}"
+    )
+    assert (
+        "error: `scitex-orochi list-agents` was renamed to "
+        "`scitex-orochi agent list`."
+    ) in result.output
+
+
+def test_make_rename_stub_swallows_trailing_args() -> None:
+    """The stub accepts trailing args so users running the *old* form with
+    its *old* flags get the rename error, not a click parse failure."""
+    import click
+    from click.testing import CliRunner
+
+    stub = dep.make_rename_stub("send", "message send")
+
+    @click.group()
+    def root() -> None:
+        pass
+
+    root.add_command(stub)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        root, ["send", "--json", "#general", "hello"]
+    )
+    assert result.exit_code == 2
+    assert "was renamed" in result.output
+
+
+def test_make_rename_stub_short_help_mentions_new_form() -> None:
+    """``--help`` on the top-level group surfaces the rename target so
+    users browsing help still see the forward pointer."""
+    import click
+    from click.testing import CliRunner
+
+    stub = dep.make_rename_stub("doctor", "system doctor")
+
+    @click.group()
+    def root() -> None:
+        pass
+
+    root.add_command(stub)
+
+    runner = CliRunner()
+    result = runner.invoke(root, ["--help"])
+    assert result.exit_code == 0
+    # Either the short-help or the command listing should carry the
+    # new form. We accept either placement to avoid coupling too tightly
+    # to click's formatter output.
+    assert "system doctor" in result.output

--- a/tests/cli/test_noun_dispatchers_skeleton.py
+++ b/tests/cli/test_noun_dispatchers_skeleton.py
@@ -1,23 +1,15 @@
-"""Tests for the Phase 1d Step B noun dispatcher skeleton.
+"""Tests for the Phase 1d Step C noun dispatchers + rename stubs.
 
-Plan PR #337 §2 / Step B scope:
+Step B (PR #342) introduced empty noun groups. Step C (plan PR #337 §2)
+now:
 
-* 11 new empty noun groups (``agent``, ``channel``, ``workspace``,
-  ``invite``, ``message``, ``push``, ``server``, ``config``, ``system``,
-  ``auth``, ``hook``) are registered under the top-level ``scitex-orochi``
-  click group.
-* Each new group's ``--help`` must succeed with exit 0, must print the
-  group's short-help, and must NOT have any subcommands yet — Step C
-  adds the verbs.
-* Each new group's class must be annotated by
-  :func:`annotate_help_with_availability` (the decorator is a no-op on
-  empty groups today, but the attribute check protects Step C from
-  regressing: nested help needs the annotated class already in place
-  the moment a verb lands).
-* The pre-existing flat verbs (``list-agents``, ``send``,
-  ``create-workspace``, ``serve``, ``doctor``, ``init``, ``login``,
-  ``deploy``, ``report``, …) must still be registered unchanged —
-  Step B is additive only.
+* migrates the verb bodies under each noun group (``agent launch`` =
+  former ``agent-launch``, ``message send`` = former ``send``, etc.);
+* replaces the flat command registrations in ``_main.py`` with
+  hard-error stubs that exit non-zero with the rename message.
+
+This test file asserts both invariants for every row of the rename
+table in plan §2.
 """
 
 from __future__ import annotations
@@ -46,51 +38,69 @@ NEW_NOUNS: list[str] = [
 ]
 
 
-#: Legacy flat commands that must remain registered in Step B. Step C
-#: will migrate / alias them; Step B touches none of them.
-LEGACY_FLAT_COMMANDS: list[str] = [
-    "agent-launch",
-    "agent-restart",
-    "agent-status",
-    "agent-stop",
-    "create-invite",
-    "create-workspace",
-    "delete-workspace",
-    "deploy",
-    "doctor",
-    "fleet",
-    "heartbeat-push",
-    "init",
-    "join",
-    "launch",
-    "list-agents",
-    "list-channels",
-    "list-invites",
-    "list-members",
-    "list-workspaces",
-    "listen",
-    "login",
-    "report",
-    "send",
-    "serve",
-    "setup-push",
-    "show-history",
-    "show-status",
-    "stop",
+#: Expected verb registry under each noun group after Step C.
+EXPECTED_NOUN_VERBS: dict[str, set[str]] = {
+    "agent": {"launch", "restart", "stop", "status", "list", "fleet-list"},
+    "auth": {"login"},
+    "channel": {"list", "join", "history", "members"},
+    "config": {"init"},
+    "hook": {"report"},
+    "invite": {"create", "list"},
+    "message": {"send", "listen"},
+    "push": {"setup"},
+    "server": {"start", "status", "deploy"},
+    "system": {"doctor"},
+    "workspace": {"create", "delete", "list"},
+}
+
+
+#: Rename table — (old_flat_name, new_noun_verb_path) per plan §2.
+RENAME_TABLE: list[tuple[str, str]] = [
+    ("agent-launch", "agent launch"),
+    ("agent-restart", "agent restart"),
+    ("agent-status", "agent status"),
+    ("agent-stop", "agent stop"),
+    ("list-agents", "agent list"),
+    ("fleet", "agent fleet-list"),
+    ("launch", "agent launch"),
+    ("stop", "agent stop"),
+    ("send", "message send"),
+    ("listen", "message listen"),
+    ("show-history", "channel history"),
+    ("join", "channel join"),
+    ("list-channels", "channel list"),
+    ("list-members", "channel members"),
+    ("create-invite", "invite create"),
+    ("list-invites", "invite list"),
+    ("create-workspace", "workspace create"),
+    ("delete-workspace", "workspace delete"),
+    ("list-workspaces", "workspace list"),
+    ("show-status", "server status"),
+    ("serve", "server start"),
+    ("deploy", "server deploy"),
+    ("setup-push", "push setup"),
+    ("init", "config init"),
+    ("doctor", "system doctor"),
+    ("login", "auth login"),
+    ("heartbeat-push", "machine heartbeat send"),
+    ("report", "hook report"),
 ]
+
+#: Flat keepers (Q5) that must remain registered and functional.
+FLAT_KEEPERS: list[str] = ["docs", "skills", "mcp"]
 
 
 # ---------------------------------------------------------------------------
-# Registration: every new noun is a click group hanging off the root.
+# Noun groups + verb migration (Step C)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("noun", NEW_NOUNS)
 def test_noun_group_is_registered(noun: str) -> None:
-    """Every Phase 1d Step B noun group is present on the top-level group."""
+    """Every noun group is present on the top-level group."""
     assert noun in orochi.commands, (
         f"noun group {noun!r} missing from scitex-orochi root "
-        f"(plan PR #337 §2 / Step B)"
+        f"(plan PR #337 §2 / Step C)"
     )
     cmd = orochi.commands[noun]
     assert isinstance(cmd, click.Group), (
@@ -99,13 +109,14 @@ def test_noun_group_is_registered(noun: str) -> None:
 
 
 @pytest.mark.parametrize("noun", NEW_NOUNS)
-def test_noun_group_has_no_verbs_yet(noun: str) -> None:
-    """Step B scope: empty groups only. Verbs land in Step C."""
+def test_noun_group_has_expected_verbs(noun: str) -> None:
+    """Step C scope: each noun group contains its migrated verbs."""
     group = orochi.commands[noun]
     assert isinstance(group, click.Group)
-    assert dict(group.commands) == {}, (
-        f"{noun!r} must be empty in Step B; found verbs: "
-        f"{sorted(group.commands.keys())}"
+    actual = set(group.commands.keys())
+    expected = EXPECTED_NOUN_VERBS[noun]
+    assert expected.issubset(actual), (
+        f"{noun!r} missing verbs: {expected - actual}. Got: {sorted(actual)}"
     )
 
 
@@ -126,40 +137,98 @@ def test_noun_help_runs_cleanly(noun: str) -> None:
         f"stderr/stdout:\n{result.output}\n"
         f"exception: {result.exception!r}"
     )
-    # Click always prints "Usage: ..." on --help; that's a safe canary.
     assert "Usage:" in result.output, (
         f"{noun} --help did not print a Usage line; got:\n{result.output}"
     )
 
 
 # ---------------------------------------------------------------------------
-# Availability annotation: each new group's class is the annotated variant,
-# so nested subcommands (arriving in Step C) inherit the `(Available Now)`
-# rendering without a second wiring step.
+# Availability annotation: each noun group's class is the annotated variant,
+# so nested subcommands render with the `(Available Now)` suffix correctly.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize("noun", NEW_NOUNS)
 def test_noun_group_is_availability_annotated(noun: str) -> None:
-    """Each Step B noun group has been passed through
-    :func:`annotate_help_with_availability` so Step C's nested verbs get
-    the suffix treatment automatically."""
+    """Each noun group is annotated by :func:`annotate_help_with_availability`."""
     group = orochi.commands[noun]
     assert isinstance(group, AvailabilityAnnotatedGroup), (
-        f"{noun!r} must be annotated by annotate_help_with_availability; "
-        f"got class {type(group).__name__}"
+        f"{noun!r} must be annotated; got class {type(group).__name__}"
     )
 
 
 # ---------------------------------------------------------------------------
-# Legacy commands stay registered (Step B is additive only).
+# Rename stubs (Step C Q1: hard-error, not alias)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("name", LEGACY_FLAT_COMMANDS)
-def test_legacy_flat_command_still_registered(name: str) -> None:
-    """Step B must not remove / rename any flat command — Step C handles that."""
-    assert name in orochi.commands, (
-        f"legacy flat command {name!r} disappeared in Step B; "
-        f"registration should be unchanged"
+@pytest.mark.parametrize("old,new", RENAME_TABLE)
+def test_rename_stub_registered(old: str, new: str) -> None:
+    """Each legacy flat name is still reachable as a command (the stub)."""
+    assert old in orochi.commands, (
+        f"legacy flat command {old!r} must remain registered as a "
+        f"hard-error rename stub (plan PR #337 §2, Q1 decision)"
+    )
+
+
+@pytest.mark.parametrize("old,new", RENAME_TABLE)
+def test_rename_stub_exits_nonzero_with_canonical_message(old: str, new: str) -> None:
+    """Invoking the old flat command prints the canonical rename error
+    to stderr and exits non-zero (exit code 2 per Step A helper).
+
+    Note: Click 8.3 dropped ``CliRunner(mix_stderr=False)``; stdout and
+    stderr are merged into ``result.output`` in the default runner. The
+    assertion below therefore checks the combined stream — sufficient
+    because ``hard_rename_error`` targets stderr exclusively and the
+    stub emits nothing on stdout before exiting.
+    """
+    runner = CliRunner()
+    result = runner.invoke(orochi, [old], obj={"host": "127.0.0.1", "port": 9559})
+    assert result.exit_code != 0, (
+        f"{old!r} stub should exit non-zero; got {result.exit_code}\n"
+        f"output: {result.output!r}"
+    )
+    expected_line = (
+        f"error: `scitex-orochi {old}` was renamed to "
+        f"`scitex-orochi {new}`."
+    )
+    assert expected_line in result.output, (
+        f"{old!r} stub did not print expected rename message.\n"
+        f"Expected line: {expected_line!r}\n"
+        f"Got output: {result.output!r}"
+    )
+
+
+@pytest.mark.parametrize("old,new", RENAME_TABLE)
+def test_rename_stub_swallows_extra_args(old: str, new: str) -> None:
+    """Users who still run the old form with old flags/args must hit the
+    rename error (not a click usage error). The stub accepts arbitrary
+    trailing tokens."""
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        [old, "--some-old-flag", "extra", "args"],
+        obj={"host": "127.0.0.1", "port": 9559},
+    )
+    assert result.exit_code != 0
+    assert "was renamed" in result.output, (
+        f"{old!r} stub should print rename message even with trailing "
+        f"args; got output: {result.output!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Flat keepers (Q5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", FLAT_KEEPERS)
+def test_flat_keeper_still_registered(name: str) -> None:
+    """`docs`, `skills`, `mcp` stay flat with their original behaviour."""
+    assert name in orochi.commands
+    cmd = orochi.commands[name]
+    # All three keepers are groups with subcommands (docs: list/get,
+    # skills: list/index, mcp: start); they must not be rename stubs.
+    assert isinstance(cmd, click.Group), (
+        f"flat keeper {name!r} must remain a click.Group, not a stub"
     )

--- a/tests/cli/test_phase1d_step_c_rename_functional.py
+++ b/tests/cli/test_phase1d_step_c_rename_functional.py
@@ -1,0 +1,94 @@
+"""Functional parity tests for Phase 1d Step C (plan PR #337 §2).
+
+For each row of the rename table:
+
+1. **(a) New form works** — ``scitex-orochi <new noun verb> --help``
+   renders cleanly (exit 0) so we know the verb actually reached its
+   target under the noun group.
+2. **(b) Old form hard-errors** — ``scitex-orochi <old>`` exits non-zero
+   and prints the canonical rename message. (The stronger parametrized
+   checks live in ``test_noun_dispatchers_skeleton.py``; this file
+   keeps a per-row functional smoke pair so a failure is legible.)
+
+We deliberately avoid running the verb *bodies* here — those hit the
+hub/filesystem and already have their own tests. Checking ``--help``
+proves the re-registration reached the right group with a callable
+command behind it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._main import orochi
+
+# Rename table — (old, new_path) where new_path is a list of CLI tokens
+# (not a space-joined string) to avoid ambiguity for verbs whose name
+# contains a hyphen (``fleet-list``).
+RENAMES: list[tuple[str, list[str]]] = [
+    ("agent-launch", ["agent", "launch"]),
+    ("agent-restart", ["agent", "restart"]),
+    ("agent-status", ["agent", "status"]),
+    ("agent-stop", ["agent", "stop"]),
+    ("list-agents", ["agent", "list"]),
+    ("fleet", ["agent", "fleet-list"]),
+    ("launch", ["agent", "launch"]),
+    ("stop", ["agent", "stop"]),
+    ("send", ["message", "send"]),
+    ("listen", ["message", "listen"]),
+    ("show-history", ["channel", "history"]),
+    ("join", ["channel", "join"]),
+    ("list-channels", ["channel", "list"]),
+    ("list-members", ["channel", "members"]),
+    ("create-invite", ["invite", "create"]),
+    ("list-invites", ["invite", "list"]),
+    ("create-workspace", ["workspace", "create"]),
+    ("delete-workspace", ["workspace", "delete"]),
+    ("list-workspaces", ["workspace", "list"]),
+    ("show-status", ["server", "status"]),
+    ("serve", ["server", "start"]),
+    ("deploy", ["server", "deploy"]),
+    ("setup-push", ["push", "setup"]),
+    ("init", ["config", "init"]),
+    ("doctor", ["system", "doctor"]),
+    ("login", ["auth", "login"]),
+    ("heartbeat-push", ["machine", "heartbeat", "send"]),
+    ("report", ["hook", "report"]),
+]
+
+
+@pytest.mark.parametrize("old,new_path", RENAMES)
+def test_new_form_help_is_reachable(old: str, new_path: list[str]) -> None:
+    """The migrated verb is reachable via the nested noun-verb path."""
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        new_path + ["--help"],
+        obj={"host": "127.0.0.1", "port": 9559},
+    )
+    assert result.exit_code == 0, (
+        f"`scitex-orochi {' '.join(new_path)} --help` failed for rename "
+        f"of {old!r}.\nexit: {result.exit_code}\noutput: {result.output}\n"
+        f"exception: {result.exception!r}"
+    )
+    # Click puts "Usage:" at the top of every help invocation.
+    assert "Usage:" in result.output
+
+
+@pytest.mark.parametrize("old,new_path", RENAMES)
+def test_old_form_hard_errors(old: str, new_path: list[str]) -> None:
+    """The legacy flat name still exists but now emits a hard rename error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, [old], obj={"host": "127.0.0.1", "port": 9559}
+    )
+    assert result.exit_code != 0, (
+        f"flat {old!r} should exit non-zero under rename policy; "
+        f"got {result.exit_code}\noutput: {result.output}"
+    )
+    expected_new = " ".join(new_path)
+    assert (
+        f"error: `scitex-orochi {old}` was renamed to "
+        f"`scitex-orochi {expected_new}`."
+    ) in result.output


### PR DESCRIPTION
## Summary

Phase 1d Step C of the CLI noun-verb refactor (plan PR #337). Builds on
Step A (#341: convention + deprecation helper) and Step B (#342: 11
empty noun-group dispatchers).

- **Verbs moved under nouns.** Every legacy flat verb now lives under
  its canonical noun group: `list-agents` → `agent list`, `send` →
  `message send`, `doctor` → `system doctor`, `deploy` → `server
  deploy`, `report` → `hook report`, etc. The verb bodies are
  unchanged — only the click registration path moves.
- **Hard-error rename redirects.** Per ywatanabe Q1 decision, the old
  flat names are registered as hard-error stubs (`_deprecation.
  make_rename_stub`). Running `scitex-orochi list-agents` now prints
  `` error: `scitex-orochi list-agents` was renamed to `scitex-orochi agent list`. `` on stderr and exits 2. No alias-with-warning, no
  grace period.
- **Flat keepers preserved (Q5):** `-h/--help`, `--help-recursive`,
  `--version`, `--json`, `docs`, `skills`, `mcp start`.

## Rename table (shipped)

| Old flat | New noun-verb |
|---|---|
| `agent-launch` | `agent launch` |
| `agent-restart` | `agent restart` |
| `agent-status` | `agent status` |
| `agent-stop` | `agent stop` |
| `list-agents` | `agent list` |
| `fleet` | `agent fleet-list` |
| `launch` (group) | `agent launch` |
| `stop` | `agent stop` |
| `send` | `message send` |
| `listen` | `message listen` |
| `show-history` | `channel history` |
| `join` | `channel join` |
| `list-channels` | `channel list` |
| `list-members` | `channel members` |
| `create-invite` | `invite create` |
| `list-invites` | `invite list` |
| `create-workspace` | `workspace create` |
| `delete-workspace` | `workspace delete` |
| `list-workspaces` | `workspace list` |
| `show-status` | `server status` |
| `serve` | `server start` |
| `deploy` (group) | `server deploy` |
| `setup-push` | `push setup` |
| `init` | `config init` |
| `doctor` | `system doctor` |
| `login` | `auth login` |
| `heartbeat-push` | `machine heartbeat send` |
| `report` (group) | `hook report` |

### Ambiguity calls resolved

- flat `launch` (the group with master/head/all subcommands) redirects
  to `agent launch` per plan §2.
- flat `stop` (takes NAME or --all, fleet-scoped in
  `stop_cmd.py`) redirects to `agent stop` because the implementation
  targets fleet agents.
- flat `heartbeat-push` redirects to `machine heartbeat send` (the
  nested form already existed from PR #336).
- flat `deploy` (group with stable/dev/status) moves wholesale under
  `server deploy`; all three sub-verbs remain reachable.
- flat `report` (group with activity/stuck/heartbeat) moves wholesale
  under `hook report`.

## Test plan

- [x] `pytest tests/` — 521 passed, 1 skipped, 1 xfailed (vs 404 pre-C
  baseline; +117 new assertions from this PR)
- [x] `ruff check src/scitex_orochi/_cli/ tests/cli/` — all checks pass
- [x] `scitex-orochi agent --help` lists all six migrated verbs
- [x] `scitex-orochi list-agents` exits 2 with the canonical rename
  message on stderr
- [x] `scitex-orochi list-agents --json` (old form + old flag) still
  hits the rename error, not a click parse failure
- [x] `scitex-orochi server deploy stable --help` reaches the nested
  deploy verb
- [x] `scitex-orochi hook report activity --help` reaches the nested
  report verb

## Files touched

- `src/scitex_orochi/_cli/_deprecation.py` — add `make_rename_stub` factory
- `src/scitex_orochi/_cli/_help_availability.py` — probe map updated for
  noun groups + stubs marked PURE_LOCAL
- `src/scitex_orochi/_cli/_main.py` — registrations replaced with rename
  table loop
- `src/scitex_orochi/_cli/commands/{agent,auth,channel,config,hook,invite,message,push,server,system,workspace}_cmd*.py`
  — verbs added to each noun group
- `tests/cli/test_noun_dispatchers_skeleton.py` — updated for Step C
  expectations
- `tests/cli/test_deprecation_helper.py` — `make_rename_stub` coverage
- `tests/cli/test_phase1d_step_c_rename_functional.py` — new functional
  parity tests (one pair per rename row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
