### PR TITLE
fix(ui/sidebar): ⭐ state persists after click — toggle ch-star-on/off too (msg#17599)

### DIFF
--- a/hub/frontend/src/app/channel-prefs.ts
+++ b/hub/frontend/src/app/channel-prefs.ts
@@ -85,6 +85,14 @@ export function _setChannelPref(ch, patch) {
       if (pinEl) {
         pinEl.classList.toggle("ch-pin-on", !!pref.is_starred);
         pinEl.classList.toggle("ch-pin-off", !pref.is_starred);
+        /* msg#17599 — the gold ⭐ color is driven by `.ch-star-on`
+         * (style-channels.css: `color: #f5a623`). Markup at
+         * channel-badge.ts:125-126 emits `ch-pin-on ch-star-on` as a
+         * pair at initial render, so the optimistic toggle must flip
+         * BOTH halves or the persistent state reads from a stale
+         * `.ch-star-off` and the gold color never sticks after click. */
+        pinEl.classList.toggle("ch-star-on", !!pref.is_starred);
+        pinEl.classList.toggle("ch-star-off", !pref.is_starred);
         pinEl.setAttribute(
           "title",
           pref.is_starred ? "Unpin" : "Pin (float to top)",


### PR DESCRIPTION
## Summary

Fixes the sidebar channel ⭐ state not persisting visually after a click (ywatanabe msg#17586 / lead dispatch msg#17599). The star flashed gold during the mousedown press then reverted on release, so pinned channels looked unpinned despite the state being persisted in both the local cache and the `/api/channel-prefs/` server record.

## Root cause

The star element in the channel row is rendered by `hub/frontend/src/channel-badge.ts:125-126` with the *pair* `ch-pin-on ch-star-on` (or `ch-pin-off ch-star-off`):

```ts
'<span class="ch-star ch-pin ' +
(m.isStarred ? "ch-pin-on ch-star-on" : "ch-pin-off ch-star-off") +
```

The persistent gold color lives on `.ch-star-on` in `hub/static/hub/style/style-channels.css:224`:

```css
.ch-star-on { color: #f5a623; }
.ch-pin-on  { opacity: 1; filter: none; }  /* no color */
```

The optimistic re-render in `_setChannelPref` (`channel-prefs.ts:86-87`) toggled only `ch-pin-on`/`ch-pin-off` — never `ch-star-on`/`ch-star-off`. So a star that was off at initial render kept its `ch-star-off` class after a click, the gold-colored `ch-star-on` was never added, and the row looked un-starred. The server round-trip through `fetchStats` did eventually re-render with the correct pair, but the re-render happens on the next stats poll (and may be short-circuited by the throttle path when the `/api/stats` payload is unchanged), so the optimistic-UI gap is what the user actually saw.

## Fix

Toggle both halves of the class pair in lockstep with `is_starred`:

```ts
pinEl.classList.toggle("ch-pin-on", !!pref.is_starred);
pinEl.classList.toggle("ch-pin-off", !pref.is_starred);
pinEl.classList.toggle("ch-star-on", !!pref.is_starred);   // added
pinEl.classList.toggle("ch-star-off", !pref.is_starred);   // added
```

One file, four added lines, no behaviour change on any other path.

## Not changed (by design)

- No server-side or persistence change — `/api/channel-prefs/` and the cache already worked.
- `channel-badge.ts` still renders the `ch-pin-on ch-star-on` pair at initial render.
- The bell/mute and eye-hide toggles in the same block are unaffected.

## Verification

- `cd hub/frontend && npm run typecheck` → clean
- `cd hub/frontend && npm run build` → 107 modules transformed, 701.90 kB bundle, no errors
- `pytest -q -m "not llm_eval"` → 66 passed, 1 deselected
- Manual trace: `_setChannelPref("#foo", { is_starred: true })` on a row whose initial state is off → after toggle, `.ch-pin` element has classes `ch-star ch-pin ch-pin-on ch-star-on`, which matches the initial-render class combination for a starred row. CSS resolves `.ch-star-on { color: #f5a623 }` → gold, persistent.

## Scope

Display-layer, one-file surgical fix. Dispatched per lead msg#17599.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
