### PR TITLE
feat(ops): pkg-audit.sh — shell-level venv drift detector for mgr-pkg cron (msg#16802)

### DIFF
--- a/deployment/host-setup/orochi-cron/cron.yaml.example
+++ b/deployment/host-setup/orochi-cron/cron.yaml.example
@@ -66,3 +66,12 @@ jobs:
   #   interval: 1h
   #   command: "scitex-orochi disk reaper-dry-run --yes"
   #   timeout: 10m
+
+  # Venv drift audit for scitex-* packages — pip show + import probe.
+  # Mgr-pkg's startup_commands will enable this per host (commented out
+  # here so fresh installs don't immediately start reinstalling editable
+  # packages). See scripts/client/pkg-audit.sh for flags / exit codes.
+  # - name: pkg-audit
+  #   interval: 15m
+  #   command: "bash ${SCITEX_OROCHI_REPO_ROOT}/scripts/client/pkg-audit.sh --auto-fix --quiet"
+  #   timeout: 5m

--- a/scripts/client/pkg-audit.sh
+++ b/scripts/client/pkg-audit.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+# -*- coding: utf-8 -*-
+# Timestamp: "2026-04-20 (ywatanabe)"
+# File: scripts/client/pkg-audit.sh
+# Description: Shell-level venv drift detector for scitex-* packages.
+#
+# Given a list of scitex-family packages, verify two independent invariants
+# per package:
+#   1. `pip show <pkg>` succeeds       (package known to the active venv)
+#   2. `python -c 'import <pkg>'` works (import actually resolves at runtime)
+#
+# Classification:
+#   ok       — both checks pass
+#   drift    — pip shows the package but import fails (stale metadata, .pth
+#              mismatch, editable install pointing at a moved path, etc.)
+#   missing  — pip show fails (package not installed at all)
+#
+# With --auto-fix, drift/missing packages whose source repo is present on
+# this host are reinstalled with `pip install -e <repo>`.
+#
+# Output modes:
+#   default     — human-readable one-liner per package, colored
+#   --json      — NDJSON (one JSON object per package, no colors)
+#   --quiet     — suppress all stdout; exit code is the signal
+#
+# Exit codes:
+#   0  — all packages ok (or fixed cleanly with --auto-fix)
+#   1  — drift/missing observed, no fix attempted
+#   2  — --auto-fix attempted but at least one install failed
+#   3  — `pip` binary not found in PATH
+#
+# Intended caller: the mgr-pkg cron job defined in
+# deployment/host-setup/orochi-cron/cron.yaml.example. Safe to run
+# interactively; safe to run under cron (silent-success with --quiet).
+
+set -uo pipefail
+
+# ──────────────────────────────────────────
+# Defaults / flag parsing
+# ──────────────────────────────────────────
+AUTO_FIX=0
+JSON_OUT=0
+QUIET=0
+SINGLE_PKG=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [--auto-fix] [--json] [--quiet] [--pkg <name>]
+
+Audit scitex-* packages for pip/import drift.
+
+Options:
+  --auto-fix       Reinstall drifting/missing packages via 'pip install -e'
+                   when the source repo is present on this host.
+  --json           Emit NDJSON (one line per package) instead of human text.
+  --quiet          Suppress all stdout; communicate only via exit code.
+  --pkg <name>     Audit a single package (default: full scitex-* list).
+  -h, --help       Show this help and exit.
+
+Environment:
+  PACKAGES         Space-separated override of the default package list.
+
+Exit codes:
+  0 ok, 1 drift/missing, 2 fix failed, 3 pip not found.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --auto-fix) AUTO_FIX=1; shift ;;
+        --json) JSON_OUT=1; shift ;;
+        --quiet) QUIET=1; shift ;;
+        --pkg)
+            if [[ $# -lt 2 ]]; then
+                echo "error: --pkg requires an argument" >&2
+                exit 64
+            fi
+            SINGLE_PKG="$2"
+            shift 2
+            ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 64
+            ;;
+    esac
+done
+
+# ──────────────────────────────────────────
+# Dependencies
+# ──────────────────────────────────────────
+PIP_BIN="${PIP_BIN:-pip}"
+PYTHON_BIN="${PYTHON_BIN:-python}"
+
+if ! command -v "$PIP_BIN" >/dev/null 2>&1; then
+    if [[ "$QUIET" -eq 0 ]]; then
+        echo "error: '$PIP_BIN' not found in PATH" >&2
+    fi
+    exit 3
+fi
+
+# ──────────────────────────────────────────
+# Package list + repo-path map
+# ──────────────────────────────────────────
+DEFAULT_PACKAGES="scitex scitex-orochi scitex-agent-container scitex-clew scitex-cloud"
+PACKAGES="${PACKAGES:-$DEFAULT_PACKAGES}"
+
+if [[ -n "$SINGLE_PKG" ]]; then
+    PACKAGES="$SINGLE_PKG"
+fi
+
+# Expand ~ once so the map lookups are direct string compares.
+HOME_DIR="${HOME:-/root}"
+
+repo_path_for() {
+    # Return the canonical source repo path for a package, or empty if
+    # this package isn't one we know how to auto-fix.
+    case "$1" in
+        scitex)                   echo "$HOME_DIR/proj/scitex-python" ;;
+        scitex-orochi)            echo "$HOME_DIR/proj/scitex-orochi" ;;
+        scitex-agent-container)   echo "$HOME_DIR/proj/scitex-agent-container" ;;
+        scitex-clew)              echo "$HOME_DIR/proj/scitex-clew" ;;
+        scitex-cloud)             echo "$HOME_DIR/proj/scitex-cloud" ;;
+        *)                        echo "" ;;
+    esac
+}
+
+import_name_for() {
+    # PEP 8 import name: scitex-orochi → scitex_orochi.
+    echo "${1//-/_}"
+}
+
+# ──────────────────────────────────────────
+# Colors (only when interactive & not JSON/quiet)
+# ──────────────────────────────────────────
+if [[ -t 1 ]] && [[ "$JSON_OUT" -eq 0 ]] && [[ "$QUIET" -eq 0 ]]; then
+    C_OK='\033[0;32m'
+    C_WARN='\033[0;33m'
+    C_ERR='\033[0;31m'
+    C_DIM='\033[2m'
+    C_RESET='\033[0m'
+else
+    C_OK=''; C_WARN=''; C_ERR=''; C_DIM=''; C_RESET=''
+fi
+
+# ──────────────────────────────────────────
+# Emit helpers
+# ──────────────────────────────────────────
+emit_human() {
+    # $1=status, $2=pkg, $3=detail
+    local status="$1" pkg="$2" detail="$3"
+    local color symbol
+    case "$status" in
+        ok)        color="$C_OK";   symbol="✓" ;;
+        drift)     color="$C_WARN"; symbol="?" ;;
+        missing)   color="$C_ERR";  symbol="✗" ;;
+        fixed)     color="$C_OK";   symbol="↻" ;;
+        fix_failed) color="$C_ERR"; symbol="!" ;;
+        *)         color="";        symbol="·" ;;
+    esac
+    printf "%b%s %-28s %s%b %s\n" \
+        "$color" "$symbol" "$pkg" "$status" "$C_RESET" \
+        "${detail:+($detail)}"
+}
+
+emit_json() {
+    # $1=pkg $2=status $3=pip_ok $4=import_ok $5=fixed $6=repo_path $7=detail
+    local pkg="$1" status="$2" pip_ok="$3" import_ok="$4" fixed="$5" repo="$6" detail="$7"
+    # Hand-rolled JSON — we avoid a python dependency on the emit path so the
+    # script stays callable even if the venv is the thing that's broken.
+    local repo_json detail_json
+    if [[ -n "$repo" ]]; then
+        repo_json="\"$repo\""
+    else
+        repo_json="null"
+    fi
+    if [[ -n "$detail" ]]; then
+        # Escape backslash + double-quote for JSON.
+        local esc="${detail//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        detail_json="\"$esc\""
+    else
+        detail_json="null"
+    fi
+    printf '{"package":"%s","status":"%s","pip_ok":%s,"import_ok":%s,"fixed":%s,"repo_path":%s,"detail":%s}\n' \
+        "$pkg" "$status" "$pip_ok" "$import_ok" "$fixed" "$repo_json" "$detail_json"
+}
+
+output() {
+    # Route a result through the right emitter. All arguments are passed
+    # to both emit_human and emit_json in the shapes they each need.
+    local pkg="$1" status="$2" pip_ok="$3" import_ok="$4" fixed="$5" repo="$6" detail="$7"
+    if [[ "$QUIET" -eq 1 ]]; then
+        return 0
+    fi
+    if [[ "$JSON_OUT" -eq 1 ]]; then
+        emit_json "$pkg" "$status" "$pip_ok" "$import_ok" "$fixed" "$repo" "$detail"
+    else
+        emit_human "$status" "$pkg" "$detail"
+    fi
+}
+
+# ──────────────────────────────────────────
+# Per-package audit
+# ──────────────────────────────────────────
+TOTAL=0
+NUM_DRIFT=0
+NUM_MISSING=0
+NUM_FIXED=0
+NUM_FIX_FAILED=0
+
+for pkg in $PACKAGES; do
+    TOTAL=$((TOTAL + 1))
+    import_name="$(import_name_for "$pkg")"
+    repo="$(repo_path_for "$pkg")"
+
+    # 1. pip show
+    if "$PIP_BIN" show "$pkg" >/dev/null 2>&1; then
+        pip_ok=true
+        pip_ok_int=1
+    else
+        pip_ok=false
+        pip_ok_int=0
+    fi
+
+    # 2. python -c 'import <import_name>'
+    if "$PYTHON_BIN" -c "import ${import_name}" >/dev/null 2>&1; then
+        import_ok=true
+        import_ok_int=1
+    else
+        import_ok=false
+        import_ok_int=0
+    fi
+
+    # 3. classify
+    if $pip_ok && $import_ok; then
+        status="ok"
+    elif $pip_ok && ! $import_ok; then
+        status="drift"
+        NUM_DRIFT=$((NUM_DRIFT + 1))
+    else
+        status="missing"
+        NUM_MISSING=$((NUM_MISSING + 1))
+    fi
+
+    fixed_flag=false
+    detail=""
+
+    # 4. optional auto-fix
+    if [[ "$AUTO_FIX" -eq 1 ]] && [[ "$status" != "ok" ]]; then
+        if [[ -n "$repo" ]] && [[ -d "$repo" ]]; then
+            if "$PIP_BIN" install -e "$repo" >/dev/null 2>&1; then
+                status="fixed"
+                fixed_flag=true
+                NUM_FIXED=$((NUM_FIXED + 1))
+                detail="reinstalled from $repo"
+            else
+                status="fix_failed"
+                NUM_FIX_FAILED=$((NUM_FIX_FAILED + 1))
+                detail="pip install -e $repo failed"
+            fi
+        else
+            # Nothing we can do automatically; stay in drift/missing.
+            detail="no repo at ${repo:-<unmapped>}"
+        fi
+    elif [[ "$status" = "drift" ]]; then
+        detail="pip ok, import fails ($import_name)"
+    elif [[ "$status" = "missing" ]]; then
+        detail="not installed"
+    fi
+
+    # 5. emit
+    fixed_json=false
+    if $fixed_flag; then fixed_json=true; fi
+    output "$pkg" "$status" "$pip_ok" "$import_ok" "$fixed_json" "$repo" "$detail"
+done
+
+# ──────────────────────────────────────────
+# Summary + exit code
+# ──────────────────────────────────────────
+if [[ "$QUIET" -eq 0 ]] && [[ "$JSON_OUT" -eq 0 ]]; then
+    printf "%b" "$C_DIM"
+    printf "── %d audited · drift=%d missing=%d fixed=%d fix_failed=%d ──\n" \
+        "$TOTAL" "$NUM_DRIFT" "$NUM_MISSING" "$NUM_FIXED" "$NUM_FIX_FAILED"
+    printf "%b" "$C_RESET"
+fi
+
+# Exit code ladder. 2 wins over 1 (fix_failed implies we tried and failed).
+if [[ "$NUM_FIX_FAILED" -gt 0 ]]; then
+    exit 2
+fi
+
+# After a successful --auto-fix, remaining drift/missing are ones where
+# the repo was missing — still a problem to report.
+REMAINING_BAD=$((NUM_DRIFT + NUM_MISSING - NUM_FIXED))
+if [[ "$REMAINING_BAD" -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0
+
+# EOF

--- a/tests/test_pkg_audit_script.py
+++ b/tests/test_pkg_audit_script.py
@@ -17,7 +17,6 @@ package, emitted strictly to stdout.
 from __future__ import annotations
 
 import json
-import os
 import stat
 import subprocess
 from pathlib import Path

--- a/tests/test_pkg_audit_script.py
+++ b/tests/test_pkg_audit_script.py
@@ -1,0 +1,358 @@
+"""Integration tests for scripts/client/pkg-audit.sh.
+
+We drive the real bash script against stub ``pip`` and ``python`` binaries
+on a tmpdir PATH so we can simulate every combination of
+(pip-show-ok, python-import-ok) without touching the real venv.
+
+The script's three exit codes under normal operation:
+    0 — all packages ok (or fixed cleanly with --auto-fix)
+    1 — drift/missing observed without fix
+    2 — --auto-fix attempted but at least one install failed
+    3 — pip not found (covered by its own test)
+
+Plus NDJSON shape: one ``{"package": ..., "status": ..., ...}`` line per
+package, emitted strictly to stdout.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "client" / "pkg-audit.sh"
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_executable(path: Path) -> None:
+    mode = path.stat().st_mode
+    path.chmod(mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _write_pip_stub(
+    bindir: Path,
+    *,
+    known: set[str],
+    install_fail: set[str] | None = None,
+    log_file: Path | None = None,
+) -> None:
+    """Write a fake 'pip' binary.
+
+    * `pip show <pkg>` exits 0 iff pkg in `known`.
+    * `pip install -e <path>` exits 0 unless the basename of <path> is in
+      `install_fail`; also appends the install target to `log_file`.
+    """
+    install_fail = install_fail or set()
+    log_file = log_file or (bindir / "pip.log")
+    known_list = " ".join(sorted(known))
+    fail_list = " ".join(sorted(install_fail))
+    script = f"""#!/usr/bin/env bash
+LOG="{log_file}"
+KNOWN="{known_list}"
+FAIL="{fail_list}"
+case "$1" in
+    show)
+        pkg="$2"
+        for k in $KNOWN; do
+            if [ "$k" = "$pkg" ]; then exit 0; fi
+        done
+        exit 1
+        ;;
+    install)
+        # pip install -e <path>
+        # argv: install -e <path>
+        shift
+        target=""
+        while [ $# -gt 0 ]; do
+            case "$1" in
+                -e) shift; target="$1"; shift ;;
+                *) shift ;;
+            esac
+        done
+        echo "install $target" >> "$LOG"
+        base="$(basename "$target")"
+        for f in $FAIL; do
+            if [ "$f" = "$base" ]; then exit 1; fi
+        done
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+"""
+    p = bindir / "pip"
+    p.write_text(script)
+    _make_executable(p)
+
+
+def _write_python_stub(
+    bindir: Path,
+    *,
+    importable: set[str],
+) -> None:
+    """Write a fake 'python' binary.
+
+    Only supports the `python -c "import <name>"` call shape used by the
+    audit script. Exits 0 iff the imported module is in `importable`.
+    """
+    importable_list = " ".join(sorted(importable))
+    script = f"""#!/usr/bin/env bash
+# argv: -c "import <name>"
+if [ "$1" != "-c" ]; then exit 2; fi
+code="$2"
+# Strip "import " prefix.
+mod="${{code#import }}"
+OK="{importable_list}"
+for m in $OK; do
+    if [ "$m" = "$mod" ]; then exit 0; fi
+done
+exit 1
+"""
+    p = bindir / "python"
+    p.write_text(script)
+    _make_executable(p)
+
+
+def _run(
+    tmp_path: Path,
+    *,
+    known: set[str],
+    importable: set[str],
+    args: list[str],
+    install_fail: set[str] | None = None,
+    packages: str | None = None,
+    create_repos: list[str] | None = None,
+) -> tuple[subprocess.CompletedProcess, Path]:
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    _write_pip_stub(bindir, known=known, install_fail=install_fail)
+    _write_python_stub(bindir, importable=importable)
+
+    # Optional fake HOME with the repo dirs the script's auto-fix map
+    # will look up.
+    home = tmp_path / "home"
+    proj = home / "proj"
+    proj.mkdir(parents=True, exist_ok=True)
+    for repo in create_repos or []:
+        (proj / repo).mkdir(parents=True, exist_ok=True)
+
+    env = {
+        "PATH": f"{bindir}:/usr/bin:/bin",
+        "HOME": str(home),
+    }
+    if packages is not None:
+        env["PACKAGES"] = packages
+
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    return proc, bindir
+
+
+def _parse_ndjson(stdout: str) -> list[dict]:
+    return [json.loads(ln) for ln in stdout.splitlines() if ln.startswith("{")]
+
+
+# ---------------------------------------------------------------------------
+# Exit-code tests
+# ---------------------------------------------------------------------------
+
+
+def test_all_ok_exit_zero(tmp_path):
+    """Every package present in pip AND importable → exit 0."""
+    proc, _ = _run(
+        tmp_path,
+        known={"scitex", "scitex_orochi_pkg"},
+        importable={"scitex", "scitex_orochi_pkg"},
+        packages="scitex",
+        args=["--json"],
+    )
+    assert proc.returncode == 0, proc.stderr
+    rows = _parse_ndjson(proc.stdout)
+    assert len(rows) == 1
+    assert rows[0]["package"] == "scitex"
+    assert rows[0]["status"] == "ok"
+    assert rows[0]["pip_ok"] is True
+    assert rows[0]["import_ok"] is True
+
+
+def test_drift_detected_exit_one(tmp_path):
+    """pip show ok but python import fails → drift, exit 1."""
+    proc, _ = _run(
+        tmp_path,
+        known={"scitex-orochi"},   # pip knows it
+        importable=set(),          # but it won't import
+        packages="scitex-orochi",
+        args=["--json"],
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    rows = _parse_ndjson(proc.stdout)
+    assert rows[0]["status"] == "drift"
+    assert rows[0]["pip_ok"] is True
+    assert rows[0]["import_ok"] is False
+
+
+def test_missing_detected_exit_one(tmp_path):
+    """pip show fails → missing, exit 1."""
+    proc, _ = _run(
+        tmp_path,
+        known=set(),
+        importable=set(),
+        packages="scitex-cloud",
+        args=["--json"],
+    )
+    assert proc.returncode == 1
+    rows = _parse_ndjson(proc.stdout)
+    assert rows[0]["status"] == "missing"
+
+
+def test_pip_not_found_exit_three(tmp_path):
+    """No pip in PATH → exit 3."""
+    # Empty bindir with only python; no pip stub at all.
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    _write_python_stub(bindir, importable=set())
+    # PATH includes /usr/bin:/bin only so the bash child can still exec
+    # basic utilities, but pip is deliberately absent.
+    env = {"PATH": f"{bindir}:/usr/bin:/bin", "HOME": str(tmp_path)}
+    # Force an absolute pip target so the shim bindir can't accidentally
+    # satisfy `command -v pip`.
+    env["PIP_BIN"] = "/nonexistent/definitely-not-pip"
+    proc = subprocess.run(
+        ["bash", str(SCRIPT), "--quiet", "--pkg", "scitex"],
+        capture_output=True, text=True, env=env, timeout=10,
+    )
+    assert proc.returncode == 3
+
+
+# ---------------------------------------------------------------------------
+# --auto-fix behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_auto_fix_repairs_drift_when_repo_present(tmp_path):
+    """Drift + repo dir present + pip install succeeds → fixed, exit 0."""
+    proc, bindir = _run(
+        tmp_path,
+        known={"scitex-orochi"},
+        importable=set(),
+        packages="scitex-orochi",
+        args=["--auto-fix", "--json"],
+        create_repos=["scitex-orochi"],
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    rows = _parse_ndjson(proc.stdout)
+    assert rows[0]["status"] == "fixed"
+    assert rows[0]["fixed"] is True
+
+    # Confirm pip install -e was invoked at the expected path.
+    log = (bindir / "pip.log").read_text()
+    assert "install" in log
+    assert "scitex-orochi" in log
+
+
+def test_auto_fix_failure_exit_two(tmp_path):
+    """--auto-fix attempts install but pip returns nonzero → exit 2."""
+    proc, _ = _run(
+        tmp_path,
+        known=set(),                      # missing
+        importable=set(),
+        packages="scitex-orochi",
+        args=["--auto-fix", "--json"],
+        create_repos=["scitex-orochi"],
+        install_fail={"scitex-orochi"},  # pip install will fail
+    )
+    assert proc.returncode == 2
+    rows = _parse_ndjson(proc.stdout)
+    assert rows[0]["status"] == "fix_failed"
+
+
+def test_auto_fix_skips_when_repo_absent(tmp_path):
+    """--auto-fix but repo dir doesn't exist → stay drift, exit 1."""
+    proc, _ = _run(
+        tmp_path,
+        known={"scitex"},
+        importable=set(),
+        packages="scitex",
+        args=["--auto-fix", "--json"],
+        create_repos=[],   # no scitex-python repo on disk
+    )
+    assert proc.returncode == 1
+    rows = _parse_ndjson(proc.stdout)
+    assert rows[0]["status"] == "drift"
+    assert rows[0]["fixed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Output mode tests
+# ---------------------------------------------------------------------------
+
+
+def test_quiet_suppresses_stdout(tmp_path):
+    """--quiet emits nothing on stdout regardless of status."""
+    proc, _ = _run(
+        tmp_path,
+        known=set(),
+        importable=set(),
+        packages="scitex",
+        args=["--quiet"],
+    )
+    assert proc.stdout == ""
+    assert proc.returncode == 1
+
+
+def test_json_emits_one_line_per_package(tmp_path):
+    """Default package list produces one NDJSON object per package."""
+    proc, _ = _run(
+        tmp_path,
+        known={"scitex", "scitex-orochi"},
+        importable={"scitex", "scitex_orochi"},
+        packages="scitex scitex-orochi scitex-clew",
+        args=["--json"],
+    )
+    lines = [ln for ln in proc.stdout.splitlines() if ln.startswith("{")]
+    assert len(lines) == 3
+    statuses = [json.loads(ln)["status"] for ln in lines]
+    assert statuses == ["ok", "ok", "missing"]
+
+
+def test_import_name_uses_underscore(tmp_path):
+    """scitex-orochi is imported as scitex_orochi, not scitex-orochi."""
+    # If the script used the literal package name, `python -c "import
+    # scitex-orochi"` would fail even when the module is importable.
+    proc, _ = _run(
+        tmp_path,
+        known={"scitex-orochi"},
+        importable={"scitex_orochi"},   # underscore form
+        packages="scitex-orochi",
+        args=["--json"],
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    rows = _parse_ndjson(proc.stdout)
+    assert rows[0]["status"] == "ok"
+
+
+def test_single_pkg_flag_restricts_scope(tmp_path):
+    """--pkg <name> audits exactly that one package, ignoring PACKAGES env."""
+    proc, _ = _run(
+        tmp_path,
+        known={"scitex"},
+        importable={"scitex"},
+        packages="scitex scitex-orochi scitex-clew",  # env says 3 pkgs
+        args=["--pkg", "scitex", "--json"],
+    )
+    rows = _parse_ndjson(proc.stdout)
+    assert len(rows) == 1
+    assert rows[0]["package"] == "scitex"


### PR DESCRIPTION
## Summary

- Adds `scripts/client/pkg-audit.sh` — self-contained bash probe that audits scitex-* packages for venv drift using `pip show` + `python -c "import ..."`, classifying each as ok / drift / missing.
- Optional `--auto-fix` reinstalls drifting packages via `pip install -e <repo>` when the source repo is present on this host. Modes: default human, `--json` (NDJSON per package), `--quiet` (exit-code-only for cron). Exit codes: 0 ok, 1 drift/missing, 2 fix failed, 3 pip not found.
- Registers a commented cron entry in `deployment/host-setup/orochi-cron/cron.yaml.example` so mgr-pkg can enable the job per host via its `startup_commands`.
- No new pip dependencies; no new CLI binary. Replaces the earlier placeholder `scitex-pkg` design (msg#16802 / worker-progress msg#16806 correction).

## Packages audited (default list)

`scitex scitex-orochi scitex-agent-container scitex-clew scitex-cloud` — overridable via `PACKAGES` env var, or narrowed to one via `--pkg <name>`.

Repo-path map for `--auto-fix`:

| package | repo |
|---|---|
| scitex | `~/proj/scitex-python` |
| scitex-orochi | `~/proj/scitex-orochi` |
| scitex-agent-container | `~/proj/scitex-agent-container` |
| scitex-clew | `~/proj/scitex-clew` |
| scitex-cloud | `~/proj/scitex-cloud` |

## Test plan

- [x] `tests/test_pkg_audit_script.py` — 11 integration cases drive the real bash script against stub `pip` + `python` binaries on a tmpdir `PATH`
  - [x] exit 0 when every package resolves
  - [x] exit 1 on drift (pip ok, import fails)
  - [x] exit 1 on missing (pip fails)
  - [x] exit 2 when `--auto-fix` attempted but `pip install -e` failed
  - [x] exit 3 when `pip` not on PATH
  - [x] `--auto-fix` repairs drift when repo dir exists
  - [x] `--auto-fix` skips (stays drift) when repo dir absent
  - [x] `--quiet` suppresses stdout
  - [x] `--json` emits exactly one NDJSON object per package
  - [x] import name converted `pkg-name` → `pkg_name` for the import probe
  - [x] `--pkg <name>` narrows scope to a single package
- [x] Manual smoke test: all modes render correctly with a hand-rolled fake venv (ok / drift / missing mix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
