### PR TITLE
fix(auto_dispatch): dispatch in thread from async WS heartbeat (SynchronousOnlyOperation)

### DIFF
--- a/hub/auto_dispatch.py
+++ b/hub/auto_dispatch.py
@@ -350,6 +350,67 @@ def _cooldown_active_locked(agent: dict, now: float, cooldown_s: int) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Fire-and-forget dispatch bridge (sync/async agnostic)
+# ---------------------------------------------------------------------------
+
+
+def _in_async_context() -> bool:
+    """Return True iff called from a thread with a running asyncio event loop.
+
+    The heartbeat path reaches ``check_agent_auto_dispatch`` from both
+    sync Django views (``POST /api/agents/register/``) and the async WS
+    consumer (``handle_heartbeat`` in ``hub/consumers/_agent_handlers.py``).
+    Django 4.1+ refuses ORM calls from an async context —
+    ``SynchronousOnlyOperation`` is raised. Detecting which side we're
+    on lets us keep the sync call cheap while moving WS-triggered fires
+    to a thread where ORM is legal.
+    """
+    try:
+        import asyncio
+
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _dispatch_in_thread(
+    agent_name: str, workspace_id: int, text: str, metadata: dict
+) -> Optional[int]:
+    """Run ``_post_dispatch_message`` in the appropriate execution context.
+
+    If called from a sync context (Django view, management command,
+    tests), run inline and return the resulting message id so
+    existing callers / tests keep their synchronous observable
+    behaviour.
+
+    If called from an async context (the WS ``handle_heartbeat`` path),
+    delegate to a daemon thread so Django ORM runs in a sync context
+    and does not raise ``SynchronousOnlyOperation``. The thread is
+    fire-and-forget — the heartbeat hot path returns immediately and
+    the returned id is ``None`` because the insert is in flight. The
+    thread's own exception handling (inside ``_post_dispatch_message``)
+    still logs on failure.
+    """
+    if not _in_async_context():
+        return _post_dispatch_message(agent_name, workspace_id, text, metadata)
+    try:
+        t = threading.Thread(
+            target=_post_dispatch_message,
+            args=(agent_name, workspace_id, text, metadata),
+            name=f"auto-dispatch-{agent_name}",
+            daemon=True,
+        )
+        t.start()
+    except Exception:  # noqa: BLE001 — heartbeat hot path must not raise
+        log.exception(
+            "auto_dispatch: failed to spawn dispatch thread for %s", agent_name
+        )
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
 
@@ -415,7 +476,20 @@ def check_agent_auto_dispatch(agent_name: str) -> Optional[dict]:
             "todo_number": (pick or {}).get("number"),
             "todo_title": (pick or {}).get("title"),
         }
