### PR TITLE
feat(acl): ChannelMembership bit-split (can_read + can_write) + write-only worker-progress seed (msg#16884)

### DIFF
--- a/hub/channel_acl.py
+++ b/hub/channel_acl.py
@@ -204,19 +204,17 @@ def check_membership_allowed(
     """Return True if ``sender`` is allowed to write to ``channel`` per
     :class:`hub.models.ChannelMembership`.
 
-    Semantics (issue #276 — closing the REST/WS write-path ACL gap):
+    Semantics (issue #276 + lead msg#16884 bit-split):
 
     * DMs are handled by :func:`_check_dm_write_allowed`; this helper
       returns ``True`` for ``dm:`` channels (deferring to the caller's
       existing DM gate).
     * If the caller did not supply ``workspace_id`` we cannot scope the
       lookup and fall back to ``True`` (preserves non-WS test fixtures).
-    * If an explicit :class:`ChannelMembership` row exists with
-      ``permission = "read-only"`` the write is **denied**. Rows with
-      ``read-write`` or ``write-only`` are **allowed** — write-only
-      blocks the read side (see ``_load_agent_channel_subs``) but
-      still permits writes (msg#16880 — worker-progress posts digests
-      to ``#ywatanabe`` but must not receive ``#ywatanabe`` traffic).
+    * If an explicit :class:`ChannelMembership` row exists, the write
+      is allowed iff ``row.can_write`` is True. The legacy ``permission``
+      enum is no longer consulted on the write path — data migration
+      0029 backfills ``can_write`` from the old column on deploy.
     * If the sender is a synthetic agent user (``agent-*`` — see
       ``hub/views/auth.py``) and *no* membership row exists for the
       target non-DM channel, the write is **denied**. Agents must be
@@ -246,12 +244,12 @@ def check_membership_allowed(
 
     row = (
         _Membership.objects.filter(channel_id=ch.id, user__username=sender)
-        .only("permission")
+        .only("can_write")
         .first()
     )
     if row is not None:
-        # read-write and write-only both permit writes; only read-only denies.
-        return row.permission != _Membership.PERM_READ_ONLY
+        # msg#16884 bit-split: write is governed solely by ``can_write``.
+        return bool(row.can_write)
 
     # No explicit row. Agents must be explicitly added; humans default-allow.
     if sender.startswith("agent-"):

--- a/hub/consumers/_agent_handlers.py
+++ b/hub/consumers/_agent_handlers.py
@@ -92,7 +92,13 @@ async def handle_register(consumer, content):
 
 
 async def handle_subscription(consumer, content, subscribe: bool):
-    """Add or remove a persistent channel subscription for the agent."""
+    """Add or remove a persistent channel subscription for the agent.
+
+    ``payload.can_read`` / ``payload.can_write`` (lead msg#16884
+    bit-split) are accepted and forwarded to the persistence helper.
+    Both default to True when omitted, preserving the pre-split
+    behaviour for agents on old clients.
+    """
     payload = content.get("payload", {})
     raw_name = payload.get("channel") or content.get("channel") or ""
     if not raw_name:
@@ -105,8 +111,17 @@ async def handle_subscription(consumer, content, subscribe: bool):
         )
         return
     ch_name = normalize_channel_name(raw_name)
+    # msg#16884: accept independent bits. Missing = True (back-compat
+    # default). unsubscribe ignores these.
+    can_read = bool(payload.get("can_read", True))
+    can_write = bool(payload.get("can_write", True))
     ok = await _persist_agent_subscription(
-        consumer.workspace_id, consumer.agent_name, ch_name, subscribe
+        consumer.workspace_id,
+        consumer.agent_name,
+        ch_name,
+        subscribe,
+        can_read=can_read,
+        can_write=can_write,
     )
     if not ok:
         await consumer.send_json(
@@ -118,14 +133,21 @@ async def handle_subscription(consumer, content, subscribe: bool):
         )
         return
     group = _sanitize_group(f"channel_{consumer.workspace_id}_{ch_name}")
-    if subscribe:
+    # msg#16884 bit-split: only join the channel-layer group + advertise
+    # the channel in agent_meta["channels"] when the subscription grants
+    # read access. A write-only subscription persists the row but must
+    # not pull chat fan-out — that is the whole point of the split.
+    joins_group = subscribe and can_read
+    if joins_group:
         await consumer.channel_layer.group_add(group, consumer.channel_name)
     else:
+        # Always discard on unsubscribe; also discard if we're flipping
+        # a prior read-write row into write-only in-place.
         await consumer.channel_layer.group_discard(group, consumer.channel_name)
     subs = list(getattr(consumer, "agent_meta", {}).get("channels", []) or [])
-    if subscribe and ch_name not in subs:
+    if joins_group and ch_name not in subs:
         subs.append(ch_name)
-    if not subscribe and ch_name in subs:
+    if (not joins_group) and ch_name in subs:
         subs.remove(ch_name)
     if hasattr(consumer, "agent_meta"):
         consumer.agent_meta["channels"] = subs

--- a/hub/consumers/_helpers.py
+++ b/hub/consumers/_helpers.py
@@ -39,15 +39,13 @@ def _load_agent_channel_subs(workspace_id, agent_name):
 
     Agent subscriptions live in :class:`ChannelMembership` rows keyed to
     the agent's synthetic ``agent-<name>`` Django user. An agent is
-    considered subscribed iff a ``ChannelMembership`` row exists; the
-    row's ``permission`` column governs read-only vs read-write vs
-    write-only.
-
-    ``write-only`` memberships are excluded from the returned list so
-    the consumer does not join the channel-layer group and the channel
-    does not appear in ``agent_meta["channels"]``. This makes chat /
-    reaction / edit / delete fan-out skip the agent on the read side
-    while still permitting writes (msg#16880 — worker-progress posts
+    considered subscribed (for the read-side fan-out) iff a row exists
+    AND ``can_read`` is True. Rows with ``can_read=False`` are excluded
+    from the returned list so the consumer does not join the channel-
+    layer group and the channel does not appear in
+    ``agent_meta["channels"]`` — chat / reaction / edit / delete fan-out
+    skips the agent on the read side while still permitting writes
+    (msg#16880 / lead msg#16884 bit-split — worker-progress posts
     digests to ``#ywatanabe`` but must not receive ``#ywatanabe``
     traffic back).
     """
@@ -62,6 +60,7 @@ def _load_agent_channel_subs(workspace_id, agent_name):
     memberships = ChannelMembership.objects.filter(
         user=user,
         channel__workspace_id=workspace_id,
+        can_read=True,
     ).select_related("channel")
     # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293 follow-up).
     # Filter out any stale DB rows so a leftover membership can't resurrect
@@ -70,16 +69,28 @@ def _load_agent_channel_subs(workspace_id, agent_name):
         m.channel.name
         for m in memberships
         if m.channel.name not in ABOLISHED_AGENT_CHANNELS
-        and m.permission != ChannelMembership.PERM_WRITE_ONLY
     ]
 
 
 @database_sync_to_async
-def _persist_agent_subscription(workspace_id, agent_name, ch_name, subscribe):
+def _persist_agent_subscription(
+    workspace_id,
+    agent_name,
+    ch_name,
+    subscribe,
+    *,
+    can_read: bool = True,
+    can_write: bool = True,
+):
     """Add or remove a persistent ``ChannelMembership`` row for an agent.
 
     Returns True on success, False if the channel or agent user cannot
     be resolved. Creates the channel if missing (group kind).
+
+    ``can_read`` / ``can_write`` control the new bit-split columns
+    (lead msg#16884). Defaults are ``(True, True)`` = full read-write,
+    matching the pre-bit-split behaviour so existing callers stay
+    backward-compatible. Unused when ``subscribe=False``.
     """
     from django.contrib.auth.models import User
 
@@ -110,10 +121,15 @@ def _persist_agent_subscription(workspace_id, agent_name, ch_name, subscribe):
         defaults={"kind": Channel.KIND_GROUP},
     )
     if subscribe:
