### PR TITLE
fix(cli): hide rename stubs from --help + convention pointer (post-Phase-1d)

### DIFF
--- a/src/scitex_orochi/_cli/_deprecation.py
+++ b/src/scitex_orochi/_cli/_deprecation.py
@@ -127,14 +127,13 @@ def hard_rename_error(
     out = sys.stderr if stream is None else stream
     exit_fn = sys.exit if exit_func is None else exit_func
     msg = (
-        f"error: `scitex-orochi {old_name}` was renamed to "
-        f"`scitex-orochi {new_name}`."
+        f"error: `scitex-orochi {old_name}` was renamed to `scitex-orochi {new_name}`."
     )
     print(msg, file=out)
     exit_fn(exit_code)
 
 
-def make_rename_stub(old_name: str, new_name: str):
+def make_rename_stub(old_name: str, new_name: str, *, hidden: bool = True):
     """Return a click.Command that fires :func:`hard_rename_error` when invoked.
 
     Used by the top-level ``_main.py`` to replace legacy flat commands
@@ -145,8 +144,12 @@ def make_rename_stub(old_name: str, new_name: str):
       ``scitex-orochi list-agents --json`` still see the rename error,
       not a click usage error that would confuse them further);
     * prints the canonical one-liner to stderr and exits ``2`` unchanged;
-    * exposes a short help string mentioning the new form, so
-      ``scitex-orochi --help`` readers see the redirect target.
+    * is **hidden from ``--help`` listings by default** so the 28 flat
+      legacy names no longer clutter the top-level command list (plan
+      §9 "最小限びっくり" / post-Phase-1d cleanup). The stub is still
+      *invokable* — users who type the old name still hit the hard
+      rename error — it just isn't *advertised* anymore. Tests pin
+      both invariants.
 
     The stub is deliberately a ``click.Command`` (not a group) — any
     former subcommand path (e.g. ``scitex-orochi deploy stable``) is
@@ -161,6 +164,7 @@ def make_rename_stub(old_name: str, new_name: str):
     @_click.command(
         old_name,
         short_help=short_help,
+        hidden=hidden,
         help=(
             f"Renamed. Use `scitex-orochi {new_name}` instead. This stub "
             f"exists only to give a clear error message; invoking it "

--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -24,7 +24,15 @@ def _get_version() -> str:
 
 
 class _HelpRecursiveGroup(click.Group):
-    """Click group that supports ``--help-recursive`` to dump every subcommand."""
+    """Click group that supports ``--help-recursive`` to dump every subcommand.
+
+    Hidden subcommands (e.g. the Phase-1d rename stubs whose presence in
+    ``--help`` would clutter the listing) are skipped entirely: they don't
+    appear in the top-level ``Commands`` block and they don't appear in
+    the recursive dump either. Invoking them by name still works — the
+    hard-error still fires — the goal here is simply to avoid advertising
+    dead paths in help output.
+    """
 
     def get_help_recursive(self, ctx: click.Context) -> str:
         lines = [
@@ -39,6 +47,8 @@ class _HelpRecursiveGroup(click.Group):
             cmd = self.get_command(ctx, name)
             if cmd is None:
                 continue
+            if getattr(cmd, "hidden", False):
+                continue
             lines.append("-" * 60)
             lines.append(f"Command: {name}")
             lines.append("-" * 60)
@@ -51,10 +61,19 @@ class _HelpRecursiveGroup(click.Group):
         return "\n".join(lines)
 
 
+# Plan §11.2: the top-level ``--help`` output ends with a one-line
+# pointer at the noun-verb convention doc so fleet agents can grep
+# ``scitex-orochi --help`` and land on the skill directly.
+_CLI_CONVENTION_EPILOG = (
+    "See docs/cli.md for the noun-verb convention (scitex-orochi/convention-cli skill)."
+)
+
+
 @click.group(
     cls=_HelpRecursiveGroup,
     context_settings={"help_option_names": ["-h", "--help"]},
     invoke_without_command=True,
+    epilog=_CLI_CONVENTION_EPILOG,
 )
 @click.version_option(version=_get_version(), prog_name="scitex-orochi")
 @click.option(

--- a/src/scitex_orochi/_skills/scitex-orochi/convention-cli.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/convention-cli.md
@@ -149,6 +149,14 @@ operator the exact string to type instead.
 
 Implemented by `scitex_orochi._cli._deprecation.hard_rename_error(old, new)`.
 
+**Post-Phase-1d cleanup (ywatanabe msg#16746 / PR fix/cli-post-phase1d-cleanup):**
+rename stubs are `hidden=True` by default on the click.Command — they stay
+*invokable* (still hard-error with the canonical message) but do not appear
+in `scitex-orochi --help` or `--help-recursive` listings. This keeps the
+top-level help clean (24 canonical nouns/groups, not 52 entries half of
+which shout "Renamed"). Tests pin the invariant in
+`tests/cli/test_post_phase1d_cleanup.py`.
+
 ### 2.2 Soft, one-time-per-shell notes for non-rename drifts
 
 For changes that are **not** renames (e.g. "this flag's semantics shifted

--- a/tests/cli/test_deprecation_helper.py
+++ b/tests/cli/test_deprecation_helper.py
@@ -48,8 +48,7 @@ def test_hard_rename_error_prints_canonical_one_liner() -> None:
     )
     out = buf.getvalue().strip()
     assert out == (
-        "error: `scitex-orochi list-agents` was renamed to "
-        "`scitex-orochi agent list`."
+        "error: `scitex-orochi list-agents` was renamed to `scitex-orochi agent list`."
     )
     assert exits == [2]
 
@@ -80,7 +79,9 @@ def test_soft_notice_first_call_prints() -> None:
 def test_soft_notice_second_call_in_same_session_is_silent() -> None:
     buf1 = io.StringIO()
     buf2 = io.StringIO()
-    assert dep.soft_notice("list-agents", "use `agent list` instead", stream=buf1) is True
+    assert (
+        dep.soft_notice("list-agents", "use `agent list` instead", stream=buf1) is True
+    )
     assert (
         dep.soft_notice("list-agents", "use `agent list` instead", stream=buf2) is False
     )
@@ -162,8 +163,7 @@ def test_make_rename_stub_emits_hard_error_when_invoked() -> None:
         f"stub must exit 2; got {result.exit_code}\n{result.output!r}"
     )
     assert (
-        "error: `scitex-orochi list-agents` was renamed to "
-        "`scitex-orochi agent list`."
+        "error: `scitex-orochi list-agents` was renamed to `scitex-orochi agent list`."
     ) in result.output
 
 
@@ -182,20 +182,25 @@ def test_make_rename_stub_swallows_trailing_args() -> None:
     root.add_command(stub)
 
     runner = CliRunner()
-    result = runner.invoke(
-        root, ["send", "--json", "#general", "hello"]
-    )
+    result = runner.invoke(root, ["send", "--json", "#general", "hello"])
     assert result.exit_code == 2
     assert "was renamed" in result.output
 
 
-def test_make_rename_stub_short_help_mentions_new_form() -> None:
-    """``--help`` on the top-level group surfaces the rename target so
-    users browsing help still see the forward pointer."""
+def test_make_rename_stub_short_help_mentions_new_form_when_visible() -> None:
+    """When a rename stub is explicitly registered with ``hidden=False``,
+    ``--help`` on the parent group surfaces the rename target so users
+    browsing help still see the forward pointer.
+
+    Post-Phase-1d cleanup (ywatanabe msg#16746): the default for
+    ``make_rename_stub`` is now ``hidden=True`` so the 28 legacy flat
+    names don't clutter the top-level ``scitex-orochi --help`` listing.
+    This test asks for a visible stub explicitly to keep covering the
+    short-help text itself."""
     import click
     from click.testing import CliRunner
 
-    stub = dep.make_rename_stub("doctor", "system doctor")
+    stub = dep.make_rename_stub("doctor", "system doctor", hidden=False)
 
     @click.group()
     def root() -> None:
@@ -210,3 +215,36 @@ def test_make_rename_stub_short_help_mentions_new_form() -> None:
     # new form. We accept either placement to avoid coupling too tightly
     # to click's formatter output.
     assert "system doctor" in result.output
+
+
+def test_make_rename_stub_is_hidden_by_default() -> None:
+    """Default ``hidden=True`` keeps the stub out of ``--help`` listings
+    but still accepts invocation (hard-error behaviour unchanged)."""
+    import click
+    from click.testing import CliRunner
+
+    stub = dep.make_rename_stub("doctor", "system doctor")
+    assert stub.hidden is True
+
+    @click.group()
+    def root() -> None:
+        pass
+
+    root.add_command(stub)
+
+    runner = CliRunner()
+    # --help on the parent group omits the stub.
+    result = runner.invoke(root, ["--help"])
+    assert result.exit_code == 0
+    assert (
+        "doctor" not in result.output.split("Commands:", 1)[-1]
+        if "Commands:" in result.output
+        else True
+    )
+
+    # Direct invocation still hard-errors.
+    result = runner.invoke(root, ["doctor"])
+    assert result.exit_code == 2
+    assert (
+        "error: `scitex-orochi doctor` was renamed to `scitex-orochi system doctor`."
+    ) in result.output

--- a/tests/cli/test_post_phase1d_cleanup.py
+++ b/tests/cli/test_post_phase1d_cleanup.py
@@ -1,0 +1,196 @@
+"""Regression tests for the post-Phase-1d CLI cleanup.
+
+After Phase 1d shipped (PRs #341–#344), the ``scitex-orochi --help``
+output still felt "dirty" (ywatanabe msg#16746) because the 28 rename
+stubs were *visible* in the top-level command listing. Each one showed
+a ``Renamed -- use ...`` short-help line next to a legit command,
+burying the actual noun groups under legacy clutter.
+
+Fix:
+
+1. Rename stubs are now ``hidden=True`` by default
+   (:func:`scitex_orochi._cli._deprecation.make_rename_stub`).
+2. The custom ``--help-recursive`` dumper in
+   :class:`scitex_orochi._cli._main._HelpRecursiveGroup` skips hidden
+   commands, so they don't appear in the recursive dump either.
+3. The top-level ``--help`` output now ends with a one-line pointer
+   at the noun-verb convention doc (plan §11.2).
+
+Invariants this file pins (so the dirt cannot come back):
+
+* ``--help`` never prints any ``Renamed -- use`` short-help line
+  (the 28 stubs stay out of the listing).
+* ``--help-recursive`` never renders a ``Command: <old-name>`` header
+  for any of the renamed flat legacy names.
+* The convention pointer (docs/cli.md) appears at the end of ``--help``.
+* Invoking the old flat name STILL hard-errors with the canonical
+  rename message (hidden ≠ removed). We re-assert one representative
+  case here; the full matrix stays in ``test_phase1d_step_c_rename_*``.
+* Every rename stub object carries ``hidden=True`` on its click.Command.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._main import orochi
+
+# Same canonical rename table the Phase 1d Step C tests use. Kept
+# inline (not imported) so a refactor of that file can't silently
+# desync this invariant.
+RENAMED_FLAT_NAMES: list[str] = [
+    "agent-launch",
+    "agent-restart",
+    "agent-status",
+    "agent-stop",
+    "list-agents",
+    "fleet",
+    "launch",
+    "stop",
+    "send",
+    "listen",
+    "show-history",
+    "join",
+    "list-channels",
+    "list-members",
+    "create-invite",
+    "list-invites",
+    "create-workspace",
+    "delete-workspace",
+    "list-workspaces",
+    "show-status",
+    "serve",
+    "deploy",
+    "setup-push",
+    "init",
+    "doctor",
+    "login",
+    "heartbeat-push",
+    "report",
+]
+
+
+# ---------------------------------------------------------------------------
+# 1. Top-level `--help` is free of rename clutter.
+# ---------------------------------------------------------------------------
+
+
+def _help_text() -> str:
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["--help"], obj={"host": "127.0.0.1", "port": 9559})
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_top_level_help_has_no_rename_clutter() -> None:
+    """The top-level ``--help`` must not advertise any ``Renamed -- use``
+    short-help line. The 28 stubs are hidden per post-Phase-1d cleanup."""
+    text = _help_text()
+    assert "Renamed -- use" not in text, (
+        "top-level --help still prints 'Renamed -- use' clutter; "
+        "rename stubs must carry hidden=True.\n--- help output ---\n"
+        f"{text}"
+    )
+
+
+@pytest.mark.parametrize("old", RENAMED_FLAT_NAMES)
+def test_top_level_help_omits_each_rename_stub(old: str) -> None:
+    """Each rename stub is *invokable* but must not show up as a
+    visible command name at the start of a help line."""
+    text = _help_text()
+    # A visible command in click's default formatter appears as
+    # ``  <name>  <short-help>`` (two leading spaces). Match that shape
+    # so we don't false-positive on the rename stub names appearing
+    # inside noun group one-liners (e.g. 'agent' mentions 'launch'
+    # legitimately).
+    needle = f"\n  {old} "
+    assert needle not in text, (
+        f"rename stub {old!r} still listed at top-level --help; it must be hidden=True."
+    )
+
+
+def test_top_level_help_ends_with_convention_pointer() -> None:
+    """Plan §11.2: top-level --help ends with a pointer at the
+    noun-verb convention doc."""
+    text = _help_text()
+    assert "docs/cli.md" in text, (
+        "top-level --help must reference docs/cli.md per plan §11.2.\n"
+        f"--- help output ---\n{text}"
+    )
+    assert "noun-verb convention" in text
+
+
+# ---------------------------------------------------------------------------
+# 2. `--help-recursive` skips hidden commands.
+# ---------------------------------------------------------------------------
+
+
+def _help_recursive_text() -> str:
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi,
+        ["--help-recursive"],
+        obj={"host": "127.0.0.1", "port": 9559},
+    )
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_help_recursive_has_no_rename_clutter() -> None:
+    """``--help-recursive`` must not dump help for any rename stub.
+    The custom ``_HelpRecursiveGroup.get_help_recursive`` now filters
+    on ``hidden=True``."""
+    text = _help_recursive_text()
+    assert "Renamed. Use" not in text, (
+        "--help-recursive still renders rename-stub help blocks; "
+        "the recursive dumper must skip hidden commands.\n--- tail ---\n"
+        f"{text[-2000:]}"
+    )
+
+
+@pytest.mark.parametrize("old", RENAMED_FLAT_NAMES)
+def test_help_recursive_skips_each_rename_stub_header(old: str) -> None:
+    """No ``Command: <old-name>`` section appears in the recursive dump."""
+    text = _help_recursive_text()
+    needle = f"Command: {old}\n"
+    assert needle not in text, f"--help-recursive still prints a section for {old!r}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Hidden ≠ removed: invoking a stub by name still hard-errors.
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_stub_still_hard_errors_when_invoked() -> None:
+    """Hiding a rename stub from ``--help`` must not regress the
+    behaviour: typing the old name still prints the canonical rename
+    error and exits non-zero. Representative spot-check; the full
+    matrix is in ``test_phase1d_step_c_rename_functional``."""
+    runner = CliRunner()
+    result = runner.invoke(
+        orochi, ["list-agents"], obj={"host": "127.0.0.1", "port": 9559}
+    )
+    assert result.exit_code == 2
+    assert (
+        "error: `scitex-orochi list-agents` was renamed to `scitex-orochi agent list`."
+    ) in result.output
+
+
+# ---------------------------------------------------------------------------
+# 4. Every rename stub carries hidden=True on its click.Command object.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("old", RENAMED_FLAT_NAMES)
+def test_rename_stub_command_is_hidden_attribute(old: str) -> None:
+    """The click.Command object registered at ``old`` must report
+    ``hidden is True`` so any future contributor re-rendering --help
+    via a non-standard formatter still gets clean output."""
+    cmd = orochi.commands.get(old)
+    assert cmd is not None, f"rename stub {old!r} not registered"
+    assert isinstance(cmd, click.Command)
+    assert cmd.hidden is True, (
+        f"rename stub {old!r} must have hidden=True; got {cmd.hidden!r}"
+    )


### PR DESCRIPTION
## Summary

- Post-Phase-1d cleanup triggered by ywatanabe msg#16746 ("CLI is still dirty"). The 28 rename stubs were *visible* in `scitex-orochi --help`, making the listing look like 52 commands (24 real + 28 "Renamed -- use ...") instead of the intended clean 24-noun-group view.
- `make_rename_stub` now defaults to `hidden=True`. Stubs still hard-error when invoked by name, but they no longer clutter `--help` or `--help-recursive`.
- Top-level group gained the `epilog` pointer at `docs/cli.md` / `scitex-orochi/convention-cli` skill that plan §11.2 specified but had slipped.

## Before / after

Before (top of `scitex-orochi --help`, 52 rows, edited):
```
Commands:
  agent             Agent lifecycle and fleet view
  agent-launch      Renamed -- use `scitex-orochi agent launch`.
  agent-restart     Renamed -- use `scitex-orochi agent restart`.
  agent-status      Renamed -- use `scitex-orochi agent status`.
  agent-stop        Renamed -- use `scitex-orochi agent stop`.
  auth              Credential / session management
  channel           Channel membership and history
  ...
```

After (24 rows + epilog):
```
Commands:
  agent            Agent lifecycle and fleet view
  auth             Credential / session management
  channel          Channel membership and history
  chrome-watchdog  macOS Chrome ``code_sign_clone`` cache reaper.
  config           Local scitex-orochi config
  ...
  workspace        Manage workspaces

  See docs/cli.md for the noun-verb convention (scitex-orochi/convention-cli skill).
```

Invoking an old name still hard-errors (regression guard in place):
```
$ scitex-orochi list-agents
error: `scitex-orochi list-agents` was renamed to `scitex-orochi agent list`.
[exit 2]
```

## Files touched

- `src/scitex_orochi/_cli/_deprecation.py` — `make_rename_stub(..., *, hidden=True)`.
- `src/scitex_orochi/_cli/_main.py` — `_HelpRecursiveGroup` skips hidden cmds; top-level `epilog` pointer.
- `src/scitex_orochi/_skills/scitex-orochi/convention-cli.md` — doc the hidden-by-default invariant.
- `tests/cli/test_post_phase1d_cleanup.py` — 88 new regression cases.
- `tests/cli/test_deprecation_helper.py` — update old test to pass `hidden=False` explicitly; add default-hidden test.

## Test plan

- [x] `pytest tests/cli/` — 399 pass (229 pre-existing + 88 new + modified).
- [x] `pytest tests/` — 625 pass / 1 skip (DeepEval gate) / 1 xfail (pre-existing).
- [x] `ruff check` clean.
- [x] `ruff format --check` clean.
- [x] Manual `scitex-orochi --help` run: 24 visible commands, no "Renamed" clutter, epilog present.
- [x] Manual `scitex-orochi --help-recursive` run: no `Command: <old>` sections.
- [x] Manual `scitex-orochi list-agents` run: canonical hard-error, exit 2.

## Phase 1d invariants preserved

- Every row of the plan §2 rename table still hard-errors (Step C tests still green).
- Every noun group + verb still renders cleanly (Step B/C tests still green).
- `(Available Now)` suffix layer unchanged (help-availability tests still green).
- `mcp start` flat keeper and `docs` / `skills` keepers unchanged (Q5 tests still green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
