### PR TITLE
fix(ui/threads): reply popup — replies render + single compose mount (msg#17058)

### DIFF
--- a/hub/frontend/src/threads/panel.ts
+++ b/hub/frontend/src/threads/panel.ts
@@ -22,6 +22,17 @@ function _threadDraftTarget(parentId) {
  * without a DOM round-trip. */
 var _threadComposer = null;
 
+/* Monotonic open-token guarding openThreadPanel against re-entrancy
+ * (msg#17058). Rapid re-opens — double-click the reply icon, popstate
+ * during an in-flight open, WS-triggered refresh racing a click —
+ * used to interleave so two `renderComposer` calls landed in the same
+ * #thread-composer-slot (bug A: stacked compose inputs) and a stale
+ * `loadThreadReplies` awaited fetch wrote into a detached panel
+ * (bug B: replies invisible). Each openThreadPanel bumps this token
+ * and stashes a local copy; any continuation after `await` checks the
+ * copy against the live token and bails if newer. */
+var _threadOpenToken = 0;
+
 /* Threading — panel open/close, replies render, send, WS handlers.
  * Reply composer (textarea + attach/sketch/voice/send buttons) is
  * provided by composer.ts::renderComposer(surface: "reply") since the
@@ -62,6 +73,10 @@ export function closeThreadPanel(opts) {
 }
 
 export async function openThreadPanel(parentId, opts) {
+  /* Invalidate any in-flight openThreadPanel before tearing down the
+   * previous panel — continuations below compare `myToken !==
+   * _threadOpenToken` to know they were superseded (msg#17058). */
+  var myToken = ++_threadOpenToken;
   closeThreadPanel({ skipPushState: true });
   (globalThis as any).threadPanelParentId = parentId;
   if (!(opts && opts.skipPushState)) {
@@ -112,6 +127,12 @@ export async function openThreadPanel(parentId, opts) {
   }
 
   await loadThreadReplies(parentId);
+  /* A newer openThreadPanel started during the fetch — its
+   * closeThreadPanel already ripped our panel out and built a fresh
+   * one. Do not proceed to mount a composer into the new panel's
+   * slot; that's the newer call's job and doing it here would stack
+   * a second composer (msg#17058 bug A). */
+  if (myToken !== _threadOpenToken) return;
 
   var composerSlot = document.getElementById("thread-composer-slot");
   /* msg#16527: clear the shared pending-attachments array IN PLACE. Do
@@ -122,6 +143,10 @@ export async function openThreadPanel(parentId, opts) {
   _renderThreadAttachmentTray();
 
   if (composerSlot) {
+    /* Belt-and-suspenders: if anything ever leaks DOM into this slot
+     * (e.g. a stale composer from an earlier race), wipe it before the
+     * new mount so we never end up with stacked inputs (msg#17058). */
+    composerSlot.innerHTML = "";
     _threadComposer = renderComposer(composerSlot as HTMLElement, {
       surface: "reply",
       placeholder: "Reply in thread\u2026",
@@ -272,6 +297,20 @@ export async function loadThreadReplies(parentId) {
     var res = await fetch(apiUrl("/api/threads/?parent_id=" + parentId), {
       credentials: "same-origin",
     });
+    /* If a newer openThreadPanel ran during the fetch, our `container`
+     * was detached when closeThreadPanel removed the old panel. Writing
+     * replies into a detached node renders nothing (msg#17058 bug B).
+     * Re-query; if the live panel is for a *different* parent, bail
+     * and let its own loadThreadReplies fill it. */
+    if (!container.isConnected) {
+      container = document.getElementById("thread-replies");
+      if (
+        !container ||
+        Number((globalThis as any).threadPanelParentId) !== Number(parentId)
+      ) {
+        return;
+      }
+    }
     if (!res.ok) {
       container.innerHTML =
         '<p class="empty-notice">Failed to load thread.</p>';


### PR DESCRIPTION
## Summary

Fixes two user-visible bugs in the thread reply popup reported in msg#17058, both tracing back to a single re-entrancy bug in `openThreadPanel`:

- **Bug A — stacked compose inputs.** Rapid re-opens of the thread panel (double-click on the reply icon, popstate during an in-flight open, WS-triggered refresh racing a click) interleaved across the `await loadThreadReplies()` boundary. Call 1's continuation resolved after Call 2 had already removed Call 1's panel, then `getElementById("thread-composer-slot")` resolved to Call 2's slot and `renderComposer` appended a second composer into it. Call 2's own continuation then appended a third. The user saw two (or more) textareas + send-button rows piled up.
- **Bug B — replies render invisibly.** Same race. Call 1's `loadThreadReplies` held a reference to the *detached* `#thread-replies` div, then wrote `container.innerHTML = …` onto the orphan node. The fetch succeeded and the reply data was correct; it just landed in a node that wasn't attached to the document.

Fix in one narrow commit touching only `hub/frontend/src/threads/panel.ts` (+39 LOC):

- Monotonic `_threadOpenToken` bumped on every `openThreadPanel` call. The continuation after `await loadThreadReplies` compares its captured token to the live one and bails if a newer open has superseded it — that newer call owns the composer mount.
- `loadThreadReplies` re-queries `#thread-replies` after the fetch and checks `container.isConnected`; if detached, re-resolve to the current panel and confirm the `parentId` still matches before rendering.
- Belt-and-suspenders `composerSlot.innerHTML = ""` before `renderComposer`. Defensive — the token gate should prevent this path, but keeps the slot idempotent if any other path ever leaks DOM in.

No API changes. No `renderComposer` signature changes. No feed-live channel-prefix code touched (PR #348 area) — not the source of this bug.

## Scope boundary

- Does NOT start the compose SSoT refactor (msg#16988 c — awaiting lead approval, separate work).
- Does NOT modify `renderComposer` (composer.ts untouched).
- Does NOT modify the `mention.ts` `#msg-input` lookups (unrelated to this pair of bugs; Overview-compose failure is a separate issue).

## Coordination

- In-flight `feat/url-hash-routing-msg17039` — touches router/boot, unrelated. Stashed on that branch before branching off develop.
- In-flight `fix/last-opened-channel-select-msg17050` — touches sidebar selection, unrelated.
- PR #357 / #358 already merged.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean; `_threadOpenToken` + `myToken !== _threadOpenToken` visible in the emitted bundle (confirms the guard survives minification)
- [ ] Manual verify post-deploy: open a thread via reply icon, confirm a **single** compose input is visible in the popup
- [ ] Manual verify post-deploy: thread with existing replies renders them immediately (not blank / not "no replies yet")
- [ ] Manual verify post-deploy: double-click the reply icon rapidly — still ends up with exactly one composer + correct replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)