+        # Use ``update_or_create`` with the bits. ``ChannelMembership.save``
+        # keeps the legacy ``permission`` enum in sync automatically.
         ChannelMembership.objects.update_or_create(
             user=user,
             channel=channel,
-            defaults={"permission": ChannelMembership.PERM_READ_WRITE},
+            defaults={
+                "can_read": bool(can_read),
+                "can_write": bool(can_write),
+            },
         )
     else:
         ChannelMembership.objects.filter(user=user, channel=channel).delete()

--- a/hub/management/commands/seed_worker_progress.py
+++ b/hub/management/commands/seed_worker_progress.py
@@ -4,13 +4,16 @@ Implements the data-plane side of todo#272 (sac-managed Claude agent
 re-spec, `#heads` msg#15416 — replaces closed PR #300 which shipped a
 Python daemon). Idempotent: running multiple times is a no-op.
 
-The synthetic ``agent-worker-progress`` user is granted ``read-write``
-``ChannelMembership`` on:
+The synthetic ``agent-worker-progress`` user is granted the following
+``ChannelMembership`` bits (lead msg#16884 bit-split):
 
-  - ``#progress``
-  - ``#heads``
-  - ``#ywatanabe``
-  - every ``#proj-*`` channel that exists in the DB **at seed time**
+  - ``#progress``  → ``can_read=True, can_write=True``  (read-write)
+  - ``#heads``     → ``can_read=True, can_write=True``  (read-write)
+  - ``#ywatanabe`` → ``can_read=False, can_write=True`` (write-only digest
+    target — posts summaries but must NOT consume the firehose back,
+    msg#16880 / msg#16884)
+  - every ``#proj-*`` channel that exists in the DB **at seed time** →
+    ``can_read=True, can_write=True``  (read-write)
 
 The ``#proj-*`` set is enumerated at runtime (not hardcoded) so new
 project channels are picked up without code changes — just re-run the
@@ -39,6 +42,14 @@ AGENT_USERNAME = f"agent-{AGENT_NAME}"
 
 # Base channels are always seeded (created if missing).
 BASE_CHANNELS = ("#progress", "#heads", "#ywatanabe")
+
+# Per-channel bit overrides. Any channel not listed gets the default
+# full read-write (True, True). ``#ywatanabe`` is seeded write-only
+# (msg#16880 / msg#16884 bit-split) so the worker can publish digest
+# summaries into the channel without consuming the firehose back.
+CHANNEL_BITS: dict[str, tuple[bool, bool]] = {
+    "#ywatanabe": (False, True),  # (can_read, can_write)
+}
 
 # Prefix for per-project channels. All existing channels whose name
 # starts with this prefix are added to the worker's membership set.
@@ -115,34 +126,57 @@ class Command(BaseCommand):
                 name=name,
                 defaults={"kind": Channel.KIND_GROUP},
             )
+            want_read, want_write = CHANNEL_BITS.get(name, (True, True))
+            label = self._bits_label(want_read, want_write)
             membership, was_created = ChannelMembership.objects.get_or_create(
                 user=user,
                 channel=channel,
-                defaults={"permission": ChannelMembership.PERM_READ_WRITE},
+                defaults={
+                    "can_read": want_read,
+                    "can_write": want_write,
+                },
             )
             if was_created:
                 created += 1
                 self.stdout.write(
-                    self.style.SUCCESS(f"  + membership: {name} (read-write)")
+                    self.style.SUCCESS(f"  + membership: {name} ({label})")
                 )
             else:
                 existed += 1
-                if membership.permission != ChannelMembership.PERM_READ_WRITE:
-                    membership.permission = ChannelMembership.PERM_READ_WRITE
-                    membership.save(update_fields=["permission"])
+                if (
+                    membership.can_read != want_read
+                    or membership.can_write != want_write
+                ):
+                    prev_label = self._bits_label(
+                        membership.can_read, membership.can_write
+                    )
+                    membership.can_read = want_read
+                    membership.can_write = want_write
+                    membership.save(update_fields=["can_read", "can_write"])
                     self.stdout.write(
                         self.style.WARNING(
-                            f"  ~ upgraded to read-write: {name}"
+                            f"  ~ updated {name}: {prev_label} → {label}"
                         )
                     )
                 else:
-                    self.stdout.write(f"  = membership exists: {name}")
+                    self.stdout.write(f"  = membership exists: {name} ({label})")
 
         self.stdout.write(
             self.style.SUCCESS(
                 f"done: {created} created, {existed} existed, {skipped} skipped."
             )
         )
+
+    @staticmethod
+    def _bits_label(can_read: bool, can_write: bool) -> str:
+        """Human-readable label for a ``(can_read, can_write)`` pair."""
+        if can_read and can_write:
+            return "read-write"
+        if can_read and not can_write:
+            return "read-only"
+        if (not can_read) and can_write:
+            return "write-only"
+        return "locked-out"
 
     def _collect_channels(self, workspace: Workspace) -> list[str]:
         """Return the ordered channel-name set to seed.

--- a/hub/migrations/0029_channelmembership_can_read_can_write.py
+++ b/hub/migrations/0029_channelmembership_can_read_can_write.py
@@ -1,0 +1,101 @@
+"""Split ``ChannelMembership.permission`` into ``can_read`` + ``can_write``.
+
+Lead directive msg#16884. Replaces the single-choice CharField with two
+independent booleans so the four combinations (read-write, read-only,
+write-only, admin lockout) are representable without juggling an enum.
+
+Forward:
+  1. ``AddField`` ``can_read`` / ``can_write`` with default ``True``.
+  2. ``RunPython`` populate the bits from the existing ``permission`` column:
+       - ``read-write`` → ``(True, True)``
+       - ``read-only``  → ``(True, False)``
+       - ``write-only`` → ``(False, True)`` (interim choice from PR #353)
+       - anything else  → ``(True, True)`` (historical permissive default)
+
+Reverse:
+  - ``RunPython`` rebuilds ``permission`` from the bits (uses
+    ``ChannelMembership.bits_to_perm`` semantics inline so the reverse
+    works without importing the model file).
+  - ``RemoveField`` drops the two booleans.
+
+``permission`` stays on the table for one release cycle (lead
+msg#16884). A follow-up migration will drop it once every deploy has
+rolled past 0029.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+def _backfill_bits(apps, schema_editor):
+    ChannelMembership = apps.get_model("hub", "ChannelMembership")
+    # Read-only rows lose the read bit only when the row says so; the
+    # default on the new columns is (True, True) which already matches
+    # the "read-write" case, so we only need to overwrite deviating rows.
+    # Use ``update()`` so the bridge in ``ChannelMembership.save()``
+    # (which lives on the app-level model, not this migration-level one)
+    # doesn't fight us.
+    ChannelMembership.objects.filter(permission="read-only").update(
+        can_read=True, can_write=False
+    )
+    ChannelMembership.objects.filter(permission="write-only").update(
+        can_read=False, can_write=True
+    )
+    # "read-write" rows already match the default; no-op update skipped.
+
+
+def _backfill_permission(apps, schema_editor):
+    ChannelMembership = apps.get_model("hub", "ChannelMembership")
+    # Symmetric reverse: derive the string from the bits so a rollback
+    # leaves the legacy column populated correctly.
+    for row in ChannelMembership.objects.all().only(
+        "id", "can_read", "can_write"
+    ):
+        cr = bool(row.can_read)
+        cw = bool(row.can_write)
+        if cr and cw:
+            perm = "read-write"
+        elif cr and not cw:
+            perm = "read-only"
+        elif (not cr) and cw:
+            perm = "write-only"
+        else:
+            # (False, False) — no legacy enum; choose read-only as the
+            # most-restrictive label.
+            perm = "read-only"
+        if row.permission != perm:
+            ChannelMembership.objects.filter(pk=row.pk).update(permission=perm)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("hub", "0028_alter_channelmembership_permission"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="channelmembership",
+            name="can_read",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "Whether the member receives chat/reaction/edit/delete "
+                    "fan-out for this channel. False = write-only (no read)."
+                ),
+            ),
+        ),
+        migrations.AddField(
+            model_name="channelmembership",
+            name="can_write",
+            field=models.BooleanField(
+                default=True,
+                help_text=(
+                    "Whether the member is allowed to post to this channel. "
+                    "False = read-only."
+                ),
+            ),
+        ),
+        migrations.RunPython(_backfill_bits, _backfill_permission),
+    ]

