### PR TITLE
fix(ui/chat): restore auto-scroll + new-message append for #ywatanabe channel (msg#16691)

### DIFF
--- a/hub/frontend/src/app/channels-equal.test.mjs
+++ b/hub/frontend/src/app/channels-equal.test.mjs
@@ -1,0 +1,139 @@
+/* app/channels-equal.test.mjs — node-runner for the channel-name equality
+ * helper (msg#16691).
+ *
+ * Matches the style of composer/composer-paste.test.mjs (no vitest/jest
+ * in this repo; run via
+ * `node hub/frontend/src/app/channels-equal.test.mjs`).
+ *
+ * Covers the bug that silenced the ``#ywatanabe`` feed: a message whose
+ * server-side canonical channel was ``#ywatanabe`` but whose client-side
+ * ``currentChannel`` had been restored from a bare ``ywatanabe`` value
+ * (legacy persisted or pre-normalize sidebar row) caused the chat-render
+ * guard to evaluate ``"#ywatanabe" !== "ywatanabe"`` and hide every row.
+ *
+ * Re-implements the helpers against the same spec instead of importing
+ * the TS module (which pulls in DOM / localStorage on load).
+ */
+
+function _normalizeChannelName(name) {
+  if (name == null) return "";
+  var s = String(name);
+  if (!s) return "";
+  if (s.charAt(0) === "#") return s;
+  if (s.indexOf("dm:") === 0) return s;
+  return "#" + s;
+}
+
+function channelsEqual(a, b) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  if (a === b) return true;
+  return _normalizeChannelName(a) === _normalizeChannelName(b);
+}
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`PASS ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`FAIL ${name}: ${e.message}`);
+    failed++;
+  }
+}
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || "assertion failed");
+}
+function assertEq(a, b, msg) {
+  if (a !== b) {
+    throw new Error(
+      `${msg || "expected"}: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`,
+    );
+  }
+}
+
+/* --- _normalizeChannelName ------------------------------------------------ */
+
+test("normalize: null → empty", () => {
+  assertEq(_normalizeChannelName(null), "");
+});
+test("normalize: undefined → empty", () => {
+  assertEq(_normalizeChannelName(undefined), "");
+});
+test("normalize: empty string → empty string", () => {
+  assertEq(_normalizeChannelName(""), "");
+});
+test("normalize: bare name gets '#' prefix", () => {
+  assertEq(_normalizeChannelName("ywatanabe"), "#ywatanabe");
+});
+test("normalize: already-prefixed name unchanged", () => {
+  assertEq(_normalizeChannelName("#ywatanabe"), "#ywatanabe");
+});
+test("normalize: DM prefix preserved", () => {
+  assertEq(
+    _normalizeChannelName("dm:agent:head|human:ywatanabe"),
+    "dm:agent:head|human:ywatanabe",
+  );
+});
+test("normalize: nested folder channel kept intact", () => {
+  assertEq(_normalizeChannelName("#proj/ripple-wm"), "#proj/ripple-wm");
+  assertEq(_normalizeChannelName("proj/ripple-wm"), "#proj/ripple-wm");
+});
+test("normalize: number coerced to string", () => {
+  assertEq(_normalizeChannelName(42), "#42");
+});
+
+/* --- channelsEqual (the ywatanabe-feed regression guard) ------------------ */
+
+test("equal: identical '#ywatanabe'", () => {
+  assert(channelsEqual("#ywatanabe", "#ywatanabe"));
+});
+test("equal: '#ywatanabe' vs 'ywatanabe' — the bug case", () => {
+  assert(
+    channelsEqual("#ywatanabe", "ywatanabe"),
+    "prefix-asymmetric comparison must match to keep the feed visible",
+  );
+  assert(channelsEqual("ywatanabe", "#ywatanabe"));
+});
+test("equal: both bare", () => {
+  assert(channelsEqual("ywatanabe", "ywatanabe"));
+});
+test("equal: different channels stay unequal", () => {
+  assert(!channelsEqual("#ywatanabe", "#general"));
+  assert(!channelsEqual("ywatanabe", "general"));
+  assert(!channelsEqual("#ywatanabe", "#ywatanabe2"));
+});
+test("equal: DM channels match themselves and not a group channel", () => {
+  assert(
+    channelsEqual(
+      "dm:agent:head|human:ywatanabe",
+      "dm:agent:head|human:ywatanabe",
+    ),
+  );
+  assert(!channelsEqual("dm:agent:head|human:ywatanabe", "#ywatanabe"));
+  /* DM prefix must NOT collapse onto a ``#dm:...`` form. */
+  assert(
+    !channelsEqual("dm:agent:head|human:ywatanabe", "#dm:agent:head|human:ywatanabe"),
+  );
+});
+test("equal: both null → true (all-channels mode invariant)", () => {
+  assert(channelsEqual(null, null));
+  assert(channelsEqual(undefined, undefined));
+  assert(channelsEqual(null, undefined));
+});
+test("equal: one side null → false", () => {
+  assert(!channelsEqual(null, "#ywatanabe"));
+  assert(!channelsEqual("#ywatanabe", null));
+});
+test("equal: empty string treated as falsy-but-equal with empty string", () => {
+  assert(channelsEqual("", ""));
+});
+test("equal: folder channels", () => {
+  assert(channelsEqual("#proj/ripple-wm", "proj/ripple-wm"));
+  assert(!channelsEqual("#proj/ripple-wm", "#proj/neurovista"));
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed ? 1 : 0);

--- a/hub/frontend/src/app/state.ts
+++ b/hub/frontend/src/app/state.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { _updateChannelTopicBanner } from "./members";
 import { chatFilterReset } from "../chat/chat-state";
+import { _normalizeChannelName } from "./utils";
 
 /* Orochi Dashboard -- core globals, WS connection, sidebar (Django hub) */
 
@@ -50,11 +51,22 @@ export var lastActiveChannel = null;
 try {
   var _persistedCh = localStorage.getItem("orochi_active_channel");
   if (_persistedCh && _persistedCh !== "__all__") {
-    currentChannel = _persistedCh;
-    lastActiveChannel = _persistedCh;
+    /* Normalize on hydrate too (msg#16691) — a prior session could have
+     * persisted the bare form. */
+    currentChannel = _normalizeChannelName(_persistedCh);
+    lastActiveChannel = currentChannel;
   }
 } catch (_) {}
 export function setCurrentChannel(ch) {
+  /* Normalize group channel names to the canonical ``#<name>`` form so
+   * every downstream comparator sees the same string the server emits on
+   * WS ``chat.message`` broadcasts and ``/api/stats``. Callers pass raw
+   * ``data-channel`` attribute values which, for some legacy sidebar rows,
+   * still arrive without the ``#`` prefix; without this normalize step the
+   * chat-render channel guard hid every inbound message for ``#ywatanabe``
+   * (msg#16691 root cause). DM channels (``dm:`` prefix) and ``null`` /
+   * empty (== all-channels mode) pass through unchanged. */
+  if (ch) ch = _normalizeChannelName(ch);
   currentChannel = ch;
   if (ch) lastActiveChannel = ch;
   /* #278: other modules read `(globalThis as any).currentChannel` — the

--- a/hub/frontend/src/app/utils.ts
+++ b/hub/frontend/src/app/utils.ts
@@ -297,6 +297,48 @@ export function messageKey(sender, ts, content) {
   );
 }
 
+/* Channel-name normalization for client-side equality checks (msg#16691).
+ *
+ * Group channels live under the ``#<name>`` namespace server-side (see
+ * ``hub/models/_helpers.py::normalize_channel_name``), but multiple code
+ * paths on the client can end up holding the bare ``<name>`` form:
+ *  - legacy API rows persisted before the write-path normalize was
+ *    enforced returned ``channel: "ywatanabe"`` from ``GET /api/messages/``
+ *    (``m.channel.name`` is the raw DB string on that endpoint, unlike
+ *    ``/api/stats`` which post-normalizes);
+ *  - sidebar ``data-channel`` attrs and ``(globalThis).currentChannel``
+ *    track whichever string the click site last handed to
+ *    ``setCurrentChannel``, which is whatever ``api_stats`` returned for
+ *    the row — usually ``#foo`` but not guaranteed after a stats-cache
+ *    miss vs hit, a channel rename, or a DB backfill gap;
+ *  - some ``chat.message`` WS fanouts (REST POST path included) round-
+ *    trip through the ``ch_name`` variable from the pre-normalized
+ *    caller field for older messages with ``is_thread_reply`` metadata.
+ *
+ * The ``#``-prefix mismatch was the root cause of the ``#ywatanabe``
+ * feed-silence regression — the chat-render channel guard hid every
+ * inbound message because ``"#ywatanabe" !== "ywatanabe"`` while other
+ * channels happened to have symmetric forms on both sides. Normalizing
+ * in the comparator (not mutating the value in place) closes the gap
+ * without affecting DM channels (``dm:`` prefix preserved) or any
+ * render surface that legitimately needs the raw string.
+ */
+export function _normalizeChannelName(name) {
+  if (name == null) return "";
+  var s = String(name);
+  if (!s) return "";
+  if (s.charAt(0) === "#") return s;
+  if (s.indexOf("dm:") === 0) return s;
+  return "#" + s;
+}
+
+export function channelsEqual(a, b) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  if (a === b) return true;
+  return _normalizeChannelName(a) === _normalizeChannelName(b);
+}
+
 export function isAgentInactive(agent) {
   if (agent.status === "offline") return true;
   if (!agent.last_heartbeat) return false;

--- a/hub/frontend/src/app/websocket.ts
+++ b/hub/frontend/src/app/websocket.ts
@@ -7,7 +7,7 @@ import { _channelDescriptions, _updateChannelTopicBanner } from "./members";
 import { fetchAgents } from "./sidebar-agents";
 import { fetchStats } from "./sidebar-stats";
 import { showSystemBanner } from "./state";
-import { apiUrl, baseTitle, channelUnread, messageKey, token } from "./utils";
+import { apiUrl, baseTitle, channelUnread, channelsEqual, messageKey, token } from "./utils";
 import { handleMessageDelete, handleMessageEdit } from "../chat/chat-actions";
 import { appendSystemMessage } from "../chat/chat-attachments";
 import { fetchNewMessages, loadHistory } from "../chat/chat-history";
@@ -194,9 +194,12 @@ export function handleMessage(msg) {
       (globalThis as any).unreadCount++;
       document.title = "(" + (globalThis as any).unreadCount + ") " + baseTitle;
     }
-    /* Per-channel unread count (#322) */
+    /* Per-channel unread count (#322). Use channelsEqual (msg#16691) so a
+     * message arriving on ``#ywatanabe`` while the user has ``ywatanabe``
+     * selected (or vice-versa) is NOT double-counted as unread in its
+     * own focused channel. */
     var msgCh = msg.channel || msg.chat_id || "";
-    if (msgCh && msgCh !== (globalThis as any).currentChannel) {
+    if (msgCh && !channelsEqual(msgCh, (globalThis as any).currentChannel)) {
       channelUnread[msgCh] = (channelUnread[msgCh] || 0) + 1;
       updateChannelUnreadBadges();
     }

--- a/hub/frontend/src/chat/chat-render.ts
+++ b/hub/frontend/src/chat/chat-render.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import { getResolvedAgentColor, getSenderIcon } from "../agent-icons";
-import { cleanAgentName, escapeHtml, hostedAgentName, timeAgo, userName } from "../app/utils";
+import { channelsEqual, cleanAgentName, escapeHtml, hostedAgentName, timeAgo, userName } from "../app/utils";
 import { _renderMermaidIn, buildAttachmentsHtml } from "./chat-attachments";
 import { _processMessageMarkdown } from "./chat-markdown";
 import { _chatFilterQuery, _mentionRegex, _pulseSidebarRow, _voiceDeferQueue, applyIssueTitleHints, isKnownAgent } from "./chat-state";
@@ -257,7 +257,15 @@ export function appendMessage(msg) {
   /* Hydrate PDF first-page thumbnails in this message's attachments
    * (todo#89). Safe no-op if pdf-thumbnail.js hasn't loaded yet. */
   if (window.pdfThumb) window.pdfThumb.hydrateAll(el);
-  if ((globalThis as any).currentChannel && channel !== (globalThis as any).currentChannel) {
+  /* Channel guard: hide this row if we're currently filtered to a single
+   * channel and the incoming message doesn't belong to it. Use channelsEqual
+   * (msg#16691) so ``#ywatanabe`` vs ``ywatanabe`` is treated as the same
+   * channel — the mismatch was the root cause of the silent-feed regression
+   * where every inbound WS message landed in the DOM with display:none. */
+  if (
+    (globalThis as any).currentChannel &&
+    !channelsEqual(channel, (globalThis as any).currentChannel)
+  ) {
     el.style.display = "none";
   }
   var container = document.getElementById("messages");
@@ -324,7 +332,10 @@ export function appendMessage(msg) {
   /* Sidebar pulses — only for messages arriving AFTER initial load,
    * and only if the message is in a non-focused channel. */
   if ((globalThis as any)._initialLoadComplete && !(globalThis as any)._isLoadingHistory && channel) {
-    var _isFocused = channel === (globalThis as any).currentChannel;
+    /* `#`-prefix-agnostic match (msg#16691) — same rationale as the
+     * display-guard above. Without this, own-channel arrivals could wrongly
+     * pulse the sidebar row as "unread mention" on legacy channel rows. */
+    var _isFocused = channelsEqual(channel, (globalThis as any).currentChannel);
     if (!_isFocused) {
       if (_hasMention) {
         _pulseSidebarRow(channel, "mention");
@@ -427,14 +438,24 @@ export function applyFeedFilter() {
         el.style.display = "";
       } else {
         var ch0 = el.getAttribute("data-channel");
-        el.style.display = ch0 === (globalThis as any).currentChannel ? "" : "none";
+        /* channelsEqual (msg#16691) tolerates ``#``-prefix asymmetry between
+         * the stored message ``data-channel`` and the sidebar-driven
+         * currentChannel — see chat-render guard above and utils.ts. */
+        el.style.display = channelsEqual(ch0, (globalThis as any).currentChannel)
+          ? ""
+          : "none";
       }
       return;
     }
     var ch = el.getAttribute("data-channel");
     var sender = el.getAttribute("data-sender");
+    /* Normalize the incoming channel so a selected sidebar row in either
+     * ``#foo`` or ``foo`` form matches an equivalent message. */
     var chOk =
-      selectedChannels.length === 0 || selectedChannels.indexOf(ch) !== -1;
+      selectedChannels.length === 0 ||
+      selectedChannels.some(function (sc) {
+        return channelsEqual(sc, ch);
+      });
     var agOk =
       selectedAgents.length === 0 || selectedAgents.indexOf(sender) !== -1;
     el.style.display = chOk && agOk ? "" : "none";

--- a/hub/frontend/src/filter/runner.ts
+++ b/hub/frontend/src/filter/runner.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { channelsEqual } from "../app/utils";
 import { _channelMatchesIsFlag, _fm, activeTags, filterInput, parseFilterInput } from "./state";
 
 /* Tag-based unified filter — matching, runFilter, sidebar/grid filters,
@@ -79,7 +80,12 @@ export function runFilter() {
      * ever exists. The legacy multi-channel bypass was removed; currentChannel
      * alone is the filter gate. */
     if (show && (globalThis as any).currentChannel) {
-      show = el.getAttribute("data-channel") === (globalThis as any).currentChannel;
+      /* channelsEqual (msg#16691) so legacy ``#`` vs bare channel names
+       * don't wrongly hide rows in the active channel. */
+      show = channelsEqual(
+        el.getAttribute("data-channel"),
+        (globalThis as any).currentChannel,
+      );
     }
     el.style.display = show ? "" : "none";
   });

