### PR TITLE
feat(system): venv-integrity probe + opt-in auto-heal (msg#16777)

### DIFF
--- a/deployment/host-setup/orochi-cron/cron.yaml.example
+++ b/deployment/host-setup/orochi-cron/cron.yaml.example
@@ -66,3 +66,21 @@ jobs:
   #   interval: 1h
   #   command: "scitex-orochi disk reaper-dry-run --yes"
   #   timeout: 10m
+
+  # Venv-integrity probe — catches the msg#16777 regression (``~/.venv``
+  # silently missing ``scitex_orochi``). Emits NDJSON per critical pkg
+  # per interpreter, exits nonzero on any failure so the cron log trips
+  # severity. Read-only: never installs.
+  - name: venv-integrity-check
+    interval: 30m
+    command: "scitex-orochi system venv-check"
+    timeout: 2m
+
+  # Venv-integrity auto-heal — opt-in. Runs ``pip install -e <repo>`` for
+  # broken critical packages whose local checkout is present on this
+  # host. Alert-only (no install) when the repo isn't on this box. Flip
+  # from the check-only job above once you're comfortable with auto-heal.
+  # - name: venv-integrity-heal
+  #   interval: 30m
+  #   command: "scitex-orochi system venv-heal --yes"
+  #   timeout: 10m

--- a/src/scitex_orochi/_cli/_help_availability.py
+++ b/src/scitex_orochi/_cli/_help_availability.py
@@ -122,6 +122,10 @@ DEFAULT_PROBE_MAP: Mapping[str, ProbeKind] = {
     "serve": ProbeKind.PURE_LOCAL,
     "setup-push": ProbeKind.PURE_LOCAL,
     "doctor": ProbeKind.PURE_LOCAL,
+    # ``system venv-check`` / ``venv-heal`` are subprocess-only probes;
+    # they run fine offline and never DM/chat by themselves.
+    "venv-check": ProbeKind.PURE_LOCAL,
+    "venv-heal": ProbeKind.PURE_LOCAL,
     "init": ProbeKind.PURE_LOCAL,
     "launch": ProbeKind.PURE_LOCAL,
     "deploy": ProbeKind.PURE_LOCAL,

--- a/src/scitex_orochi/_cli/commands/system_cmd.py
+++ b/src/scitex_orochi/_cli/commands/system_cmd.py
@@ -1,8 +1,8 @@
-"""``scitex-orochi system {doctor}`` (Phase 1d Step C).
+"""``scitex-orochi system {doctor,venv-check,venv-heal}`` (Phase 1d Step C).
 
-The verb body lives in ``doctor_cmd.py`` (the flat command was plain
-``doctor``). We re-expose it under the ``system`` noun group with a
-short name.
+``doctor``      -- existing full-stack health check (see ``doctor_cmd``).
+``venv-check``  -- critical-package import probe (msg#16777 regression).
+``venv-heal``   -- ``venv-check`` + opt-in ``pip install -e`` remediation.
 
 The old flat spelling (``doctor``) is stubbed in ``_main.py`` to emit
 ``hard_rename_error`` (plan PR #337 §2, Q1 decision).
@@ -21,14 +21,22 @@ from scitex_orochi._cli._help_availability import annotate_help_with_availabilit
 @click.group(
     "system",
     short_help="Host-side self-diagnosis",
-    help="Host-side self-diagnosis (doctor).",
+    help="Host-side self-diagnosis (doctor, venv-check, venv-heal).",
 )
 def system() -> None:
     """System-scoped verbs (Phase 1d Step C)."""
 
 
 from scitex_orochi._cli.commands.doctor_cmd import doctor_cmd as _doctor_cmd
+from scitex_orochi._cli.commands.venv_check_cmd import (
+    venv_check_cmd as _venv_check_cmd,
+)
+from scitex_orochi._cli.commands.venv_check_cmd import (
+    venv_heal_cmd as _venv_heal_cmd,
+)
 
 system.add_command(_doctor_cmd, name="doctor")
+system.add_command(_venv_check_cmd, name="venv-check")
+system.add_command(_venv_heal_cmd, name="venv-heal")
 
 annotate_help_with_availability(system)

--- a/src/scitex_orochi/_cli/commands/venv_check_cmd.py
+++ b/src/scitex_orochi/_cli/commands/venv_check_cmd.py
@@ -1,0 +1,431 @@
+"""``scitex-orochi system {venv-check,venv-heal}`` subcommands.
+
+Periodic integrity probe for the critical Python interpreters used by
+the fleet-side scripts. Catches the exact failure mode seen on mba in
+msg#16777 / msg#16779, where the shared ``~/.venv`` was missing the
+``scitex_orochi`` package -- manually detected, not alerted.
+
+Detection
+---------
+For each interpreter we care about (``sys.executable`` and, if it
+exists, ``~/.venv/bin/python``) and each critical package in the
+hard-coded list, we run ``<interp> -c 'import <pkg>'`` in a subprocess
+and record the outcome.
+
+Remediation
+-----------
+If a critical package is missing AND the repo path exists locally, the
+failure is an editable-install-that-drifted scenario and ``venv-heal
+--yes`` will run ``<interp> -m pip install -e <repo>``. Without
+``--yes`` it's always a dry run. If the repo isn't on this host the
+package should have come from PyPI; we alert but don't auto-heal.
+
+Output
+------
+NDJSON lines (one per probe result), schema
+``scitex-orochi/venv-integrity-probe/v1``.
+
+Exit codes
+----------
+* ``0`` -- all critical packages importable from every audited interp.
+* ``1`` -- at least one critical import failed (severity ``critical``).
+* ``2`` -- probe itself failed (couldn't even launch the interpreter).
+
+Silent-success: no orochi DM, no chat post -- just NDJSON + log. A
+future PR can wire the heal events into ``healer-<host>`` for
+tmux-level recovery (msg#16777 brief).
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import click
+
+SCHEMA = "scitex-orochi/venv-integrity-probe/v1"
+
+
+# ---------------------------------------------------------------------------
+# Critical-package registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CriticalPackage:
+    """One entry in the critical-package list.
+
+    ``import_name``  — the dotted name you'd type after ``import``.
+    ``repo_path``    — candidate local-checkout paths (first existing wins).
+                       ``pip install -e <repo>`` restores an editable install
+                       when a package silently disappears.
+    """
+
+    import_name: str
+    repo_paths: tuple[Path, ...]
+
+
+def _default_repo_paths(*names: str) -> tuple[Path, ...]:
+    """Standard developer-layout candidates for a given project name.
+
+    Handles both ``~/proj/<name>`` (personal checkout) and a few
+    ``~/proj/<parent>/<name>`` nestings we've seen in the fleet.
+    """
+    home = Path.home()
+    out: list[Path] = []
+    for n in names:
+        out.append(home / "proj" / n)
+    return tuple(out)
+
+
+def _build_critical_packages() -> list[CriticalPackage]:
+    """The hard-coded critical list. Ordered most-to-least load-bearing.
+
+    Judgment call: we start with the three packages named in the brief
+    (scitex, scitex-orochi, scitex-agent-container). Easy to extend.
+    """
+    return [
+        CriticalPackage(
+            import_name="scitex",
+            repo_paths=_default_repo_paths("scitex"),
+        ),
+        CriticalPackage(
+            import_name="scitex_orochi",
+            repo_paths=_default_repo_paths("scitex-orochi"),
+        ),
+        CriticalPackage(
+            import_name="scitex_agent_container",
+            repo_paths=_default_repo_paths(
+                "scitex-agent-container",
+                "scitex_agent_container",
+            ),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Interpreter discovery
+# ---------------------------------------------------------------------------
+
+
+def _discover_interpreters() -> list[Path]:
+    """Return interpreters to audit, in precedence order.
+
+    * ``sys.executable`` -- the one running us right now. Always audited.
+    * ``~/.venv/bin/python`` -- the shared venv common to fleet scripts
+      (the one that was broken on mba per msg#16777). Audited if present
+      and distinct from ``sys.executable``.
+    """
+    interps: list[Path] = []
+    this = Path(sys.executable).resolve()
+    interps.append(this)
+    shared = (Path.home() / ".venv" / "bin" / "python").resolve()
+    if shared.is_file() and shared != this:
+        interps.append(shared)
+    return interps
+
+
+# ---------------------------------------------------------------------------
+# Import probe
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProbeResult:
+    pkg: str
+    interpreter: str
+    importable: bool
+    repo_path_found: str | None
+    error: str = ""
+
+
+def _probe_import(interp: Path, pkg: str, *, timeout: float = 10.0) -> tuple[bool, str]:
+    """Return (importable, stderr-tail) for ``<interp> -c 'import <pkg>'``."""
+    try:
+        proc = subprocess.run(
+            [str(interp), "-c", f"import {pkg}"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return False, "interpreter_not_found"
+    except subprocess.TimeoutExpired:
+        return False, "timeout"
+    if proc.returncode == 0:
+        return True, ""
+    # Keep error compact -- NDJSON stays one line per probe.
+    err = (proc.stderr or proc.stdout or "").strip().splitlines()
+    return False, (err[-1] if err else f"exit={proc.returncode}")[:240]
+
+
+def _pick_repo_path(pkg: CriticalPackage) -> Path | None:
+    for candidate in pkg.repo_paths:
+        if candidate.is_dir() and (candidate / "pyproject.toml").is_file():
+            return candidate
+        # Allow repos that only have setup.py (older layouts).
+        if candidate.is_dir() and (candidate / "setup.py").is_file():
+            return candidate
+    return None
+
+
+def _run_probe(
+    packages: Iterable[CriticalPackage],
+    interpreters: Iterable[Path],
+) -> list[ProbeResult]:
+    out: list[ProbeResult] = []
+    for interp in interpreters:
+        for pkg in packages:
+            ok, err = _probe_import(interp, pkg.import_name)
+            repo = _pick_repo_path(pkg)
+            out.append(
+                ProbeResult(
+                    pkg=pkg.import_name,
+                    interpreter=str(interp),
+                    importable=ok,
+                    repo_path_found=str(repo) if repo else None,
+                    error=err,
+                )
+            )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# NDJSON emit
+# ---------------------------------------------------------------------------
+
+
+def _emit_ndjson(
+    results: list[ProbeResult],
+    *,
+    host: str,
+    mode: str,
+    heal_actions: dict[tuple[str, str], str] | None = None,
+) -> int:
+    """Print one NDJSON line per probe result. Returns count of failures."""
+    heal_actions = heal_actions or {}
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fails = 0
+    severity_bumped = False
+    for r in results:
+        key = (r.interpreter, r.pkg)
+        was_healed = key in heal_actions and heal_actions[key] == "ok"
+        if not r.importable:
+            fails += 1
+            severity_bumped = True
+            # Decide the action label for this probe row.
+            if r.repo_path_found:
+                default_action = "heal"
+            else:
+                default_action = "alert"
+            heal_result = heal_actions.get(key, "skipped")
+            action = default_action
+        elif was_healed:
+            # Package became importable because we just installed it.
+            # Surface that clearly so cron consumers can count heals.
+            action = "heal"
+            heal_result = "ok"
+        else:
+            action = "none"
+            heal_result = "skipped"
+        record = {
+            "schema": SCHEMA,
+            "ts": ts,
+            "host": host,
+            "mode": mode,
+            "pkg": r.pkg,
+            "interpreter": r.interpreter,
+            "importable": r.importable,
+            "repo_path_found": r.repo_path_found,
+            "action": action,
+            "heal_result": heal_result,
+            "error": r.error,
+            "severity": "critical" if not r.importable else "ok",
+        }
+        click.echo(json.dumps(record, separators=(",", ":"), sort_keys=False))
+    # If nothing failed we still emit a summary record so cron logs prove
+    # the probe ran (silent-success is per-chat, not per-NDJSON-line).
+    if not severity_bumped:
+        click.echo(
+            json.dumps(
+                {
+                    "schema": SCHEMA,
+                    "ts": ts,
+                    "host": host,
+                    "mode": mode,
+                    "summary": "all_ok",
+                    "probes": len(results),
+                    "severity": "ok",
+                },
+                separators=(",", ":"),
+            )
+        )
+    return fails
+
+
+# ---------------------------------------------------------------------------
+# Heal
+# ---------------------------------------------------------------------------
+
+
+def _pip_install_editable(
+    interp: Path,
+    repo: Path,
+    *,
+    timeout: float = 300.0,
+) -> tuple[bool, str]:
+    """Run ``<interp> -m pip install -e <repo>`` and return (ok, tail-stderr)."""
+    try:
+        proc = subprocess.run(
+            [str(interp), "-m", "pip", "install", "-e", str(repo)],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return False, "interpreter_not_found"
+    except subprocess.TimeoutExpired:
+        return False, "pip_timeout"
+    if proc.returncode == 0:
+        return True, ""
+    tail = (proc.stderr or proc.stdout or "").strip().splitlines()
+    return False, (tail[-1] if tail else f"exit={proc.returncode}")[:240]
+
+
+# ---------------------------------------------------------------------------
+# Click commands
+# ---------------------------------------------------------------------------
+
+
+@click.command("venv-check")
+def venv_check_cmd() -> None:
+    """Probe critical packages are importable; emit NDJSON; exit nonzero on failure.
+
+    Read-only health check. Never installs. Pair with ``venv-heal --yes``
+    on hosts where auto-remediation is acceptable.
+    """
+    host = platform.node().split(".")[0]
+    interpreters = _discover_interpreters()
+    packages = _build_critical_packages()
+
+    # If the interpreter we're running on can't even start a subprocess
+    # of itself, the probe is broken -- exit 2, not 1.
+    if not interpreters:
+        click.echo(
+            json.dumps(
+                {
+                    "schema": SCHEMA,
+                    "host": host,
+                    "mode": "check",
+                    "error": "no_interpreters_found",
+                    "severity": "critical",
+                },
+                separators=(",", ":"),
+            )
+        )
+        sys.exit(2)
+
+    results = _run_probe(packages, interpreters)
+    fails = _emit_ndjson(results, host=host, mode="check")
+    sys.exit(1 if fails else 0)
+
+
+@click.command("venv-heal")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Actually run 'pip install -e <repo>' (default is dry-run).",
+)
+@click.option(
+    "--dry-run",
+    "dry_run_flag",
+    is_flag=True,
+    help="Explicit dry-run (the default).",
+)
+def venv_heal_cmd(yes: bool, dry_run_flag: bool) -> None:
+    """Probe critical packages; for broken + local-repo-present cases run pip install -e.
+
+    Dry-run by default. ``--yes`` enables the actual install. When a
+    package is broken but the repo is NOT on this host, we cannot
+    auto-heal (the package should come from PyPI); that case is still
+    reported with ``action: "alert"`` but ``heal_result: "skipped"``.
+    """
+    del dry_run_flag
+    dry_run = not yes
+    host = platform.node().split(".")[0]
+    interpreters = _discover_interpreters()
+    packages = _build_critical_packages()
+    by_name = {p.import_name: p for p in packages}
+
+    if not interpreters:
+        click.echo(
+            json.dumps(
+                {
+                    "schema": SCHEMA,
+                    "host": host,
+                    "mode": "heal",
+                    "error": "no_interpreters_found",
+                    "severity": "critical",
+                },
+                separators=(",", ":"),
+            )
+        )
+        sys.exit(2)
+
+    results = _run_probe(packages, interpreters)
+
+    heal_actions: dict[tuple[str, str], str] = {}
+    for r in results:
+        if r.importable:
+            continue
+        if not r.repo_path_found:
+            # Alert-only; nothing to install from.
+            heal_actions[(r.interpreter, r.pkg)] = "skipped"
+            continue
+        if dry_run:
+            heal_actions[(r.interpreter, r.pkg)] = "skipped"
+            continue
+        pkg = by_name.get(r.pkg)
+        if pkg is None:
+            heal_actions[(r.interpreter, r.pkg)] = "skipped"
+            continue
+        ok, err = _pip_install_editable(Path(r.interpreter), Path(r.repo_path_found))
+        # Optimistically flip the probe row to importable on success so
+        # downstream cron consumers see the fresh state without needing
+        # a second probe run. Re-verify with a fast import check.
+        if ok:
+            verify_ok, _verify_err = _probe_import(Path(r.interpreter), r.pkg)
+            heal_actions[(r.interpreter, r.pkg)] = "ok" if verify_ok else "failed"
+            if verify_ok:
+                r.importable = True
+                r.error = ""
+        else:
+            heal_actions[(r.interpreter, r.pkg)] = "failed"
+            r.error = err or r.error
+
+    mode = "heal-dry-run" if dry_run else "heal"
+    fails = _emit_ndjson(results, host=host, mode=mode, heal_actions=heal_actions)
+    sys.exit(1 if fails else 0)
+
+
+__all__ = [
+    "CriticalPackage",
+    "ProbeResult",
+    "venv_check_cmd",
+    "venv_heal_cmd",
+    "_build_critical_packages",
+    "_discover_interpreters",
+    "_pip_install_editable",
+    "_probe_import",
+    "_run_probe",
+]
+
+# Prevent pytest from collecting the helper dataclass as a test fixture.
+ProbeResult.__test__ = False  # type: ignore[attr-defined]

--- a/tests/cli/test_system_venv_check.py
+++ b/tests/cli/test_system_venv_check.py
@@ -1,0 +1,487 @@
+"""Unit tests for ``scitex-orochi system {venv-check,venv-heal}``.
+
+The probe shells out to Python subprocesses to validate imports. Tests
+monkeypatch the subprocess helpers so we don't actually launch real
+interpreters -- a pure unit-test cost profile.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+from click.testing import CliRunner
+
+from scitex_orochi._cli._main import orochi
+from scitex_orochi._cli.commands import venv_check_cmd as vcc
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_system_group_has_venv_verbs() -> None:
+    """Both verbs must be registered under the ``system`` noun group."""
+    assert "system" in orochi.commands
+    system = orochi.commands["system"]
+    cmds = set(system.commands.keys())  # type: ignore[attr-defined]
+    assert "venv-check" in cmds
+    assert "venv-heal" in cmds
+    # The existing ``doctor`` verb must still be present (regression).
+    assert "doctor" in cmds
+
+
+# ---------------------------------------------------------------------------
+# Helpers for tests
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_packages(
+    tmp_path: Path,
+    *,
+    create_repos: Iterable[str] = (),
+) -> list[vcc.CriticalPackage]:
+    """Build a small critical-package list pointing at ``tmp_path`` dirs.
+
+    For each name in ``create_repos`` we drop a ``pyproject.toml`` so
+    ``_pick_repo_path`` accepts the dir.
+    """
+    pkgs: list[vcc.CriticalPackage] = []
+    all_names = [
+        ("alpha_pkg", "alpha"),
+        ("beta_pkg", "beta"),
+        ("gamma_pkg", "gamma"),
+    ]
+    for import_name, dirname in all_names:
+        candidate = tmp_path / dirname
+        if dirname in create_repos:
+            candidate.mkdir(parents=True, exist_ok=True)
+            (candidate / "pyproject.toml").write_text("[project]\nname='x'\n")
+        pkgs.append(
+            vcc.CriticalPackage(
+                import_name=import_name,
+                repo_paths=(candidate,),
+            )
+        )
+    return pkgs
+
+
+def _parse_ndjson(stdout: str) -> list[dict]:
+    return [
+        json.loads(ln)
+        for ln in stdout.splitlines()
+        if ln.strip().startswith("{")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# _probe_import behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_probe_import_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    monkeypatch.setattr(
+        vcc.subprocess, "run", lambda *a, **kw: _Proc()
+    )
+    ok, err = vcc._probe_import(Path("/fake/python"), "whatever")
+    assert ok is True
+    assert err == ""
+
+
+def test_probe_import_failure_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Proc:
+        returncode = 1
+        stderr = "Traceback (most recent call last):\n  ...\nModuleNotFoundError: No module named 'X'"
+        stdout = ""
+
+    monkeypatch.setattr(
+        vcc.subprocess, "run", lambda *a, **kw: _Proc()
+    )
+    ok, err = vcc._probe_import(Path("/fake/python"), "X")
+    assert ok is False
+    assert "ModuleNotFoundError" in err
+
+
+def test_probe_import_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_timeout(*a, **kw):
+        raise vcc.subprocess.TimeoutExpired(cmd="python", timeout=1)
+
+    monkeypatch.setattr(vcc.subprocess, "run", _raise_timeout)
+    ok, err = vcc._probe_import(Path("/fake/python"), "X")
+    assert ok is False
+    assert err == "timeout"
+
+
+def test_probe_import_interpreter_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_fnf(*a, **kw):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(vcc.subprocess, "run", _raise_fnf)
+    ok, err = vcc._probe_import(Path("/fake/python"), "X")
+    assert ok is False
+    assert err == "interpreter_not_found"
+
+
+# ---------------------------------------------------------------------------
+# venv-check: NDJSON + exit code
+# ---------------------------------------------------------------------------
+
+
+def test_venv_check_all_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All imports succeed → exit 0, NDJSON summary record 'all_ok'."""
+    monkeypatch.setattr(
+        vcc, "_build_critical_packages",
+        lambda: _make_fake_packages(tmp_path, create_repos=()),
+    )
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters",
+        lambda: [Path("/fake/python")],
+    )
+    monkeypatch.setattr(
+        vcc, "_probe_import", lambda *a, **kw: (True, "")
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-check"], obj={})
+    assert result.exit_code == 0, result.output
+    objs = _parse_ndjson(result.output)
+    assert objs, result.output
+    # We emit a summary record when nothing failed.
+    assert objs[-1].get("summary") == "all_ok"
+    assert objs[-1]["severity"] == "ok"
+
+
+def test_venv_check_partial_failure_exit1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One pkg fails → exit 1, NDJSON has severity=critical."""
+    pkgs = _make_fake_packages(tmp_path, create_repos=("beta",))
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters", lambda: [Path("/fake/python")]
+    )
+
+    def _probe(interp, pkg, *, timeout=10.0):
+        # alpha_pkg fails, rest succeed.
+        if pkg == "alpha_pkg":
+            return False, "ModuleNotFoundError"
+        return True, ""
+
+    monkeypatch.setattr(vcc, "_probe_import", _probe)
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-check"], obj={})
+    assert result.exit_code == 1, result.output
+    objs = _parse_ndjson(result.output)
+    # One of the NDJSON rows is the failing alpha_pkg, action=alert.
+    alpha = [o for o in objs if o.get("pkg") == "alpha_pkg"]
+    assert alpha and alpha[0]["importable"] is False
+    assert alpha[0]["severity"] == "critical"
+    # alpha has no repo present → action=alert, heal_result=skipped.
+    assert alpha[0]["action"] == "alert"
+    assert alpha[0]["heal_result"] == "skipped"
+
+
+def test_venv_check_failure_with_repo_tags_heal_action(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Failure + repo-present → action=heal (check mode still exits 1)."""
+    pkgs = _make_fake_packages(tmp_path, create_repos=("alpha",))
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters", lambda: [Path("/fake/python")]
+    )
+    monkeypatch.setattr(
+        vcc, "_probe_import",
+        lambda interp, pkg, **kw: (False, "boom") if pkg == "alpha_pkg" else (True, ""),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-check"], obj={})
+    assert result.exit_code == 1
+    objs = _parse_ndjson(result.output)
+    alpha = [o for o in objs if o.get("pkg") == "alpha_pkg"][0]
+    assert alpha["action"] == "heal"
+    # venv-check never installs; heal_result stays 'skipped'.
+    assert alpha["heal_result"] == "skipped"
+    # And the repo_path_found got set.
+    assert alpha["repo_path_found"] and alpha["repo_path_found"].endswith("alpha")
+
+
+def test_venv_check_multiple_interpreters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two interpreters × N pkgs → 2N NDJSON data rows."""
+    pkgs = _make_fake_packages(tmp_path, create_repos=())
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters",
+        lambda: [Path("/fake/python-a"), Path("/fake/python-b")],
+    )
+    monkeypatch.setattr(vcc, "_probe_import", lambda *a, **kw: (True, ""))
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-check"], obj={})
+    assert result.exit_code == 0
+    objs = _parse_ndjson(result.output)
+    per_pkg = [o for o in objs if "pkg" in o]
+    assert len(per_pkg) == len(pkgs) * 2
+
+
+# ---------------------------------------------------------------------------
+# venv-heal: dry-run vs --yes
+# ---------------------------------------------------------------------------
+
+
+def test_venv_heal_default_is_dry_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without ``--yes`` no pip install fires, even for broken+local-repo pkgs."""
+    pkgs = _make_fake_packages(tmp_path, create_repos=("alpha",))
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters", lambda: [Path("/fake/python")]
+    )
+    monkeypatch.setattr(
+        vcc, "_probe_import",
+        lambda interp, pkg, **kw: (False, "boom") if pkg == "alpha_pkg" else (True, ""),
+    )
+    pip_called: dict[str, int] = {"n": 0}
+
+    def _pip(interp, repo, **kw):
+        pip_called["n"] += 1
+        return True, ""
+
+    monkeypatch.setattr(vcc, "_pip_install_editable", _pip)
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-heal"], obj={})
+    assert result.exit_code == 1  # still broken
+    assert pip_called["n"] == 0
+    objs = _parse_ndjson(result.output)
+    alpha = [o for o in objs if o.get("pkg") == "alpha_pkg"][0]
+    assert alpha["action"] == "heal"
+    # Dry-run mode: no install, heal_result is 'skipped'.
+    assert alpha["heal_result"] == "skipped"
+    assert alpha["mode"] == "heal-dry-run"
+
+
+def test_venv_heal_yes_runs_pip_install_editable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pkgs = _make_fake_packages(tmp_path, create_repos=("alpha",))
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters", lambda: [Path("/fake/python")]
+    )
+
+    call_log: list[tuple[str, str]] = []
+    state = {"healed": set()}
+
+    def _probe(interp, pkg, **kw):
+        # alpha fails until it's "healed".
+        if pkg == "alpha_pkg" and pkg not in state["healed"]:
+            return False, "ModuleNotFoundError"
+        return True, ""
+
+    def _pip(interp, repo, **kw):
+        call_log.append((str(interp), str(repo)))
+        # Simulate successful install → probe now passes.
+        state["healed"].add("alpha_pkg")
+        return True, ""
+
+    monkeypatch.setattr(vcc, "_probe_import", _probe)
+    monkeypatch.setattr(vcc, "_pip_install_editable", _pip)
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-heal", "--yes"], obj={})
+    assert result.exit_code == 0, result.output
+    # pip install ran exactly once (for the one failing pkg).
+    assert len(call_log) == 1
+    assert call_log[0][1].endswith("alpha")
+    objs = _parse_ndjson(result.output)
+    alpha = [o for o in objs if o.get("pkg") == "alpha_pkg"][0]
+    assert alpha["importable"] is True  # re-verified after heal
+    assert alpha["heal_result"] == "ok"
+    assert alpha["mode"] == "heal"
+
+
+def test_venv_heal_yes_pip_failure_records_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pkgs = _make_fake_packages(tmp_path, create_repos=("alpha",))
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters", lambda: [Path("/fake/python")]
+    )
+    monkeypatch.setattr(
+        vcc, "_probe_import",
+        lambda interp, pkg, **kw: (False, "boom") if pkg == "alpha_pkg" else (True, ""),
+    )
+    monkeypatch.setattr(
+        vcc, "_pip_install_editable",
+        lambda interp, repo, **kw: (False, "ResolutionImpossible"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-heal", "--yes"], obj={})
+    assert result.exit_code == 1  # still failing
+    objs = _parse_ndjson(result.output)
+    alpha = [o for o in objs if o.get("pkg") == "alpha_pkg"][0]
+    assert alpha["heal_result"] == "failed"
+
+
+def test_venv_heal_yes_alert_only_when_no_local_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Broken pkg but no local checkout → never calls pip; action=alert."""
+    pkgs = _make_fake_packages(tmp_path, create_repos=())  # none on disk
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters", lambda: [Path("/fake/python")]
+    )
+    monkeypatch.setattr(
+        vcc, "_probe_import",
+        lambda interp, pkg, **kw: (False, "boom") if pkg == "alpha_pkg" else (True, ""),
+    )
+    pip_called: dict[str, int] = {"n": 0}
+    monkeypatch.setattr(
+        vcc, "_pip_install_editable",
+        lambda *a, **kw: (pip_called.__setitem__("n", pip_called["n"] + 1), (True, ""))[-1],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-heal", "--yes"], obj={})
+    assert result.exit_code == 1
+    assert pip_called["n"] == 0  # no local repo → no pip
+    objs = _parse_ndjson(result.output)
+    alpha = [o for o in objs if o.get("pkg") == "alpha_pkg"][0]
+    assert alpha["action"] == "alert"
+    assert alpha["heal_result"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Interpreter discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discover_interpreters_dedupes_self_and_shared(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When ``~/.venv/bin/python`` resolves to the same file as sys.executable,
+    we should not audit it twice."""
+    fake_self = tmp_path / "python-real"
+    fake_self.write_text("#!/bin/sh\nexit 0\n")
+
+    monkeypatch.setattr(vcc.sys, "executable", str(fake_self))
+    # Point Path.home() at a dir with no ``.venv``.
+    monkeypatch.setattr(vcc.Path, "home", classmethod(lambda cls: tmp_path))
+
+    interps = vcc._discover_interpreters()
+    assert len(interps) == 1
+    assert interps[0] == fake_self.resolve()
+
+
+def test_discover_interpreters_adds_shared_venv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake_self = tmp_path / "python-real"
+    fake_self.write_text("#!/bin/sh\nexit 0\n")
+    shared_dir = tmp_path / ".venv" / "bin"
+    shared_dir.mkdir(parents=True)
+    shared = shared_dir / "python"
+    shared.write_text("#!/bin/sh\nexit 0\n")
+
+    monkeypatch.setattr(vcc.sys, "executable", str(fake_self))
+    monkeypatch.setattr(vcc.Path, "home", classmethod(lambda cls: tmp_path))
+
+    interps = vcc._discover_interpreters()
+    assert len(interps) == 2
+    paths = [str(p) for p in interps]
+    assert str(shared.resolve()) in paths
+
+
+# ---------------------------------------------------------------------------
+# Repo-path discovery
+# ---------------------------------------------------------------------------
+
+
+def test_pick_repo_path_accepts_pyproject(tmp_path: Path) -> None:
+    repo = tmp_path / "mypkg"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+    pkg = vcc.CriticalPackage(import_name="mypkg", repo_paths=(repo,))
+    assert vcc._pick_repo_path(pkg) == repo
+
+
+def test_pick_repo_path_accepts_setup_py(tmp_path: Path) -> None:
+    repo = tmp_path / "mypkg"
+    repo.mkdir()
+    (repo / "setup.py").write_text("from setuptools import setup; setup()\n")
+    pkg = vcc.CriticalPackage(import_name="mypkg", repo_paths=(repo,))
+    assert vcc._pick_repo_path(pkg) == repo
+
+
+def test_pick_repo_path_returns_none_when_missing(tmp_path: Path) -> None:
+    pkg = vcc.CriticalPackage(
+        import_name="mypkg",
+        repo_paths=(tmp_path / "nope",),
+    )
+    assert vcc._pick_repo_path(pkg) is None
+
+
+# ---------------------------------------------------------------------------
+# Severity escalation
+# ---------------------------------------------------------------------------
+
+
+def test_severity_critical_when_any_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pkgs = _make_fake_packages(tmp_path, create_repos=())
+    monkeypatch.setattr(vcc, "_build_critical_packages", lambda: pkgs)
+    monkeypatch.setattr(
+        vcc, "_discover_interpreters", lambda: [Path("/fake/python")]
+    )
+    monkeypatch.setattr(
+        vcc, "_probe_import",
+        lambda interp, pkg, **kw: (False, "boom") if pkg == "gamma_pkg" else (True, ""),
+    )
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-check"], obj={})
+    assert result.exit_code == 1
+    objs = _parse_ndjson(result.output)
+    # No summary line in failure mode; at least one per-pkg row must be
+    # severity=critical.
+    assert any(
+        o.get("severity") == "critical" for o in objs if "pkg" in o
+    )
+    # The green rows still report severity=ok.
+    ok_rows = [o for o in objs if o.get("pkg") in ("alpha_pkg", "beta_pkg")]
+    assert all(o["severity"] == "ok" for o in ok_rows)
+
+
+# ---------------------------------------------------------------------------
+# Empty-interpreter edge case
+# ---------------------------------------------------------------------------
+
+
+def test_venv_check_no_interpreters_exits_2(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(vcc, "_discover_interpreters", lambda: [])
+    runner = CliRunner()
+    result = runner.invoke(orochi, ["system", "venv-check"], obj={})
+    assert result.exit_code == 2
+    objs = _parse_ndjson(result.output)
+    assert objs[0]["error"] == "no_interpreters_found"
+    assert objs[0]["severity"] == "critical"


### PR DESCRIPTION
## Summary

Catch the msg#16777 regression automatically. The mba shared `~/.venv` was silently missing `scitex_orochi`; only manual poking surfaced it. This PR adds a periodic probe that catches the same class of breakage on every fleet host before ywatanabe has to.

- `scitex-orochi system venv-check` - read-only import probe (sys.executable + `~/.venv/bin/python`) for `scitex`, `scitex_orochi`, `scitex_agent_container`. Emits NDJSON (schema `scitex-orochi/venv-integrity-probe/v1`), exits 1 on any failure, 2 if the probe itself is broken. Dry-run always.
- `scitex-orochi system venv-heal` - same probe + remediation. Dry-run by default; `--yes` runs `<interp> -m pip install -e <repo>` for broken-but-local-repo cases. Broken pkgs with no local checkout stay `action=alert` (would need PyPI reinstall).
- `deployment/host-setup/orochi-cron/cron.yaml.example` gets a live `venv-integrity-check` job at 30m cadence plus a commented-out `venv-integrity-heal --yes` alternative so operators pick based on their comfort with auto-heal.

Silent-success: no chat posts, no DM fanout -- NDJSON + cron log only. A follow-up PR can wire heal events into `healer-<host>` for tmux-level recovery.

## Files touched

- `src/scitex_orochi/_cli/commands/venv_check_cmd.py` (new, ~315 LOC)
- `tests/cli/test_system_venv_check.py` (new, 20 tests)
- `src/scitex_orochi/_cli/commands/system_cmd.py` (register two new verbs)
- `src/scitex_orochi/_cli/_help_availability.py` (mark new verbs PURE_LOCAL)
- `deployment/host-setup/orochi-cron/cron.yaml.example` (cron entries)

## Test plan

- [x] `pytest tests/cli/test_system_venv_check.py` - 20/20 pass
- [x] `pytest tests/cli/` - 330/330 pass (full CLI suite, no regression)
- [x] `pytest tests/` - 556 pass / 1 skip / 1 xfail (full suite)
- [x] `ruff check` clean on all touched files
- [x] Smoke run: `scitex-orochi system venv-check` on Yusukes-MacBook-Air emits NDJSON with severity=ok for all three critical packages
- [ ] CI green on develop-targeted PR
- [ ] Post-merge: flip mba `cron.yaml` entry on and verify NDJSON shows up in the orochi-cron log

## Notes / judgment calls

- Critical package list: `scitex`, `scitex-orochi`, `scitex-agent-container` as specified in the brief. No additional packages added -- these three are the load-bearing fleet imports. Easy to extend `_build_critical_packages()` later.
- Repo-path heuristic: checks `~/proj/<name>` with a `pyproject.toml` (or `setup.py` as fallback). Matches the developer convention used across `_host_ops.py`.
- Silent-success: no orochi DM/chat post from the probe itself -- the cron log carries severity. Wiring into `healer-<host>` is explicitly deferred per the brief.