### PR TITLE
feat(cli): message react add|remove subcommands (msg#16489 queue)

### DIFF
--- a/src/scitex_orochi/_cli/commands/_message_react_cmd.py
+++ b/src/scitex_orochi/_cli/commands/_message_react_cmd.py
@@ -1,0 +1,314 @@
+"""``scitex-orochi message react {add,remove}`` (msg#16489).
+
+Thin HTTP client over the existing ``/api/reactions/`` endpoint in
+``hub/views/api/_reactions.py`` (POST = add, DELETE = remove). The same
+endpoint backs the web dashboard (``hub/static/hub/reactions.js``) and
+the MCP ``react`` tool (``ts/src/tools/messaging.ts``); this CLI is the
+shell-script / non-Claude client-side convenience.
+
+Auth: workspace token (``$SCITEX_OROCHI_TOKEN``, ``--token``, or
+dotfiles secret file) — same pattern as ``dispatch`` and ``machine``.
+The endpoint derives the workspace from the token; ``--workspace`` is
+accepted as an advisory override (forwarded in the body; server ignores
+today, honoured if/when a future PR adds cross-workspace moderation).
+
+The ``reactor`` identity is passed in the body as the agent name
+(``$SCITEX_OROCHI_AGENT`` → fallback ``platform.node()``); the hub
+stores reactor+emoji+message as a unique tuple so re-adding is a
+no-op (``action: "existed"``) and removing a non-existent reaction is
+also a no-op (``action: "not_found"``).
+
+Emoji encoding: pure JSON body — emoji characters are serialised as
+UTF-8 inside the JSON string, which Python's ``json.dumps`` handles
+natively. No URL-encoding is required because the emoji never appears
+in the path or query string (unlike the REST sketch in the original
+spec where ``DELETE /api/messages/<id>/reactions/<emoji>/`` was
+considered — that flavour does not exist on the hub and is not needed
+given the body-based endpoint).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from urllib import request as _urllib_request
+from urllib.error import HTTPError, URLError
+
+import click
+
+from scitex_orochi._cli._helpers import EXAMPLES_HEADER, get_agent_name
+
+from ._host_ops import load_workspace_token
+
+DEFAULT_HUB = "https://scitex-orochi.com"
+
+
+@click.group(
+    "react",
+    short_help="Add/remove emoji reactions on a message",
+    help=(
+        "Add or remove emoji reactions on a message (add, remove).\n"
+        "\n"
+        "The MCP tool ``mcp__scitex-orochi__react`` provides the same "
+        "functionality for in-Claude use; this CLI is aimed at shell "
+        "scripts and non-Claude clients."
+    ),
+)
+def react() -> None:
+    """Message-reaction verbs (msg#16489, Phase 1d follow-up)."""
+
+
+def _resolve_token(token: str | None) -> str:
+    resolved = token or load_workspace_token()
+    if not resolved:
+        raise click.ClickException(
+            "no SCITEX_OROCHI_TOKEN (env, --token, or dotfiles secret)."
+        )
+    return resolved
+
+
+def _http_json(
+    method: str,
+    url: str,
+    token: str,
+    body: dict | None = None,
+    timeout: int = 15,
+) -> tuple[int, Any]:
+    """Tiny stdlib HTTP-JSON client (same shape as dispatch_cmd._http_json).
+
+    Returns (status_code, parsed_body_or_text). Never raises on HTTP
+    errors — the caller maps status → exit code itself so ``--json``
+    mode can still emit a structured error payload.
+    """
+    sep = "&" if "?" in url else "?"
+    full_url = f"{url}{sep}token={token}"
+    data = None
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "scitex-orochi-cli/1.0",
+    }
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    req = _urllib_request.Request(full_url, data=data, headers=headers, method=method)
+    try:
+        with _urllib_request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+            code = resp.status
+    except HTTPError as exc:
+        try:
+            err_body = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            err_body = str(exc)
+        try:
+            return exc.code, json.loads(err_body)
+        except (json.JSONDecodeError, ValueError):
+            return exc.code, err_body
+    except URLError as exc:
+        raise click.ClickException(f"hub unreachable: {exc.reason}") from exc
+    try:
+        return code, json.loads(raw or "null")
+    except json.JSONDecodeError:
+        return code, raw
+
+
+def _run_reaction(
+    ctx: click.Context,
+    *,
+    action: str,
+    msg_id: int,
+    emoji: str,
+    workspace: str | None,
+    hub: str,
+    token: str | None,
+) -> None:
+    """Shared body for ``add`` and ``remove``.
+
+    ``action`` is the client-facing label (``"add"``/``"remove"``).
+    The HTTP method is POST for add and DELETE for remove — matching
+    the existing ``api_reactions`` view.
+    """
+    resolved = _resolve_token(token)
+    method = "POST" if action == "add" else "DELETE"
+    body: dict[str, Any] = {
+        "message_id": int(msg_id),
+        "emoji": emoji,
+        "reactor": get_agent_name(),
+    }
+    if workspace:
+        # Forwarded for future cross-workspace moderation; server
+        # currently derives workspace from the token and ignores this.
+        body["workspace"] = workspace
+
+    url = hub.rstrip("/") + "/api/reactions/"
+    status_code, payload = _http_json(method, url, resolved, body=body)
+    as_json = bool(ctx.obj and ctx.obj.get("json"))
+
+    if status_code >= 400:
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "http": status_code,
+                        "body": payload,
+                        "msg_id": int(msg_id),
+                        "emoji": emoji,
+                        "action": action,
+                    },
+                    separators=(",", ":"),
+                )
+            )
+        else:
+            # Surface the hub's error body verbatim on stderr.
+            click.echo(f"hub returned HTTP {status_code}: {payload}", err=True)
+        sys.exit(1)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "status": "ok",
+                    "msg_id": int(msg_id),
+                    "emoji": emoji,
+                    "action": action,
+                    "hub_action": (
+                        payload.get("action") if isinstance(payload, dict) else None
+                    ),
+                },
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    # Human-readable
+    hub_action = payload.get("action") if isinstance(payload, dict) else None
+    if action == "add":
+        note = {
+            "added": f"reacted {emoji} to msg#{msg_id}",
+            "existed": f"already reacted {emoji} to msg#{msg_id} (no-op)",
+        }.get(hub_action or "", f"reacted {emoji} to msg#{msg_id}")
+    else:
+        note = {
+            "removed": f"removed {emoji} from msg#{msg_id}",
+            "not_found": f"no {emoji} reaction on msg#{msg_id} (no-op)",
+        }.get(hub_action or "", f"removed {emoji} from msg#{msg_id}")
+    click.echo(note)
+
+
+# ---------------------------------------------------------------------------
+# react add
+# ---------------------------------------------------------------------------
+
+
+@react.command(
+    "add",
+    epilog=EXAMPLES_HEADER
+    + "  scitex-orochi message react add 12345 👍\n"
+    + "  scitex-orochi --json message react add 12345 ✅\n"
+    + "  scitex-orochi message react add 12345 :+1: --workspace scitex\n",
+)
+@click.argument("msg_id", type=int)
+@click.argument("emoji")
+@click.option(
+    "--workspace",
+    envvar="SCITEX_OROCHI_WORKSPACE",
+    default=None,
+    help=(
+        "Workspace slug override [$SCITEX_OROCHI_WORKSPACE]. Defaults to "
+        "the workspace derived from the token."
+    ),
+)
+@click.option(
+    "--hub",
+    envvar="SCITEX_OROCHI_URL",
+    default=DEFAULT_HUB,
+    show_default=True,
+    help="Hub base URL [$SCITEX_OROCHI_URL].",
+)
+@click.option(
+    "--token",
+    envvar="SCITEX_OROCHI_TOKEN",
+    default=None,
+    help="Workspace token [$SCITEX_OROCHI_TOKEN].",
+)
+@click.pass_context
+def react_add(
+    ctx: click.Context,
+    msg_id: int,
+    emoji: str,
+    workspace: str | None,
+    hub: str,
+    token: str | None,
+) -> None:
+    """Add a reaction EMOJI to message MSG_ID."""
+    _run_reaction(
+        ctx,
+        action="add",
+        msg_id=msg_id,
+        emoji=emoji,
+        workspace=workspace,
+        hub=hub,
+        token=token,
+    )
+
+
+# ---------------------------------------------------------------------------
+# react remove
+# ---------------------------------------------------------------------------
+
+
+@react.command(
+    "remove",
+    epilog=EXAMPLES_HEADER
+    + "  scitex-orochi message react remove 12345 👍\n"
+    + "  scitex-orochi --json message react remove 12345 ✅\n",
+)
+@click.argument("msg_id", type=int)
+@click.argument("emoji")
+@click.option(
+    "--workspace",
+    envvar="SCITEX_OROCHI_WORKSPACE",
+    default=None,
+    help=(
+        "Workspace slug override [$SCITEX_OROCHI_WORKSPACE]. Defaults to "
+        "the workspace derived from the token."
+    ),
+)
+@click.option(
+    "--hub",
+    envvar="SCITEX_OROCHI_URL",
+    default=DEFAULT_HUB,
+    show_default=True,
+    help="Hub base URL [$SCITEX_OROCHI_URL].",
+)
+@click.option(
+    "--token",
+    envvar="SCITEX_OROCHI_TOKEN",
+    default=None,
+    help="Workspace token [$SCITEX_OROCHI_TOKEN].",
+)
+@click.pass_context
+def react_remove(
+    ctx: click.Context,
+    msg_id: int,
+    emoji: str,
+    workspace: str | None,
+    hub: str,
+    token: str | None,
+) -> None:
+    """Remove a reaction EMOJI from message MSG_ID."""
+    _run_reaction(
+        ctx,
+        action="remove",
+        msg_id=msg_id,
+        emoji=emoji,
+        workspace=workspace,
+        hub=hub,
+        token=token,
+    )
+
+
+__all__ = ["react", "react_add", "react_remove"]

