### PR TITLE
fix(ui/sidebar): channel-card star/eye/mute double-toggle race (msg#16979)

### DIFF
--- a/hub/frontend/src/app/channel-prefs.ts
+++ b/hub/frontend/src/app/channel-prefs.ts
@@ -83,11 +83,20 @@ export function _setChannelPref(ch, patch) {
       var pref = _channelPrefs[elNorm] || _channelPrefs[elCh] || {};
       var pinEl = el.querySelector(".ch-pin");
       if (pinEl) {
+        /* msg#16979: renderChannelBadgeHtml SSoT emits BOTH .ch-pin-on/off
+         * AND .ch-star-on/off; the star's yellow fill is owned by
+         * .ch-star-on. Toggle both pairs + swap the ★/☆ glyph so the
+         * optimistic update produces the same visual as the SSoT render
+         * (prior code only toggled .ch-pin-* which left the star looking
+         * unchanged until fetchStats re-ran). */
         pinEl.classList.toggle("ch-pin-on", !!pref.is_starred);
         pinEl.classList.toggle("ch-pin-off", !pref.is_starred);
+        pinEl.classList.toggle("ch-star-on", !!pref.is_starred);
+        pinEl.classList.toggle("ch-star-off", !pref.is_starred);
+        pinEl.textContent = pref.is_starred ? "\u2605" : "\u2606";
         pinEl.setAttribute(
           "title",
-          pref.is_starred ? "Unpin" : "Pin (float to top)",
+          pref.is_starred ? "Unstar" : "Star (float to top)",
         );
       }
       var watchEl = el.querySelector(".ch-watch");
@@ -103,12 +112,19 @@ export function _setChannelPref(ch, patch) {
       }
       /* Keep the per-row eye icon (todo#418) in sync immediately after a
        * hide/unhide click so the user gets instant visual feedback before
-       * fetchStats() re-renders the list. */
+       * fetchStats() re-renders the list.
+       *
+       * msg#16979: renderChannelBadgeHtml uses the SAME 👁 glyph in both
+       * states — the red diagonal strike is drawn by .ch-eye-off::after
+       * in style-channels.css. Don't rewrite textContent to 🚫 here; the
+       * class toggle alone drives the red overlay via CSS, and staying
+       * aligned with the SSoT prevents a brief 🚫 flicker before
+       * fetchStats re-renders back to 👁. */
       var eyeEl = el.querySelector(".ch-eye");
       if (eyeEl) {
         eyeEl.classList.toggle("ch-eye-on", !pref.is_hidden);
         eyeEl.classList.toggle("ch-eye-off", !!pref.is_hidden);
-        eyeEl.textContent = pref.is_hidden ? "\uD83D\uDEAB" : "\uD83D\uDC41";
+        eyeEl.textContent = "\uD83D\uDC41";
         eyeEl.setAttribute(
           "title",
           pref.is_hidden
@@ -355,13 +371,12 @@ export function _renderStarredSection() {
       loadChannelHistory(ch);
       if (typeof applyFeedFilter === "function") applyFeedFilter();
     });
-    var star = el.querySelector(".ch-pin");
-    if (star)
-      star.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        var ch = star.getAttribute("data-ch");
-        _setChannelPref(ch, { is_starred: false });
-      });
+    /* msg#16979: star (.ch-pin) clicks are owned by the body-level
+     * capture-phase delegate in channel-badge.ts. A per-row listener
+     * here caused a double-toggle race (the delegate's _setChannelPref
+     * ran first and kicked off a DOM rebuild; the bubble handler then
+     * fired on the detached old node and called _setChannelPref a
+     * second time, reverting the visual flip). */
     _addChannelContextMenu(el);
   });
   _addDragAndDrop(container, "starred");

--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -227,50 +227,21 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
        * added it above. Belt-and-braces against any stale DOM state. */
       el.classList.remove("selected");
     }
-    /* Pin icon click — toggle is_starred (pinned-to-top) */
-    var pinEl = el.querySelector(".ch-pin");
-    if (pinEl) {
-      pinEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        var norm = pinEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_starred: !curPref.is_starred });
-      });
-    }
-    /* Eye icon click — toggle is_muted (watching vs muted) */
-    var watchEl = el.querySelector(".ch-watch");
-    if (watchEl) {
-      watchEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        var norm = watchEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_muted: !curPref.is_muted });
-      });
-    }
-    /* Bell/mute placeholder click — toggle is_muted. Placeholder is
-     * always rendered (reserved slot) so channel-name columns line up
-     * whether the row is muted or not. */
-    var muteEl = el.querySelector(".ch-mute");
-    if (muteEl) {
-      muteEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        ev.preventDefault();
-        var norm = muteEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_muted: !curPref.is_muted });
-      });
-    }
-    /* Hide/unhide icon click — toggle is_hidden (todo#418). */
-    var eyeEl = el.querySelector(".ch-eye");
-    if (eyeEl) {
-      eyeEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        ev.preventDefault();
-        var norm = eyeEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_hidden: !curPref.is_hidden });
-      });
-    }
+    /* msg#16979 — channel-card double-handler race.
+     *
+     * Star (.ch-pin), eye (.ch-eye), mute (.ch-mute) and watch (.ch-watch)
+     * clicks are owned by the body-level capture-phase delegate in
+     * channel-badge.ts (attachChannelBadgeHandlers). Per-row wiring
+     * here duplicated the same _setChannelPref call on the same click,
+     * causing a double-toggle that looked like "nothing happens" — the
+     * second call inverted the optimistic update from the first (the
+     * per-row bubble handler ran on the detached old element even after
+     * the delegate tore down the DOM, and by that point _channelPrefs
+     * already held the new value, so !curPref.is_* flipped it back).
+     *
+     * The delegate covers every surface that renders a channel badge
+     * (sidebar row, pool chip, topology canvas), so the per-row
+     * listeners are intentionally omitted here. */
     /* Context menu */
     _addChannelContextMenu(el);
     /* todo#49: accept agent-card drops to toggle subscription. */