--- a/hub/models/_messaging.py
+++ b/hub/models/_messaging.py
@@ -119,12 +119,24 @@ class ChannelPreference(models.Model):
 
 
 class ChannelMembership(models.Model):
-    """Explicit per-member channel permissions (todo#407).
+    """Explicit per-member channel permissions (todo#407, lead msg#16884).
 
-    Stores the access level for a given (user, channel) pair.
-    Default is read-write — only entries that deviate from the default
-    need explicit rows. All agents and humans can post by default;
-    admins can create read-only rows to restrict specific members.
+    Stores the access level for a given (user, channel) pair via two
+    independent boolean bits — ``can_read`` and ``can_write`` — so the
+    four combinations (RW / R-only / W-only / no-op) are representable
+    without juggling an enum string.
+
+    The legacy ``permission`` CharField is preserved for one release
+    cycle (data migration 0029 backfills it in both directions); new
+    consumer code should rely exclusively on the bits. The field will be
+    dropped in a follow-up migration once every deploy has rolled past
+    0029.
+
+    Default is ``can_read=True``, ``can_write=True`` (full read-write,
+    matching the pre-bit-split default) so rows that exist only to
+    track presence keep behaving identically. Admins can flip either
+    bit False to restrict a specific member (e.g. write-only digest
+    targets: ``can_read=False, can_write=True``).
 
     This model serves humans and agent-synthetic-users equally (spec §2.1).
     """
@@ -148,10 +160,29 @@ class ChannelMembership(models.Model):
         on_delete=models.CASCADE,
         related_name="memberships",
     )
+    # Deprecated — kept for one release cycle (lead msg#16884). Consumer
+    # code must use ``can_read`` / ``can_write`` instead. The
+    # post_save/migration bridge in 0029 keeps the string in sync with the
+    # bits so admin UIs / legacy callers that still read the enum see the
+    # right value, and a future migration will drop the column.
     permission = models.CharField(
         max_length=12,
         choices=PERM_CHOICES,
         default=PERM_READ_WRITE,
+    )
+    can_read = models.BooleanField(
+        default=True,
+        help_text=(
+            "Whether the member receives chat/reaction/edit/delete "
+            "fan-out for this channel. False = write-only (no read)."
+        ),
+    )
+    can_write = models.BooleanField(
+        default=True,
+        help_text=(
+            "Whether the member is allowed to post to this channel. "
+            "False = read-only."
+        ),
     )
     joined_at = models.DateTimeField(auto_now_add=True)
 
@@ -160,7 +191,85 @@ class ChannelMembership(models.Model):
         unique_together = ("user", "channel")
 
     def __str__(self):
-        return f"{self.user.username} → {self.channel.name} ({self.permission})"
+        bits = f"r={int(self.can_read)},w={int(self.can_write)}"
+        return f"{self.user.username} → {self.channel.name} ({bits})"
+
+    # -- bit <-> legacy-string bridge (msg#16884, deprecated string) -----
+
+    @staticmethod
+    def perm_to_bits(permission: str) -> tuple[bool, bool]:
+        """Map the legacy ``permission`` enum to ``(can_read, can_write)``.
+
+        Unknown values fall through to ``(True, True)`` — the historical
+        default — so garbage data never locks a member out silently.
+        """
+        if permission == ChannelMembership.PERM_READ_ONLY:
+            return (True, False)
+        if permission == ChannelMembership.PERM_WRITE_ONLY:
+            return (False, True)
+        return (True, True)
+
+    @staticmethod
+    def bits_to_perm(can_read: bool, can_write: bool) -> str:
+        """Map ``(can_read, can_write)`` back to the legacy enum.
+
+        The ``(False, False)`` case (admin lockout) has no legacy enum —
+        we map it to ``read-only`` (the most restrictive value the old
+        enum could express) so legacy readers continue to treat the row
+        as no-write. Callers that care about lockout must check the
+        bits directly.
+        """
+        if can_read and can_write:
+            return ChannelMembership.PERM_READ_WRITE
+        if can_read and not can_write:
+            return ChannelMembership.PERM_READ_ONLY
+        if (not can_read) and can_write:
+            return ChannelMembership.PERM_WRITE_ONLY
+        # (False, False) — admin lockout, no legacy enum for it.
+        return ChannelMembership.PERM_READ_ONLY
+
+    def __init__(self, *args, **kwargs):
+        """One-release-cycle deprecation bridge for the ``permission`` enum.
+
+        Legacy callers that still pass ``permission=...`` at construct
+        time (without bits) deserve to keep working — the test suite in
+        particular leans on this shape. When a caller supplies
+        ``permission`` but NOT the bits, derive the bits from the enum
+        so both views stay consistent. When bits are explicitly set they
+        win (they are the new source of truth).
+        """
+        has_perm = "permission" in kwargs
+        has_read = "can_read" in kwargs
+        has_write = "can_write" in kwargs
+        super().__init__(*args, **kwargs)
+        if has_perm and not (has_read or has_write):
+            bits = ChannelMembership.perm_to_bits(self.permission)
+            self.can_read, self.can_write = bits
+
+    def save(self, *args, **kwargs):
+        """Keep ``permission`` in sync with the bits on every write.
+
+        Bits are the authoritative source. ``__init__`` already converts
+        a legacy ``permission=...`` construct into the matching bits, so
+        by save-time the bits reflect the caller's intent regardless of
+        which surface they used. We then normalize the string from the
+        bits so the deprecated column stays truthful for one-release
+        readers.
+
+        When ``save(update_fields=...)`` is used (Django's partial-update
+        path — ``update_or_create`` and ``save(update_fields=[...])``),
+        we must include ``permission`` in the update-fields set so the
+        normalized string actually hits the DB. Without this the bridge
+        silently no-ops on partial writes.
+        """
+        self.permission = self.bits_to_perm(self.can_read, self.can_write)
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None:
+            fields = set(update_fields)
+            if "can_read" in fields or "can_write" in fields:
+                fields.add("permission")
+                kwargs["update_fields"] = list(fields)
+        super().save(*args, **kwargs)
 
 
 class DMParticipant(models.Model):

--- a/hub/tests/consumers/test_agent_subscription.py
+++ b/hub/tests/consumers/test_agent_subscription.py
@@ -28,7 +28,6 @@ class AgentChannelSubscriptionPersistenceTest(TestCase):
     """
 
     def setUp(self):
-        from hub.models import Channel, ChannelMembership
 
         self.ChannelMembership = ChannelMembership
         self.Channel = Channel
@@ -36,7 +35,6 @@ class AgentChannelSubscriptionPersistenceTest(TestCase):
 
     def test_persist_subscribe_creates_membership(self):
         from asgiref.sync import async_to_sync
-        from django.contrib.auth.models import User
 
         from hub.consumers import _persist_agent_subscription
 
@@ -111,7 +109,6 @@ class AgentChannelSubscriptionPersistenceTest(TestCase):
         subscribe op can't resurrect the channel.
         """
         from asgiref.sync import async_to_sync
-        from django.contrib.auth.models import User
 
         from hub.consumers import _persist_agent_subscription
 
@@ -126,13 +123,64 @@ class AgentChannelSubscriptionPersistenceTest(TestCase):
         # No synthetic agent user created as a side-effect either:
         self.assertFalse(User.objects.filter(username="agent-worker-e").exists())
 
+    def test_persist_subscribe_accepts_bits(self):
+        """lead msg#16884 bit-split — ``_persist_agent_subscription``
+        accepts ``can_read`` / ``can_write`` and writes them to the row.
+        """
+        from asgiref.sync import async_to_sync
+
+        from hub.consumers import _persist_agent_subscription
+
+        ok = async_to_sync(_persist_agent_subscription)(
+            self.ws.id,
+            "worker-wo",
+            "#digest",
+            True,
+            can_read=False,
+            can_write=True,
+        )
+        self.assertTrue(ok)
+        user = User.objects.get(username="agent-worker-wo")
+        ch = self.Channel.objects.get(workspace=self.ws, name="#digest")
+        row = self.ChannelMembership.objects.get(user=user, channel=ch)
+        self.assertFalse(row.can_read)
+        self.assertTrue(row.can_write)
+        self.assertEqual(row.permission, self.ChannelMembership.PERM_WRITE_ONLY)
+
+    def test_load_excludes_write_only_rows(self):
+        """``_load_agent_channel_subs`` hides rows where ``can_read=False``
+        — the consumer must not group_add those channels, so the agent
+        never receives fan-out for them (msg#16884 bit-split)."""
+        from asgiref.sync import async_to_sync
+
+        from hub.consumers import _load_agent_channel_subs
+
+        user = User.objects.create_user(username="agent-worker-readfilter")
+        readable = self.Channel.objects.create(
+            workspace=self.ws, name="#reads-this"
+        )
+        hidden = self.Channel.objects.create(
+            workspace=self.ws, name="#posts-only"
+        )
+        self.ChannelMembership.objects.create(
+            user=user, channel=readable, can_read=True, can_write=True
+        )
+        self.ChannelMembership.objects.create(
+            user=user, channel=hidden, can_read=False, can_write=True
+        )
+
+        subs = async_to_sync(_load_agent_channel_subs)(
+            self.ws.id, "worker-readfilter"
+        )
+        self.assertIn("#reads-this", subs)
+        self.assertNotIn("#posts-only", subs)
+
     def test_load_filters_abolished_agent_channel(self):
         """Stale ``#agent`` ``ChannelMembership`` rows from before the
         2026-04-21 abolition must NOT surface in ``_load_agent_channel_subs``
         — otherwise the WS consumer would re-join the group on connect.
         """
         from asgiref.sync import async_to_sync
-        from django.contrib.auth.models import User
 
         from hub.consumers import _load_agent_channel_subs
 

--- a/hub/tests/models/test_channel_membership_bits.py
+++ b/hub/tests/models/test_channel_membership_bits.py
@@ -1,0 +1,309 @@
+"""Tests for the ``ChannelMembership.can_read`` / ``can_write`` bit-split.
+
+Lead directive msg#16884. Covers the model-level bridge between the
+legacy ``permission`` enum and the new boolean bits, and the data-
+migration forward + reverse paths. Read-side / write-side / seed
+behaviour live in sibling tests:
+
+  - ``hub/tests/consumers/test_agent_subscription.py`` (+ new cases
+    in this file) — ``can_read=False`` → no group join.
+  - ``hub/tests/views/api/test_channel_members.py`` — REST body accepts
+    bits.
+  - ``hub/tests/test_worker_progress_seed.py`` — #ywatanabe seeded
+    ``can_read=False, can_write=True``.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth.models import User
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TestCase, TransactionTestCase
+
+from hub.channel_acl import check_membership_allowed
+from hub.models import Channel, ChannelMembership, Workspace
+
+
+class ChannelMembershipBitsModelTest(TestCase):
+    """Bridge between the legacy ``permission`` enum and the new bits."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="bits-ws")
+        self.ch = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.user = User.objects.create(username="agent-bits-user")
+
+    def test_defaults_are_read_write(self):
+        m = ChannelMembership.objects.create(user=self.user, channel=self.ch)
+        self.assertTrue(m.can_read)
+        self.assertTrue(m.can_write)
+        # Legacy-string bridge stays in sync on save().
+        self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
+
+    def test_read_only_bits_set_legacy_enum(self):
+        m = ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=True, can_write=False
+        )
+        self.assertEqual(m.permission, ChannelMembership.PERM_READ_ONLY)
+
+    def test_write_only_bits_set_legacy_enum(self):
+        m = ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=False, can_write=True
+        )
+        self.assertEqual(m.permission, ChannelMembership.PERM_WRITE_ONLY)
+
+    def test_locked_out_bits_fall_back_to_read_only_label(self):
+        # (False, False) has no legacy enum — save() maps it to the
+        # most-restrictive label so legacy readers stay safe.
+        m = ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=False, can_write=False
+        )
+        self.assertEqual(m.permission, ChannelMembership.PERM_READ_ONLY)
+
+    def test_save_update_fields_auto_adds_permission(self):
+        """Partial update of the bits must still sync the legacy enum.
+
+        Without the ``update_fields`` fix-up in ``save()`` the enum
+        silently desyncs on partial writes (``update_or_create``).
+        """
+        m = ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=True, can_write=True
+        )
+        m.can_write = False
+        m.save(update_fields=["can_write"])
+        m.refresh_from_db()
+        self.assertFalse(m.can_write)
+        self.assertEqual(m.permission, ChannelMembership.PERM_READ_ONLY)
+
+    def test_update_or_create_on_bits(self):
+        """``update_or_create`` (used by ``_persist_agent_subscription``)
+        must flip the bits AND the legacy enum."""
+        ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=True, can_write=True
+        )
+        ChannelMembership.objects.update_or_create(
+            user=self.user,
+            channel=self.ch,
+            defaults={"can_read": False, "can_write": True},
+        )
+        m = ChannelMembership.objects.get(user=self.user, channel=self.ch)
+        self.assertFalse(m.can_read)
+        self.assertTrue(m.can_write)
+        self.assertEqual(m.permission, ChannelMembership.PERM_WRITE_ONLY)
+
+    def test_perm_to_bits_helper(self):
+        self.assertEqual(
+            ChannelMembership.perm_to_bits(ChannelMembership.PERM_READ_WRITE),
+            (True, True),
+        )
+        self.assertEqual(
+            ChannelMembership.perm_to_bits(ChannelMembership.PERM_READ_ONLY),
+            (True, False),
+        )
+        self.assertEqual(
+            ChannelMembership.perm_to_bits(ChannelMembership.PERM_WRITE_ONLY),
+            (False, True),
+        )
+        # Unknown → permissive default.
+        self.assertEqual(
+            ChannelMembership.perm_to_bits("garbage-unknown"), (True, True)
+        )
+
+    def test_bits_to_perm_helper(self):
+        self.assertEqual(
+            ChannelMembership.bits_to_perm(True, True),
+            ChannelMembership.PERM_READ_WRITE,
+        )
+        self.assertEqual(
+            ChannelMembership.bits_to_perm(True, False),
+            ChannelMembership.PERM_READ_ONLY,
+        )
+        self.assertEqual(
+            ChannelMembership.bits_to_perm(False, True),
+            ChannelMembership.PERM_WRITE_ONLY,
+        )
+        # Lockout → read-only label.
+        self.assertEqual(
+            ChannelMembership.bits_to_perm(False, False),
+            ChannelMembership.PERM_READ_ONLY,
+        )
+
+
+class ChannelMembershipWriteAclTest(TestCase):
+    """``check_membership_allowed`` uses the ``can_write`` bit."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="acl-ws")
+        self.ch = Channel.objects.create(workspace=self.ws, name="#ops")
+        self.user = User.objects.create(username="agent-acl-user")
+
+    def test_can_write_true_allows(self):
+        ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=True, can_write=True
+        )
+        self.assertTrue(
+            check_membership_allowed(
+                "agent-acl-user", "#ops", workspace_id=self.ws.id
+            )
+        )
+
+    def test_can_write_false_denies(self):
+        ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=True, can_write=False
+        )
+        self.assertFalse(
+            check_membership_allowed(
+                "agent-acl-user", "#ops", workspace_id=self.ws.id
+            )
+        )
+
+    def test_write_only_allows_write(self):
+        ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=False, can_write=True
+        )
+        self.assertTrue(
+            check_membership_allowed(
+                "agent-acl-user", "#ops", workspace_id=self.ws.id
+            )
+        )
+
+    def test_locked_out_denies_write(self):
+        ChannelMembership.objects.create(
+            user=self.user, channel=self.ch, can_read=False, can_write=False
+        )
+        self.assertFalse(
+            check_membership_allowed(
+                "agent-acl-user", "#ops", workspace_id=self.ws.id
+            )
+        )
+
+
+class ChannelMembershipReadFilterTest(TestCase):
+    """``_load_agent_channel_subs`` excludes ``can_read=False`` rows."""
+
+    def setUp(self):
+        self.ws = Workspace.objects.create(name="read-filter-ws")
+        self.readable = Channel.objects.create(workspace=self.ws, name="#readable")
+        self.write_only = Channel.objects.create(
+            workspace=self.ws, name="#write-only-ch"
+        )
+        self.user = User.objects.create(username="agent-reader")
+        ChannelMembership.objects.create(
+            user=self.user, channel=self.readable, can_read=True, can_write=True
+        )
+        ChannelMembership.objects.create(
+            user=self.user,
+            channel=self.write_only,
+            can_read=False,
+            can_write=True,
+        )
+
+    def test_write_only_excluded_from_subs(self):
+        from asgiref.sync import async_to_sync
+
+        from hub.consumers import _load_agent_channel_subs
+
+        subs = async_to_sync(_load_agent_channel_subs)(self.ws.id, "reader")
+        self.assertIn("#readable", subs)
+        self.assertNotIn(
+            "#write-only-ch",
+            subs,
+            "write-only (can_read=False) row must not appear in read-side subs",
+        )
+
+
+class ChannelMembershipMigrationDataTest(TransactionTestCase):
+    """Data-preserving test: 0029 backfills bits from the enum.
+
+    Uses ``MigrationExecutor`` to run the migration graph up to 0028
+    (pre-bit-split), stamp data, run 0029, and assert the bits reflect
+    the enum values. Then reverses 0029 and asserts the enum survives.
+    """
+
+    reset_sequences = True
+
+    def test_forward_backfills_bits_from_permission(self):
+        executor = MigrationExecutor(connection)
+        # Roll back to the pre-bit-split schema.
+        executor.migrate([("hub", "0028_alter_channelmembership_permission")])
+        executor.loader.build_graph()
+        old_state = executor.loader.project_state(
+            [("hub", "0028_alter_channelmembership_permission")]
+        ).apps
+        OldWorkspace = old_state.get_model("hub", "Workspace")
+        OldChannel = old_state.get_model("hub", "Channel")
+        OldMembership = old_state.get_model("hub", "ChannelMembership")
+        OldUser = old_state.get_model("auth", "User")
+
+        ws = OldWorkspace.objects.create(name="mig-ws")
+        ch_rw = OldChannel.objects.create(workspace=ws, name="#rw")
+        ch_ro = OldChannel.objects.create(workspace=ws, name="#ro")
+        ch_wo = OldChannel.objects.create(workspace=ws, name="#wo")
+        u = OldUser.objects.create(username="agent-mig-user")
+        OldMembership.objects.create(user=u, channel=ch_rw, permission="read-write")
+        OldMembership.objects.create(user=u, channel=ch_ro, permission="read-only")
+        OldMembership.objects.create(user=u, channel=ch_wo, permission="write-only")
+
+        # Roll forward to 0029 — bits should be backfilled.
+        executor.loader.build_graph()
+        executor.migrate([("hub", "0029_channelmembership_can_read_can_write")])
+        new_state = executor.loader.project_state(
+            [("hub", "0029_channelmembership_can_read_can_write")]
+        ).apps
+        NewMembership = new_state.get_model("hub", "ChannelMembership")
+
+        rw_row = NewMembership.objects.get(channel__name="#rw")
+        self.assertTrue(rw_row.can_read)
+        self.assertTrue(rw_row.can_write)
+
+        ro_row = NewMembership.objects.get(channel__name="#ro")
+        self.assertTrue(ro_row.can_read)
+        self.assertFalse(ro_row.can_write)
+
+        wo_row = NewMembership.objects.get(channel__name="#wo")
+        self.assertFalse(wo_row.can_read)
+        self.assertTrue(wo_row.can_write)
+
+    def test_reverse_rebuilds_permission_from_bits(self):
+        executor = MigrationExecutor(connection)
+        executor.migrate(
+            [("hub", "0029_channelmembership_can_read_can_write")]
+        )
+        new_state = executor.loader.project_state(
+            [("hub", "0029_channelmembership_can_read_can_write")]
+        ).apps
+        Workspace = new_state.get_model("hub", "Workspace")
+        Channel = new_state.get_model("hub", "Channel")
+        Membership = new_state.get_model("hub", "ChannelMembership")
+        User = new_state.get_model("auth", "User")
+
+        ws = Workspace.objects.create(name="rev-ws")
+        ch = Channel.objects.create(workspace=ws, name="#revert-target")
+        u = User.objects.create(username="agent-rev-user")
+        # Write-only bits, stale permission string (simulates a partial write
+        # that the new save() bridge would have fixed on the app layer).
+        Membership.objects.create(
+            user=u,
+            channel=ch,
+            permission="read-write",
+            can_read=False,
+            can_write=True,
+        )
+
+        # Reverse 0029 — permission must be rebuilt from the bits before
+        # the columns go away.
+        executor.loader.build_graph()
+        executor.migrate(
+            [("hub", "0028_alter_channelmembership_permission")]
+        )
+        old_state = executor.loader.project_state(
+            [("hub", "0028_alter_channelmembership_permission")]
+        ).apps
+        OldMembership = old_state.get_model("hub", "ChannelMembership")
+        row = OldMembership.objects.get(channel__name="#revert-target")
+        self.assertEqual(row.permission, "write-only")
+
+        # Leave the DB in the forward state for subsequent tests.
+        executor.loader.build_graph()
+        executor.migrate(
+            [("hub", "0029_channelmembership_can_read_can_write")]
+        )

--- a/hub/tests/test_worker_progress_seed.py
+++ b/hub/tests/test_worker_progress_seed.py
@@ -48,10 +48,22 @@ class SeedWorkerProgressTest(TestCase):
         self.assertTrue(
             WorkspaceMember.objects.filter(user=user, workspace=self.ws).exists()
         )
-        for name in ("#progress", "#heads", "#ywatanabe"):
+        # #progress + #heads stay fully read-write. #ywatanabe switches
+        # to write-only per lead msg#16884 (can_read=False, can_write=True)
+        # so the worker posts digests without consuming the firehose back.
+        for name in ("#progress", "#heads"):
             ch = Channel.objects.get(workspace=self.ws, name=name)
             m = ChannelMembership.objects.get(user=user, channel=ch)
+            self.assertTrue(m.can_read, f"{name} should have can_read=True")
+            self.assertTrue(m.can_write, f"{name} should have can_write=True")
             self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
+
+        yw = Channel.objects.get(workspace=self.ws, name="#ywatanabe")
+        yw_mem = ChannelMembership.objects.get(user=user, channel=yw)
+        self.assertFalse(yw_mem.can_read, "#ywatanabe must be write-only (no read)")
+        self.assertTrue(yw_mem.can_write, "#ywatanabe must allow writes")
+        # Deprecation bridge keeps the legacy enum synced — "write-only".
+        self.assertEqual(yw_mem.permission, ChannelMembership.PERM_WRITE_ONLY)
 
     # --- dynamic #proj-* enumeration -------------------------------------
 
@@ -65,10 +77,12 @@ class SeedWorkerProgressTest(TestCase):
         self._run("--workspace", "default")
         user = self._agent_user()
 
-        # #proj-* subscribed.
+        # #proj-* subscribed read-write (both bits True).
         for name in ("#proj-alpha", "#proj-beta"):
             ch = Channel.objects.get(workspace=self.ws, name=name)
             m = ChannelMembership.objects.get(user=user, channel=ch)
+            self.assertTrue(m.can_read)
+            self.assertTrue(m.can_write)
             self.assertEqual(m.permission, ChannelMembership.PERM_READ_WRITE)
 
         # Non-matching lookalike must NOT be subscribed.
@@ -142,13 +156,38 @@ class SeedWorkerProgressTest(TestCase):
         user, _ = User.objects.get_or_create(username="agent-worker-progress")
         WorkspaceMember.objects.create(user=user, workspace=self.ws)
         ch = Channel.objects.create(workspace=self.ws, name="#progress")
+        # Pre-existing read-only row: can_read=True, can_write=False.
         ChannelMembership.objects.create(
-            user=user, channel=ch, permission=ChannelMembership.PERM_READ_ONLY
+            user=user, channel=ch, can_read=True, can_write=False
         )
         output = self._run("--workspace", "default")
-        self.assertIn("upgraded to read-write", output)
+        self.assertIn("#progress", output)
+        self.assertIn("read-only", output)  # prev-label in the diff line
         refreshed = ChannelMembership.objects.get(user=user, channel=ch)
+        self.assertTrue(refreshed.can_read)
+        self.assertTrue(refreshed.can_write)
         self.assertEqual(refreshed.permission, ChannelMembership.PERM_READ_WRITE)
+
+    def test_reseeds_ywatanabe_as_write_only(self):
+        """Stale read-write ``#ywatanabe`` row is downgraded to write-only.
+
+        Codifies the lead msg#16884 flip so a re-run of the seed
+        converts the legacy read-write membership into the new
+        ``can_read=False, can_write=True`` shape without manual DB edits.
+        """
+        user, _ = User.objects.get_or_create(username="agent-worker-progress")
+        WorkspaceMember.objects.create(user=user, workspace=self.ws)
+        ch = Channel.objects.create(workspace=self.ws, name="#ywatanabe")
+        ChannelMembership.objects.create(
+            user=user, channel=ch, can_read=True, can_write=True
+        )
+        output = self._run("--workspace", "default")
+        self.assertIn("#ywatanabe", output)
+        self.assertIn("write-only", output)
+        refreshed = ChannelMembership.objects.get(user=user, channel=ch)
+        self.assertFalse(refreshed.can_read)
+        self.assertTrue(refreshed.can_write)
+        self.assertEqual(refreshed.permission, ChannelMembership.PERM_WRITE_ONLY)
 
     # --- error handling --------------------------------------------------
 

--- a/hub/tests/views/api/test_channel_members.py
+++ b/hub/tests/views/api/test_channel_members.py
@@ -161,6 +161,110 @@ class ChannelMembersAdminApiTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["deleted"], 0)
 
+    def test_post_accepts_can_read_can_write_bits(self):
+        """REST subscribe accepts ``can_read`` / ``can_write`` bits
+        (lead msg#16884). Body shape takes precedence over the legacy
+        ``permission`` enum when bits are present."""
+        self.client.force_login(self.admin)
+        resp = self.client.post(
+            "/api/channel-members/",
+            data=json.dumps(
+                {
+                    "channel": "#digest",
+                    "username": "agent-worker-x",
+                    "can_read": False,
+                    "can_write": True,
+                }
+            ),
+            content_type="application/json",
+            HTTP_HOST=self.host,
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertFalse(body["can_read"])
+        self.assertTrue(body["can_write"])
+        self.assertEqual(body["permission"], "write-only")
+        # DB reflects the bits.
+        ch = self.Channel.objects.get(workspace=self.ws, name="#digest")
+        row = self.ChannelMembership.objects.get(
+            user=self.agent_user, channel=ch
+        )
+        self.assertFalse(row.can_read)
+        self.assertTrue(row.can_write)
+
+    def test_patch_flips_bits_in_place(self):
+        """PATCH updates existing row bits (round-trip)."""
+        self.client.force_login(self.admin)
+        ch = self.Channel.objects.create(workspace=self.ws, name="#toggle")
+        self.ChannelMembership.objects.create(
+            user=self.agent_user, channel=ch, can_read=True, can_write=True
+        )
+        resp = self.client.patch(
+            "/api/channel-members/",
+            data=json.dumps(
+                {
+                    "channel": "#toggle",
+                    "username": "agent-worker-x",
+                    "can_read": True,
+                    "can_write": False,
+                }
+            ),
+            content_type="application/json",
+            HTTP_HOST=self.host,
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body["can_read"])
+        self.assertFalse(body["can_write"])
+        self.assertEqual(body["permission"], "read-only")
+        row = self.ChannelMembership.objects.get(
+            user=self.agent_user, channel=ch
+        )
+        self.assertEqual(row.permission, "read-only")
+
+    def test_legacy_permission_enum_still_accepted(self):
+        """Callers that still pass ``permission`` (no bits) keep working
+        — bridge maps the enum to the right bit pair."""
+        self.client.force_login(self.admin)
+        resp = self.client.post(
+            "/api/channel-members/",
+            data=json.dumps(
+                {
+                    "channel": "#legacy-body",
+                    "username": "agent-worker-x",
+                    "permission": "write-only",
+                }
+            ),
+            content_type="application/json",
+            HTTP_HOST=self.host,
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertFalse(body["can_read"])
+        self.assertTrue(body["can_write"])
+
+    def test_get_includes_bits_in_member_rows(self):
+        """GET /api/channel-members/?channel=… exposes bits alongside
+        the deprecated ``permission`` enum."""
+        self.client.force_login(self.admin)
+        ch = self.Channel.objects.create(workspace=self.ws, name="#get-bits")
+        self.ChannelMembership.objects.create(
+            user=self.agent_user, channel=ch, can_read=False, can_write=True
+        )
+        resp = self.client.get(
+            "/api/channel-members/?channel=%23get-bits",
+            HTTP_HOST=self.host,
+        )
+        self.assertEqual(resp.status_code, 200)
+        rows = resp.json()
+        match = next(
+            (r for r in rows if r["username"] == "agent-worker-x"), None
+        )
+        self.assertIsNotNone(match, "agent row missing in response")
+        self.assertFalse(match["can_read"])
+        self.assertTrue(match["can_write"])
+        self.assertEqual(match["permission"], "write-only")
+
     def test_post_subscribe_abolished_agent_channel_returns_403(self):
         """``#agent`` was abolished 2026-04-21 (lead directive, PR #293
         follow-up). POST/PATCH must return 403 so the client gets a real

