### PR TITLE
fix(ui/overview): drag ghost visible + drop re-renders (msg#16988 a+b)

### DIFF
--- a/hub/frontend/src/app/agent-actions.ts
+++ b/hub/frontend/src/app/agent-actions.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { _channelPrefs } from "./members";
 import { fetchAgents } from "./sidebar-agents";
+import { fetchStats } from "./sidebar-stats";
 import { setCurrentChannel } from "./state";
 import { apiUrl, getCsrfToken, token } from "./utils";
 import { fetchAgentsThrottled } from "./websocket";
@@ -148,6 +149,27 @@ export function _addDragAndDrop(container, section) {
       el.classList.add("ch-dragging");
       ev.dataTransfer.effectAllowed = "move";
       ev.dataTransfer.setData("text/plain", el.getAttribute("data-channel"));
+      /* msg#16988 (a): full-card drag image. See sidebar-agents.ts
+       * for the same treatment on agent cards. Without this the
+       * browser default ghost is just the text node under the cursor
+       * so the drop position is invisible. */
+      try {
+        var rect = el.getBoundingClientRect();
+        var clone = el.cloneNode(true);
+        clone.style.position = "absolute";
+        clone.style.top = "-10000px";
+        clone.style.left = "-10000px";
+        clone.style.width = rect.width + "px";
+        clone.style.pointerEvents = "none";
+        clone.classList.remove("ch-dragging");
+        document.body.appendChild(clone);
+        var ox = ev.clientX - rect.left;
+        var oy = ev.clientY - rect.top;
+        ev.dataTransfer.setDragImage(clone, ox, oy);
+        setTimeout(function () {
+          if (clone.parentNode) clone.parentNode.removeChild(clone);
+        }, 0);
+      } catch (_) {}
     });
 
     el.addEventListener("dragend", function () {
@@ -209,6 +231,18 @@ export function _addDragAndDrop(container, section) {
         }
       });
       el.classList.remove("ch-drop-target");
+      /* msg#16988 (b): synchronously re-render the sidebar from the
+       * updated local _channelPrefs — do NOT rely on the next
+       * fetchStats() tick / WS round-trip, which can arrive with
+       * stale server data (PATCH still in-flight) and revert the
+       * visible order until the user reloads. Bust the stats cache
+       * so fetchStats rebuilds from our sort_order snapshot, then
+       * call it imperatively. */
+      try {
+        var chContainer = document.getElementById("channels");
+        if (chContainer) chContainer._lastStatsJson = null;
+      } catch (_) {}
+      if (typeof fetchStats === "function") fetchStats();
     });
   });
 }

--- a/hub/frontend/src/app/sidebar-agents.ts
+++ b/hub/frontend/src/app/sidebar-agents.ts
@@ -233,6 +233,28 @@ export async function fetchAgents() {
             /* Carry current subscriptions so the drop handler can render
              * add/remove affordance without an extra fetch. */
             ev.dataTransfer.setData("application/x-orochi-agent-channels", chs);
+            /* msg#16988 (a): browser default ghost is often just the
+             * text node under the cursor, leaving the drop position
+             * invisible. Hand setDragImage a full off-screen clone of
+             * the card (bg + border + icon + name) so the user sees
+             * exactly what they're moving. The clone is removed on
+             * the next microtask — the browser has already rasterised
+             * it by the time dragstart returns. */
+            var rect = el.getBoundingClientRect();
+            var clone = el.cloneNode(true);
+            clone.style.position = "absolute";
+            clone.style.top = "-10000px";
+            clone.style.left = "-10000px";
+            clone.style.width = rect.width + "px";
+            clone.style.pointerEvents = "none";
+            clone.classList.remove("agent-dragging");
+            document.body.appendChild(clone);
+            var ox = ev.clientX - rect.left;
+            var oy = ev.clientY - rect.top;
+            ev.dataTransfer.setDragImage(clone, ox, oy);
+            setTimeout(function () {
+              if (clone.parentNode) clone.parentNode.removeChild(clone);
+            }, 0);
           } catch (e) {}
           window.__orochiDragAgent = { name: n, channels: chs };
         });

--- a/hub/static/hub/style/style-modals.css
+++ b/hub/static/hub/style/style-modals.css
@@ -98,8 +98,13 @@
   opacity: 1;
 }
 .ch-dragging {
-  opacity: 0.4;
+  opacity: 0.5;
   background: #0d1a28 !important;
+  /* msg#16988 (a): dashed accent outline makes the source row read
+   * clearly as "being dragged" in addition to the off-screen clone
+   * that rides the cursor (set via dataTransfer.setDragImage). */
+  outline: 2px dashed var(--accent, #4a9eff);
+  outline-offset: -2px;
 }
 .ch-drop-target {
   border-top: 2px solid #4af;
@@ -112,6 +117,9 @@
 .agent-card.agent-dragging {
   opacity: 0.5;
   background: #0d1a28 !important;
+  /* msg#16988 (a): see .ch-dragging above — same affordance. */
+  outline: 2px dashed var(--accent, #4a9eff);
+  outline-offset: -2px;
 }
 .channel-item.drop-target-agent-add {
   outline: 2px solid #22c55e;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -22,7 +22,7 @@
     <link rel="stylesheet"
           href="{% static 'hub/style/style-menus.css' %}?v=135">
     <link rel="stylesheet"
-          href="{% static 'hub/style/style-modals.css' %}?v=134">
+          href="{% static 'hub/style/style-modals.css' %}?v=135">
     <link rel="stylesheet"
           href="{% static 'hub/components/components-badges-filter.css' %}?v=105">
     <link rel="stylesheet"


### PR DESCRIPTION
## Summary

Two narrow fixes to the Overview-tab drag-drop affordances on sidebar
agent + channel cards (lead msg#16988):

- **a)** dragstart now calls dataTransfer.setDragImage(clone, x, y)
  with a full off-screen clone of the card (bg + border + icon + name),
  so the drop position is visible during drag. Applied to both
  .agent-card dragstart (sidebar-agents.ts) and .channel-item
  dragstart (agent-actions.ts _addDragAndDrop). CSS adds a dashed
  accent outline on .agent-dragging / .ch-dragging so the source row
  also reads clearly as "being dragged".
- **b)** The channel-reorder drop handler imperatively re-renders the
  sidebar (bust _lastStatsJson cache, then call fetchStats()) instead
  of relying on the next WS / REST tick. The DOM now reflects the new
  position synchronously instead of reverting when a stale stats poll
  lands first.

## Scope

- 1 CSS file: hub/static/hub/style/style-modals.css (+ cache-bust
  v134 -> v135 in dashboard.html).
- 2 TS files: hub/frontend/src/app/sidebar-agents.ts,
  hub/frontend/src/app/agent-actions.ts.
- renderAgentBadge / renderChannelBadge signatures untouched
  (SSoT preserved).
- No API contract change.
- Independent of the PR #348 feed-live channel-prefix asymmetry work.

## Test plan

- [ ] Drag an agent card from the sidebar over a channel row - the
      full card now rides the cursor, drop-target highlight visible.
- [ ] Drag a channel card within the Starred section - full card ghost
      visible, source row shows dashed accent outline.
- [ ] Drop a channel onto a new slot - order updates immediately with
      no reload.
- [ ] Check dashed outline on .agent-card.agent-dragging /
      .ch-dragging in devtools while mid-drag.

Generated with Claude Code