--- a/hub/static/hub/app/sidebar-channel-tree.js
+++ b/hub/static/hub/app/sidebar-channel-tree.js
@@ -213,50 +213,11 @@ function _wireChannelItemHandlers(chContainer, prevSelected) {
        * added it above. Belt-and-braces against any stale DOM state. */
       el.classList.remove("selected");
     }
-    /* Pin icon click — toggle is_starred (pinned-to-top) */
-    var pinEl = el.querySelector(".ch-pin");
-    if (pinEl) {
-      pinEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        var norm = pinEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_starred: !curPref.is_starred });
-      });
-    }
-    /* Eye icon click — toggle is_muted (watching vs muted) */
-    var watchEl = el.querySelector(".ch-watch");
-    if (watchEl) {
-      watchEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        var norm = watchEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_muted: !curPref.is_muted });
-      });
-    }
-    /* Bell/mute placeholder click — toggle is_muted. Placeholder is
-     * always rendered (reserved slot) so channel-name columns line up
-     * whether the row is muted or not. */
-    var muteEl = el.querySelector(".ch-mute");
-    if (muteEl) {
-      muteEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        ev.preventDefault();
-        var norm = muteEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_muted: !curPref.is_muted });
-      });
-    }
-    /* Hide/unhide icon click — toggle is_hidden (todo#418). */
-    var eyeEl = el.querySelector(".ch-eye");
-    if (eyeEl) {
-      eyeEl.addEventListener("click", function (ev) {
-        ev.stopPropagation();
-        ev.preventDefault();
-        var norm = eyeEl.getAttribute("data-ch");
-        var curPref = _channelPrefs[norm] || {};
-        _setChannelPref(norm, { is_hidden: !curPref.is_hidden });
-      });
-    }
+    /* msg#16979: star/eye/mute click wiring lives in the body-level
+     * capture-phase delegate in channel-badge.js. Duplicating it here
+     * caused a double-toggle race (same _setChannelPref call fired
+     * twice on one click → net no-op). See ts mirror in
+     * hub/frontend/src/app/sidebar-channel-tree.ts. */
     /* Context menu */
     _addChannelContextMenu(el);
     /* todo#49: accept agent-card drops to toggle subscription. */


### PR DESCRIPTION
## Summary

Fixes msg#16979: clicking the star/eye/mute on a channel card flipped the state server-side, but the visual state didn't change. ywatanabe's hypothesis ("two scripts fire on the same click, state-overwrite race") was correct.

**Root cause — double-bind.** The body-level capture-phase delegate in `channel-badge.ts` (`attachChannelBadgeHandlers`) is documented as the SSoT for `.ch-star` / `.ch-eye` / `.ch-mute` clicks, but `_wireChannelItemHandlers` in `app/sidebar-channel-tree.ts` and `_renderStarredSection` in `app/channel-prefs.ts` kept attaching their own per-row listeners that called `_setChannelPref` with the opposite of the cache value. Sequence on a click:

1. Capture-phase delegate fires on `document.body`, calls `_setChannelPref(ch, {is_starred: !cur.is_starred})`, which mutates `_channelPrefs` in place and synchronously tears down / rebuilds the row DOM.
2. Bubble-phase per-row listener (still attached to the now-detached old node) fires, reads `_channelPrefs[norm]` which now holds the NEW value, and calls `_setChannelPref(ch, {is_starred: !newValue})` — reverting the flip.

Net: the server ends up at the original state, the DOM rebuilds from the reverted cache, the user sees nothing happen.

**Secondary bug — stale optimistic update.** `_setChannelPref`'s optimistic DOM-patch path only toggled the legacy `.ch-pin-on` / `.ch-pin-off` classes. `renderChannelBadgeHtml` (the SSoT) now emits `.ch-star-on` / `.ch-star-off` as the dominant semantic class (owner of the yellow fill) and swaps the star glyph. So even with one handler, the star "changed state" invisibly until `fetchStats()` completed its network round-trip. Aligned the optimistic update to the SSoT markup. The `.ch-eye` optimistic code was also rewriting `textContent` to a prohibition glyph, conflicting with the new SSoT convention (same eye glyph in both states, red strike via `.ch-eye-off::after`) — switched to the SSoT pattern so there's no brief glyph flicker.

**Scope.** Minimal-surgery fix — didn't touch `renderChannelBadge*`, didn't change the API contract, didn't refactor the broader state flow. Mirror edit on `hub/static/hub/app/sidebar-channel-tree.js` (still referenced by `workspace_settings.html`) so legacy template gets the same fix.

## Test plan

- [x] `npm run build` in `hub/frontend/` succeeds
- [x] `npm run typecheck` succeeds
- [x] `node hub/frontend/src/app/channels-equal.test.mjs` still passes (17/17)
- [ ] Deploy to mba stable stack, click star on a channel — expect star to flip colour/glyph immediately
- [ ] Click eye on a channel — expect `.ch-eye-off::after` red strike to appear
- [ ] Click mute on a channel — expect bell glyph to flip
- [ ] Starred section: click the star on a starred channel — expect it to un-star and drop out of the starred list

## Related

- Delegate architecture: PR #311 (`renderChannelBadge` SSoT)
- Icon brightness context: PR #290/#291

Generated with Claude Code