--- a/hub/views/api/_agents_subscribe.py
+++ b/hub/views/api/_agents_subscribe.py
@@ -95,12 +95,24 @@ def _admin_subscribe(request, target, *, slug=None, subscribe: bool):
 
     ch_name = normalize_channel_name(raw_channel)
 
+    # msg#16884 bit-split: admin callers may pass ``can_read`` /
+    # ``can_write`` booleans to install a write-only / read-only row
+    # instead of the default read-write. Omitted = True = pre-split
+    # behaviour, so existing admin scripts keep working untouched.
+    can_read = bool(body.get("can_read", True))
+    can_write = bool(body.get("can_write", True))
+
     # ``_persist_agent_subscription`` is an async helper; wrap it so the
     # synchronous view can call it without spinning a loop. It returns
     # ``False`` only when the workspace cannot be resolved — every other
     # failure raises.
     ok = async_to_sync(_persist_agent_subscription)(
-        workspace.id, target_name, ch_name, subscribe
+        workspace.id,
+        target_name,
+        ch_name,
+        subscribe,
+        can_read=can_read,
+        can_write=can_write,
     )
     if not ok:
         return JsonResponse(

--- a/hub/views/api/_channels.py
+++ b/hub/views/api/_channels.py
@@ -286,9 +286,23 @@ def api_channel_members(request, slug=None):
             ).delete()
             return JsonResponse({"status": "ok", "deleted": deleted})
 
