### PR TITLE
feat(mcp): cron_status tool — MCP-exposed /api/cron/ (lead msg#16684 follow-up)

### DIFF
--- a/hub/tests/views/api/test_cron.py
+++ b/hub/tests/views/api/test_cron.py
@@ -349,3 +349,115 @@ class ApiCronTest(TestCase):
         resp = self._get_cron()
         hosts = resp.json()["hosts"]
         self.assertIn("bare-host.example", hosts)
+
+    # ------------------------------------------------------------------
+    # ``?host=<name>`` filter + token-auth path (lead msg#16684 /
+    # PR #346 follow-up — the MCP ``cron_status`` tool relies on both).
+    # ------------------------------------------------------------------
+
+    def test_host_filter_returns_only_matching_host(self):
+        """``GET /api/cron/?host=mba`` returns just the mba row, not nas."""
+        self._post_heartbeat(
+            {
+                "token": self.token.token,
+                "name": "head-mba",
+                "machine": "mba",
+                "cron_jobs": [
+                    {
+                        "name": "machine-heartbeat",
+                        "interval": 120,
+                        "last_run": time.time() - 60,
+                        "last_exit": 0,
+                        "next_run": time.time() + 60,
+                    }
+                ],
+            }
+        )
+        self._post_heartbeat(
+            {
+                "token": self.token.token,
+                "name": "head-nas",
+                "machine": "nas",
+                "cron_jobs": [],
+            }
+        )
+        resp = self.client.get(
+            "/api/cron/?host=mba", HTTP_HOST=self.SUBDOMAIN_HOST
+        )
+        self.assertEqual(resp.status_code, 200)
+        hosts = resp.json()["hosts"]
+        self.assertEqual(set(hosts.keys()), {"mba"})
+        self.assertEqual(hosts["mba"]["agent"], "head-mba")
+
+    def test_host_filter_unknown_host_returns_empty_hosts(self):
+        """Unknown host key → ``{"hosts": {}}`` (not 404)."""
+        self._post_heartbeat(
+            {
+                "token": self.token.token,
+                "name": "head-mba",
+                "machine": "mba",
+                "cron_jobs": [],
+            }
+        )
+        resp = self.client.get(
+            "/api/cron/?host=no-such-host", HTTP_HOST=self.SUBDOMAIN_HOST
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"hosts": {}})
+
+    def test_token_auth_allows_mcp_sidecar_access(self):
+        """MCP sidecars hit ``/api/cron/?token=wks_...&agent=<self>``
+        on the bare domain. Session-less requests with a valid workspace
+        token must be accepted; this is the path the MCP ``cron_status``
+        tool uses.
+        """
+        self._post_heartbeat(
+            {
+                "token": self.token.token,
+                "name": "head-mba",
+                "machine": "mba",
+                "cron_jobs": [],
+            }
+        )
+        anon = Client()
+        resp = anon.get(
+            f"/api/cron/?token={self.token.token}&agent=cron-status-probe",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("mba", resp.json()["hosts"])
+
+    def test_token_auth_with_host_filter(self):
+        """Token auth + ``?host=<name>`` compose — MCP callers pass both."""
+        self._post_heartbeat(
+            {
+                "token": self.token.token,
+                "name": "head-mba",
+                "machine": "mba",
+                "cron_jobs": [],
+            }
+        )
+        self._post_heartbeat(
+            {
+                "token": self.token.token,
+                "name": "head-nas",
+                "machine": "nas",
+                "cron_jobs": [],
+            }
+        )
+        anon = Client()
+        resp = anon.get(
+            f"/api/cron/?token={self.token.token}&agent=probe&host=nas",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(set(resp.json()["hosts"].keys()), {"nas"})
+
+    def test_token_auth_rejects_invalid_token(self):
+        """A bad token → 401 (not a silent empty response)."""
+        anon = Client()
+        resp = anon.get(
+            "/api/cron/?token=wks_bogus&agent=probe",
+            HTTP_HOST="lvh.me",
+        )
+        self.assertEqual(resp.status_code, 401)

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -143,6 +143,10 @@ urlpatterns = [
     ),
     path("api/agents/", views.api_agents, name="api-agents"),
     path("api/agents/health/", views.api_agent_health, name="api-agent-health"),
+    # Fleet-wide cron status (Phase 2 msg#16406, MCP tool lead msg#16684).
+    # Mounted on the bare domain too so MCP sidecars can call
+    # ``/api/cron/?token=wks_...&agent=<self>`` without a subdomain.
+    path("api/cron/", views.api_cron, name="api-cron-bare"),
     # Auto-dispatch operator triggers + inspection (Phase 1c msg#16477).
     path(
         "api/auto-dispatch/fire/",

--- a/hub/views/api/_cron.py
+++ b/hub/views/api/_cron.py
@@ -35,15 +35,25 @@ Staleness: a host is marked ``stale: true`` when the hub has not seen a
 heartbeat in >10 minutes (``HEARTBEAT_STALE_THRESHOLD_S``). The hub keeps
 serving the last-known ``jobs`` array so the UI can show stale data with
 a warning rather than dropping the card.
+
+Auth (lead msg#16684 follow-up): accepts either a Django session OR a
+workspace token (``?token=wks_...&agent=<name>``) so the MCP
+``cron_status`` tool can hit it from the bare domain without a browser
+session. Routing falls back on the same ``resolve_workspace_and_actor``
+helper used by other agent-callable read-only endpoints (channel_members,
+my_subscriptions, ...).
+
+Optional ``?host=<name>`` query param filters the response server-side
+to a single host key — cheaper than pulling all hosts and discarding the
+rest on the client.
 """
 
 import time
 from datetime import datetime, timezone
 
+from hub.views._helpers import resolve_workspace_and_actor
 from hub.views.api._common import (
     JsonResponse,
-    get_workspace,
-    login_required,
     require_GET,
 )
 
@@ -81,15 +91,21 @@ def _to_iso(ts: str | float | None) -> str | None:
     return None
 
 
-@login_required
 @require_GET
 def api_cron(request):
     """GET /api/cron/ — fleet-wide cron status aggregated from heartbeats.
 
-    Auth: same pattern as ``/api/agents/`` — Django session via
-    ``login_required``. Workspace-scoped: the registry read is filtered
-    by ``get_workspace(request)``, so users on different workspaces see
-    disjoint host sets.
+    Auth: accepts either a Django session (dashboard) OR a workspace
+    token (``?token=wks_...&agent=<name>`` — MCP sidecars on the bare
+    domain). Workspace-scoped: the registry read is filtered by the
+    resolved workspace, so users on different workspaces see disjoint
+    host sets.
+
+    Query params:
+        host: optional host key (machine label, e.g. ``mba``). When
+            present, the response is filtered server-side to that
+            single host. If the host is unknown, ``{"hosts": {}}`` is
+            returned — the same shape as "no hosts reporting".
 
     Returns ``{"hosts": {<machine>: {agent, last_heartbeat_at, stale,
     jobs}}}``. An empty registry (or a workspace with no heads) returns
@@ -104,7 +120,11 @@ def api_cron(request):
     """
     from hub.registry import get_agents
 
-    workspace = get_workspace(request)
+    workspace, _actor, err = resolve_workspace_and_actor(request)
+    if err is not None:
+        return err
+
+    host_filter = (request.GET.get("host") or "").strip() or None
     agents = get_agents(workspace_id=workspace.id)
 
     now = time.time()
@@ -116,6 +136,11 @@ def api_cron(request):
     for a in agents:
         host = _host_key(a)
         if not host:
+            continue
+        # ``?host=<name>`` short-circuits the aggregation: skip any row
+        # whose host key doesn't match. Done at loop-head so collision
+        # resolution (freshness wins) stays scoped to the filtered host.
+        if host_filter is not None and host != host_filter:
             continue
         jobs = a.get("cron_jobs") or []
         # Parse last_heartbeat to an epoch float for the stale check +

--- a/ts/mcp_channel/handlers.ts
+++ b/ts/mcp_channel/handlers.ts
@@ -9,6 +9,7 @@ import {
 import { TOOL_DEFS } from "../src/tool_defs.js";
 import {
   handleContext,
+  handleCronStatus,
   handleDmList,
   handleDmOpen,
   handleDownloadMedia,
@@ -63,6 +64,7 @@ export function registerMcpHandlers(mcp: Server): void {
     if (name === "rsync_status") return handleRsyncStatus(args as any);
     if (name === "sidecar_status") return handleSidecarStatus();
     if (name === "connectivity_matrix") return handleConnectivityMatrix();
+    if (name === "cron_status") return handleCronStatus(args as any);
     if (name === "self_command") return handleSelfCommand(args as any);
     if (name === "dm_list") return handleDmList(args as any);
     if (name === "dm_open") return handleDmOpen(args as any);

--- a/ts/src/tool_defs.ts
+++ b/ts/src/tool_defs.ts
@@ -411,6 +411,29 @@ export const TOOL_DEFS = [
     },
   },
   {
+    name: "cron_status",
+    description:
+      "Fleet-wide cron job status (lead msg#16684 follow-up to PR #346). " +
+      "Mirrors the ``GET /api/cron/`` endpoint that powers the Machines " +
+      "tab cron panel, exposed via MCP so any agent can observe daemon " +
+      "state without scraping the dashboard. Returns " +
+      "``{\"hosts\": {<machine>: {agent, last_heartbeat_at, stale, " +
+      "jobs}}}``. Optional ``host`` arg filters to a single host " +
+      "server-side. Workspace-scoped via the MCP sidecar's token; " +
+      "read-only.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        host: {
+          type: "string",
+          description:
+            "Optional host key (e.g. 'mba', 'nas'). When omitted, all " +
+            "hosts in the workspace are returned.",
+        },
+      },
+    },
+  },
+  {
     name: "export_channel",
     description:
       "Export chat channel messages as JSON, Markdown, or plain text with date slicing. Returns the export content as a string.",

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -36,6 +36,7 @@ export { handleRsyncMedia, handleRsyncStatus } from "./tools/rsync.js";
 
 export {
   handleConnectivityMatrix,
+  handleCronStatus,
   handleSidecarStatus,
 } from "./tools/sidecar.js";
 

--- a/ts/src/tools/cron_status.test.ts
+++ b/ts/src/tools/cron_status.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the ``cron_status`` MCP tool (lead msg#16684 follow-up to
+ * PR #346). The tool is a thin pass-through to the hub's
+ * ``GET /api/cron/`` endpoint; what matters here is the URL/query
+ * shape and error-envelope handling — the hub behaviour itself is
+ * covered by ``hub/tests/views/api/test_cron.py``.
+ *
+ * Run with ``bun test ts/src/tools/cron_status.test.ts``.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+
+import { handleCronStatus } from "./sidecar";
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function installFetchStub(
+  respond: (call: FetchCall) => {
+    status?: number;
+    body?: unknown;
+    bodyText?: string;
+  },
+) {
+  const calls: FetchCall[] = [];
+  const original = globalThis.fetch;
+  (globalThis as any).fetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    const call: FetchCall = { url, init };
+    calls.push(call);
+    const r = respond(call);
+    const status = r.status ?? 200;
+    const text =
+      r.bodyText !== undefined
+        ? r.bodyText
+        : JSON.stringify(r.body ?? { hosts: {} });
+    return new Response(text, {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+describe("handleCronStatus", () => {
+  let savedToken: string | undefined;
+  let savedAgent: string | undefined;
+  let savedUrl: string | undefined;
+
+  beforeEach(() => {
+    savedToken = process.env.SCITEX_OROCHI_TOKEN;
+    savedAgent = process.env.SCITEX_OROCHI_AGENT;
+    savedUrl = process.env.SCITEX_OROCHI_URL;
+  });
+
+  afterEach(() => {
+    if (savedToken === undefined) delete process.env.SCITEX_OROCHI_TOKEN;
+    else process.env.SCITEX_OROCHI_TOKEN = savedToken;
+    if (savedAgent === undefined) delete process.env.SCITEX_OROCHI_AGENT;
+    else process.env.SCITEX_OROCHI_AGENT = savedAgent;
+    if (savedUrl === undefined) delete process.env.SCITEX_OROCHI_URL;
+    else process.env.SCITEX_OROCHI_URL = savedUrl;
+  });
+
+  test("hits /api/cron/ with token + agent query params and parses response", async () => {
+    const stub = installFetchStub(() => ({
+      body: { hosts: { mba: { agent: "head-mba", jobs: [] } } },
+    }));
+    try {
+      const result = await handleCronStatus({});
+      expect(stub.calls.length).toBe(1);
+      const url = new URL(stub.calls[0].url);
+      expect(url.pathname).toBe("/api/cron/");
+      // Token + agent always appended when the env provides them.
+      // (Captured at module load — values seeded by config.ts.)
+      expect(url.searchParams.has("token")).toBe(true);
+      expect(url.searchParams.has("agent")).toBe(true);
+      // No host filter when the arg is omitted.
+      expect(url.searchParams.has("host")).toBe(false);
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.hosts.mba.agent).toBe("head-mba");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("propagates host arg as ?host= query param", async () => {
+    const stub = installFetchStub(() => ({
+      body: { hosts: { nas: { agent: "head-nas", jobs: [] } } },
+    }));
+    try {
+      await handleCronStatus({ host: "nas" });
+      const url = new URL(stub.calls[0].url);
+      expect(url.searchParams.get("host")).toBe("nas");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("trims whitespace from host arg and drops empty host", async () => {
+    const stub = installFetchStub(() => ({ body: { hosts: {} } }));
+    try {
+      await handleCronStatus({ host: "   " });
+      const url = new URL(stub.calls[0].url);
+      expect(url.searchParams.has("host")).toBe(false);
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("HTTP 401 maps to permission_denied error envelope", async () => {
+    const stub = installFetchStub(() => ({
+      status: 401,
+      bodyText: "invalid token",
+    }));
+    try {
+      const result = await handleCronStatus({});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error.code).toBe("permission_denied");
+      expect(parsed.error.reason).toContain("HTTP 401");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("HTTP 500 maps to internal_error envelope", async () => {
+    const stub = installFetchStub(() => ({
+      status: 500,
+      bodyText: "boom",
+    }));
+    try {
+      const result = await handleCronStatus({});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error.code).toBe("internal_error");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("network failure surfaces internal_error with hint", async () => {
+    const original = globalThis.fetch;
+    (globalThis as any).fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    try {
+      const result = await handleCronStatus({});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.error.code).toBe("internal_error");
+      expect(parsed.error.reason).toContain("ECONNREFUSED");
+      expect(parsed.error.hint).toMatch(/reachability|OROCHI_URL/);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});

--- a/ts/src/tools/sidecar.ts
+++ b/ts/src/tools/sidecar.ts
@@ -1,5 +1,5 @@
 /**
- * Fleet observability tools: connectivity_matrix, sidecar_status.
+ * Fleet observability tools: connectivity_matrix, sidecar_status, cron_status.
  *
  * connectivity_matrix — fleet 4×4 reachability matrix (todo#297 layer 3).
  *   Reads connectivity rows produced by the per-host fleet-watch producers
@@ -10,10 +10,23 @@
  * sidecar_status — Orochi-side sidecar PID visibility (todo#287 Slice A).
  *   Returns mcp_server PID + outstanding rsync_media jobs. The orochi half
  *   of the 3-layer PID model agreed in msg#8120.
+ *
+ * cron_status — fleet-wide cron daemon status (lead msg#16684 follow-up
+ *   to PR #346). Thin pass-through to ``GET /api/cron/`` on the hub,
+ *   using the workspace token. Lets any agent observe per-host cron
+ *   jobs without hitting the dashboard.
  */
 import { readFileSync, existsSync } from "fs";
 import { join as pathJoin } from "path";
-import { OROCHI_AGENT, MCP_SERVER_STARTED_AT } from "./_shared.js";
+import {
+  MCP_ERROR_CODES,
+  MCP_SERVER_STARTED_AT,
+  OROCHI_AGENT,
+  OROCHI_TOKEN,
+  buildFetchHeaders,
+  httpBase,
+  mcpError,
+} from "./_shared.js";
 import { rsyncJobs } from "./rsync.js";
 
 function connectivityCacheDir(): string {
@@ -89,6 +102,52 @@ export async function handleConnectivityMatrix(): Promise<{
       },
     ],
   };
+}
+
+export async function handleCronStatus(args: {
+  host?: string;
+}): Promise<{ content: Array<{ type: string; text: string }> }> {
+  // Build ``${base}/api/cron/?token=<wks>&agent=<self>[&host=<name>]``.
+  // The ``&agent=`` param is how ``resolve_workspace_and_actor`` picks
+  // the actor identity for token-auth paths; same convention as
+  // ``channel_members`` / ``my_subscriptions``.
+  const params = new URLSearchParams();
+  if (OROCHI_TOKEN) params.set("token", OROCHI_TOKEN);
+  if (OROCHI_AGENT) params.set("agent", OROCHI_AGENT);
+  const hostArg = (args?.host || "").trim();
+  if (hostArg) params.set("host", hostArg);
+  const qs = params.toString();
+  const url = `${httpBase}/api/cron/${qs ? `?${qs}` : ""}`;
+  try {
+    const resp = await fetch(url, {
+      method: "GET",
+      headers: buildFetchHeaders({ Accept: "application/json" }),
+    });
+    if (!resp.ok) {
+      const body = await resp.text();
+      const code =
+        resp.status === 401 || resp.status === 403
+          ? MCP_ERROR_CODES.PERMISSION_DENIED
+          : resp.status === 404
+            ? MCP_ERROR_CODES.NOT_FOUND
+            : resp.status === 400
+              ? MCP_ERROR_CODES.INVALID_INPUT
+              : MCP_ERROR_CODES.INTERNAL_ERROR;
+      return mcpError(
+        code,
+        `cron_status HTTP ${resp.status}`,
+        body.slice(0, 200) || "no response body",
+      );
+    }
+    const out = await resp.json();
+    return { content: [{ type: "text", text: JSON.stringify(out) }] };
+  } catch (err) {
+    return mcpError(
+      MCP_ERROR_CODES.INTERNAL_ERROR,
+      `cron_status request failed: ${(err as Error).message}`,
+      "check hub reachability and SCITEX_OROCHI_URL",
+    );
+  }
 }
 
 export async function handleSidecarStatus(): Promise<{


### PR DESCRIPTION
## Summary

Follow-up to PR #346 per lead msg#16684. Adds a `cron_status` MCP tool that mirrors `GET /api/cron/` so any fleet agent can observe per-host cron-daemon state without scraping the Machines tab or hitting the dashboard.

- **MCP tool** (`cron_status(host=None)`): thin pass-through to the hub endpoint, appends the workspace token + `agent=<self>` and optional `?host=<name>` filter. Returns `{"hosts": {<machine>: {agent, last_heartbeat_at, stale, jobs}}}` verbatim. 401/403/404/500/network failures surface as structured `{error: {code, reason, hint}}` envelopes (#262 §9.2).
- **Backend**: `/api/cron/` now accepts session **or** workspace token via the shared `resolve_workspace_and_actor` helper (same auth path used by `channel_members` / `my_subscriptions`), and honours `?host=<name>` server-side — cheaper than pulling and discarding client-side.
- **Routing**: `/api/cron/` is also mounted on `hub.urls_bare` — MCP sidecars talk to the bare domain, not a workspace subdomain, so this is required for the token path to actually work.

## Files touched

- `ts/src/tool_defs.ts` — tool registration
- `ts/src/tools/sidecar.ts` — `handleCronStatus` handler (co-located with other fleet-observability tools)
- `ts/src/tools.ts` + `ts/mcp_channel/handlers.ts` — re-export + dispatch
- `ts/src/tools/cron_status.test.ts` — 6 bun tests
- `hub/views/api/_cron.py` — token auth + `?host=` filter
- `hub/urls_bare.py` — bare-domain route
- `hub/tests/views/api/test_cron.py` — 5 new Django tests

## Test plan

- [x] `bun test ts/` — 19 pass (6 new + 13 existing)
- [x] `pytest hub/tests/views/api/test_cron.py` — 16 pass (5 new + 11 existing)
- [x] `pytest hub/tests/views/` — 135 pass (no regressions)
- [x] `bun build ts/mcp_channel.ts` — bundles cleanly (no type/import errors)
- [ ] CI green
- [ ] Manual smoke: `cron_status()` / `cron_status(host="mba")` from an agent sidecar against the hub

## Non-goals

- No changes to `hub/frontend/` or the `ts-migration-v2` tree (per spec).
- No new DB model — reuses the in-memory registry populated by `/api/agents/register/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
