### PR TITLE
feat(heartbeat): subagent_count via process tree (not tmux parse) — auto-detect subagent spawn (msg#16727)

### DIFF
--- a/scripts/client/agent_meta_pkg/_collect.py
+++ b/scripts/client/agent_meta_pkg/_collect.py
@@ -25,6 +25,7 @@ from ._metrics import collect_machine_metrics, collect_slurm_status
 from ._multiplexer import detect_multiplexer
 from ._pane import capture_pane, filter_pane_tail, parse_subagent_count
 from ._proc import _read_process_env
+from ._process_tree import count_subagents_via_ps
 from ._statusline import parse_statusline
 from ._transcript import find_jsonl_transcripts, parse_transcript
 
@@ -65,7 +66,22 @@ def collect(agent: str) -> dict:
     pane_tail, pane_tail_block, pane_tail_block_clean, pane_tail_full = (
         filter_pane_tail(pane)
     )
-    subagents = parse_subagent_count(pane)
+    # Subagent count — prefer the process-tree walk (msg#16727: the
+    # regex-on-tmux-pane approach false-positives on chat-embedded
+    # quotes of the marker phrase; see
+    # ``tests/test_subagent_count_lifecycle.test_quoted_marker_phrase_false_positive``
+    # for the pinned bug). ``count_subagents_via_ps`` returns ``-1`` on
+    # walk failure — then we fall back to the legacy pane parser so
+    # hosts without psutil / pgrep / session registry keep the old
+    # signal. Belt-and-suspenders: if both fail, report 0 (conservative
+    # — auto-dispatch then fires, which is the desired behaviour for a
+    # head we can't introspect: assume it's idle and re-check next
+    # tick).
+    _pt_count = count_subagents_via_ps(agent)
+    if _pt_count >= 0:
+        subagents = _pt_count
+    else:
+        subagents = parse_subagent_count(pane)
 
     # Statusline (claude-hud) — context_pct, quota_5h, quota_weekly, model, email.
     sl = parse_statusline(pane_tail_block)

--- a/scripts/client/agent_meta_pkg/_process_tree.py
+++ b/scripts/client/agent_meta_pkg/_process_tree.py
@@ -1,0 +1,381 @@
+"""Process-tree based subagent detection (replaces tmux-pane regex parse).
+
+Rationale
+---------
+The legacy ``_pane.parse_subagent_count`` regex-scans the tmux pane for
+Claude Code's status-line marker ``N local agent(s) running``. That path
+has two known failure modes:
+
+1. **Chat-embedded quotes** — prose quoting the literal marker phrase
+   (help text, channel citations) false-positively matches and inflates
+   the count (``test_subagent_count_lifecycle.test_quoted_marker_phrase_false_positive``
+   — pinned as ``xfail`` in PR #333).
+2. **Status-line invisibility** — if Claude Code suppresses or rewords
+   the marker in a future release, the parser silently floors to zero
+   while subagents are actually live. The auto-dispatch pipeline
+   (PR #334) then misfires because ``subagent_count == 0`` is its
+   "head is idle" trigger.
+
+This module counts subagents **programmatically** by walking the
+process tree:
+
+- Each head/worker agent is a top-level ``claude`` process spawned by
+  a tmux launcher. Its PID is discoverable via ``~/.claude/sessions/<pid>.json``
+  whose ``cwd`` matches ``~/.scitex/agent-container/workspaces/<agent>``.
+- When the head invokes the ``Agent()`` tool, Claude Code spawns a
+  **separate ``claude`` subprocess** as a descendant of the head's PID.
+- The count of descendant ``claude`` processes IS the subagent count.
+
+Auxiliary descendants (bun MCP sidecar, caffeinate, bash one-shots
+like ``pgrep``) are filtered out by requiring ``claude`` in the
+cmdline — they never match.
+
+Fallback chain
+--------------
+1. ``psutil`` children walk (preferred — cross-platform, rich metadata).
+2. ``pgrep -P`` recursive walk (Linux/macOS stdlib).
+3. Returns ``-1`` on total failure so the caller can fall back to
+   ``_pane.parse_subagent_count``. A zero here means "we walked and
+   found zero descendants" — an authoritative zero, not a failure.
+
+The wire-in in ``_collect.py`` composes this with the pane parser:
+process-tree first, pane parser on failure, ``0`` if both fail.
+
+Audit log
+---------
+Each invocation appends a structured NDJSON record to
+``~/.scitex/orochi/runtime/subagent-count/<agent>.ndjson`` with the
+source (``process_tree``, ``pane_parser``, ``none``) and the count. The
+hub can diff sources over time to flag regressions ("pane says 3,
+process-tree says 0 — which is real?") without operators having to
+scrape logs by hand.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Agent -> head Claude PID resolution
+# ---------------------------------------------------------------------------
+
+
+def _sessions_dir() -> Path:
+    """Return ``~/.claude/sessions``.
+
+    Claude Code writes one ``<pid>.json`` per live session here, each
+    carrying ``{pid, sessionId, cwd, startedAt, ...}``. Walking this
+    directory is how we associate an agent name to its claude PID
+    without parsing tmux (the multiplexer is orthogonal to the session
+    registry).
+    """
+    return Path.home() / ".claude" / "sessions"
+
+
+def _workspace_for(agent: str) -> str:
+    """Return the canonical workspace path for ``agent``.
+
+    Matches the ``cwd`` field inside the Claude session registry so we
+    can resolve ``agent -> pid`` by path equality without pulling the
+    rest of the fleet config.
+    """
+    return str(
+        Path.home() / ".scitex" / "agent-container" / "workspaces" / agent
+    )
+
+
+def find_head_pid(agent: str) -> Optional[int]:
+    """Return the live Claude PID for ``agent`` via the session registry.
+
+    Returns ``None`` if no matching session file exists (agent not
+    running, or the registry hasn't caught up yet — sessions are
+    written at claude spawn and deleted on exit).
+
+    Matching is by ``cwd`` equality against ``workspaces/<agent>``; a
+    single agent can legitimately have only one live session, so the
+    first match wins. In the rare stale-file case (crashed claude that
+    left a ``<pid>.json`` behind) the PID will fail to resolve later
+    in the walk and the function's caller naturally falls back.
+    """
+    sess_dir = _sessions_dir()
+    if not sess_dir.is_dir():
+        return None
+    workspace = _workspace_for(agent)
+    for entry in sess_dir.iterdir():
+        if entry.suffix != ".json":
+            continue
+        try:
+            data = json.loads(entry.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if str(data.get("cwd", "")).rstrip("/") == workspace.rstrip("/"):
+            pid = data.get("pid")
+            if isinstance(pid, int) and pid > 0:
+                return pid
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Claude-descendant counting — psutil preferred, pgrep fallback
+# ---------------------------------------------------------------------------
+
+
+def _count_claude_descendants_psutil(head_pid: int) -> int:
+    """Return the number of descendant claude processes of ``head_pid`` via psutil.
+
+    Returns ``-1`` if psutil is unavailable or the PID is already gone;
+    the caller distinguishes "authoritative 0 descendants" from
+    "couldn't walk" by checking the sign.
+    """
+    try:
+        import psutil  # type: ignore
+    except ImportError:
+        return -1
+    try:
+        head = psutil.Process(head_pid)
+    except psutil.NoSuchProcess:
+        return -1
+    except Exception:
+        return -1
+    count = 0
+    try:
+        for child in head.children(recursive=True):
+            try:
+                cmdline = child.cmdline()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+            except Exception:
+                continue
+            if _looks_like_claude(cmdline):
+                count += 1
+    except psutil.NoSuchProcess:
+        return -1
+    except Exception:
+        return -1
+    return count
+
+
+def _count_claude_descendants_pgrep(head_pid: int) -> int:
+    """Return the number of descendant claude processes via ``pgrep``.
+
+    Walks the tree level-by-level with ``pgrep -P <pid>`` because
+    neither POSIX nor GNU pgrep has a recursive flag. Each candidate
+    PID is re-inspected with ``ps`` so we can match on the command
+    line (filtering out bun, bash, caffeinate — they're children of
+    claude too but aren't subagents).
+
+    Returns ``-1`` on pgrep invocation failure (binary missing, PID
+    doesn't exist at all). An empty walk returns ``0``.
+    """
+    # Verify the head PID exists at all — ``pgrep -P`` against a dead
+    # PID returns empty, which is indistinguishable from "head exists
+    # but has no children". We want to surface "walk failed" distinctly
+    # so the caller can fall back.
+    try:
+        os.kill(head_pid, 0)
+    except ProcessLookupError:
+        return -1
+    except PermissionError:
+        # Process exists but we can't signal it — walk is still OK.
+        pass
+    except Exception:
+        return -1
+
+    to_visit = [head_pid]
+    descendants: list[int] = []
+    # Bound the walk at 10_000 nodes — pathological cycles shouldn't
+    # hang the heartbeat. Real agent trees are <20 nodes.
+    max_nodes = 10_000
+    while to_visit and len(descendants) < max_nodes:
+        parent = to_visit.pop()
+        try:
+            result = subprocess.run(
+                ["pgrep", "-P", str(parent)],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            # pgrep missing entirely → can't walk; tell caller so it
+            # falls back to the pane parser.
+            if parent == head_pid and not descendants:
+                return -1
+            # Partial walk is fine — just stop descending this branch.
+            continue
+        except Exception:
+            continue
+        for line in result.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                child_pid = int(line)
+            except ValueError:
+                continue
+            descendants.append(child_pid)
+            to_visit.append(child_pid)
+
+    if not descendants:
+        return 0
+
+    # Single ps invocation to fetch cmdlines for all descendants.
+    try:
+        ps_out = subprocess.run(
+            ["ps", "-o", "pid=,command="] + ["-p"] + [str(p) for p in descendants],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return -1
+    except Exception:
+        return -1
+
+    count = 0
+    for line in ps_out.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # ``pid command with args`` — split on first whitespace.
+        parts = line.split(None, 1)
+        if len(parts) < 2:
+            continue
+        cmdline = parts[1]
+        if _looks_like_claude([cmdline]):
+            count += 1
+    return count
+
+
+_SHELL_BASENAMES = frozenset({"bash", "sh", "zsh", "fish", "dash", "ksh"})
+
+
+def _looks_like_claude(cmdline: list[str]) -> bool:
+    """Return True if ``cmdline`` is a ``claude`` CLI invocation.
+
+    ``cmdline`` is the argv list as returned by ``psutil.Process.cmdline()``
+    or, in the pgrep fallback, a single-string wrapped in a one-element
+    list (from ``ps -o command=``).
+
+    Detection strategy: look at argv[0]'s basename. If it's exactly
+    ``claude`` (the CLI binary), accept. Everything else — caffeinate,
+    bun, node, python, bash one-liners that happen to mention "claude",
+    sibling tools like ``claude-hud`` or ``claude-code-telegrammer`` —
+    is rejected. We do NOT attempt to pin the ``Agent()`` spawn flags:
+    by construction any ``claude``-binary descendant of the head's PID
+    is a subagent (the head has no other reason to fork ``claude``).
+
+    The single-string cmdline case (``"claude --model opus ..."``) is
+    handled by splitting on whitespace before the basename check.
+    """
+    if not cmdline:
+        return False
+    head = cmdline[0]
+    # Flatten the "single string with spaces" shape (pgrep fallback
+    # yields this) before the basename check.
+    if len(cmdline) == 1 and " " in head:
+        head = head.split(None, 1)[0]
+    base = os.path.basename(head).lower()
+    # Skip shell wrappers — they show up as children of claude (the
+    # head's Bash-tool invocations, our own ``pgrep`` shell-out) but
+    # are not subagents.
+    if base in _SHELL_BASENAMES:
+        return False
+    return base == "claude"
+
+
+# ---------------------------------------------------------------------------
+# Public API — the orchestrated walk with fallback
+# ---------------------------------------------------------------------------
+
+
+def count_subagents_via_ps(agent: str) -> int:
+    """Return the subagent count for ``agent`` via process-tree inspection.
+
+    Returns ``-1`` on total failure (agent PID unknown, both psutil
+    and pgrep walks failed). The caller (``_collect.py``) treats
+    ``-1`` as "fall back to the pane parser"; a non-negative value is
+    authoritative.
+
+    Contract:
+
+    - ``0``  — head has no live claude descendants. (Authoritative.)
+    - ``N``  — head has exactly N live claude descendants.
+    - ``-1`` — the walk failed; caller should fall back.
+    """
+    head_pid = find_head_pid(agent)
+    if head_pid is None:
+        _audit_log(agent, -1, source="none", head_pid=None, note="no_session_file")
+        return -1
+
+    # Preferred backend: psutil.
+    ps_count = _count_claude_descendants_psutil(head_pid)
+    if ps_count >= 0:
+        _audit_log(agent, ps_count, source="process_tree_psutil", head_pid=head_pid)
+        return ps_count
+
+    # Secondary backend: pgrep.
+    pg_count = _count_claude_descendants_pgrep(head_pid)
+    if pg_count >= 0:
+        _audit_log(agent, pg_count, source="process_tree_pgrep", head_pid=head_pid)
+        return pg_count
+
+    _audit_log(agent, -1, source="none", head_pid=head_pid, note="walk_failed")
+    return -1
+
+
+# ---------------------------------------------------------------------------
+# Audit log — structured NDJSON so operators can diff sources.
+# ---------------------------------------------------------------------------
+
+
+def _audit_log_path(agent: str) -> Path:
+    """Return the NDJSON audit-log path for ``agent``.
+
+    Stored under the standard runtime root so telemetry-rotate.sh
+    picks it up (daily gzip + 7d retention, same lifecycle as the
+    connection and quota telemetry files).
+    """
+    root = (
+        Path.home()
+        / ".scitex"
+        / "orochi"
+        / "runtime"
+        / "subagent-count"
+    )
+    root.mkdir(parents=True, exist_ok=True)
+    return root / f"{agent}.ndjson"
+
+
+def _audit_log(
+    agent: str,
+    count: int,
+    *,
+    source: str,
+    head_pid: Optional[int],
+    note: str = "",
+) -> None:
+    """Append one NDJSON record describing this count's provenance.
+
+    Best-effort — a write failure must NOT break heartbeat collection.
+    """
+    try:
+        payload = {
+            "ts": time.time(),
+            "agent": agent,
+            "count": count,
+            "source": source,
+            "head_pid": head_pid,
+        }
+        if note:
+            payload["note"] = note
+        path = _audit_log_path(agent)
+        with path.open("a") as f:
+            f.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    except Exception:
+        # Never let audit logging break the heartbeat.
+        pass

--- a/tests/test_subagent_count_process_tree.py
+++ b/tests/test_subagent_count_process_tree.py
@@ -1,0 +1,586 @@
+"""Tests for process-tree based subagent counting.
+
+The programmatic walk in
+``scripts/client/agent_meta_pkg/_process_tree.py::count_subagents_via_ps``
+replaces the tmux-pane regex parse as the primary
+``subagent_count`` signal (msg#16727). These tests pin:
+
+1. psutil happy paths — 0/3 children, mixed claude+non-claude children.
+2. psutil failure → fall through to pgrep.
+3. pgrep failure → function returns ``-1`` so ``_collect.py`` falls
+   back to the pane parser.
+4. Session-registry resolution — ``find_head_pid`` walks
+   ``~/.claude/sessions/*.json`` by ``cwd`` match.
+5. ``_looks_like_claude`` binary detector — accepts ``claude`` argv,
+   rejects bash/bun/caffeinate/unrelated-claude-* tooling.
+6. End-to-end ``_collect.collect`` fallback chain: process-tree first,
+   pane parser on failure, 0 if both fail.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# agent_meta_pkg lives under scripts/client/ — add to sys.path so we
+# can import without an editable install.
+_AGENT_META_DIR = Path(__file__).resolve().parents[1] / "scripts" / "client"
+if str(_AGENT_META_DIR) not in sys.path:
+    sys.path.insert(0, str(_AGENT_META_DIR))
+
+from agent_meta_pkg import _process_tree  # noqa: E402
+from agent_meta_pkg._process_tree import (  # noqa: E402
+    _looks_like_claude,
+    count_subagents_via_ps,
+    find_head_pid,
+)
+
+# ---------------------------------------------------------------------------
+# _looks_like_claude — binary detector unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmdline, expected",
+    [
+        # Canonical claude-code invocation shapes.
+        (["claude", "--model", "opus[1m]"], True),
+        (["/usr/local/bin/claude", "--dangerously-skip-permissions"], True),
+        (["/opt/homebrew/bin/claude"], True),
+        # Single-string cmdline (pgrep fallback shape).
+        (["claude --model opus --add-dir /workspace"], True),
+        # Non-claude auxiliary descendants — all rejected.
+        (["caffeinate", "-i", "-t", "300"], False),
+        (["bun", "run", "/path/to/mcp_channel.ts"], False),
+        (["node", "/app/index.js"], False),
+        (["python3", "-c", "print('claude mentioned')"], False),
+        # Shell one-liners that mention claude — not a subagent.
+        (["/bin/bash", "-c", "grep claude /tmp/foo.log"], False),
+        (["sh", "-c", "ps -eo command | awk '/claude/'"], False),
+        # Sibling tools — NOT the claude CLI itself.
+        (["claude-hud", "--poll"], False),
+        (["claude-code-telegrammer", "serve"], False),
+        # Empty / degenerate inputs.
+        ([], False),
+        ([""], False),
+    ],
+    ids=[
+        "claude-opus",
+        "claude-absolute-path",
+        "claude-homebrew",
+        "claude-single-string",
+        "caffeinate",
+        "bun",
+        "node",
+        "python-mentioning",
+        "bash-grep",
+        "sh-awk",
+        "claude-hud-sibling",
+        "telegrammer-sibling",
+        "empty-list",
+        "empty-string-arg",
+    ],
+)
+def test_looks_like_claude(cmdline, expected):
+    """The binary detector accepts only the ``claude`` CLI itself."""
+    assert _looks_like_claude(cmdline) is expected
+
+
+# ---------------------------------------------------------------------------
+# find_head_pid — session-registry resolution
+# ---------------------------------------------------------------------------
+
+
+def test_find_head_pid_matches_by_cwd(tmp_path, monkeypatch):
+    """``~/.claude/sessions/<pid>.json`` whose ``cwd`` matches the
+    agent's workspace path IS that agent's head PID."""
+    sessions = tmp_path / ".claude" / "sessions"
+    sessions.mkdir(parents=True)
+    workspace_root = tmp_path / ".scitex" / "agent-container" / "workspaces"
+    workspace_root.mkdir(parents=True)
+
+    # Two sessions — one matches, one doesn't.
+    (sessions / "42.json").write_text(
+        json.dumps(
+            {
+                "pid": 42,
+                "sessionId": "abc",
+                "cwd": str(workspace_root / "head-mba"),
+                "startedAt": 1,
+            }
+        )
+    )
+    (sessions / "99.json").write_text(
+        json.dumps(
+            {
+                "pid": 99,
+                "sessionId": "xyz",
+                "cwd": str(workspace_root / "some-other-agent"),
+                "startedAt": 2,
+            }
+        )
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert find_head_pid("head-mba") == 42
+
+
+def test_find_head_pid_none_when_no_session(tmp_path, monkeypatch):
+    """Missing session file → ``None`` (the caller falls back)."""
+    (tmp_path / ".claude" / "sessions").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert find_head_pid("head-nonexistent") is None
+
+
+def test_find_head_pid_skips_malformed_json(tmp_path, monkeypatch):
+    """A junk ``<pid>.json`` doesn't crash the scan."""
+    sessions = tmp_path / ".claude" / "sessions"
+    sessions.mkdir(parents=True)
+    workspace_root = tmp_path / ".scitex" / "agent-container" / "workspaces"
+    workspace_root.mkdir(parents=True)
+    (sessions / "42.json").write_text("not json at all {{{")
+    (sessions / "43.json").write_text(
+        json.dumps(
+            {
+                "pid": 43,
+                "cwd": str(workspace_root / "head-mba"),
+                "startedAt": 1,
+            }
+        )
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert find_head_pid("head-mba") == 43
+
+
+# ---------------------------------------------------------------------------
+# count_subagents_via_ps — orchestrated walk with fallback chain
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    """Minimal psutil.Process stand-in for children() / cmdline() tests."""
+
+    def __init__(self, children=None, cmdline_value=None):
+        self._children = children or []
+        self._cmdline = cmdline_value or []
+
+    def children(self, recursive=True):
+        return self._children
+
+    def cmdline(self):
+        return self._cmdline
+
+
+def _install_fake_psutil(monkeypatch, head_proc_factory):
+    """Install a fake ``psutil`` module under the import name so that
+    ``import psutil`` inside ``_process_tree`` returns our stub.
+
+    ``head_proc_factory`` is a callable that returns the fake ``Process``
+    instance for the head PID.
+    """
+
+    class _NoSuchProcess(Exception):
+        pass
+
+    class _AccessDenied(Exception):
+        pass
+
+    class _FakePsutil:
+        NoSuchProcess = _NoSuchProcess
+        AccessDenied = _AccessDenied
+
+        @staticmethod
+        def Process(pid):  # noqa: N802 — mirror psutil API
+            return head_proc_factory(pid)
+
+    monkeypatch.setitem(sys.modules, "psutil", _FakePsutil)
+
+
+def test_count_zero_children(monkeypatch, tmp_path):
+    """Head has no descendants → count 0 (authoritative, not fallback)."""
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        lambda pid: _FakeProcess(children=[]),
+    )
+    # Redirect audit log to tmp so we don't pollute the real runtime dir.
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert count_subagents_via_ps("head-mba") == 0
+
+
+def test_count_three_claude_children(monkeypatch, tmp_path):
+    """Three ``claude`` descendants → count 3."""
+    children = [
+        _FakeProcess(cmdline_value=["claude", "--model", "opus[1m]"]),
+        _FakeProcess(cmdline_value=["/usr/local/bin/claude", "--flag"]),
+        _FakeProcess(cmdline_value=["claude"]),
+    ]
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        lambda pid: _FakeProcess(children=children),
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert count_subagents_via_ps("head-mba") == 3
+
+
+def test_count_mixed_claude_and_non_claude_children(monkeypatch, tmp_path):
+    """Only claude descendants are counted; bun / caffeinate / bash are filtered."""
+    children = [
+        _FakeProcess(cmdline_value=["claude", "--model", "opus[1m]"]),
+        _FakeProcess(cmdline_value=["caffeinate", "-i", "-t", "300"]),
+        _FakeProcess(cmdline_value=["bun", "run", "/mcp.ts"]),
+    ]
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        lambda pid: _FakeProcess(children=children),
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert count_subagents_via_ps("head-mba") == 1
+
+
+def test_no_session_file_returns_minus_one(monkeypatch, tmp_path):
+    """No matching ``<pid>.json`` → return ``-1`` so caller falls back."""
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: None
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert count_subagents_via_ps("head-mba") == -1
+
+
+def test_psutil_noSuchProcess_falls_back_to_pgrep(monkeypatch, tmp_path):
+    """If psutil raises NoSuchProcess (stale PID) AND pgrep succeeds,
+    the pgrep count wins."""
+
+    class _NoSuchProcess(Exception):
+        pass
+
+    class _AccessDenied(Exception):
+        pass
+
+    class _FakePsutil:
+        NoSuchProcess = _NoSuchProcess
+        AccessDenied = _AccessDenied
+
+        @staticmethod
+        def Process(pid):  # noqa: N802
+            raise _NoSuchProcess("dead")
+
+    monkeypatch.setitem(sys.modules, "psutil", _FakePsutil)
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    # Short-circuit pgrep path — return 2 authoritatively.
+    monkeypatch.setattr(
+        _process_tree,
+        "_count_claude_descendants_pgrep",
+        lambda pid: 2,
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert count_subagents_via_ps("head-mba") == 2
+
+
+def test_both_backends_fail_returns_minus_one(monkeypatch, tmp_path):
+    """psutil unavailable + pgrep walk failed → ``-1`` so ``_collect.py``
+    falls back to the pane parser."""
+    # Hide psutil so the psutil path returns -1.
+    monkeypatch.setitem(sys.modules, "psutil", None)
+
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    monkeypatch.setattr(
+        _process_tree,
+        "_count_claude_descendants_pgrep",
+        lambda pid: -1,
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    assert count_subagents_via_ps("head-mba") == -1
+
+
+# ---------------------------------------------------------------------------
+# Integration — _collect.py fallback chain end to end
+# ---------------------------------------------------------------------------
+
+
+def test_collect_prefers_process_tree_over_pane_parser(monkeypatch):
+    """``_collect.collect`` uses the process-tree count when it's
+    non-negative, even when the pane marker says something different."""
+    from agent_meta_pkg import _collect
+
+    # Make the pane parser return 5 (lie). Process-tree returns 1.
+    # _collect must surface 1, not 5.
+    monkeypatch.setattr(_collect, "detect_multiplexer", lambda a: "tmux")
+    monkeypatch.setattr(_collect, "capture_pane", lambda a, m: "fake pane")
+    monkeypatch.setattr(
+        _collect,
+        "filter_pane_tail",
+        lambda p: ("", "", "", ""),
+    )
+    monkeypatch.setattr(
+        _collect,
+        "parse_subagent_count",
+        lambda p: 5,
+    )
+    monkeypatch.setattr(
+        _collect,
+        "count_subagents_via_ps",
+        lambda a: 1,
+    )
+    # Neutralise the heavier collectors so the test stays focused.
+    _neutralise_heavy_collectors(monkeypatch, _collect)
+
+    result = _collect.collect("head-mba")
+    assert result["subagent_count"] == 1
+    assert result["subagents"] == 1
+
+
+def test_collect_falls_back_to_pane_parser_on_process_tree_failure(monkeypatch):
+    """When the process-tree walk returns ``-1``, ``_collect.collect``
+    uses the pane parser's count."""
+    from agent_meta_pkg import _collect
+
+    monkeypatch.setattr(_collect, "detect_multiplexer", lambda a: "tmux")
+    monkeypatch.setattr(_collect, "capture_pane", lambda a, m: "pane text")
+    monkeypatch.setattr(
+        _collect,
+        "filter_pane_tail",
+        lambda p: ("", "", "", ""),
+    )
+    monkeypatch.setattr(
+        _collect,
+        "parse_subagent_count",
+        lambda p: 4,
+    )
+    monkeypatch.setattr(
+        _collect,
+        "count_subagents_via_ps",
+        lambda a: -1,
+    )
+    _neutralise_heavy_collectors(monkeypatch, _collect)
+
+    result = _collect.collect("head-mba")
+    assert result["subagent_count"] == 4
+
+
+def test_collect_reports_zero_when_both_backends_fail(monkeypatch):
+    """Process-tree returns ``-1`` AND pane parser returns 0 → ``subagent_count == 0``."""
+    from agent_meta_pkg import _collect
+
+    monkeypatch.setattr(_collect, "detect_multiplexer", lambda a: "tmux")
+    monkeypatch.setattr(_collect, "capture_pane", lambda a, m: "")
+    monkeypatch.setattr(
+        _collect,
+        "filter_pane_tail",
+        lambda p: ("", "", "", ""),
+    )
+    monkeypatch.setattr(
+        _collect,
+        "parse_subagent_count",
+        lambda p: 0,
+    )
+    monkeypatch.setattr(
+        _collect,
+        "count_subagents_via_ps",
+        lambda a: -1,
+    )
+    _neutralise_heavy_collectors(monkeypatch, _collect)
+
+    result = _collect.collect("head-mba")
+    assert result["subagent_count"] == 0
+
+
+def _neutralise_heavy_collectors(monkeypatch, _collect):
+    """Stub out the non-count collectors so the integration tests stay
+    deterministic and don't hit the filesystem / subprocess heavy paths.
+    """
+    monkeypatch.setattr(
+        _collect,
+        "parse_statusline",
+        lambda pane_tail_block: {
+            "statusline_context_pct": None,
+            "quota_5h_pct": None,
+            "quota_5h_remaining": None,
+            "quota_weekly_pct": None,
+            "quota_weekly_remaining": None,
+            "statusline_model": "",
+            "account_email": "",
+        },
+    )
+    monkeypatch.setattr(
+        _collect,
+        "find_jsonl_transcripts",
+        lambda ws: [],
+    )
+    monkeypatch.setattr(
+        _collect,
+        "parse_transcript",
+        lambda jsonls: {
+            "model": "",
+            "last_activity": "",
+            "context_pct": None,
+            "current_tool": "",
+            "started_at": "",
+            "recent_actions": [],
+        },
+    )
+    monkeypatch.setattr(
+        _collect,
+        "find_session_pids",
+        lambda a, m: (0, 0),
+    )
+    monkeypatch.setattr(
+        _collect,
+        "collect_skills_loaded",
+        lambda ws: [],
+    )
+    monkeypatch.setattr(
+        _collect,
+        "collect_mcp_servers",
+        lambda ws: [],
+    )
+    monkeypatch.setattr(
+        _collect,
+        "resolve_machine_label",
+        lambda: "mba",
+    )
+    monkeypatch.setattr(
+        _collect,
+        "collect_claude_md",
+        lambda ws: ("", ""),
+    )
+    monkeypatch.setattr(
+        _collect,
+        "collect_mcp_json",
+        lambda ws: "",
+    )
+    monkeypatch.setattr(
+        _collect,
+        "_classify_pane_state",
+        lambda *a, **kw: "online",
+    )
+    monkeypatch.setattr(
+        _collect,
+        "_extract_stuck_prompt",
+        lambda *a, **kw: "",
+    )
+    monkeypatch.setattr(
+        _collect,
+        "_detect_contradiction",
+        lambda *a, **kw: "",
+    )
+    monkeypatch.setattr(
+        _collect,
+        "_log_contradiction_evidence",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        _collect,
+        "_resolve_canonical_hostname",
+        lambda: "mba.local",
+    )
+    monkeypatch.setattr(
+        _collect,
+        "_collect_hook_events",
+        lambda a: {},
+    )
+    monkeypatch.setattr(
+        _collect,
+        "collect_machine_metrics",
+        lambda: {},
+    )
+    monkeypatch.setattr(
+        _collect,
+        "collect_slurm_status",
+        lambda: None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle mirror — process-tree counts should agree with spawn /
+# partial / complete transitions (extend PR #333 coverage).
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_spawn_then_complete(monkeypatch, tmp_path):
+    """Tick 1: 1 claude descendant. Tick 2: 0 (batch finished)."""
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    # Tick 1 — one child claude.
+    _install_fake_psutil(
+        monkeypatch,
+        lambda pid: _FakeProcess(
+            children=[_FakeProcess(cmdline_value=["claude", "--flag"])]
+        ),
+    )
+    assert count_subagents_via_ps("head-mba") == 1
+
+    # Tick 2 — no children.
+    _install_fake_psutil(
+        monkeypatch,
+        lambda pid: _FakeProcess(children=[]),
+    )
+    assert count_subagents_via_ps("head-mba") == 0
+
+
+def test_lifecycle_partial_completion(monkeypatch, tmp_path):
+    """Three spawned, one finished → process-tree count 2."""
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    _install_fake_psutil(
+        monkeypatch,
+        lambda pid: _FakeProcess(
+            children=[
+                _FakeProcess(cmdline_value=["claude", "--flag"]),
+                _FakeProcess(cmdline_value=["claude", "--flag2"]),
+            ]
+        ),
+    )
+    assert count_subagents_via_ps("head-mba") == 2
+
+
+def test_audit_log_written(monkeypatch, tmp_path):
+    """Every call appends one NDJSON record to the audit log."""
+    monkeypatch.setattr(
+        _process_tree, "find_head_pid", lambda agent: 1000
+    )
+    _install_fake_psutil(
+        monkeypatch,
+        lambda pid: _FakeProcess(
+            children=[_FakeProcess(cmdline_value=["claude"])]
+        ),
+    )
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    assert count_subagents_via_ps("head-mba") == 1
+
+    log_file = (
+        tmp_path
+        / ".scitex"
+        / "orochi"
+        / "runtime"
+        / "subagent-count"
+        / "head-mba.ndjson"
+    )
+    assert log_file.exists()
+    lines = log_file.read_text().strip().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["agent"] == "head-mba"
+    assert record["count"] == 1
+    assert record["source"] == "process_tree_psutil"
+    assert record["head_pid"] == 1000


### PR DESCRIPTION
## Summary

Replace tmux-pane regex parsing with a programmatic **process-tree walk** as the primary ``subagent_count`` signal (msg#16727).

- New ``scripts/client/agent_meta_pkg/_process_tree.py`` locates each agent's Claude PID via ``~/.claude/sessions/<pid>.json`` (``cwd`` match) then counts descendant ``claude`` processes via **psutil** (preferred) with **``pgrep -P``** recursive fallback.
- ``_collect.py`` composes the fallback chain: process-tree first → pane parser (kept as fallback per directive, not removed) → ``0`` if both fail.
- Structured **NDJSON audit log** at ``~/.scitex/orochi/runtime/subagent-count/<agent>.ndjson`` records which source produced each count so operators can audit accuracy without scraping logs.

### Why
PR #318's pane parser is subject to known failure modes: (1) chat-embedded quotes false-positively match (pinned xfail in ``test_subagent_count_lifecycle``), (2) if Claude Code reworks the marker the parser silently floors to zero, misfiring the PR #334 auto-dispatch pipeline which relies on ``subagent_count == 0`` as its "head is idle" trigger. The process tree is ground truth — no stdout dependency.

### Subagent identification heuristic
``_looks_like_claude`` accepts argv whose ``basename(argv[0]) == "claude"`` and rejects shell wrappers (bash/sh/zsh/fish/dash/ksh) and sibling tools (``claude-hud``, ``claude-code-telegrammer``). By construction, any ``claude``-binary **descendant** of the head's PID is an ``Agent()`` spawn — the head has no other reason to fork ``claude``. Auxiliary descendants (bun MCP sidecar, caffeinate, bash one-liners) don't match and don't count.

### Fallback shape
- psutil path returns ``-1`` on ``ImportError`` / ``NoSuchProcess`` / unexpected exception.
- pgrep path returns ``-1`` on missing ``pgrep`` binary or dead head PID; returns ``0`` for "walked, no descendants".
- Non-negative from either backend → authoritative; ``-1`` → caller falls back to ``_pane.parse_subagent_count``.

### Files touched
- ``scripts/client/agent_meta_pkg/_process_tree.py`` (new, ~290 lines)
- ``scripts/client/agent_meta_pkg/_collect.py`` (wire-in + comment block)
- ``tests/test_subagent_count_process_tree.py`` (new, 29 tests)

### Tests
29 new tests across binary detector / session resolution / fallback chain / end-to-end ``_collect`` composition / lifecycle mirror (spawn→complete, partial completion) / audit log shape.

Locally: ``pytest tests/test_subagent_count_process_tree.py tests/test_subagent_count_parse.py tests/test_subagent_count_lifecycle.py`` → **71 passed, 1 xfailed** (the known pane-parser quoted-marker bug — now provably mitigated by preferring the process-tree source). Broader suite: **545 passed, 1 skipped, 1 xfailed**.

### Don't-touch adherence
- ``_pane.parse_subagent_count`` kept as fallback (not removed).
- ``ts-migration-v2`` / ``hub/frontend/`` untouched.
- Heartbeat payload schema unchanged — only the compute path changed before send.

## Test plan

- [x] ``pytest tests/test_subagent_count_process_tree.py`` → 29 pass
- [x] ``pytest tests/test_subagent_count_parse.py tests/test_subagent_count_lifecycle.py`` → 42 pass + 1 xfailed (unchanged)
- [x] ``ruff check`` clean on new/modified files
- [ ] CI green on develop target
- [ ] Post-merge: head-mba heartbeat NDJSON under ``~/.scitex/orochi/runtime/subagent-count/`` shows ``source: process_tree_psutil`` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)