-        perm = body.get("permission", "read-write")
-        if perm not in ("read-write", "read-only", "write-only"):
-            return JsonResponse({"error": "invalid permission"}, status=400)
+        # msg#16884 bit-split body shape. Callers may send either the
+        # legacy ``permission`` enum (still accepted, backwards-compat)
+        # OR the two independent bits ``can_read`` / ``can_write``.
+        # When both are present the bits win — they are the new
+        # authoritative surface, the enum is the one-release deprecation
+        # bridge. Missing bits default to True (full read-write), which
+        # matches the pre-split default.
+        has_can_read = "can_read" in body
+        has_can_write = "can_write" in body
+        if has_can_read or has_can_write:
+            can_read = bool(body.get("can_read", True))
+            can_write = bool(body.get("can_write", True))
+        else:
+            perm = body.get("permission", "read-write")
+            if perm not in ("read-write", "read-only", "write-only"):
+                return JsonResponse({"error": "invalid permission"}, status=400)
+            can_read, can_write = ChannelMembership.perm_to_bits(perm)
 
         # ``#agent`` was abolished 2026-04-21 (lead directive, PR #293
         # follow-up). Block any subscribe/update attempt at the REST layer
@@ -313,17 +327,22 @@ def api_channel_members(request, slug=None):
                 return JsonResponse({"error": "channel not found"}, status=404)
 
         m, created = ChannelMembership.objects.get_or_create(
-            user=user, channel=ch, defaults={"permission": perm}
+            user=user,
+            channel=ch,
+            defaults={"can_read": can_read, "can_write": can_write},
         )
         if not created and request.method == "PATCH":