--- a/hub/static/hub/app/state.js
+++ b/hub/static/hub/app/state.js
@@ -46,11 +46,26 @@ var lastActiveChannel = null;
 try {
   var _persistedCh = localStorage.getItem("orochi_active_channel");
   if (_persistedCh && _persistedCh !== "__all__") {
-    currentChannel = _persistedCh;
-    lastActiveChannel = _persistedCh;
+    /* Normalize on hydrate (msg#16691) — a prior session could have
+     * persisted the bare form. See app/utils.ts::_normalizeChannelName. */
+    currentChannel =
+      typeof _normalizeChannelName === "function"
+        ? _normalizeChannelName(_persistedCh)
+        : _persistedCh;
+    lastActiveChannel = currentChannel;
   }
 } catch (_) {}
 function setCurrentChannel(ch) {
+  /* Normalize group channel names to the canonical ``#<name>`` form so
+   * every downstream comparator sees the same string the server emits
+   * (msg#16691). Callers pass raw ``data-channel`` attribute values which,
+   * for some legacy sidebar rows, still arrive without the ``#`` prefix;
+   * without this normalize step the chat-render channel guard hid every
+   * inbound message for ``#ywatanabe``. DM channels (``dm:`` prefix) and
+   * null / empty (== all-channels mode) pass through unchanged. */
+  if (ch && typeof _normalizeChannelName === "function") {
+    ch = _normalizeChannelName(ch);
+  }
   currentChannel = ch;
   if (ch) lastActiveChannel = ch;
   try {

--- a/hub/static/hub/app/utils.js
+++ b/hub/static/hub/app/utils.js
@@ -294,6 +294,27 @@ function messageKey(sender, ts, content) {
   );
 }
 
+/* Channel-name normalization for client-side equality checks (msg#16691).
+ * See hub/frontend/src/app/utils.ts for the full rationale — root cause of
+ * the #ywatanabe feed-silence regression was ``#ywatanabe !== ywatanabe``
+ * in the chat-render channel guard when legacy sidebar rows or persisted
+ * localStorage handed the bare form into setCurrentChannel. */
+function _normalizeChannelName(name) {
+  if (name == null) return "";
+  var s = String(name);
+  if (!s) return "";
+  if (s.charAt(0) === "#") return s;
+  if (s.indexOf("dm:") === 0) return s;
+  return "#" + s;
+}
+
+function channelsEqual(a, b) {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  if (a === b) return true;
+  return _normalizeChannelName(a) === _normalizeChannelName(b);
+}
+
 function isAgentInactive(agent) {
   if (agent.status === "offline") return true;
   if (!agent.last_heartbeat) return false;

--- a/hub/static/hub/app/websocket.js
+++ b/hub/static/hub/app/websocket.js
@@ -164,9 +164,12 @@ function handleMessage(msg) {
       unreadCount++;
       document.title = "(" + unreadCount + ") " + baseTitle;
     }
-    /* Per-channel unread count (#322) */
+    /* Per-channel unread count (#322). Use channelsEqual (msg#16691) so a
+     * message arriving on ``#ywatanabe`` while the user has ``ywatanabe``
+     * selected (or vice-versa) is NOT double-counted as unread in its own
+     * focused channel. */
     var msgCh = msg.channel || msg.chat_id || "";
-    if (msgCh && msgCh !== currentChannel) {
+    if (msgCh && !channelsEqual(msgCh, currentChannel)) {
       channelUnread[msgCh] = (channelUnread[msgCh] || 0) + 1;
       updateChannelUnreadBadges();
     }

--- a/hub/static/hub/chat/chat-render.js
+++ b/hub/static/hub/chat/chat-render.js
@@ -234,7 +234,11 @@ function appendMessage(msg) {
   /* Hydrate PDF first-page thumbnails in this message's attachments
    * (todo#89). Safe no-op if pdf-thumbnail.js hasn't loaded yet. */
   if (window.pdfThumb) window.pdfThumb.hydrateAll(el);
-  if (currentChannel && channel !== currentChannel) {
+  /* Channel guard: hide this row if we're currently filtered to a single
+   * channel and the incoming message doesn't belong to it. Use channelsEqual
+   * (msg#16691) so ``#ywatanabe`` vs ``ywatanabe`` is treated as the same
+   * channel — the mismatch was the root cause of the silent-feed regression. */
+  if (currentChannel && !channelsEqual(channel, currentChannel)) {
     el.style.display = "none";
   }
   var container = document.getElementById("messages");
@@ -301,7 +305,8 @@ function appendMessage(msg) {
   /* Sidebar pulses — only for messages arriving AFTER initial load,
    * and only if the message is in a non-focused channel. */
   if (_initialLoadComplete && !_isLoadingHistory && channel) {
-    var _isFocused = channel === currentChannel;
+    /* `#`-prefix-agnostic match (msg#16691) — same rationale as above. */
+    var _isFocused = channelsEqual(channel, currentChannel);
     if (!_isFocused) {
       if (_hasMention) {
         _pulseSidebarRow(channel, "mention");
@@ -404,14 +409,20 @@ function applyFeedFilter() {
         el.style.display = "";
       } else {
         var ch0 = el.getAttribute("data-channel");
-        el.style.display = ch0 === currentChannel ? "" : "none";
+        /* channelsEqual (msg#16691) tolerates ``#``-prefix asymmetry between
+         * the stored message ``data-channel`` and the sidebar-driven
+         * currentChannel. */
+        el.style.display = channelsEqual(ch0, currentChannel) ? "" : "none";
       }
       return;
     }
     var ch = el.getAttribute("data-channel");
     var sender = el.getAttribute("data-sender");
     var chOk =
-      selectedChannels.length === 0 || selectedChannels.indexOf(ch) !== -1;
+      selectedChannels.length === 0 ||
+      selectedChannels.some(function (sc) {
+        return channelsEqual(sc, ch);
+      });
     var agOk =
       selectedAgents.length === 0 || selectedAgents.indexOf(sender) !== -1;
     el.style.display = chOk && agOk ? "" : "none";

--- a/hub/static/hub/filter/runner.js
+++ b/hub/static/hub/filter/runner.js
@@ -76,7 +76,9 @@ function runFilter() {
      * ever exists. The legacy multi-channel bypass was removed; currentChannel
      * alone is the filter gate. */
     if (show && currentChannel) {
-      show = el.getAttribute("data-channel") === currentChannel;
+      /* channelsEqual (msg#16691) so legacy ``#`` vs bare channel names
+       * don't wrongly hide rows in the active channel. */
+      show = channelsEqual(el.getAttribute("data-channel"), currentChannel);
     }
     el.style.display = show ? "" : "none";
   });


### PR DESCRIPTION
## Summary

Fixes worker-progress msg#16693 / ywatanabe msg#16691: on the Chat tab with `#ywatanabe` selected, new inbound WS messages were appended to the DOM but set to `display:none`, so the feed looked frozen and never auto-scrolled. Manual scroll / re-render was the only workaround.

**Root cause:** the chat-render channel guard compared channel strings with strict `===`. The server emits the canonical `#<name>` form (via `hub/models/_helpers.py::normalize_channel_name`) on every WS `chat.message` broadcast, but several client-side paths could hand the bare `<name>` form into `setCurrentChannel`:

- `localStorage["orochi_active_channel"]` persists whatever was last set; older sessions wrote the bare form.
- Some legacy sidebar rows carry `data-channel` attributes without the `#` prefix depending on the source endpoint (`api_messages` returns raw `m.channel.name` unmodified).
- Channel renames / backfill gaps leave pre-normalize rows.

When `(globalThis).currentChannel === "ywatanabe"` and a WS message arrived with `channel === "#ywatanabe"`, the guard evaluated `"#ywatanabe" !== "ywatanabe"` and hid the element. Other channels happened to have symmetric prefix forms on both sides so they were unaffected.

## Fix

- New `_normalizeChannelName` + `channelsEqual` helpers in `hub/frontend/src/app/utils.ts` (mirror: `hub/static/hub/app/utils.js`). `channelsEqual` tolerates `#`-prefix asymmetry while preserving DM channel identity (`dm:` prefix is not re-wrapped).
- `chat/chat-render.ts` channel guard, `_isFocused` sidebar-pulse gate, and `applyFeedFilter` now use `channelsEqual` instead of `===`.
- `filter/runner.ts` active-channel gate and `app/websocket.ts` per-channel unread-badge gate likewise use `channelsEqual` (prevents double-counting unread on the own-focused channel).
- `app/state.ts::setCurrentChannel` normalizes `ch` at the boundary, and the localStorage hydrate path normalizes the restored value, so downstream comparators always see the canonical form.
- JS mirrors under `hub/static/hub/...` hand-updated to match.

## Preserved invariants

- Other channels' feed still auto-scrolls correctly — they already matched exactly; the change is additive.
- PR #246 (manual selection persists across new messages): no change to `setCurrentChannel` semantics beyond the normalize call.
- Single-channel-select / selection-highlight invariants (#284 / #293 / #323): no sidebar rendering touched.
- DM routing: `_normalizeChannelName` explicitly passes `dm:` prefixes through unchanged.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run build` passes (749.31 kB bundle unchanged surface)
- [x] New `node hub/frontend/src/app/channels-equal.test.mjs` passes (17/17), including the exact bug case `channelsEqual("#ywatanabe", "ywatanabe") === true`
- [x] Existing `composer-paste.test.mjs` (8/8) and `draft-store.test.mjs` (19/19) still green
- [ ] Manual: select `#ywatanabe` in Chat tab, have an agent post there, verify message appears + feed auto-scrolls to bottom
- [ ] Manual: select `#general`, post a message — auto-scroll still works (regression gate)
- [ ] Manual: reload while on `#ywatanabe` — hydrated state stays in focus, feed visible
- [ ] Manual: DM channel (`dm:...`) — opening and messaging works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