-        msg_id = _post_dispatch_message(agent_name, int(workspace_id), text, metadata)
+        # The heartbeat hot path may be called from either a sync view
+        # (``/api/agents/register/``) or the async WS consumer
+        # (``handle_heartbeat`` in ``hub/consumers/_agent_handlers.py``).
+        # ``_post_dispatch_message`` performs Django ORM work which
+        # Django 4.1+ refuses to run from an async context, raising
+        # ``SynchronousOnlyOperation``. That exception was being caught
+        # and logged but meant no auto-dispatch DM was ever delivered
+        # through the WS path. Offload to a worker thread so the ORM
+        # runs in a sync context regardless of where the heartbeat
+        # came from. Fire-and-forget matches the "best-effort" contract
+        # of this whole module — the caller never awaited the result.
+        msg_id = _dispatch_in_thread(
+            agent_name, int(workspace_id), text, metadata
+        )
         log.info(
             "auto_dispatch: fired agent=%s lane=%s streak=%d todo=%s msg=%s",
             agent_name,

--- a/hub/tests/test_auto_dispatch.py
+++ b/hub/tests/test_auto_dispatch.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import time
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from hub import auto_dispatch as ad
 from hub.auto_dispatch import (
@@ -434,3 +434,105 @@ class RunPickTodoContractTest(TestCase):
             got = ad._run_pick_todo("infrastructure")
         self.assertEqual(got["number"], 7)
         self.assertEqual(got["title"], "fix it")
+
+
+# ---------------------------------------------------------------------------
+# 6. Async-context fire path — regression for the SynchronousOnlyOperation
+#    seen in prod logs on 2026-04-21: the WS ``handle_heartbeat`` handler
+#    runs on the asyncio loop, and Django 4.1+ refuses ORM calls from an
+#    async context. Before the fix, every WS-triggered auto-dispatch
+#    fire silently lost its DM because ``_post_dispatch_message`` raised
+#    inside the broad ``except Exception`` and returned None.
+# ---------------------------------------------------------------------------
+
+
+@override_settings(CHANNEL_LAYERS=_INMEM_CHANNELS)
+class AsyncContextFireTest(TransactionTestCase):
+    """``check_agent_auto_dispatch`` must dispatch cleanly from asyncio.
+
+    Uses ``TransactionTestCase`` (not ``TestCase``) because the fix
+    offloads the ORM work to a worker thread. The thread uses its own
+    DB connection; with the default ``TestCase`` transaction wrapping,
+    the test connection and the worker connection don't see each
+    other's writes — so assertions about persisted rows would always
+    fail. TransactionTestCase truncates tables per-test instead, which
+    permits the cross-connection visibility this path relies on in
+    production.
+    """
+
+    def setUp(self):
+        self.agent_name = "head-mba"
+        with _lock:
+            _agents.pop(self.agent_name, None)
+        self.ws = Workspace.objects.create(name="auto-dispatch-async-ws")
+        register_agent(self.agent_name, self.ws.id, {"role": "head"})
+        _reset_auto_dispatch_state_for_tests(self.agent_name)
+
+    def tearDown(self):
+        with _lock:
+            _agents.pop(self.agent_name, None)
+
+    def test_in_async_context_detection(self):
+        """``_in_async_context`` matches the caller's execution context."""
+        import asyncio
+
+        self.assertFalse(ad._in_async_context())
+
+        async def _probe():
+            return ad._in_async_context()
+
+        self.assertTrue(asyncio.new_event_loop().run_until_complete(_probe()))
+
+    def test_fire_from_async_does_not_raise_sync_only(self):
+        """Regression for SynchronousOnlyOperation on WS heartbeat fire path.
+
+        Simulates the WS handler calling ``check_agent_auto_dispatch``
+        from an asyncio coroutine. Before the fix, the inline
+        ``Workspace.objects.get(...)`` raised ``SynchronousOnlyOperation``;
+        after the fix, the ORM work is moved to a worker thread and the
+        DM lands exactly like the sync path.
+        """
+        import asyncio
+        import threading
+
+        with _lock:
+            _agents[self.agent_name]["subagent_count"] = 0
+
+        captured: dict = {}
+
+        async def _driver():
+            # First heartbeat: streak -> 1 (no fire).
+            with mock.patch.object(ad, "_run_pick_todo", return_value=None):
+                r1 = ad.check_agent_auto_dispatch(self.agent_name)
+                # Second heartbeat: streak -> 2 -> fire.
+                r2 = ad.check_agent_auto_dispatch(self.agent_name)
+            captured["r1"] = r1
+            captured["r2"] = r2
+
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(_driver())
+        finally:
+            loop.close()
+
+        self.assertEqual(captured["r1"]["decision"], "streak_increment")
+        self.assertEqual(captured["r2"]["decision"], "fired")
+
+        # The DM Message is written by the worker thread launched from
+        # the async context — join any live ones so the assert is
+        # deterministic. Name prefix matches ``_dispatch_in_thread``.
+        for t in list(threading.enumerate()):
+            if t.name.startswith("auto-dispatch-"):
+                t.join(timeout=5.0)
+
+        dm_name = _canonical_auto_dispatch_dm_name(self.agent_name)
+        msgs = list(Message.objects.filter(channel__name=dm_name))
+        self.assertEqual(
+            len(msgs),
+            1,
+            msg=(
+                "WS-context fire must still persist exactly one "
+                "auto-dispatch DM (SynchronousOnlyOperation regression)."
+            ),
+        )
+        self.assertEqual(msgs[0].metadata.get("kind"), "auto-dispatch")


### PR DESCRIPTION
## Summary
- Auto-dispatch's DB fan-out raised ``SynchronousOnlyOperation`` every time a head's heartbeat arrived over the WS path (Django 4.1+ forbids ORM from async context). The module swallowed the exception, so idle heads never got their DM.
- Fix: ``_dispatch_in_thread`` detects asyncio context and offloads to a daemon thread where ORM is legal. Sync callers (``POST /api/agents/register/``, tests, management commands) keep running inline — no behavior change.
- Regression test drives ``check_agent_auto_dispatch`` from ``asyncio.new_event_loop()`` and asserts the DM message row lands exactly once.

## Context on the "registry empty" hypothesis
The reported blocker symptoms were:
- ``list_sibling_channels("head-mba") == []``
- ``get_online_count() == 0``
- ``get_agents() == []``
- but WS connections + heartbeats observed in logs + MCP status ``connected``

These match ``shared/skills/scitex-orochi-private/dashboard-development-discipline.md`` rule #3: ``hub.registry._agents`` is a module-level dict populated by the running Daphne worker only. A fresh ``python -c 'from hub.registry import get_agents'`` (or ``manage.py shell``) spawns a new process with its own empty ``_agents`` dict. Verified in prod: ``GET /api/agents/?token=...`` returns 600KB+ of live rows, and the read path is the same ``hub.registry.get_agents()`` the shell probe calls. The registry is NOT empty.

However, while grepping logs for this, a real bug surfaced:
```
django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.
...
File "/app/hub/auto_dispatch.py", line 258, in _post_dispatch_message
  workspace = Workspace.objects.get(id=workspace_id)
```
Fires every heartbeat cycle, swallowed by the broad ``except Exception``. That means no head has received a WS-triggered auto-dispatch DM since PR #334 landed. This PR fixes that.

## Test plan
- [x] ``python3 manage.py test hub.tests.test_auto_dispatch`` — 36/36 pass (34 existing + 2 new).
- [x] ``python3 manage.py test hub.tests.registry hub.tests.consumers`` — 130 tests pass.
- [x] New ``AsyncContextFireTest`` reproduces the async-context fire path and asserts exactly one persisted DM. Uses ``TransactionTestCase`` because the worker thread uses its own DB connection.
- [ ] Post-deploy: confirm ``grep SynchronousOnlyOperation`` on ``docker logs orochi-server-stable`` drops to zero over a 10-min window.
- [ ] Post-deploy: verify an idle head receives the ``[auto-dispatch]`` DM after ~2 heartbeat cycles of zero subagents.

## Files touched
- ``hub/auto_dispatch.py`` — ``_in_async_context`` helper + ``_dispatch_in_thread`` bridge; ``check_agent_auto_dispatch`` now calls the bridge instead of ``_post_dispatch_message`` directly.
- ``hub/tests/test_auto_dispatch.py`` — new ``AsyncContextFireTest`` with two cases.

## Not included / ruled out
- No change to the in-memory registry itself — registry write path is unaffected by this bug (the ``register_agent`` call completes before the failing ``check_agent_auto_dispatch``, which is wrapped in its own try/except).
- PR #318 (heartbeat sac_status), PR #335 (orochi-cron), PR #345 (subagent_count via process tree), PR #282 (agent_meta DB-authoritative signal) — reviewed, none touch the register or connect path.
- Signal handlers in ``hub/signals.py`` already handle exceptions per-socket; no additional guards needed there.

## Related
- PR #334 introduced the auto-dispatch hook.
- Rule #3 from ``dashboard-development-discipline.md`` was the diagnostic trap that produced the original blocker report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)