### PR TITLE
fix(sidecar): remove receive-side bare #NN issue-ref decoration (#367)

### DIFF
--- a/ts/mcp_channel/dispatch.ts
+++ b/ts/mcp_channel/dispatch.ts
@@ -7,10 +7,6 @@ import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type WebSocket from "ws";
 import { OROCHI_AGENT } from "../src/config.js";
 import { addMessage } from "../src/message_buffer.js";
-import {
-  refreshIssueTitleCache,
-  decorateIssueRefs,
-} from "../src/issue_cache.js";
 import { dbg } from "./guards.js";
 
 // Dedup: track recently delivered message IDs to prevent duplicate notifications
@@ -246,10 +242,10 @@ export async function handleWsMessage(
 
     const attachmentInfo = normalizeAttachments(msg, payload);
 
-    refreshIssueTitleCache();
-    const decoratedContent = decorateIssueRefs(content);
-
-    const notifContent = `${decoratedContent}${attachmentInfo}`;
+    /* Bare-`#NN` decoration intentionally NOT applied: receive-side had no
+     * repo context and pulled titles from hardcoded `ywatanabe1989/todo`,
+     * causing wrong-repo annotations. Matches frontend policy #275. #367. */
+    const notifContent = `${content}${attachmentInfo}`;
     // Meta values must all be strings — Claude Code ignores
     // notifications where meta contains non-string values (numbers, null).
     const notifMeta: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Remove the `decorateIssueRefs(content)` call at `ts/mcp_channel/dispatch.ts:250` (and its now-unused import) so inbound chat messages are delivered to Claude Code verbatim.
- Replace with a short WHY-comment referencing the triage issue so the next reader doesn't restore the call.

## Why

Triaged as part of msg#17550 (see #367 for the full write-up). Root cause: the receive-side decorator pulled titles from a single hardcoded repo (`ywatanabe1989/todo`, `hub/views/github.py:114`) with no per-message repo context, so `#70` in a message about scitex-orochi's PR #70 got annotated with ywatanabe1989/todo#70's unrelated title. Symptom was doubled, wrong-repo parenthesized titles on digest posts (worker-progress msg#17471, msg#17498; mgr-code-quality msg#17548).

Aligns the sidecar notification path with the frontend markdown renderer's policy #275 (`hub/frontend/src/chat/chat-markdown.ts:10-18`) — bare `#N` stays plain, only `owner/repo#N` auto-links. Ambiguity beats wrong-repo noise.

The `ts/src/issue_cache.ts` module is kept in place; it becomes callable infrastructure for the follow-up scoped `owner/repo#N` decorator (triage fix-direction #2 in #367), no changes needed there for this PR.

## Scope

- No behavior change for `owner/repo#N` references (the canonical form, handled by the web renderer).
- No identity / content-layer change.
- No hub-side change.

## Test plan

- [x] `git diff` — 4+/8-, single file, single logical change.
- [ ] CI green (sidecar TS build / typecheck).
- [ ] Post-merge manual: observe a message containing `#70` in any Orochi channel and verify no `(ywatanabe1989/todo-title)` decoration appears in the Claude Code notification.

Closes part of #367 (short-term / option 1). Long-term fix-direction #3 (repo inference from sender context) left as a follow-up.

Dispatched via lead msg#17571 / msg#17577.

🤖 Generated with [Claude Code](https://claude.com/claude-code)