-            m.permission = perm
-            m.save(update_fields=["permission"])
+            m.can_read = can_read
+            m.can_write = can_write
+            m.save(update_fields=["can_read", "can_write"])
         return JsonResponse(
             {
                 "status": "ok",
                 "username": username,
                 "channel": ch_name,
                 "permission": m.permission,
+                "can_read": m.can_read,
+                "can_write": m.can_write,
                 "created": created,
             }
         )
@@ -339,9 +358,11 @@ def api_channel_members(request, slug=None):
 
     from hub.models import ChannelMembership
 
-    # Explicit memberships
+    # Explicit memberships — keyed by username, carrying the row itself
+    # so the lookup below can surface both the legacy enum AND the new
+    # bits (msg#16884 bit-split) without an extra query.
     memberships = {
-        m.user.username: m.permission
+        m.user.username: m
         for m in ChannelMembership.objects.filter(channel=ch).select_related("user")
     }
     # Only return explicitly subscribed members (not all workspace members).
@@ -357,7 +378,14 @@ def api_channel_members(request, slug=None):
         except WorkspaceMember.DoesNotExist:
             role = ""
         data.append(
-            {"username": uname, "permission": m.permission, "kind": kind, "role": role}
+            {
+                "username": uname,
+                "permission": m.permission,
+                "can_read": m.can_read,
+                "can_write": m.can_write,
+                "kind": kind,
+                "role": role,
+            }
         )
     # Always include human workspace members (ywatanabe etc.) for visibility
     human_members = WorkspaceMember.objects.filter(workspace=workspace).select_related(
@@ -367,11 +395,21 @@ def api_channel_members(request, slug=None):
     for wm in human_members:
         uname = wm.user.username
         if uname not in existing and not uname.startswith("agent-"):
-            perm = memberships.get(uname, "read-write")
+            row = memberships.get(uname)
+            if row is None:
+                perm = "read-write"
+                can_read = True
+                can_write = True
+            else:
+                perm = row.permission
+                can_read = row.can_read
+                can_write = row.can_write
             data.append(
                 {
                     "username": uname,
                     "permission": perm,
+                    "can_read": can_read,
+                    "can_write": can_write,
                     "kind": "human",
                     "role": wm.role,
                 }
@@ -417,6 +455,8 @@ def api_my_subscriptions(request, slug=None):
             "channel": m.channel.name,
             "joined_at": m.joined_at.isoformat() if m.joined_at else None,
             "role": m.permission,
+            "can_read": m.can_read,
+            "can_write": m.can_write,
         }
         for m in memberships
     ]

