### PR TITLE
fix(ui/display): canonical host alias in chat headers + sidebar (msg#17472)

### DIFF
--- a/hub/frontend/src/app/utils.ts
+++ b/hub/frontend/src/app/utils.ts
@@ -133,6 +133,42 @@ export function escapeHtml(s) {
  * "head-mba"), but the dashboard already shows "@<host>" separately,
  * so the duplication just adds noise. This renderer-level fix keeps
  * the registered IDs intact and only affects display. */
+/**
+ * Display-layer map from raw `hostname(1)` → canonical fleet label.
+ *
+ * msg#17472 — heartbeat payloads now carry the raw `os.hostname()` on
+ * the identity path (lead msg#15578 fix guarantees identity can't be
+ * spoofed via env), which means the display path has to map the raw
+ * value to the short canonical host label (`mba` / `nas` / `spartan`
+ * / `ywata-note-win`). Keys cover both the short form and any common
+ * fqdn the kernel might return.
+ *
+ * Mirrors the server-side ``hostname_aliases`` declared in the shared
+ * config at ``~/.dotfiles/src/.scitex/orochi/shared/config.yaml``. Keep
+ * these two lists in sync when fleet hosts change. todo#fut — serve
+ * the yaml via /api/config so the frontend doesn't need a hard-coded
+ * copy (tracked as the follow-up to this PR).
+ */
+export var HOSTNAME_ALIASES: Record<string, string> = {
+  "Yusukes-MacBook-Air": "mba",
+  "Yusukes-MacBook-Air.local": "mba",
+  "DXP480TPLUS-994": "nas",
+  "nas.local": "nas",
+  "spartan-login1": "spartan",
+  "spartan-login1.hpc.unimelb.edu.au": "spartan",
+  // ywata-note-win is its own canonical label — no entry needed.
+};
+
+/**
+ * Resolve a raw hostname to the short canonical fleet label.
+ * Falls back to the input unchanged for unknown hosts so the UI degrades
+ * gracefully on new machines before HOSTNAME_ALIASES gets updated.
+ */
+export function canonicalHost(raw) {
+  if (!raw) return raw;
+  return HOSTNAME_ALIASES[raw] || raw;
+}
+
 export function cleanAgentName(name) {
   if (!name) return name;
   var parts = name.split("@");
@@ -145,10 +181,16 @@ export function cleanAgentName(name) {
   if (parts.length === 2) {
     var lead = parts[0];
     var host = parts[1];
+    /* msg#17472 — alias-map the embedded host before the dedupe so the
+     * `<role>-<host>@<host>` collapse sees the canonical label on both
+     * sides (e.g. `lead@Yusukes-MacBook-Air` → `lead@mba`,
+     * `head-mba@Yusukes-MacBook-Air` → `head@mba`). */
+    host = canonicalHost(host);
     var suffix = "-" + host;
     if (host && lead.length > suffix.length && lead.endsWith(suffix)) {
       return lead.slice(0, -suffix.length) + "@" + host;
     }
+    return lead + "@" + host;
   }
   return name;
 }
@@ -173,8 +215,9 @@ export function hostedAgentName(a) {
   var host = a && a.hostname ? a.hostname : a && a.machine ? a.machine : "";
   /* Always pipe the constructed "<name>@<host>" string through
    * cleanAgentName so the role-host suffix gets collapsed
-   * (head-mba@mba → head@mba). The earlier form returned the raw
-   * concatenation and the dedupe never fired. */
+   * (head-mba@mba → head@mba) AND the alias-map fires
+   * (lead@Yusukes-MacBook-Air → lead@mba, msg#17472). The earlier form
+   * returned the raw concatenation and neither transform ran. */
   return host ? cleanAgentName(name + "@" + host) : name;
 }
 

--- a/hub/frontend/src/resources-tab/tab.ts
+++ b/hub/frontend/src/resources-tab/tab.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { apiUrl, escapeHtml, getAgentColor } from "../app/utils";
+import { apiUrl, escapeHtml, getAgentColor, HOSTNAME_ALIASES } from "../app/utils";
 import { syncHostHover } from "../connectivity-map";
 import { addTag } from "../filter/state";
 import { _applyMachinesViewVisibility, _machineIcons, _wireMachinesControls, donutHtml, hideMachineTooltip, moveMachineTooltip, resourceData, setMachineIcon, showMachineTooltip } from "./panel";
@@ -324,16 +324,17 @@ export function buildResourceCard(k) {
   return html;
 }
 
-/* todo#337: friendly canonical names so DXP480TPLUS-994 shows as "nas" etc. */
-export var MACHINE_ALIASES = {
-  "DXP480TPLUS-994": "nas",
-  "Yusukes-MacBook-Air.local": "mba",
-  "spartan-login1.hpc.unimelb.edu.au": "spartan",
-  "spartan-login1": "spartan",
-};
+/* todo#337: friendly canonical names so DXP480TPLUS-994 shows as "nas" etc.
+ *
+ * msg#17472 — the alias map used to be hard-coded here (resources tab
+ * local). Consolidated to ``HOSTNAME_ALIASES`` in ``app/utils.ts`` so
+ * the chat header / sidebar / agents-tab all apply the same canonical
+ * labels. Re-export under the old name for any external caller that
+ * still imports it directly. */
+export var MACHINE_ALIASES = HOSTNAME_ALIASES;
 export function _friendlyMachine(raw) {
   if (!raw) return raw;
-  if (MACHINE_ALIASES[raw]) return MACHINE_ALIASES[raw] + " (" + raw + ")";
+  if (HOSTNAME_ALIASES[raw]) return HOSTNAME_ALIASES[raw] + " (" + raw + ")";
   return raw;
 }
 


### PR DESCRIPTION
## Summary

Display-layer fix for the chat header / sidebar showing agents as `lead@Yusukes-MacBook-Air` / `head-mba@Yusukes-MacBook-Air` instead of the canonical `lead@mba` / `head@mba`. Matches ywatanabe's expectation in lead msg#17472.

## Root cause (from diagnosis in #proj-scitex-orochi msg#17485)

The chain is correct up to the display layer:

1. TS sidecar (`ts/mcp_channel/connection.ts`, post-msg#15578) sends raw `os.hostname()` as `machine` + `hostname` — deliberately, so identity can't be spoofed via env.
2. Hub (`hub/consumers/_agent_handlers.py`) forwards those raw fields unchanged.
3. Frontend `hostedAgentName(a)` in `hub/frontend/src/app/utils.ts` does `cleanAgentName(name + "@" + host)`. `cleanAgentName` collapses `<role>-<host>@<host>` but never alias-maps the host. So `Yusukes-MacBook-Air` flowed through unchanged.
4. A partial `MACHINE_ALIASES` map existed in `hub/frontend/src/resources-tab/tab.ts` (Resources-tab local) — but only covered FQDN keys (`Yusukes-MacBook-Air.local`), missing the short form clients actually send after the msg#15578 fix.

## Changes

- **`hub/frontend/src/app/utils.ts`** — add `HOSTNAME_ALIASES` map + `canonicalHost()` helper. Cover both short (`Yusukes-MacBook-Air`) and FQDN (`Yusukes-MacBook-Air.local`) keys for mba / nas / spartan. Wire `cleanAgentName` to alias-map the host before running the dedupe, so `lead@Yusukes-MacBook-Air` → `lead@mba` and `head-mba@Yusukes-MacBook-Air` → `head@mba`.
- **`hub/frontend/src/resources-tab/tab.ts`** — drop the Resources-tab-local copy of `MACHINE_ALIASES`. Import `HOSTNAME_ALIASES` from `app/utils` and re-export `MACHINE_ALIASES` as an alias for backward compat. `_friendlyMachine()` now uses the unified map.

All other display sites (`hub/frontend/src/app/sidebar-agents.ts`, `agent-badge.ts`, `agent-icons.ts`, `activity-tab/row.ts`, `chat/chat-render.ts`) already go through `hostedAgentName`, so they pick up the fix automatically.

## Not changed (by design)

- TS sidecar heartbeat builders — continue to send raw `os.hostname()`.
- Hub `_agent_handlers.py` / `registry/_register.py` — continue to store raw values.
- `hub/tests/registry/test_host_identity_from_client.py` — continues to guard the "no hub-side host derivation" invariant from lead msg#15578.

Keeps the identity layer raw and ghost-agent-resistant; canonical labels are a pure display concern.

## Verification

- `cd hub/frontend && npm run typecheck` → clean
- `cd hub/frontend && npm run build` → 107 modules transformed, 701.77 kB bundle, no errors
- `pytest -q -m "not llm_eval"` → 66 passed, 1 deselected (no identity-layer regression)
- Manually traced: `hostedAgentName({name:"lead", hostname:"Yusukes-MacBook-Air"})` → `"lead@mba"`, `hostedAgentName({name:"head-mba", hostname:"Yusukes-MacBook-Air"})` → `"head@mba"`, `hostedAgentName({name:"healer-nas", hostname:"DXP480TPLUS-994"})` → `"healer@nas"`.

## Follow-up (not in this PR)

The shared config yaml at `~/.dotfiles/src/.scitex/orochi/shared/config.yaml` already declares the canonical `hostname_aliases` map. Serving it via `/api/config` so the frontend doesn't need a hard-coded copy is a long-term cleanup — filed as a note in the `HOSTNAME_ALIASES` docstring. When a new fleet host is added, bump both places until that lands.

## Scope

Display-layer only, two files, no behavior change on identity / storage / write paths. Fleet-lead dispatched per msg#17489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