--- a/src/scitex_orochi/_cli/commands/message_cmd.py
+++ b/src/scitex_orochi/_cli/commands/message_cmd.py
@@ -1,13 +1,14 @@
-"""``scitex-orochi message {send,listen}`` (Phase 1d Step C).
+"""``scitex-orochi message {send,listen,react}`` (Phase 1d Step C + follow-up).
 
-The underlying verb bodies still live in ``messaging_cmd.py`` — this
-module just re-exposes them under the ``message`` noun group with short
-names. ``react add/remove`` remain future work (plan §2 lists them in
-the noun registry; no flat verb to migrate).
+The underlying verb bodies for ``send``/``listen`` still live in
+``messaging_cmd.py``; ``react add|remove`` bodies live in
+``_message_react_cmd.py`` (msg#16489 queue). This module just re-exposes
+them under the ``message`` noun group with short names.
 
 The old flat spellings (``send``, ``listen``) are stubbed in
 ``_main.py`` to emit ``hard_rename_error`` (plan PR #337 §2, Q1
-decision).
+decision). ``react`` has no flat-legacy form to rename — it was added
+directly under the noun group.
 """
 # ruff: noqa: E402
 
@@ -20,17 +21,19 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
 
 @click.group(
     "message",
-    short_help="Send and listen to messages",
-    help="Send and listen to messages (send, listen).",
+    short_help="Send, listen, and react to messages",
+    help="Send, listen, and react to messages (send, listen, react).",
 )
 def message() -> None:
-    """Message-scoped verbs (Phase 1d Step C)."""
+    """Message-scoped verbs (Phase 1d Step C + react follow-up)."""
 
 
+from scitex_orochi._cli.commands._message_react_cmd import react as _react
 from scitex_orochi._cli.commands.messaging_cmd import listen as _listen
 from scitex_orochi._cli.commands.messaging_cmd import send as _send
 
 message.add_command(_send, name="send")
 message.add_command(_listen, name="listen")
+message.add_command(_react, name="react")
 
 annotate_help_with_availability(message)

--- a/tests/cli/test_message_react.py
+++ b/tests/cli/test_message_react.py
@@ -1,0 +1,321 @@
+"""Tests for ``scitex-orochi message react {add,remove}`` (msg#16489).
+
+Covers:
+
+* Group registration: ``react`` exists under the ``message`` noun group
+  with ``add`` and ``remove`` sub-verbs.
+* Happy path: both verbs POST/DELETE the correct URL + JSON body,
+  surface the hub's ``action`` field in human + JSON output.
+* Auth: missing token → exit !=0 with a helpful message.
+* Error propagation: 401/404/500 → exit 1, hub body surfaced.
+* ``--json`` top-level flag flows through to the sub-verb.
+* Unicode emoji passes through the body round-trip (``ensure_ascii=False``
+  in the JSON output, UTF-8 on the wire).
+
+No live network — ``_http_json`` is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._main import orochi
+from scitex_orochi._cli.commands import _message_react_cmd as mr
+
+# ---------------------------------------------------------------------------
+# Group registration
+# ---------------------------------------------------------------------------
+
+
+def test_react_group_registered_under_message() -> None:
+    """``message react`` is a click.Group with ``add`` and ``remove``."""
+    message = orochi.commands["message"]
+    assert "react" in message.commands  # type: ignore[attr-defined]
+    react = message.commands["react"]  # type: ignore[attr-defined]
+    assert set(react.commands.keys()) == {"add", "remove"}
+
+
+def test_message_help_mentions_react() -> None:
+    """``scitex-orochi message --help`` advertises the new ``react`` verb."""
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["message", "--help"], obj={"host": "127.0.0.1", "port": 9559}
+    )
+    assert result.exit_code == 0
+    assert "react" in result.output
+
+
+def test_react_help_renders_cleanly() -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["message", "react", "--help"], obj={"host": "127.0.0.1", "port": 9559}
+    )
+    assert result.exit_code == 0
+    assert "add" in result.output
+    assert "remove" in result.output
+    # Help text notes the MCP tool parity
+    assert "MCP" in result.output or "mcp" in result.output
+
+
+# ---------------------------------------------------------------------------
+# react add — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_react_add_posts_reaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``message react add <id> <emoji>`` POSTs to /api/reactions/."""
+    calls: dict = {}
+
+    def fake_http(method, url, token, body=None, timeout=15):
+        calls["method"] = method
+        calls["url"] = url
+        calls["token"] = token
+        calls["body"] = body
+        return 200, {"status": "ok", "action": "added"}
+
+    monkeypatch.setattr(mr, "_http_json", fake_http)
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk-abc")
+    monkeypatch.setenv("SCITEX_OROCHI_AGENT", "head-mba")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["message", "react", "add", "12345", "👍"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    assert calls["method"] == "POST"
+    assert calls["url"].endswith("/api/reactions/")
+    assert calls["token"] == "tk-abc"
+    assert calls["body"] == {
+        "message_id": 12345,
+        "emoji": "👍",
+        "reactor": "head-mba",
+    }
+    assert "reacted" in result.output
+    assert "12345" in result.output
+
+
+def test_react_add_idempotent_existed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-adding an existing reaction prints the no-op notice."""
+    monkeypatch.setattr(
+        mr, "_http_json", lambda *a, **kw: (200, {"status": "ok", "action": "existed"})
+    )
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["message", "react", "add", "7", "✅"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    assert "already reacted" in result.output
+    assert "no-op" in result.output
+
+
+def test_react_add_json_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Top-level ``--json`` emits the canonical payload on stdout."""
+    monkeypatch.setattr(
+        mr, "_http_json", lambda *a, **kw: (200, {"status": "ok", "action": "added"})
+    )
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["--json", "message", "react", "add", "42", "🎉"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    last = result.output.strip().splitlines()[-1]
+    payload = json.loads(last)
+    assert payload == {
+        "status": "ok",
+        "msg_id": 42,
+        "emoji": "🎉",
+        "action": "add",
+        "hub_action": "added",
+    }
+
+
+# ---------------------------------------------------------------------------
+# react remove — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_react_remove_deletes_reaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``message react remove`` issues DELETE with the same body shape."""
+    calls: dict = {}
+
+    def fake_http(method, url, token, body=None, timeout=15):
+        calls["method"] = method
+        calls["url"] = url
+        calls["body"] = body
+        return 200, {"status": "ok", "action": "removed"}
+
+    monkeypatch.setattr(mr, "_http_json", fake_http)
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    monkeypatch.setenv("SCITEX_OROCHI_AGENT", "head-nas")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["message", "react", "remove", "99", "🚀"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    assert calls["method"] == "DELETE"
+    assert calls["url"].endswith("/api/reactions/")
+    assert calls["body"] == {
+        "message_id": 99,
+        "emoji": "🚀",
+        "reactor": "head-nas",
+    }
+    assert "removed" in result.output
+    assert "99" in result.output
+
+
+def test_react_remove_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Removing a non-existent reaction prints the no-op notice (exit 0)."""
+    monkeypatch.setattr(
+        mr,
+        "_http_json",
+        lambda *a, **kw: (200, {"status": "ok", "action": "not_found"}),
+    )
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["message", "react", "remove", "7", "✅"],
+        obj={},
+    )
+    assert result.exit_code == 0
+    assert "no ✅ reaction" in result.output
+    assert "no-op" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --workspace override is forwarded in the body
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_override_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--workspace`` and ``$SCITEX_OROCHI_WORKSPACE`` are forwarded in the body."""
+    captured: dict = {}
+
+    def fake_http(method, url, token, body=None, timeout=15):
+        captured["body"] = body
+        return 200, {"status": "ok", "action": "added"}
+
+    monkeypatch.setattr(mr, "_http_json", fake_http)
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        [
+            "message",
+            "react",
+            "add",
+            "1",
+            "👍",
+            "--workspace",
+            "scitex",
+        ],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["body"]["workspace"] == "scitex"
+
+
+def test_workspace_env_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``$SCITEX_OROCHI_WORKSPACE`` supplies the default when flag is absent."""
+    captured: dict = {}
+
+    def fake_http(method, url, token, body=None, timeout=15):
+        captured["body"] = body
+        return 200, {"status": "ok", "action": "added"}
+
+    monkeypatch.setattr(mr, "_http_json", fake_http)
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    monkeypatch.setenv("SCITEX_OROCHI_WORKSPACE", "lab-alpha")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["message", "react", "add", "2", "👀"],
+        obj={},
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["body"]["workspace"] == "lab-alpha"
+
+
+# ---------------------------------------------------------------------------
+# Auth: missing token
+# ---------------------------------------------------------------------------
+
+
+def test_react_add_missing_token_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No token anywhere → exit !=0 with the SCITEX_OROCHI_TOKEN hint."""
+    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
+    monkeypatch.setattr(mr, "load_workspace_token", lambda: None)
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["message", "react", "add", "1", "👍"],
+        obj={},
+    )
+    assert result.exit_code != 0
+    combined = result.output + str(result.exception or "")
+    assert "SCITEX_OROCHI_TOKEN" in combined
+
+
+# ---------------------------------------------------------------------------
+# HTTP error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "status,body,needle",
+    [
+        (401, {"error": "invalid token"}, "invalid token"),
+        (404, {"error": "message not found"}, "not found"),
+        (500, "boom", "500"),
+    ],
+)
+def test_react_add_http_error_exit_1(
+    monkeypatch: pytest.MonkeyPatch, status: int, body, needle: str
+) -> None:
+    """Non-2xx → exit 1; stderr carries the hub's body."""
+    monkeypatch.setattr(mr, "_http_json", lambda *a, **kw: (status, body))
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["message", "react", "add", "1", "👍"],
+        obj={},
+    )
+    assert result.exit_code == 1
+    assert needle in result.output or str(status) in result.output
+
+
+def test_react_remove_http_error_json_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--json`` mode emits a structured error envelope and exits 1."""
+    monkeypatch.setattr(
+        mr, "_http_json", lambda *a, **kw: (404, {"error": "message not found"})
+    )
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "tk")
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["--json", "message", "react", "remove", "99", "👍"],
+        obj={},
+    )
+    assert result.exit_code == 1
+    last = result.output.strip().splitlines()[-1]
+    payload = json.loads(last)
+    assert payload["status"] == "error"
+    assert payload["http"] == 404
+    assert payload["action"] == "remove"
+    assert payload["msg_id"] == 99
+    assert payload["emoji"] == "👍"

--- a/tests/cli/test_noun_dispatchers_skeleton.py
+++ b/tests/cli/test_noun_dispatchers_skeleton.py
@@ -46,7 +46,7 @@ EXPECTED_NOUN_VERBS: dict[str, set[str]] = {
     "config": {"init"},
     "hook": {"report"},
     "invite": {"create", "list"},
-    "message": {"send", "listen"},
+    "message": {"send", "listen", "react"},
     "push": {"setup"},
     "server": {"start", "status", "deploy"},
     "system": {"doctor"},


### PR DESCRIPTION
## Summary

- Adds `scitex-orochi message react {add,remove} <msg_id> <emoji>` as a shell-script / non-Claude client-side complement to the existing MCP `react` tool.
- Reuses the existing `/api/reactions/` endpoint in `hub/views/api/_reactions.py` (POST = add, DELETE = remove). No backend changes.
- Auth + HTTP shape mirrors `dispatch_cmd.py`: stdlib urllib, `?token=` query param, `reactor: $SCITEX_OROCHI_AGENT` in body. Emoji rides UTF-8 inside the JSON body — no URL-encoding needed since it never appears in the path.
- `--workspace` (and `$SCITEX_OROCHI_WORKSPACE` env) is accepted and forwarded in the body as an advisory override. Server currently derives workspace from the token; the flag is in place for future cross-workspace moderation without a CLI breaking change.
- `--json` emits a stable envelope: `{"status":"ok|error","msg_id","emoji","action":"add|remove","hub_action":"added|existed|removed|not_found"}`.
- Exit 0 on 2xx (incl. idempotent `existed`/`not_found` no-ops), exit 1 on 4xx/5xx with the hub body surfaced.

## Files touched

- `src/scitex_orochi/_cli/commands/_message_react_cmd.py` (new, ~260 LoC)
- `src/scitex_orochi/_cli/commands/message_cmd.py` (wires `react` under the `message` noun group alongside `send`/`listen`)
- `tests/cli/test_message_react.py` (new, 15 tests)
- `tests/cli/test_noun_dispatchers_skeleton.py` (adds `react` to the `message` verb-coverage set; pre-existing `issubset` check was already permissive)

## MCP parity

No MCP code touched — `mcp__scitex-orochi__react` already exists and covers the same endpoint. The CLI help text notes the MCP tool for in-Claude use; the CLI is the shell-script / non-Claude convenience.

## Test plan

- [x] `pytest tests/cli/test_message_react.py` — 15 passed.
- [x] `pytest tests/cli/` — 310 passed (no regressions vs Phase 1d Step C baseline).
- [x] `ruff check` + `ruff format --check` — clean on all three touched files.
- [x] `scitex-orochi message react --help`, `message react add --help`, `message react remove --help` all render cleanly (verified via `click.testing.CliRunner`).
- [ ] Live smoke against `https://scitex-orochi.com` (deferred — no breaking change vs MCP tool, which uses the same endpoint today).

## Constraints honoured

- No touch to `ts-migration-v2` or `hub/frontend/`.
- No Phase 1d invariant regression (`test_noun_dispatchers_skeleton.py`, `test_phase1d_step_c_rename_functional.py` both pass).
- No ``--no-verify``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)