--- a/src/scitex_orochi/_client.py
+++ b/src/scitex_orochi/_client.py
@@ -229,14 +229,36 @@ class OrochiClient:
         msg = Message(type="status_update", sender=self.name, payload=payload)
         await self._ws.send(msg.to_json())
 
-    async def subscribe(self, channel: str) -> None:
-        """Subscribe to an additional channel (persisted server-side)."""
+    async def subscribe(
+        self,
+        channel: str,
+        *,
+        can_read: bool = True,
+        can_write: bool = True,
+    ) -> None:
+        """Subscribe to an additional channel (persisted server-side).
+
+        ``can_read`` / ``can_write`` (lead msg#16884 bit-split) map to
+        the two independent boolean bits on the persisted
+        :class:`ChannelMembership` row. Both default to True (full
+        read-write) so existing callers keep the pre-split behaviour.
+        Examples:
+
+        * ``can_read=True, can_write=True``  — full read-write (default)
+        * ``can_read=True, can_write=False`` — read-only (listen, no post)
+        * ``can_read=False, can_write=True`` — write-only (post digests
+          without pulling the firehose back)
+        """
         if not self._ws:
             raise RuntimeError("Not connected")
         msg = Message(
             type="subscribe",
             sender=self.name,
-            payload={"channel": channel},
+            payload={
+                "channel": channel,
+                "can_read": bool(can_read),
+                "can_write": bool(can_write),
+            },
         )
         await self._ws.send(msg.to_json())
 

