### PR TITLE
feat(ui): persist last-opened tab + channel across reload (msg#16999)

### DIFF
--- a/hub/frontend/src/app/last-opened.ts
+++ b/hub/frontend/src/app/last-opened.ts
@@ -1,0 +1,107 @@
+// @ts-nocheck
+/* Last-opened UI state persistence across hard reload (msg#16999).
+ *
+ * Persists `{activeTab, activeChannel}` to localStorage on every
+ * selection change so Ctrl+Shift+R lands the user back on the tab +
+ * channel they were viewing. Value shape is versioned via the key
+ * suffix (`.v1`) so a future schema change can bump to `.v2` without
+ * a migration — callers just read whatever is current and fall back
+ * silently on shape mismatch.
+ *
+ * Legacy keys (`orochi_active_tab`, `orochi_active_channel`) are
+ * written in parallel so older bundles and in-flight tabs keep
+ * working during a staged deploy; once the new bundle is universal
+ * those can be removed.
+ *
+ * scrollPosition is intentionally NOT included in v1 — the chat feed
+ * aggressively snaps to bottom on channel activation (tabs.ts line
+ * 163), and the Overview / TODO / other tabs have their own
+ * view-specific scroll anchors. Adding a global scroll field would
+ * cost more correctness debt than it buys.
+ */
+
+const LAST_OPENED_KEY = "orochi.ui.lastOpened.v1";
+const LEGACY_TAB_KEY = "orochi_active_tab";
+const LEGACY_CHANNEL_KEY = "orochi_active_channel";
+
+type LastOpened = {
+  activeTab?: string | null;
+  activeChannel?: string | null;
+};
+
+/* Read the persisted record. Returns {} on storage error / parse
+ * failure / schema mismatch — callers treat a missing field as
+ * "use default" and never crash on the hydrate path. */
+export function readLastOpened(): LastOpened {
+  try {
+    const raw = localStorage.getItem(LAST_OPENED_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        return {
+          activeTab:
+            typeof parsed.activeTab === "string" ? parsed.activeTab : null,
+          activeChannel:
+            typeof parsed.activeChannel === "string"
+              ? parsed.activeChannel
+              : null,
+        };
+      }
+    }
+  } catch (_) {
+    /* Parse error or storage disabled — fall through to legacy. */
+  }
+  /* Back-compat: earlier bundles wrote two flat keys. Fold them into
+   * the v1 shape so users upgrading a tab mid-session don't lose their
+   * spot. */
+  try {
+    const legacyTab = localStorage.getItem(LEGACY_TAB_KEY);
+    const legacyCh = localStorage.getItem(LEGACY_CHANNEL_KEY);
+    if (legacyTab || legacyCh) {
+      return {
+        activeTab: legacyTab || null,
+        activeChannel:
+          legacyCh && legacyCh !== "__all__" ? legacyCh : null,
+      };
+    }
+  } catch (_) {}
+  return {};
+}
+
+/* Merge-write a partial update. Only the provided fields are
+ * overwritten — omit `activeChannel` to update only the tab, etc.
+ * Any localStorage error (private mode, SecurityError, quota) is
+ * swallowed; persistence is a nice-to-have, never a hard dependency. */
+export function writeLastOpened(patch: LastOpened): void {
+  try {
+    const current = readLastOpened();
+    const next: LastOpened = {
+      activeTab:
+        "activeTab" in patch ? patch.activeTab : current.activeTab || null,
+      activeChannel:
+        "activeChannel" in patch
+          ? patch.activeChannel
+          : current.activeChannel || null,
+    };
+    localStorage.setItem(LAST_OPENED_KEY, JSON.stringify(next));
+    /* Mirror to legacy keys so older-bundle tabs in the same browser
+     * stay in sync. Safe to delete once the bundle rollout is complete. */
+    if ("activeTab" in patch && patch.activeTab) {
+      localStorage.setItem(LEGACY_TAB_KEY, patch.activeTab);
+    }
+    if ("activeChannel" in patch) {
+      localStorage.setItem(
+        LEGACY_CHANNEL_KEY,
+        patch.activeChannel == null ? "__all__" : patch.activeChannel,
+      );
+    }
+  } catch (_) {
+    /* storage disabled / SecurityError — accept the loss. */
+  }
+}
+
+/* Clear the persisted channel after a missing-channel fallback so the
+ * next reload doesn't re-trigger the same miss. Preserves the tab. */
+export function clearLastOpenedChannel(): void {
+  writeLastOpened({ activeChannel: null });
+}

