### PR TITLE
chore: backport main hotfixes (#363 #368) to develop

### DIFF
--- a/hub/frontend/src/app/utils.ts
+++ b/hub/frontend/src/app/utils.ts
@@ -133,6 +133,42 @@ export function escapeHtml(s) {
  * "head-mba"), but the dashboard already shows "@<host>" separately,
  * so the duplication just adds noise. This renderer-level fix keeps
  * the registered IDs intact and only affects display. */
+/**
+ * Display-layer map from raw `hostname(1)` → canonical fleet label.
+ *
+ * msg#17472 — heartbeat payloads now carry the raw `os.hostname()` on
+ * the identity path (lead msg#15578 fix guarantees identity can't be
+ * spoofed via env), which means the display path has to map the raw
+ * value to the short canonical host label (`mba` / `nas` / `spartan`
+ * / `ywata-note-win`). Keys cover both the short form and any common
+ * fqdn the kernel might return.
+ *
+ * Mirrors the server-side ``hostname_aliases`` declared in the shared
+ * config at ``~/.dotfiles/src/.scitex/orochi/shared/config.yaml``. Keep
+ * these two lists in sync when fleet hosts change. todo#fut — serve
+ * the yaml via /api/config so the frontend doesn't need a hard-coded
+ * copy (tracked as the follow-up to this PR).
+ */
+export var HOSTNAME_ALIASES: Record<string, string> = {
+  "Yusukes-MacBook-Air": "mba",
+  "Yusukes-MacBook-Air.local": "mba",
+  "DXP480TPLUS-994": "nas",
+  "nas.local": "nas",
+  "spartan-login1": "spartan",
+  "spartan-login1.hpc.unimelb.edu.au": "spartan",
+  // ywata-note-win is its own canonical label — no entry needed.
+};
+
+/**
+ * Resolve a raw hostname to the short canonical fleet label.
+ * Falls back to the input unchanged for unknown hosts so the UI degrades
+ * gracefully on new machines before HOSTNAME_ALIASES gets updated.
+ */
+export function canonicalHost(raw) {
+  if (!raw) return raw;
+  return HOSTNAME_ALIASES[raw] || raw;
+}
+
 export function cleanAgentName(name) {
   if (!name) return name;
   var parts = name.split("@");
@@ -145,10 +181,16 @@ export function cleanAgentName(name) {
   if (parts.length === 2) {
     var lead = parts[0];
     var host = parts[1];
+    /* msg#17472 — alias-map the embedded host before the dedupe so the
+     * `<role>-<host>@<host>` collapse sees the canonical label on both
+     * sides (e.g. `lead@Yusukes-MacBook-Air` → `lead@mba`,
+     * `head-mba@Yusukes-MacBook-Air` → `head@mba`). */
+    host = canonicalHost(host);
     var suffix = "-" + host;
     if (host && lead.length > suffix.length && lead.endsWith(suffix)) {
       return lead.slice(0, -suffix.length) + "@" + host;
     }
+    return lead + "@" + host;
   }
   return name;
 }
@@ -173,8 +215,9 @@ export function hostedAgentName(a) {
   var host = a && a.hostname ? a.hostname : a && a.machine ? a.machine : "";
   /* Always pipe the constructed "<name>@<host>" string through
    * cleanAgentName so the role-host suffix gets collapsed
-   * (head-mba@mba → head@mba). The earlier form returned the raw
-   * concatenation and the dedupe never fired. */
+   * (head-mba@mba → head@mba) AND the alias-map fires
+   * (lead@Yusukes-MacBook-Air → lead@mba, msg#17472). The earlier form
+   * returned the raw concatenation and neither transform ran. */
   return host ? cleanAgentName(name + "@" + host) : name;
 }
 

--- a/hub/frontend/src/resources-tab/tab.ts
+++ b/hub/frontend/src/resources-tab/tab.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { apiUrl, escapeHtml, getAgentColor } from "../app/utils";
+import { apiUrl, escapeHtml, getAgentColor, HOSTNAME_ALIASES } from "../app/utils";
 import { syncHostHover } from "../connectivity-map";
 import { addTag } from "../filter/state";
 import { _applyMachinesViewVisibility, _machineIcons, _wireMachinesControls, donutHtml, hideMachineTooltip, moveMachineTooltip, resourceData, setMachineIcon, showMachineTooltip } from "./panel";
@@ -392,16 +392,17 @@ export function buildResourceCard(k) {
   return html;
 }
 
-/* todo#337: friendly canonical names so DXP480TPLUS-994 shows as "nas" etc. */
-export var MACHINE_ALIASES = {
-  "DXP480TPLUS-994": "nas",
-  "Yusukes-MacBook-Air.local": "mba",
-  "spartan-login1.hpc.unimelb.edu.au": "spartan",
-  "spartan-login1": "spartan",
-};
+/* todo#337: friendly canonical names so DXP480TPLUS-994 shows as "nas" etc.
+ *
+ * msg#17472 — the alias map used to be hard-coded here (resources tab
+ * local). Consolidated to ``HOSTNAME_ALIASES`` in ``app/utils.ts`` so
+ * the chat header / sidebar / agents-tab all apply the same canonical
+ * labels. Re-export under the old name for any external caller that
+ * still imports it directly. */
+export var MACHINE_ALIASES = HOSTNAME_ALIASES;
 export function _friendlyMachine(raw) {
   if (!raw) return raw;
-  if (MACHINE_ALIASES[raw]) return MACHINE_ALIASES[raw] + " (" + raw + ")";
+  if (HOSTNAME_ALIASES[raw]) return HOSTNAME_ALIASES[raw] + " (" + raw + ")";
   return raw;
 }
 

--- a/ts/mcp_channel/dispatch.ts
+++ b/ts/mcp_channel/dispatch.ts
@@ -7,10 +7,6 @@ import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type WebSocket from "ws";
 import { OROCHI_AGENT } from "../src/config.js";
 import { addMessage } from "../src/message_buffer.js";
-import {
-  refreshIssueTitleCache,
-  decorateIssueRefs,
-} from "../src/issue_cache.js";
 import { dbg } from "./guards.js";
 
 // Dedup: track recently delivered message IDs to prevent duplicate notifications
@@ -246,10 +242,10 @@ export async function handleWsMessage(
 
     const attachmentInfo = normalizeAttachments(msg, payload);
 
-    refreshIssueTitleCache();
-    const decoratedContent = decorateIssueRefs(content);
-
-    const notifContent = `${decoratedContent}${attachmentInfo}`;
+    /* Bare-`#NN` decoration intentionally NOT applied: receive-side had no
+     * repo context and pulled titles from hardcoded `ywatanabe1989/todo`,
+     * causing wrong-repo annotations. Matches frontend policy #275. #367. */
+    const notifContent = `${content}${attachmentInfo}`;
     // Meta values must all be strings — Claude Code ignores
     // notifications where meta contains non-string values (numbers, null).
     const notifMeta: Record<string, string> = {


### PR DESCRIPTION
## Summary
Cherry-picks two hotfixes that landed on `main` so they also exist on `develop`:
- #363 — canonical host alias resolution in chat headers + sidebar (msg#17472)
- #368 — remove receive-side bare #NN issue-ref decoration (msg#17550 / #367)

Part of the four-machine sync to keep `develop` as the shared working branch.

## Test plan
- [ ] CI green
- [ ] `git diff origin/develop..HEAD` is limited to the two backport commits