### PR TITLE
fix(mcp/sidecar): drop receiver-side #NN decoration — fixes cross-repo + duplicated-title noise (msg#17571)

### DIFF
--- a/ts/mcp_channel/dispatch.ts
+++ b/ts/mcp_channel/dispatch.ts
@@ -7,10 +7,6 @@ import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type WebSocket from "ws";
 import { OROCHI_AGENT } from "../src/config.js";
 import { addMessage } from "../src/message_buffer.js";
-import {
-  refreshIssueTitleCache,
-  decorateIssueRefs,
-} from "../src/issue_cache.js";
 import { dbg } from "./guards.js";
 
 // Dedup: track recently delivered message IDs to prevent duplicate notifications
@@ -246,10 +242,15 @@ export async function handleWsMessage(
 
     const attachmentInfo = normalizeAttachments(msg, payload);
 
-    refreshIssueTitleCache();
-    const decoratedContent = decorateIssueRefs(content);
-
-    const notifContent = `${decoratedContent}${attachmentInfo}`;
+    // msg#17571 / msg#17577 — receiver-side `#NN (title)` decoration
+    // removed. Sender bots already embed `#NN (gh-title)` at compose
+    // time (scitex-agent-container / mgr-code-quality composers), so
+    // running decorateIssueRefs here produced the duplicated wrong-repo
+    // title pattern observed in msg#17471 / #17498 / #17548. Frontend
+    // policy from #275 / PR #292 already landed the same "bare #N stays
+    // plain text" stance on the renderer side; aligning the sidecar
+    // with it keeps behaviour consistent across both paths.
+    const notifContent = `${content}${attachmentInfo}`;
     // Meta values must all be strings — Claude Code ignores
     // notifications where meta contains non-string values (numbers, null).
     const notifMeta: Record<string, string> = {


### PR DESCRIPTION
## Summary

Drops the receiver-side `#NN (title)` decoration from the MCP channel sidecar. Closes #366 (scitex-orochi part).

## What was broken

The sidecar (`ts/mcp_channel/dispatch.ts:249-250`) called `refreshIssueTitleCache()` + `decorateIssueRefs(content)` on every inbound message before forwarding to Claude Code. The cache was populated from `/api/github/issues` on the default repo (scitex-orochi), so every bare `#NN` in any incoming message got annotated with "whatever scitex-orochi has at number NN" — regardless of what the sender intended.

Two observed failure modes:

1. **Wrong-repo titles.** A `#70` from scitex-agent-container got rendered with scitex-orochi's `#70` title. Even lead's own msg#17571 shipped with `#366 (sbatch claude spawn: auto-accept --dangerously-load-development-channels prompt)` attached to what is actually `triage(display): agent composers bake wrong/duplicated cross-repo #NN titles into messages`.
2. **Duplicated titles.** Senders like worker-progress digests and mgr-code-quality status lines already embed `#NN (gh-title)` at compose time. The sidecar then annotated a second time, producing the observed `#NN (X) (X)` pattern (msg#17471, #17498, #17548).

## Fix

Remove the call. Frontend policy from #275 / PR #292 already landed the same "bare `#N` stays plain text" stance on the chat renderer; aligning the sidecar with it keeps both paths consistent. Senders that want a title must emit `owner/repo#N` (rendered by the frontend) or bake the title in deliberately.

Changes in one file:

- `ts/mcp_channel/dispatch.ts`: drop the two call lines + the two imports + replace `decoratedContent` with raw `content` in the notifContent template. Added an inline comment pointing at msg#17571 / msg#17577 / #275 for future readers.

The helpers in `ts/src/issue_cache.ts` are left as unreferenced exports — tree-shaken from the production bundle (verified below). Kept as a file so a future opt-in expansion feature can reuse the plumbing.

## Verification

- `bun build --target=node ./mcp_channel.ts` → 247 modules bundled in 207 ms, 0.64 MB output, clean.
- `grep decorateIssueRefs` on the built bundle → empty (tree-shaken).
- `pytest -q -m "not llm_eval"` → 66 passed, 1 deselected.
- `grep -rn decorateIssueRefs refreshIssueTitleCache ts/ src/scitex_orochi/_ts/` → only the dead definitions in `issue_cache.ts` remain; no other callers.

## Scope

One-file surgical removal, no behaviour change for senders that use `owner/repo#N` (still rendered by frontend), behaviour change only for bare `#NN` (was: auto-expanded with wrong-repo title, now: plain text — matching frontend policy). Dispatched per msg#17571 / msg#17577.

## Out of scope (follow-up)

- Sender-side composers that embed `#NN (gh-title)` at compose time: that lives in scitex-agent-container / dotfiles shared skills per issue #366. Removing the receiver-side decoration here stops the *doubling*; fully stopping wrong-repo titles requires the sender-side fix too. Tracking in #366.
- Opting the sidecar back into title expansion with a correct-repo resolver (option 2 / option 3 from the msg#17550 triage): intentionally deferred, no urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
