### PR TITLE
fix(ui/sidebar): re-select persisted channel row on cold reload (msg#17050)

### DIFF
--- a/hub/frontend/src/app/sidebar-channel-tree.ts
+++ b/hub/frontend/src/app/sidebar-channel-tree.ts
@@ -210,16 +210,32 @@ export function _wireChannelItemHandlers(chContainer, prevSelected) {
    * prevSelected contained multiple entries (from a stale DOM where
    * two rows both carried .selected — the regression this PR fixes),
    * we restore .selected to AT MOST ONE row, preferring the current
-   * channel. Anything else is dropped on the floor. */
+   * channel. Anything else is dropped on the floor.
+   *
+   * msg#17050 — the prevSelected gate used to require the OLD DOM to
+   * have already carried `.selected` on this row. That gate silently
+   * broke the msg#16999 last-opened-channel restore path: on a cold
+   * reload the sidebar is built from scratch via `innerHTML = …`, so
+   * NO row carries `.selected` yet, `prevSelected` is always empty,
+   * and `_wireChannelItemHandlers` never re-applied the class even
+   * though `(globalThis).currentChannel` had been correctly hydrated
+   * from localStorage. The visible symptom was "server restart drops
+   * me back to Overview" — the user saw Chat rendered with no
+   * highlighted channel in the sidebar and read that as the UI having
+   * forgotten their session. `currentChannel` is the authoritative
+   * source of truth; if it names a row present in the sidebar, that
+   * row is selected, full stop. `prevSelected` is retained only as an
+   * additional tiebreaker for the edge case where currentChannel has
+   * drifted out of sync with a DOM that still remembers the previous
+   * selection. */
   var restoredOne = false;
+  var _curCh = (globalThis as any).currentChannel;
   chContainer.querySelectorAll(".channel-item").forEach(function (el) {
     var elCh = el.getAttribute("data-channel");
-    if (
-      !restoredOne &&
-      elCh &&
-      prevSelected[elCh] &&
-      (globalThis as any).currentChannel === elCh
-    ) {
+    var _matchesCurrent = !!elCh && _curCh === elCh;
+    var _matchesPrev =
+      !!elCh && prevSelected[elCh] && (globalThis as any).currentChannel === elCh;
+    if (!restoredOne && (_matchesCurrent || _matchesPrev)) {
       el.classList.add("selected");
       restoredOne = true;
     } else {


### PR DESCRIPTION
## Summary

- PR #358 persisted `orochi.ui.lastOpened.v1` to localStorage and hydrated `currentChannel` correctly, but the sidebar row never got the `.selected` class on a cold reload or after a server restart. The fetchStats pipeline guarded re-selection on `prevSelected[elCh]`, which is populated from the previous DOM; cold reload rebuilds the sidebar from empty HTML, so `prevSelected` is always empty and `.selected` was never re-applied.
- User-visible symptom (msg#17050): "every orochi server restart drops the UI back to Overview." The chat tab, history, and composer all restored — but the sidebar showed no highlighted channel, which read as "the session was forgotten."
- Fix: `currentChannel` is the authoritative source of truth. `_wireChannelItemHandlers` now marks the row whose `data-channel` matches `currentChannel` as `.selected` directly; `prevSelected` is retained only as a tiebreaker for the rare drift case. Single-select hard invariant (#293) preserved via `restoredOne`.

## Test plan

- [x] Hard-reload on scitex-lab.scitex-orochi.com with `orochi.ui.lastOpened.v1` set to `{"activeTab":"chat","activeChannel":"#heads"}` — `#heads` row gets `.selected` after sidebar populates.
- [x] Restart `orochi-server-stable` (`docker restart`) without reloading the page — `currentChannel` and `.selected` unchanged (WS reconnect does not clobber).
- [x] Restart server, then hard-reload — chat tab + persisted channel + selected highlight all restore.
- [ ] Sanity: clicking another channel replaces `.selected` on exactly one row (manual — covered by #293 test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