--- a/src/scitex_orochi/mcp_server.py
+++ b/src/scitex_orochi/mcp_server.py
@@ -125,16 +125,40 @@ if _FASTMCP_AVAILABLE:
         )
 
     @mcp.tool()
-    async def orochi_subscribe(channel: str) -> str:
+    async def orochi_subscribe(
+        channel: str,
+        read: bool = True,
+        write: bool = True,
+    ) -> str:
         """Subscribe to an Orochi channel at runtime (no restart needed).
 
         The subscription is persisted server-side (ChannelMembership row),
-        so it survives agent reboot. Default permission is read-write;
-        use ``/api/channel-members/`` PATCH to change to read-only.
+        so it survives agent reboot. The two independent flags map to
+        the lead msg#16884 bit-split:
+
+        * ``read=True, write=True``  — full read-write (default)
+        * ``read=True, write=False`` — listen only (no posts)
+        * ``read=False, write=True`` — write-only digest target
+          (post without pulling the firehose back — e.g. worker-progress
+          → ``#ywatanabe``)
+
+        Both flags default to True so existing call sites (``subscribe
+        #chan``) keep the pre-split behaviour.
         """
-        async with _make_client(channels=[channel]) as client:
-            await client.subscribe(channel)
-        return json.dumps({"status": "subscribed", "channel": channel})
+        async with _make_client(channels=[channel] if read else []) as client:
+            await client.subscribe(
+                channel,
+                can_read=bool(read),
+                can_write=bool(write),
+            )
+        return json.dumps(
+            {
+                "status": "subscribed",
+                "channel": channel,
+                "can_read": bool(read),
+                "can_write": bool(write),
+            }
+        )
 
     @mcp.tool()
     async def orochi_unsubscribe(channel: str) -> str:

--- a/tests/test_client_subscribe_bits.py
+++ b/tests/test_client_subscribe_bits.py
@@ -1,0 +1,56 @@
+"""Unit test — ``Client.subscribe(can_read=..., can_write=...)`` sends
+the bit-split payload shape expected by the hub (lead msg#16884).
+
+Exercises the client in isolation by replacing ``_ws`` with an async
+mock that captures the frame string. No real server needed.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from scitex_orochi._client import OrochiClient
+
+
+def _build_client() -> OrochiClient:
+    """Minimal client instance with a mocked websocket."""
+    c = OrochiClient.__new__(OrochiClient)
+    c.name = "worker-bits-test"
+    c._ws = AsyncMock()
+    return c
+
+
+@pytest.mark.asyncio
+async def test_subscribe_defaults_send_both_bits_true():
+    c = _build_client()
+    await c.subscribe("#progress")
+    c._ws.send.assert_awaited_once()
+    raw = c._ws.send.call_args.args[0]
+    frame = json.loads(raw)
+    assert frame["type"] == "subscribe"
+    payload = frame.get("payload") or {}
+    assert payload.get("channel") == "#progress"
+    assert payload.get("can_read") is True
+    assert payload.get("can_write") is True
+
+
+@pytest.mark.asyncio
+async def test_subscribe_write_only_flag():
+    c = _build_client()
+    await c.subscribe("#ywatanabe", can_read=False, can_write=True)
+    raw = c._ws.send.call_args.args[0]
+    payload = json.loads(raw).get("payload") or {}
+    assert payload.get("can_read") is False
+    assert payload.get("can_write") is True
+
+
+@pytest.mark.asyncio
+async def test_subscribe_read_only_flag():
+    c = _build_client()
+    await c.subscribe("#listen", can_read=True, can_write=False)
+    payload = json.loads(c._ws.send.call_args.args[0]).get("payload") or {}
+    assert payload.get("can_read") is True
+    assert payload.get("can_write") is False


### PR DESCRIPTION
## Summary

Lead directive msg#16884 — replace the single-choice
`ChannelMembership.permission` CharField with two independent
boolean bits (`can_read` + `can_write`) so the four combinations
(read-write / read-only / write-only / admin lockout) are
representable without juggling an enum. Supersedes the interim
`write-only` enum from PR #353 (kept as a deprecation-bridge column
for one release cycle).

- **Schema**: new migration `0029_channelmembership_can_read_can_write`
  adds `can_read` / `can_write` booleans (default `True`, backward-
  compat) and `RunPython`-backfills them from the legacy enum in both
  directions. `permission` stays on the row for one release; a follow-
  up migration will drop it once every deploy has rolled past 0029.
- **Consumers**:
  - Read path (`_load_agent_channel_subs`) filters on `can_read=True`,
    not ad-hoc `permission != write-only`.
  - Write path (`check_membership_allowed`) checks `can_write` only.
  - WS `subscribe` handler + admin REST endpoints accept bit payloads.
- **MCP**: `orochi_subscribe` gains independent `read` / `write` flags
  (both default True → pre-split behaviour).
- **REST**: `/api/channel-members/` POST/PATCH accept `can_read` /
  `can_write`; GET surfaces the bits alongside the deprecated enum.
- **Seed**: `seed_worker_progress` sets `#ywatanabe` to
  `can_read=False, can_write=True` (write-only digest target,
  msg#16880). Re-runs downgrade a stale read-write row in place.
- **Registry-empty blocker**: already cleared via PR #352.

## Test plan

- [x] `hub/tests/models/test_channel_membership_bits.py` — 15 new tests
  covering bit semantics, enum bridge, `save(update_fields=...)` sync,
  `update_or_create`, write ACL under every combo, read-filter
  exclusion, forward + reverse data migration via `MigrationExecutor`.
- [x] `hub/tests/consumers/test_agent_subscription.py` — +2 tests for
  the new `can_read` / `can_write` kwargs and write-only exclusion.
- [x] `hub/tests/views/api/test_channel_members.py` — +4 tests for
  REST POST/PATCH with bits, legacy enum back-compat, GET bit shape.
- [x] `hub/tests/test_worker_progress_seed.py` — updated base-channel
  test for `#ywatanabe` write-only; +1 new reseed-in-place test.
- [x] `tests/test_client_subscribe_bits.py` — 3 new client-level tests
  confirming the subscribe payload shape.
- [x] Full hub test suite locally: 421 run, 412 pass (+ 9 pre-existing
  `test_auth.py` static-manifest errors on develop, unrelated).
- [x] Top-level `pytest tests/`: 568 passed (no regression).

## Post-deploy manual step

After `manage.py migrate` lands on prod, head-mba should run

```
python manage.py seed_worker_progress --workspace default
```

to flip the live `agent-worker-progress` / `#ywatanabe` membership
from the existing read-write row to `can_read=False, can_write=True`.
The seed is idempotent — safe to re-run.

Generated with [Claude Code](https://claude.com/claude-code)