--- a/hub/frontend/src/app/state.ts
+++ b/hub/frontend/src/app/state.ts
@@ -2,6 +2,7 @@
 import { _updateChannelTopicBanner } from "./members";
 import { chatFilterReset } from "../chat/chat-state";
 import { _normalizeChannelName } from "./utils";
+import { readLastOpened, writeLastOpened } from "./last-opened";
 
 /* Orochi Dashboard -- core globals, WS connection, sidebar (Django hub) */
 
@@ -49,7 +50,11 @@ var currentChannel = null;
  * Used as posting target when multi-select is active (currentChannel=null). */
 export var lastActiveChannel = null;
 try {
-  var _persistedCh = localStorage.getItem("orochi_active_channel");
+  /* msg#16999: hydrate from the unified `orochi.ui.lastOpened.v1` record;
+   * readLastOpened() also folds in the legacy `orochi_active_channel` key
+   * so a user whose bundle updated mid-session doesn't lose their spot. */
+  var _lastOpened = readLastOpened();
+  var _persistedCh = _lastOpened.activeChannel || null;
   if (_persistedCh && _persistedCh !== "__all__") {
     /* Normalize on hydrate too (msg#16691) — a prior session could have
      * persisted the bare form. */
@@ -77,9 +82,11 @@ export function setCurrentChannel(ch) {
    * channel, and sendMessage() to post to the original channel instead of
    * the one the sidebar highlights. Mirror every update to the global. */
   (globalThis as any).currentChannel = ch;
-  try {
-    localStorage.setItem("orochi_active_channel", ch == null ? "__all__" : ch);
-  } catch (_) {}
+  /* msg#16999: persist the channel half of the last-opened UI record.
+   * writeLastOpened() also mirrors to the legacy `orochi_active_channel`
+   * key so older in-flight bundles keep reading a consistent value.
+   * Silently no-ops if storage is disabled / SecurityError. */
+  writeLastOpened({ activeChannel: ch == null ? null : ch });
   /* Per-channel chat filter: reset whenever the user switches channels so
    * a stale filter from the previous channel doesn't hide messages here. */
   if (typeof chatFilterReset === "function") {

--- a/hub/frontend/src/tabs.ts
+++ b/hub/frontend/src/tabs.ts
@@ -12,6 +12,11 @@ import { renderVizTab, stopVizTab } from "./viz-tab";
 import { fetchWorkspaces } from "./workspaces-tab";
 import { setCurrentChannel } from "./app/state";
 import { channelUnread } from "./app/utils";
+import {
+  clearLastOpenedChannel,
+  readLastOpened,
+  writeLastOpened,
+} from "./app/last-opened";
 
 /* Tab switching, collapsible sections, mobile sidebar */
 /* globals: activeTab, fetchTodoList, renderAgentsTab, renderResourcesTab,
@@ -226,9 +231,11 @@ export function _activateTab(tab) {
     settingsView.style.flex = "1";
     fetchSettings();
   }
-  try {
-    localStorage.setItem("orochi_active_tab", tab);
-  } catch (_) {}
+  /* msg#16999: persist the tab half of the last-opened UI record so a
+   * hard reload (Ctrl+Shift+R) lands the user back where they were.
+   * writeLastOpened() also mirrors to the legacy `orochi_active_tab`
+   * key for older in-flight bundles. */
+  writeLastOpened({ activeTab: tab });
 }
 
 /* msg#16116 Item 3: cmd-click / ctrl-click / middle-click on a tab
@@ -319,7 +326,12 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
     } catch (_) {
       hash = "";
     }
-    var last = localStorage.getItem("orochi_active_tab");
+    /* msg#16999: read the unified last-opened record. readLastOpened()
+     * also folds in the legacy `orochi_active_tab` / `orochi_active_channel`
+     * keys so users on an older bundle at boot time don't lose their
+     * spot. */
+    var _lastOpened = readLastOpened();
+    var last = _lastOpened.activeTab || null;
     /* Step 3c: the top-level Terminal tab has been removed (terminal
      * preview now lives only inside the agent-detail pane's SSH action).
      * Users who left their last session on "terminal" fall through. */
@@ -343,7 +355,7 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
         if (_legacyOverviewView === "list" || _legacyOverviewView === "tiled") {
           last = "agents-tab";
           localStorage.setItem("orochi.overviewView", "topology");
-          localStorage.setItem("orochi_active_tab", "agents-tab");
+          writeLastOpened({ activeTab: "agents-tab" });
         }
       } catch (_) {}
     }
@@ -356,6 +368,32 @@ document.querySelectorAll(".tab-btn").forEach(function (btn) {
       btn = document.querySelector('.tab-btn[data-tab="' + target + '"]');
     }
     if (btn) _activateTab(target);
+    /* msg#16999: validate the persisted channel actually exists in the
+     * current sidebar. It may have been deleted, belong to a workspace
+     * the user no longer has access to, or simply never resolved. When
+     * the channel is missing we clear the persisted value so a
+     * subsequent reload doesn't keep hitting the same stale ref — the
+     * fallback-pick in _activateTab("chat") / the default feed handle
+     * the empty state without further intervention. The sidebar is
+     * populated asynchronously via /api/stats, so defer one rAF tick
+     * plus a short grace window to give the first stats render a
+     * chance to land. */
+    var _persistedCh = _lastOpened.activeChannel || null;
+    if (_persistedCh && _persistedCh !== "__all__") {
+      setTimeout(function () {
+        try {
+          var safe = _persistedCh.replace(/"/g, '\\"');
+          var row = document.querySelector(
+            '.sidebar .channel-item[data-channel="' +
+              safe +
+              '"], .sidebar [data-channel="' +
+              safe +
+              '"]',
+          );
+          if (!row) clearLastOpenedChannel();
+        } catch (__) {}
+      }, 2000);
+    }
   } catch (_) {
     /* Even if localStorage is unavailable (private mode / quota), we
      * still want to land on Overview. */


### PR DESCRIPTION
## Summary

- Unify `orochi_active_tab` + `orochi_active_channel` persistence behind a single versioned `orochi.ui.lastOpened.v1` localStorage key so Ctrl+Shift+R lands the user on the tab + channel they were viewing (msg#16999).
- New `hub/frontend/src/app/last-opened.ts` with read/write/clear helpers; all wrapped in try/catch against SecurityError, storage-disabled, and quota.
- Boot path in `tabs.ts` now validates the persisted channel exists in the sidebar after first stats render; if the channel is gone (deleted, workspace mismatch) it silently clears the channel half of the record so the next reload does not re-hit the stale ref.
- Legacy keys are mirrored for back-compat so older in-flight bundles keep reading consistent values during rollout.
- `scrollPosition` intentionally deferred — chat feed already auto-snaps to bottom and per-tab scroll state is view-specific (see module comment).

## Test plan

- [ ] Open channel `#ywatanabe`, switch to TODO tab, hard reload (Ctrl+Shift+R) — lands on TODO.
- [ ] Open channel `#some-channel`, switch to Chat, hard reload — Chat tab with that channel selected.
- [ ] Manually corrupt `orochi.ui.lastOpened.v1` in devtools to `"garbage"` — boot falls back to default without throwing.
- [ ] Delete current channel in another tab, reload — silently falls back and the bad channel is cleared from storage.
- [ ] Private-window / storage-disabled — no boot errors; tab lands on Overview default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
