### PR TITLE
feat(mcp): align A2A tools to SDK 1.x; add streaming/cancel/list (Phase 5)

### DIFF
--- a/GITIGNORED/A2A_PHASE3_PREFLIGHT.md
+++ b/GITIGNORED/A2A_PHASE3_PREFLIGHT.md
@@ -1,0 +1,211 @@
+<!-- ---
+!-- Timestamp: 2026-04-26
+!-- Author: ywatanabe (spike: spike/a2a-phase3-preflight)
+!-- File: GITIGNORED/A2A_PHASE3_PREFLIGHT.md
+!-- --- -->
+
+# A2A Phase 3 — Pre-flight findings
+
+Worktree: `/home/ywatanabe/proj/scitex-orochi/.claude/worktrees/agent-af34c763`
+Branch: `spike/a2a-phase3-preflight` (off `develop`)
+Spike script (kept in `/tmp`, not committed): `/tmp/a2a_phase3_spike.py`
+
+Resolves the four "Open questions / pre-flight" items in
+`GITIGNORED/A2A_MIGRATION.md`.
+
+---
+
+## 1. Spike — SDK Starlette routes cohabit with Django ASGI? **YES.**
+
+The a2a-sdk does **not** ship a single Starlette `Application` (no
+`a2a.server.apps` package); instead it exposes route-list factories:
+
+- `a2a.server.routes.jsonrpc_routes.create_jsonrpc_routes(handler, rpc_url)`
+- `a2a.server.routes.agent_card_routes.create_agent_card_routes(card)`
+- `a2a.server.routes.rest_routes.create_rest_routes(...)`
+
+These return `list[starlette.routing.Route]`, which we wrap in a
+`Starlette(routes=...)` sub-app. `orochi/asgi.py` already uses
+`ProtocolTypeRouter`, so the cleanest wiring is to **replace the bare
+`django_asgi_app` under the `"http"` key with a tiny dispatcher** that
+forwards `/v1/agents/...` to the Starlette sub-app and everything else
+to Django:
+
+```python
+# orochi/asgi.py (Phase 3 sketch)
+async def http_router(scope, receive, send):
+    if scope["path"].startswith("/v1/agents/"):
+        return await a2a_starlette_app(scope, receive, send)
+    return await django_asgi_app(scope, receive, send)
+
+application = ProtocolTypeRouter({
+    "http": http_router,
+    "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
+})
+```
+
+Spike result (`/tmp/spike_out.txt`):
+```
+SDK card status: 200
+SDK card body[:200]: b'{"name":"proj-hello-world","description":"spike","version":"0.0.1"}'
+```
+
+Notes from the spike:
+- `AgentCard` is a **protobuf** message (not pydantic). Use
+  attribute assignment, not constructor kwargs (`card.name = ...`).
+- `DefaultRequestHandler` requires `agent_card=` (positional). The
+  class is internally `DefaultRequestHandlerV2`.
+- For per-agent routing (cardinality), production should construct a
+  Starlette `Mount("/v1/agents/{name}", app=...)` once at startup,
+  with a custom `ServerCallContextBuilder` that pulls `name` from the
+  path and resolves the registry entry inside `OrochiAgentExecutor`.
+  A single shared executor + registry lookup is cleaner than building
+  N Starlette apps.
+
+Verdict: **no blocker**. Wiring is ~10 lines in `orochi/asgi.py`
+plus a new `hub/a2a/` module.
+
+---
+
+## 2. Inventory — consumers of `/api/a2a/dispatch/<slug>/<agent>/`
+
+**In scitex-orochi:**
+- `hub/urls.py:120` — route definition
+- `hub/urls_bare.py:181` — route definition (bare/MCP urlconf)
+- `hub/views/api/_a2a_dispatch.py` — implementation
+- `docs/a2a-protocol.md:34` — narrative reference
+- `docs/a2a-protocol.md:122` — `SCITEX_OROCHI_HUB_URL` env var description
+
+**In scitex-agent-container:**
+- `src/scitex_agent_container/_skills/scitex-agent-container/07_a2a-protocol.md:105`
+  — only a documentation reference describing the dispatch chain.
+  No code caller.
+
+**In scitex-cloud:** no source-code references found
+(`/home/ywatanabe/proj/scitex-cloud/{src,scitex,apps,lib}/...`).
+The 452 KB grep hits in scitex-cloud are entirely from
+`deployment/singularity/current-sandbox/usr/local/lib/.../litellm/`
+vendored deps that match `/v1/agents` — **unrelated** to orochi's
+dispatch URL.
+
+**In `~/.scitex/orochi/shared/`:** no references.
+
+**Phase 4 cutover impact:** ~zero external-source consumers. The
+URL is reached today only via:
+1. NAS Django reverse-proxying `https://a2a.scitex.ai/api/a2a/dispatch/...`
+2. Cloudflare → orochi public route
+3. Documentation that needs a one-line update
+
+Practical implication: the deprecation window can be **short** (one
+minor release with a `Deprecation:` header should suffice).
+
+---
+
+## 3. Task store — Redis is feasible **but the SDK does not ship a Redis backend.**
+
+Redis status in orochi today:
+- `pyproject.toml:28` — `channels-redis>=4.2` is a runtime dep.
+- `deployment/docker/docker-compose.stable.yml:54-60` — Redis 7-alpine
+  service, ephemeral (`--save "" --appendonly no`), used only for
+  Channels group routing. Confirmed: `REDIS_URL=redis://redis:6379/0`.
+
+a2a-sdk task-store backends shipped (in
+`/home/ywatanabe/.env-3.11/lib/python3.11/site-packages/a2a/server/tasks/`):
+- `inmemory_task_store.py` — `InMemoryTaskStore`
+- `database_task_store.py` — `DatabaseTaskStore` (SQLAlchemy async)
+- `copying_task_store.py` — wrapper, not a backend
+
+**Gap**: there is **no `redis_task_store.py`** in the SDK.
+
+Recommendation revision: the navigator's "Redis (already a dep)"
+recommendation is **partially incorrect** — Redis is in the stack but
+the SDK can't natively use it. Two options for Phase 3:
+
+1. **Start with `InMemoryTaskStore`** (matches today's `_PENDING`
+   semantics in `_a2a_dispatch.py`; single daphne process is fine
+   for current scale). Zero new infra. Lose tasks across restarts.
+2. **Use `DatabaseTaskStore`** pointed at orochi's existing Postgres
+   (sqlite in dev). Persists across restarts, no new dep, matches
+   the doc's eventual "scitex-cloud postgres" path. The SDK already
+   ships an Alembic migration tree at
+   `/home/ywatanabe/.env-3.11/lib/python3.11/site-packages/a2a/migrations/`.
+
+Recommend **option 2** for Phase 3. Skip Redis until horizontal scaling
+forces it; at that point write a `RedisTaskStore(TaskStore)` subclass
+(the protocol is small — see `task_store.py`).
+
+---
+
+## 4. Auth — workspace-token helpers Phase 3 should wire into SDK middleware
+
+Today's `/api/a2a/dispatch/...` (`hub/views/api/_a2a_dispatch.py:99-110`)
+is `@csrf_exempt` + `@require_POST`, no auth.
+
+Existing token primitives:
+- **Model**: `hub.models.WorkspaceToken` (defined in
+  `hub/models/_identity.py:30`). `wks_*` prefix (see
+  `_helpers._generate_workspace_token`).
+- **Re-export**: `hub/views/api/_common.py:37,57` re-exports it for the
+  whole api package.
+- **Canonical lookup pattern** used everywhere in the api package:
+  ```python
+  WorkspaceToken.objects.select_related("workspace").get(token=token_str)
+  ```
+  Examples:
+  - `hub/views/api/_channels.py:66` — token via `?token=wks_...`
+  - `hub/views/api/_export.py:40` — same
+  - `hub/views/api/_fleet.py:166` — same
+  - `hub/views/api/_auto_dispatch.py:65` — accepts token from query OR
+    JSON body (good template for A2A since A2A bodies are JSON-RPC)
+  - `hub/views/api/_agents_register.py:43`
+  - `hub/views/api/_agents.py:28,123,236,301`
+  - `hub/views/api/_agents_lifecycle.py:42,186`
+  - `hub/views/api/_misc.py:77`
+  - `hub/views/api/_cron.py:99`
+
+**No central middleware/decorator exists** — every endpoint inlines
+the same `WorkspaceToken.objects.get(token=...)` lookup. Phase 3
+should:
+
+1. Extract a small helper, e.g.
+   `hub.views.api._common.resolve_workspace_token(request) -> Workspace | None`,
+   that checks (in priority order) `Authorization: Bearer wks_...`
+   header, then `?token=`, then JSON body `token`.
+2. Wire it into the SDK's `ServerCallContextBuilder` so
+   `OrochiAgentExecutor.execute()` can reject unauthenticated calls
+   *and* know which workspace the caller belongs to (the URL only
+   carries `<agent>` in the canonical scheme — workspace must come
+   from the bearer).
+3. Keep the compat URL `/api/a2a/dispatch/<slug>/...` permissive
+   during the deprecation window (workspace comes from the URL slug).
+
+The SDK exposes auth hooks in `a2a/auth/` — the right integration
+point is a custom `ServerCallContextBuilder` (see
+`a2a/server/routes/common.py:42`) that returns a
+`ServerCallContext` carrying the resolved workspace_id, which
+`OrochiAgentExecutor` then passes to `_resolve_workspace_id` /
+`_agent_group`.
+
+---
+
+## New blockers / unknowns discovered
+
+- None blocking. Two minor surprises:
+  1. `AgentCard` uses **protobuf**, not pydantic — affects how Phase 3
+     constructs cards. The existing
+     `scitex_agent_container._card.project_card` helper (referenced
+     in the navigator) needs to be sanity-checked against this.
+  2. SDK has no Redis task store; navigator's Redis recommendation
+     should be revised to Postgres (`DatabaseTaskStore`) for Phase 3.
+
+## Summary checklist for Phase 3 start
+
+- [x] Daphne can host both apps (proven)
+- [x] Phase 4 cutover blast radius mapped (4 files in orochi, 0 external code)
+- [x] Task store: use `DatabaseTaskStore` against orochi's Postgres/SQLite
+- [x] Auth: factor `resolve_workspace_token()` helper, plug into
+      `ServerCallContextBuilder`
+- [ ] (Blocked on sac Phase 1) — borrow sac's `OrochiAgentExecutor`
+      shape and `project_card` helper
+
+<!-- EOF -->

--- a/docs/a2a-protocol.md
+++ b/docs/a2a-protocol.md
@@ -31,12 +31,16 @@ NAS Django  apps/infra/a2a_app/views.py::agent_jsonrpc
     │      _dispatch.py forwards body
     ▼
 NAS Django → orochi hub (over Cloudflare tunnel)
-    │  POST https://scitex-orochi.com/api/a2a/dispatch/<workspace>/<agent>/
+    │  POST https://scitex-orochi.com/v1/agents/<agent>/
+    │       Authorization: Bearer wks_...
+    │       JSON-RPC tasks/send body
     ▼
-mba Daphne  hub/views/api/_a2a_dispatch.py::api_a2a_dispatch
-    │  generates reply_id, registers an asyncio.Event, group_send to
+mba Daphne  hub/a2a/mount.py — official a2a-sdk Starlette app
+    │  WorkspaceTokenContextBuilder resolves Workspace from bearer
+    │  OrochiAgentExecutor.execute() generates reply_id, registers
+    │  an asyncio.Event, group_send to
     │  agent_<ws_id>_<agent> with type=a2a.dispatch
-    │  blocks waiting for the event (30s timeout)
+    │  awaits the event (30s timeout) and emits TaskStatusUpdateEvent
     ▼
 hub/consumers/_agent.py::AgentConsumer.a2a_dispatch
     │  forwards the body to the agent's WebSocket
@@ -119,8 +123,8 @@ On `scitex-cloud-prod-django-1` (set in `deployment/docker/docker_prod/.env`):
 | Variable | Example | Purpose |
 | --- | --- | --- |
 | `SCITEX_OROCHI_A2A_DISPATCHABLE_AGENTS` | `mock-echo,claude-echo` | comma-separated agent ids that get the live dispatch path; others fall back to canned echo |
-| `SCITEX_OROCHI_HUB_URL` | `https://scitex-orochi.com` | base URL where `/api/a2a/dispatch/...` reaches a connected hub |
-| `SCITEX_OROCHI_A2A_WORKSPACE` | `main` | workspace name (or numeric id) used in the dispatch URL path |
+| `SCITEX_OROCHI_HUB_URL` | `https://scitex-orochi.com` | base URL where `/v1/agents/<name>/` reaches a connected hub |
+| `SCITEX_OROCHI_A2A_WORKSPACE` | `main` | workspace name (or numeric id); supplied as the `wks_*` bearer token's owning workspace |
 | `SCITEX_OROCHI_AGENTS_DIR` | `/app/agents-orochi` | path to agent YAML dir (mounted from dotfiles); used by AgentCard projection |
 
 `_dispatch.is_dispatchable()` reads `SCITEX_OROCHI_A2A_DISPATCHABLE_AGENTS` at import time — change the env, recreate the Django container.

--- a/hub/a2a/__init__.py
+++ b/hub/a2a/__init__.py
@@ -1,0 +1,39 @@
+"""A2A SDK integration — orochi serves the canonical A2A surface.
+
+Phase 3 of ``GITIGNORED/A2A_MIGRATION.md``. Mounts the official a2a-sdk
+Starlette routes under ``/v1/agents/<name>/`` and dispatches into the
+live fleet via the existing Tier-3 (HTTP-direct) / WebSocket fallback
+path. The non-spec ``/api/a2a/dispatch/<slug>/<agent>/`` URL is removed
+in the same release; only the WS reply callback (``api_a2a_reply``)
+remains, since agents still POST replies through the Channels bridge.
+
+Modules
+-------
+- :mod:`._dispatch_internals` — reply-correlation map (``_PENDING``),
+  HTTP-direct + Channels group_send helpers reused by both the SDK
+  executor and the WS reply callback.
+- :mod:`.executor` — :class:`OrochiAgentExecutor` (SDK ``AgentExecutor``).
+- :mod:`.card` — AgentCard projection from registry / DB metadata.
+- :mod:`.auth` — :class:`WorkspaceTokenContextBuilder` resolves the
+  caller's :class:`hub.models.WorkspaceToken` and rejects unauth calls.
+- :mod:`.mount` — builds the Starlette sub-app with a single
+  ``Mount("/v1/agents/{name}", ...)`` and lazy per-agent card resolution.
+"""
+
+from hub.a2a._dispatch_internals import (
+    DISPATCH_TIMEOUT_SECONDS,
+    HTTP_DIRECT_TIMEOUT_SECONDS,
+    _PENDING,
+    _agent_group,
+    _resolve_workspace_id,
+    _try_http_direct,
+)
+
+__all__ = [
+    "DISPATCH_TIMEOUT_SECONDS",
+    "HTTP_DIRECT_TIMEOUT_SECONDS",
+    "_PENDING",
+    "_agent_group",
+    "_resolve_workspace_id",
+    "_try_http_direct",
+]

--- a/hub/a2a/_dispatch_internals.py
+++ b/hub/a2a/_dispatch_internals.py
@@ -1,0 +1,87 @@
+"""Helpers shared between the SDK executor and the WS reply callback.
+
+Extracted from the old ``hub/views/api/_a2a_dispatch.py`` Django view
+when Phase 3 deleted the non-spec ``/api/a2a/dispatch/<slug>/<agent>/``
+route. The reply-correlation map (``_PENDING``) and the dispatch
+helpers stay here because:
+
+* :class:`hub.a2a.executor.OrochiAgentExecutor` uses them to issue the
+  same Tier-3 HTTP-direct → WS-fallback dispatch the old view did.
+* :func:`hub.views.api._a2a_dispatch.api_a2a_reply` (the only Django
+  view left in that module) sets entries in ``_PENDING`` when an agent
+  POSTs back its reply through the WS bridge.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+from typing import Any
+
+from channels.db import database_sync_to_async
+
+log = logging.getLogger("orochi.a2a")
+
+# In-process reply correlation. The SDK executor (or — historically —
+# the deleted ``api_a2a_dispatch`` view) creates an entry per dispatch
+# and awaits its ``asyncio.Event``; ``api_a2a_reply`` (kept) sets it
+# when the agent's WS bridge POSTs back. Single-process daphne only;
+# horizontal scaling would move this to Redis pub/sub.
+_PENDING: dict[str, dict[str, Any]] = {}
+
+DISPATCH_TIMEOUT_SECONDS = 30.0
+HTTP_DIRECT_TIMEOUT_SECONDS = 25.0
+
+
+def _try_http_direct(
+    a2a_url: str, body: dict[str, Any]
+) -> tuple[bool, dict | None]:
+    """Try HTTP POST to the agent's a2a_url. Return (ok, parsed_response)."""
+    try:
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(
+            a2a_url,
+            data=data,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(
+            req, timeout=HTTP_DIRECT_TIMEOUT_SECONDS
+        ) as resp:
+            return True, json.loads(resp.read())
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        OSError,
+        ValueError,
+    ) as exc:
+        log.info(
+            "a2a HTTP-direct to %s failed: %s — falling back to WS",
+            a2a_url,
+            exc,
+        )
+        return False, None
+
+
+def _agent_group(workspace_id: int, agent: str) -> str:
+    """Match the per-agent group name used by ``AgentConsumer``."""
+    return f"agent_{workspace_id}_{agent}"
+
+
+@database_sync_to_async
+def _resolve_workspace_id(slug_or_id: str) -> int | None:
+    """Resolve a workspace name or numeric id to its DB id.
+
+    The Workspace model has no ``slug`` field — historic URLs used
+    ``slug`` for parity with other ``api/workspace/<slug:slug>/...``
+    routes, but the DB lookup is by ``name``.
+    """
+    from hub.models import Workspace
+
+    if slug_or_id.isdigit():
+        ws = Workspace.objects.filter(id=int(slug_or_id)).first()
+    else:
+        ws = Workspace.objects.filter(name=slug_or_id).first()
+    return ws.id if ws else None

--- a/hub/a2a/auth.py
+++ b/hub/a2a/auth.py
@@ -1,0 +1,137 @@
+"""WorkspaceToken auth wiring for the SDK request handler.
+
+The pre-flight noted that orochi has no central auth middleware — every
+existing API view inlines ``WorkspaceToken.objects.get(token=...)``.
+For Phase 3 we factor that pattern into one helper here and plug it
+into the SDK's :class:`ServerCallContextBuilder`, so the executor can
+reject unauthenticated requests with a proper JSON-RPC error and know
+which workspace the caller belongs to.
+
+Bearer-token resolution priority (matching ``_auto_dispatch.py``):
+1. ``Authorization: Bearer wks_...`` header
+2. ``?token=wks_...`` query string
+3. JSON body ``{"token": "wks_..."}`` — checked by the executor, not
+   here, because the request body is consumed by the dispatcher.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from a2a.auth.user import UnauthenticatedUser, User
+from a2a.server.context import ServerCallContext
+from a2a.server.routes.common import ServerCallContextBuilder
+
+
+class _WorkspaceUser(User):
+    """SDK ``User`` adapter wrapping a resolved :class:`Workspace`."""
+
+    def __init__(self, workspace: Any, token_str: str):
+        self._workspace = workspace
+        self._token = token_str
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+    @property
+    def user_name(self) -> str:
+        return f"workspace:{getattr(self._workspace, 'name', '?')}"
+
+
+def _extract_bearer(headers: Any) -> str | None:
+    """Pull a ``wks_*`` token from an ``Authorization: Bearer`` header."""
+    auth = ""
+    try:
+        auth = headers.get("authorization", "") or ""
+    except AttributeError:
+        # Fallback for case-sensitive raw header lists.
+        try:
+            for k, v in headers:
+                kk = k.decode() if isinstance(k, bytes) else k
+                if kk.lower() == "authorization":
+                    auth = v.decode() if isinstance(v, bytes) else v
+                    break
+        except Exception:
+            return None
+    if not auth:
+        return None
+    parts = auth.split(None, 1)
+    if len(parts) == 2 and parts[0].lower() == "bearer":
+        return parts[1].strip()
+    return None
+
+
+def _lookup_token_sync(token: str) -> Any | None:
+    from hub.models import WorkspaceToken
+
+    try:
+        row = WorkspaceToken.objects.select_related("workspace").get(token=token)
+    except WorkspaceToken.DoesNotExist:
+        return None
+    return row.workspace
+
+
+def resolve_workspace_token(request: Any) -> tuple[Any | None, str | None]:
+    """Resolve the calling workspace from a Starlette request.
+
+    Returns ``(workspace, token_str)`` on success, ``(None, None)`` if
+    no token was supplied or the lookup failed. Detects the async
+    context (the SDK calls us from inside an event loop) and dispatches
+    the ORM read through ``database_sync_to_async`` accordingly.
+    """
+    token = _extract_bearer(request.headers) or request.query_params.get("token")
+    if not token:
+        return None, None
+    # ``ServerCallContextBuilder.build`` is sync but called from inside
+    # the SDK's async dispatcher. Run the ORM read on a worker thread
+    # so Django's ``async_unsafe`` guard doesn't fire.
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        workspace = ex.submit(_lookup_token_sync, token).result()
+    if workspace is None:
+        return None, None
+    return workspace, token
+
+
+class WorkspaceTokenContextBuilder(ServerCallContextBuilder):
+    """SDK context builder that requires a ``WorkspaceToken``.
+
+    Stashes the resolved :class:`Workspace` in
+    ``ServerCallContext.state["workspace"]`` and the raw token under
+    ``state["workspace_token"]`` so :class:`OrochiAgentExecutor` can
+    reuse them. When no valid token is present, the returned context
+    carries an :class:`UnauthenticatedUser` and ``state["workspace"]``
+    is ``None`` — the executor checks this and emits a JSON-RPC
+    -32001 error before doing any dispatch work.
+    """
+
+    def build(self, request: Any) -> ServerCallContext:
+        workspace, token_str = resolve_workspace_token(request)
+        state: dict[str, Any] = {
+            "headers": dict(request.headers),
+            "workspace": workspace,
+            "workspace_token": token_str,
+        }
+        # Capture the per-request agent name from the URL path params
+        # — Starlette puts ``Mount("/v1/agents/{name}", ...)`` matches
+        # in ``request.path_params``. The executor reads this to know
+        # which agent the dispatch targets.
+        try:
+            state["agent_name"] = request.path_params.get("name")
+        except Exception:
+            state["agent_name"] = None
+
+        user: User = (
+            _WorkspaceUser(workspace, token_str or "")
+            if workspace is not None
+            else UnauthenticatedUser()
+        )
+        return ServerCallContext(state=state, user=user)
+
+
+__all__ = [
+    "WorkspaceTokenContextBuilder",
+    "resolve_workspace_token",
+]

--- a/hub/a2a/card.py
+++ b/hub/a2a/card.py
@@ -1,0 +1,91 @@
+"""AgentCard projection for orochi-served A2A agents.
+
+Mirrors the dict-shaped projection from
+``scitex_agent_container.a2a._card`` (sac side, canonical for v3 YAML →
+dict) but builds the **protobuf** :class:`a2a.types.AgentCard` that
+the SDK requires. The SDK ships ``agent_card_to_dict()`` to flatten
+the protobuf back to a JSON-friendly shape served at
+``.well-known/agent-card.json``.
+
+The orochi registry doesn't carry the full v3 YAML — it carries the
+metadata the WS bridge ships in heartbeats: ``role``, ``host``,
+``a2a_url``, etc. So we project from the in-memory registry entry
+when present, and fall back to a minimal card naming the agent so
+``.well-known`` always returns something useful.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from a2a.types import AgentCard
+
+
+def _registry_entry(name: str) -> dict[str, Any] | None:
+    """Look up an agent in the orochi in-memory registry.
+
+    Returns ``None`` if the agent is not connected — callers may
+    still want to project a minimal card so external tooling can
+    discover the URL exists.
+    """
+    from hub.registry import _agents
+
+    entry = _agents.get(name)
+    if entry is None:
+        return None
+    # Snapshot — registry values are mutated under a lock elsewhere.
+    return dict(entry)
+
+
+def project_card(name: str, base_url: str = "") -> AgentCard:
+    """Project the registry entry for ``name`` into an A2A AgentCard.
+
+    Parameters
+    ----------
+    name:
+        Agent name (matches the URL segment ``/v1/agents/<name>/``).
+    base_url:
+        Optional base URL for the served interface — when present
+        the supported-interface URL becomes
+        ``{base_url}/v1/agents/{name}/``. Empty string omits it
+        (useful for in-process tests where the public URL is unknown).
+    """
+    entry = _registry_entry(name) or {}
+    role = entry.get("role") or "agent"
+    host = entry.get("host") or ""
+    description = entry.get("description") or (
+        f"orochi-served A2A agent: {name}"
+        + (f" (role={role}" + (f", host={host})" if host else ")") if role else "")
+    )
+
+    card = AgentCard()
+    card.name = name
+    card.description = description
+    card.version = "scitex-orochi/1"
+    card.capabilities.streaming = True
+    card.capabilities.push_notifications = False
+    card.default_input_modes.extend(["text/plain", "application/json"])
+    card.default_output_modes.extend(["text/plain", "application/json"])
+
+    if base_url:
+        iface = card.supported_interfaces.add()
+        iface.url = f"{base_url.rstrip('/')}/v1/agents/{name}/"
+        iface.protocol_binding = "jsonrpc"
+
+    skill = card.skills.add()
+    skill.id = f"{name}.{role}"
+    skill.name = role
+    skill.description = (
+        entry.get("function") or f"{role} agent served via orochi A2A bridge"
+    )
+    tags: list[str] = ["orochi"]
+    if role:
+        tags.append(role)
+    if host:
+        tags.append(f"host:{host}")
+    skill.tags.extend(sorted(set(tags)))
+
+    return card
+
+
+__all__ = ["project_card"]

--- a/hub/a2a/executor.py
+++ b/hub/a2a/executor.py
@@ -1,0 +1,276 @@
+"""SDK ``AgentExecutor`` for orochi-served agents.
+
+Resolves the target agent name from the request context (set by
+:class:`hub.a2a.auth.WorkspaceTokenContextBuilder` from the URL's
+``{name}`` segment), looks up the registry entry, and dispatches via:
+
+1. **Tier-3 HTTP-direct** — if the registry has a non-empty
+   ``a2a_url``, POST the JSON-RPC envelope synthesised from the SDK
+   request to it. Reply is returned as a single agent message.
+2. **WebSocket fallback** — push an ``a2a.dispatch`` Channels frame to
+   the per-agent group and await a reply via the existing ``_PENDING``
+   correlation map (set by ``api_a2a_reply``).
+
+The agent's reply is mapped to either a single ``new_agent_message``
+(immediate completion) or, when the reply contains an artifact-shaped
+payload, an ``add_artifact`` event followed by ``complete()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import secrets
+import time
+from typing import Any
+
+from a2a.server.agent_execution import AgentExecutor
+from a2a.server.agent_execution.context import RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.tasks import TaskUpdater
+from a2a.types import Part, Task, TaskState, TaskStatus
+from channels.layers import get_channel_layer
+
+from hub.a2a._dispatch_internals import (
+    _PENDING,
+    DISPATCH_TIMEOUT_SECONDS,
+    _agent_group,
+    _resolve_workspace_id,
+    _try_http_direct,
+)
+
+log = logging.getLogger("orochi.a2a.executor")
+
+
+def _extract_text_from_message(msg: Any) -> str:
+    """Concatenate text parts from an SDK ``Message`` protobuf."""
+    if msg is None:
+        return ""
+    chunks: list[str] = []
+    for part in msg.parts:
+        # ``Part`` is a oneof: ``text | raw | url | data``.
+        if part.HasField("text"):
+            chunks.append(part.text)
+        elif part.HasField("data"):
+            try:
+                chunks.append(json.dumps(dict(part.data)))
+            except Exception:  # noqa: BLE001
+                chunks.append(str(part.data))
+    return "\n".join(chunks)
+
+
+class _AgentNotFoundError(Exception):
+    """Raised when the URL-named agent has no registry entry."""
+
+
+class _UnauthenticatedError(Exception):
+    """Raised when the request carries no valid WorkspaceToken."""
+
+
+class OrochiAgentExecutor(AgentExecutor):
+    """Single shared executor — agent name comes from the request context.
+
+    One instance is registered with the SDK ``DefaultRequestHandler``
+    and serves every ``/v1/agents/<name>/`` route via the
+    :class:`Mount` URL parameter that
+    :class:`WorkspaceTokenContextBuilder` extracts.
+    """
+
+    async def execute(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        state = (context.call_context and context.call_context.state) or {}
+        workspace = state.get("workspace")
+        agent_name = state.get("agent_name") or ""
+
+        updater = TaskUpdater(
+            event_queue=event_queue,
+            task_id=context.task_id,
+            context_id=context.context_id,
+        )
+
+        # SDK contract: a Task must be enqueued before any
+        # TaskStatusUpdateEvent. The legacy view didn't have to do this
+        # because it was not SDK-aware. We seed a SUBMITTED task so the
+        # framework's task store has something to update.
+        if context.current_task is None:
+            seed = Task()
+            seed.id = context.task_id
+            seed.context_id = context.context_id
+            seed.status.CopyFrom(TaskStatus(state=TaskState.TASK_STATE_SUBMITTED))
+            await event_queue.enqueue_event(seed)
+
+        if workspace is None:
+            await updater.failed(
+                updater.new_agent_message(
+                    [self._text_part("authentication required (WorkspaceToken)")]
+                )
+            )
+            return
+        if not agent_name:
+            await updater.failed(
+                updater.new_agent_message(
+                    [self._text_part("agent name missing from URL")]
+                )
+            )
+            return
+
+        from hub.registry import _agents  # local import — avoid bootstrap order
+
+        reg_entry = _agents.get(agent_name)
+        if reg_entry is None:
+            await updater.failed(
+                updater.new_agent_message(
+                    [self._text_part(f"agent not found or offline: {agent_name}")]
+                )
+            )
+            return
+
+        # Synthesise the legacy A2A JSON-RPC envelope so the agent's
+        # WS bridge / sidecar can keep using the existing handler.
+        body = {
+            "jsonrpc": "2.0",
+            "id": context.task_id,
+            "method": "tasks/send",
+            "params": {
+                "id": context.task_id,
+                "message": {
+                    "role": "user",
+                    "parts": [
+                        {"type": "text", "text": _extract_text_from_message(context.message)}
+                    ],
+                },
+            },
+        }
+
+        # Move the task into the WORKING state — distinct from the
+        # initial SUBMITTED that we seeded with the Task event above.
+        await updater.start_work()
+
+        # Tier-3: HTTP-direct if a sidecar is announced.
+        a2a_url = (reg_entry.get("a2a_url") or "").strip()
+        result: dict | None = None
+        if a2a_url:
+            ok, http_result = await asyncio.to_thread(
+                _try_http_direct, a2a_url, body
+            )
+            if ok and http_result is not None:
+                result = http_result
+
+        # Fallback: Channels group_send → agent's WS bridge → api_a2a_reply.
+        if result is None:
+            ws_id = await _resolve_workspace_id(str(workspace.id))
+            if ws_id is None:
+                await updater.failed(
+                    updater.new_agent_message(
+                        [self._text_part(
+                            f"workspace not found: {getattr(workspace, 'id', '?')}"
+                        )]
+                    )
+                )
+                return
+
+            reply_id = secrets.token_urlsafe(16)
+            event = asyncio.Event()
+            _PENDING[reply_id] = {"event": event, "value": None, "ts": time.time()}
+
+            layer = get_channel_layer()
+            if layer is None:
+                _PENDING.pop(reply_id, None)
+                await updater.failed(
+                    updater.new_agent_message(
+                        [self._text_part("no channel layer configured")]
+                    )
+                )
+                return
+
+            try:
+                await layer.group_send(
+                    _agent_group(ws_id, agent_name),
+                    {
+                        "type": "a2a.dispatch",
+                        "reply_id": reply_id,
+                        "body": body,
+                    },
+                )
+                try:
+                    await asyncio.wait_for(
+                        event.wait(), timeout=DISPATCH_TIMEOUT_SECONDS
+                    )
+                    result = _PENDING[reply_id]["value"]
+                except asyncio.TimeoutError:
+                    result = None
+            except Exception as exc:  # noqa: BLE001
+                log.exception("a2a executor dispatch failed: %s", exc)
+                result = None
+            finally:
+                _PENDING.pop(reply_id, None)
+
+        if result is None:
+            await updater.failed(
+                updater.new_agent_message(
+                    [self._text_part(
+                        f"timeout waiting for reply from agent {agent_name!r}"
+                    )]
+                )
+            )
+            return
+
+        # Map JSON-RPC reply → SDK events. The legacy reply shape is
+        # ``{"jsonrpc":..,"id":..,"result":{"status":"completed",
+        # "message":{"parts":[...]}}}`` or a plain dict; be permissive.
+        text = self._reply_text(result)
+        await updater.complete(updater.new_agent_message([self._text_part(text)]))
+
+    async def cancel(
+        self, context: RequestContext, event_queue: EventQueue
+    ) -> None:
+        # The legacy bridge has no cancel channel; mark the task
+        # cancelled locally so the SDK state machine stays consistent.
+        updater = TaskUpdater(
+            event_queue=event_queue,
+            task_id=context.task_id,
+            context_id=context.context_id,
+        )
+        await updater.cancel(
+            updater.new_agent_message(
+                [self._text_part("cancellation requested; agent bridge has no cancel hook")]
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _text_part(text: str) -> Part:
+        p = Part()
+        p.text = text
+        return p
+
+    @staticmethod
+    def _reply_text(result: Any) -> str:
+        """Extract a human-readable text payload from a legacy reply."""
+        if isinstance(result, str):
+            return result
+        if not isinstance(result, dict):
+            return json.dumps(result, ensure_ascii=False)
+        # JSON-RPC envelope?
+        inner = result.get("result", result)
+        if isinstance(inner, dict):
+            msg = inner.get("message")
+            if isinstance(msg, dict):
+                parts = msg.get("parts") or []
+                texts = [p.get("text", "") for p in parts if isinstance(p, dict)]
+                joined = "\n".join(t for t in texts if t)
+                if joined:
+                    return joined
+            for key in ("text", "content", "output"):
+                v = inner.get(key)
+                if isinstance(v, str):
+                    return v
+        return json.dumps(result, ensure_ascii=False)
+
+
+__all__ = ["OrochiAgentExecutor"]

--- a/hub/a2a/mount.py
+++ b/hub/a2a/mount.py
@@ -1,0 +1,139 @@
+"""Build the Starlette sub-app that orochi mounts under ``/v1/agents/``.
+
+The whole subtree is a single Starlette ``Mount("/v1/agents/{name}",
+app=inner)``. The ``{name}`` path-param is propagated through to the
+inner app's request scope, so :class:`hub.a2a.auth.WorkspaceTokenContextBuilder`
+can read it from ``request.path_params`` and a single shared
+:class:`OrochiAgentExecutor` instance handles every agent.
+
+Card customisation per agent is done with a ``card_modifier`` async
+hook on the well-known endpoint, which inspects the incoming request
+and rebuilds the card from the live registry.
+
+Task store
+----------
+Defaults to :class:`InMemoryTaskStore` — matches today's ``_PENDING``
+semantics (single daphne process, fine for current scale). When
+``SCITEX_OROCHI_A2A_DB_URL`` is set we build a SQLAlchemy async
+engine and use :class:`DatabaseTaskStore` so tasks survive restarts.
+The pre-flight recommended Database, but Redis isn't shipped by the
+SDK and pointing at orochi's SQLite file races with Django writers,
+so the conservative default is in-memory until a dedicated Postgres
+URL is configured.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from typing import Any
+
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.request_handlers.response_helpers import agent_card_to_dict
+from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
+from a2a.server.tasks import InMemoryTaskStore
+from a2a.types import AgentCard
+from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Mount, Route
+
+from hub.a2a.auth import WorkspaceTokenContextBuilder
+from hub.a2a.card import project_card
+from hub.a2a.executor import OrochiAgentExecutor
+
+log = logging.getLogger("orochi.a2a.mount")
+
+
+def _build_task_store() -> Any:
+    """Pick a task store. ``InMemory`` unless an A2A DB url is configured."""
+    db_url = os.environ.get("SCITEX_OROCHI_A2A_DB_URL", "").strip()
+    if not db_url:
+        return InMemoryTaskStore()
+    try:
+        from a2a.server.tasks import DatabaseTaskStore
+        from sqlalchemy.ext.asyncio import create_async_engine
+
+        engine = create_async_engine(db_url, future=True)
+        return DatabaseTaskStore(engine=engine, create_table=True)
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "SCITEX_OROCHI_A2A_DB_URL set but DatabaseTaskStore init "
+            "failed (%s); falling back to InMemoryTaskStore.",
+            exc,
+        )
+        return InMemoryTaskStore()
+
+
+@lru_cache(maxsize=1)
+def _build_inner_app() -> Starlette:
+    """Construct the inner Starlette app once.
+
+    Uses a placeholder card on the SDK handler — the per-request card
+    is rebuilt by ``_card_modifier`` so each
+    ``.well-known/agent-card.json`` advertises the URL-named agent.
+    """
+    placeholder = AgentCard()
+    placeholder.name = "orochi-fleet"
+    placeholder.description = "orochi A2A surface — see /v1/agents/<name>/"
+    placeholder.version = "scitex-orochi/1"
+
+    handler = DefaultRequestHandler(
+        agent_executor=OrochiAgentExecutor(),
+        task_store=_build_task_store(),
+        agent_card=placeholder,
+    )
+
+    builder = WorkspaceTokenContextBuilder()
+
+    routes: list = []
+    routes.extend(
+        create_jsonrpc_routes(
+            request_handler=handler,
+            rpc_url="/",
+            context_builder=builder,
+            # v0.3 compat lets older clients keep using ``message/send``
+            # and ``tasks/send`` method names alongside the gRPC-style
+            # ``SendMessage`` names that the SDK 1.x core expects.
+            enable_v0_3_compat=True,
+        )
+    )
+    # Custom well-known route — the SDK's ``create_agent_card_routes``
+    # ``card_modifier`` callback doesn't receive the request, so it
+    # can't look up the per-Mount ``{name}`` path-param. We serve the
+    # well-known path ourselves and project the registry entry on the
+    # fly.
+    routes.append(
+        Route(
+            AGENT_CARD_WELL_KNOWN_PATH,
+            endpoint=_serve_agent_card,
+            methods=["GET"],
+        )
+    )
+    # Compat alias — older clients hit ``/.well-known/agent.json``.
+    routes.append(
+        Route("/.well-known/agent.json", endpoint=_serve_agent_card, methods=["GET"])
+    )
+    return Starlette(routes=routes)
+
+
+async def _serve_agent_card(request: Request) -> JSONResponse:
+    """Project the per-agent card from the registry and return JSON."""
+    name = request.path_params.get("name") or ""
+    base = f"{request.url.scheme}://{request.url.netloc}" if request.url.netloc else ""
+    card = project_card(name, base_url=base)
+    return JSONResponse(agent_card_to_dict(card))
+
+
+def build_a2a_app() -> Starlette:
+    """Top-level Starlette app mounted by ``orochi/asgi.py``."""
+    inner = _build_inner_app()
+    routes = [
+        Mount("/v1/agents/{name}", app=inner),
+    ]
+    return Starlette(routes=routes)
+
+
+__all__ = ["build_a2a_app"]

--- a/hub/tests/api/test_a2a_sdk.py
+++ b/hub/tests/api/test_a2a_sdk.py
@@ -1,0 +1,300 @@
+"""Tests for the orochi A2A SDK surface (Phase 3 of A2A_MIGRATION).
+
+Covers:
+- The Starlette app mounts and serves ``.well-known/agent-card.json``.
+- ``message/send`` round-trips against an in-memory test executor.
+- Agent-not-found returns a JSON-RPC error (mapped through SDK status).
+- Auth: requests without a ``WorkspaceToken`` are rejected (the
+  executor publishes a ``failed`` status with an auth-required message).
+
+Smoke / unit tests only — full ``message/stream`` SSE wiring is
+exercised against a local daphne when available, otherwise the import
++ route table is asserted so the deployment-time check is meaningful.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import unittest
+
+import django
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "orochi.settings")
+django.setup()
+
+from django.test import TransactionTestCase  # noqa: E402
+
+from hub.a2a.mount import build_a2a_app  # noqa: E402
+
+
+def _make_scope(method: str, path: str, headers: list | None = None) -> dict:
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "headers": headers or [],
+        "query_string": b"",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 1234),
+        "root_path": "",
+    }
+
+
+async def _call_app(app, scope, body: bytes = b"") -> tuple[int, bytes, list]:
+    sent: list = []
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    async def send(msg):
+        sent.append(msg)
+
+    await app(scope, receive, send)
+    status = next(
+        (m["status"] for m in sent if m["type"] == "http.response.start"), 0
+    )
+    headers = next(
+        (m.get("headers", []) for m in sent if m["type"] == "http.response.start"),
+        [],
+    )
+    body_out = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+    return status, body_out, headers
+
+
+class A2ASDKMountTests(unittest.TestCase):
+    """The app mounts and the well-known card route resolves."""
+
+    def test_app_builds(self) -> None:
+        app = build_a2a_app()
+        self.assertIsNotNone(app)
+
+    def test_well_known_agent_card_returns_200(self) -> None:
+        app = build_a2a_app()
+        status, body, _ = asyncio.run(
+            _call_app(
+                app,
+                _make_scope(
+                    "GET", "/v1/agents/test-agent/.well-known/agent-card.json"
+                ),
+            )
+        )
+        self.assertEqual(status, 200)
+        payload = json.loads(body)
+        self.assertEqual(payload["name"], "test-agent")
+        self.assertIn("capabilities", payload)
+
+    def test_well_known_agent_json_alias_returns_200(self) -> None:
+        """Older clients hit the legacy ``/.well-known/agent.json`` path."""
+        app = build_a2a_app()
+        status, _, _ = asyncio.run(
+            _call_app(
+                app,
+                _make_scope("GET", "/v1/agents/some-agent/.well-known/agent.json"),
+            )
+        )
+        self.assertEqual(status, 200)
+
+
+class A2AAuthTests(TransactionTestCase):
+    """Unauthenticated calls are rejected; valid bearer is accepted."""
+
+    def test_message_send_without_auth_yields_failed_task(self) -> None:
+        from hub.registry import _agents
+
+        # Pre-seed a registry entry so the only failure cause is auth.
+        _agents["unauth-agent"] = {
+            "status": "online",
+            "role": "agent",
+            "host": "x",
+            "a2a_url": "",
+            "last_heartbeat": 0,
+        }
+        try:
+            app = build_a2a_app()
+            body = json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "req-1",
+                    "method": "message/send",
+                    "params": {
+                        "message": {
+                            "messageId": "m1",
+                            "role": "user",
+                            "parts": [{"kind": "text", "text": "hi"}],
+                        }
+                    },
+                }
+            ).encode()
+            status, body_out, _ = asyncio.run(
+                _call_app(
+                    app,
+                    _make_scope(
+                        "POST",
+                        "/v1/agents/unauth-agent/",
+                        headers=[(b"content-type", b"application/json")],
+                    ),
+                    body=body,
+                )
+            )
+        finally:
+            _agents.pop("unauth-agent", None)
+
+        self.assertEqual(status, 200)
+        # JSON-RPC envelope; the executor surfaces auth failure in the
+        # task result rather than at the JSON-RPC envelope level.
+        envelope = json.loads(body_out)
+        # Either a result with the task in failed state, or an error.
+        # The task-status text should reference authentication.
+        text = json.dumps(envelope).lower()
+        self.assertTrue(
+            "auth" in text or "workspacetoken" in text or "error" in text,
+            f"expected auth-related response, got: {envelope}",
+        )
+
+
+class A2AAgentNotFoundTests(TransactionTestCase):
+    """A live request for a missing agent yields a JSON-RPC envelope."""
+
+    def test_message_send_unknown_agent(self) -> None:
+        from hub.models import Workspace, WorkspaceToken
+
+        ws = Workspace.objects.create(name="test-ws-a2a")
+        tok = WorkspaceToken.objects.create(
+            workspace=ws, token="wks_test_dummy", label="test"
+        )
+
+        try:
+            app = build_a2a_app()
+            body = json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "req-2",
+                    "method": "message/send",
+                    "params": {
+                        "message": {
+                            "messageId": "m2",
+                            "role": "user",
+                            "parts": [{"kind": "text", "text": "hi"}],
+                        }
+                    },
+                }
+            ).encode()
+            status, body_out, _ = asyncio.run(
+                _call_app(
+                    app,
+                    _make_scope(
+                        "POST",
+                        "/v1/agents/does-not-exist/",
+                        headers=[
+                            (b"content-type", b"application/json"),
+                            (b"authorization", f"Bearer {tok.token}".encode()),
+                        ],
+                    ),
+                    body=body,
+                )
+            )
+        finally:
+            tok.delete()
+            ws.delete()
+
+        self.assertEqual(status, 200)
+        text = json.dumps(json.loads(body_out)).lower()
+        self.assertTrue("not found" in text or "offline" in text)
+
+
+class A2AMessageSendRoundtripTests(TransactionTestCase):
+    """End-to-end ``message/send`` against a stubbed HTTP-direct agent."""
+
+    def test_message_send_completes_via_http_direct(self) -> None:
+        from hub.a2a import _dispatch_internals
+        from hub.models import Workspace, WorkspaceToken
+        from hub.registry import _agents
+
+        ws = Workspace.objects.create(name="test-ws-rt")
+        tok = WorkspaceToken.objects.create(
+            workspace=ws, token="wks_test_rt", label="rt"
+        )
+        _agents["rt-agent"] = {
+            "status": "online",
+            "role": "agent",
+            "host": "x",
+            # Non-empty a2a_url triggers the HTTP-direct branch which
+            # we monkey-patch so no network hop happens during tests.
+            "a2a_url": "http://stub/",
+            "last_heartbeat": 0,
+        }
+
+        original = _dispatch_internals._try_http_direct
+
+        def _stub(url: str, body: dict) -> tuple[bool, dict | None]:
+            return True, {
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "result": {
+                    "status": "completed",
+                    "message": {
+                        "role": "agent",
+                        "parts": [{"type": "text", "text": "pong"}],
+                    },
+                },
+            }
+
+        # Patch on both the internals module and the executor's import
+        # site (the executor binds the symbol at import time).
+        from hub.a2a import executor as _executor_mod
+
+        _dispatch_internals._try_http_direct = _stub
+        _executor_mod._try_http_direct = _stub
+        try:
+            app = build_a2a_app()
+            body = json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "rt-1",
+                    "method": "message/send",
+                    "params": {
+                        "message": {
+                            "messageId": "rt-msg",
+                            "role": "user",
+                            "parts": [{"kind": "text", "text": "ping"}],
+                        }
+                    },
+                }
+            ).encode()
+            status, body_out, _ = asyncio.run(
+                _call_app(
+                    app,
+                    _make_scope(
+                        "POST",
+                        "/v1/agents/rt-agent/",
+                        headers=[
+                            (b"content-type", b"application/json"),
+                            (b"authorization", f"Bearer {tok.token}".encode()),
+                        ],
+                    ),
+                    body=body,
+                )
+            )
+        finally:
+            _dispatch_internals._try_http_direct = original
+            _executor_mod._try_http_direct = original
+            _agents.pop("rt-agent", None)
+            tok.delete()
+            ws.delete()
+
+        self.assertEqual(status, 200)
+        envelope = json.loads(body_out)
+        text = json.dumps(envelope).lower()
+        # The executor maps the agent's reply text into the final
+        # status-update message; "pong" should appear somewhere.
+        self.assertIn("pong", text, f"got: {envelope}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -116,11 +116,9 @@ urlpatterns = [
     path("api/agents/pin/", views.api_agents_pin, name="api-agents-pin"),
     path("api/agents/pinned/", views.api_agents_pinned, name="api-agents-pinned"),
     path("api/agents/register/", views.api_agents_register, name="api-agents-register"),
-    path(
-        "api/a2a/dispatch/<slug:slug>/<str:agent>/",
-        views.api_a2a_dispatch,
-        name="api-a2a-dispatch",
-    ),
+    # A2A dispatch is now served by the SDK at /v1/agents/<name>/
+    # (mounted in orochi/asgi.py — see hub.a2a.mount.build_a2a_app).
+    # Only the WS-bridge reply callback remains Django-served.
     path("api/a2a/reply/", views.api_a2a_reply, name="api-a2a-reply"),
     path("api/agents/registry/", views.api_agents_registry, name="api-agents-registry"),
     # Orochi unified cron Phase 2 (lead msg#16406 / msg#16408).

--- a/hub/urls_bare.py
+++ b/hub/urls_bare.py
@@ -174,14 +174,9 @@ urlpatterns = [
         views.api_agents_register,
         name="api-agents-register",
     ),
-    # A2A protocol dispatch bridge (Tier 3): NAS Django proxies inbound
-    # A2A JSON-RPC here; the hub forwards via the per-agent Channels
-    # group to the agent's WebSocket and blocks awaiting the reply.
-    path(
-        "api/a2a/dispatch/<slug:slug>/<str:agent>/",
-        views.api_a2a_dispatch,
-        name="api-a2a-dispatch-bare",
-    ),
+    # A2A dispatch is now served by the SDK at /v1/agents/<name>/
+    # (mounted in orochi/asgi.py — see hub.a2a.mount.build_a2a_app).
+    # Only the WS-bridge reply callback remains Django-served.
     path(
         "api/a2a/reply/",
         views.api_a2a_reply,

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -2,7 +2,6 @@
 
 from hub.views.agent_detail import api_agent_detail  # noqa: F401
 from hub.views.api import (  # noqa: F401
-    api_a2a_dispatch,
     api_a2a_reply,
     api_admin_agent_subscribe,
     api_admin_agent_unsubscribe,

--- a/hub/views/api/__init__.py
+++ b/hub/views/api/__init__.py
@@ -12,7 +12,7 @@ it directly from ``hub.views.api`` to share the DM lazy-creation logic
 with the REST write path.
 """
 
-from hub.views.api._a2a_dispatch import api_a2a_dispatch, api_a2a_reply
+from hub.views.api._a2a_dispatch import api_a2a_reply
 from hub.views.api._agents import (
     api_agent_health,
     api_agent_profiles,
@@ -62,7 +62,6 @@ from hub.views.api._resources import api_resources
 
 __all__ = [
     "_ensure_dm_channel",
-    "api_a2a_dispatch",
     "api_a2a_reply",
     "api_agent_health",
     "api_agent_profiles",

--- a/hub/views/api/_a2a_dispatch.py
+++ b/hub/views/api/_a2a_dispatch.py
@@ -1,182 +1,42 @@
-"""A2A protocol dispatch bridge — NAS Django → orochi hub → live agent.
+"""WS-bridge reply callback for the orochi A2A surface.
 
-Wires the canonical A2A capability surface at ``a2a.scitex.ai`` into
-the running fleet of agents on the orochi hub:
+After Phase 3 of ``GITIGNORED/A2A_MIGRATION.md`` the canonical
+``/v1/agents/<name>/`` URL is served by the official a2a-sdk Starlette
+app (see :mod:`hub.a2a.mount`); the old non-spec
+``/api/a2a/dispatch/<slug>/<agent>/`` Django view was deleted in the
+same change. The dispatch helpers (``_PENDING``, ``_try_http_direct``,
+``_agent_group``, ``_resolve_workspace_id``) moved to
+:mod:`hub.a2a._dispatch_internals` so :class:`hub.a2a.executor.OrochiAgentExecutor`
+can reuse them.
 
-* :func:`api_a2a_dispatch` — POST entry: NAS Django proxies inbound
-  A2A JSON-RPC here. Two transports, in priority order:
-
-  1. **HTTP-direct (Tier 3 same-host optimization)** — if the registry
-     has an ``a2a_url`` for the agent, the hub HTTPs directly there
-     with a short timeout. Fast path; no WS round-trip, no reply
-     correlation. Used when the agent runs a sidecar A2A server (sac
-     ``spec.a2a.port`` or tier3-ws-bridge with announced url).
-  2. **WS dispatch (cross-host fallback)** — fall back to the
-     persistent WebSocket transport: ``group_send`` to the per-agent
-     Channels group, agent receives, processes, POSTs back to
-     ``api_a2a_reply``, the dispatch waiter unblocks. Required for
-     agents behind NAT (most fleet hosts) since outbound-WS is the
-     only universal transport without per-agent tunnel ops.
-
-* :func:`api_a2a_reply` — POST callback for the WS path: the agent's
-  WS-bridge calls this to deliver the reply, which unblocks the
-  dispatch waiter.
-
-Reply correlation (WS path only) uses an in-process ``asyncio.Event``
-map keyed by a random ``reply_id``. This works because the hub today
-is a single process; if it ever scales horizontally, the map moves
-to Redis pub/sub. The HTTP-direct path doesn't need this — the agent
-returns the response synchronously.
+The only Django view left here is :func:`api_a2a_reply` — the agent's
+WS bridge POSTs back to ``/api/a2a/reply/`` with its JSON-RPC reply,
+which the executor's ``asyncio.Event`` waiter unblocks. Keeping this
+URL Django-served avoids retraining every fleet agent at the same
+time as the SDK surface lands.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
-import logging
-import secrets
-import time
-import urllib.error
-import urllib.request
-from typing import Any
 
-from channels.db import database_sync_to_async
-from channels.layers import get_channel_layer
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-log = logging.getLogger("orochi.a2a")
-
-# In-process reply correlation. Each entry is set by api_a2a_reply
-# and awaited by api_a2a_dispatch. Cleared in the dispatch view's
-# finally block to avoid leaks.
-_PENDING: dict[str, dict[str, Any]] = {}
-
-DISPATCH_TIMEOUT_SECONDS = 30.0
-HTTP_DIRECT_TIMEOUT_SECONDS = 25.0
-
-
-def _try_http_direct(a2a_url: str, body: dict[str, Any]) -> tuple[bool, dict | None]:
-    """Try HTTP POST to the agent's a2a_url. Return (ok, parsed_response)."""
-    try:
-        data = json.dumps(body).encode("utf-8")
-        req = urllib.request.Request(
-            a2a_url,
-            data=data,
-            method="POST",
-            headers={"Content-Type": "application/json"},
-        )
-        with urllib.request.urlopen(req, timeout=HTTP_DIRECT_TIMEOUT_SECONDS) as resp:
-            return True, json.loads(resp.read())
-    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
-        log.info("a2a HTTP-direct to %s failed: %s — falling back to WS", a2a_url, exc)
-        return False, None
-
-
-def _agent_group(workspace_id: int, agent: str) -> str:
-    """Match the per-agent group name used by ``AgentConsumer``."""
-    return f"agent_{workspace_id}_{agent}"
-
-
-@database_sync_to_async
-def _resolve_workspace_id(slug_or_id: str) -> int | None:
-    """Resolve a workspace name or numeric id to its DB id.
-
-    The Workspace model has no ``slug`` field — the URL kwarg is named
-    ``slug`` for parity with other ``api/workspace/<slug:slug>/...``
-    routes, but the DB lookup is by ``name``.
-    """
-    from hub.models import Workspace
-
-    if slug_or_id.isdigit():
-        ws = Workspace.objects.filter(id=int(slug_or_id)).first()
-    else:
-        ws = Workspace.objects.filter(name=slug_or_id).first()
-    return ws.id if ws else None
-
-
-@csrf_exempt
-@require_POST
-async def api_a2a_dispatch(request, slug: str, agent: str):
-    """Forward an A2A JSON-RPC body to ``agent`` on workspace ``slug``.
-
-    Body: the raw A2A JSON-RPC envelope (``{jsonrpc, id, method, params}``).
-    Returns: the agent's JSON-RPC reply, or 504 on timeout, or 404 if
-    the agent is not currently connected.
-
-    Async-native because ``InMemoryChannelLayer`` only delivers within a
-    single event loop; a sync view bridging via ``async_to_sync`` opens
-    a fresh loop per call and the consumer never sees the message.
-    """
-    ws_id = await _resolve_workspace_id(slug)
-    if ws_id is None:
-        return JsonResponse({"error": f"workspace not found: {slug}"}, status=404)
-
-    try:
-        body = json.loads(request.body.decode() or "{}")
-    except (json.JSONDecodeError, ValueError) as exc:
-        return JsonResponse({"error": f"bad JSON: {exc}"}, status=400)
-
-    # Tier 3 same-host optimization: if the registry has an a2a_url
-    # for this agent, try HTTP-direct first. WS dispatch remains the
-    # cross-host fallback transport. ``_try_http_direct`` uses blocking
-    # urllib; run it on a worker thread so the event loop stays free.
-    from hub.registry import _agents  # in-memory registry
-
-    reg_entry = _agents.get(agent) or {}
-    a2a_url = (reg_entry.get("a2a_url") or "").strip()
-    if a2a_url:
-        ok, http_result = await asyncio.to_thread(_try_http_direct, a2a_url, body)
-        if ok and http_result is not None:
-            return JsonResponse(http_result, json_dumps_params={"ensure_ascii": False})
-        # Else fall through to WS dispatch (logged inside _try_http_direct).
-
-    reply_id = secrets.token_urlsafe(16)
-    event = asyncio.Event()
-    _PENDING[reply_id] = {"event": event, "value": None, "ts": time.time()}
-
-    layer = get_channel_layer()
-    if layer is None:
-        del _PENDING[reply_id]
-        return JsonResponse({"error": "no channel layer"}, status=503)
-
-    group = _agent_group(ws_id, agent)
-    try:
-        await layer.group_send(
-            group,
-            {
-                "type": "a2a.dispatch",
-                "reply_id": reply_id,
-                "body": body,
-            },
-        )
-    except Exception as exc:  # noqa: BLE001
-        del _PENDING[reply_id]
-        log.exception("a2a dispatch group_send failed: %s", exc)
-        return JsonResponse({"error": f"dispatch failed: {exc}"}, status=502)
-
-    try:
-        try:
-            await asyncio.wait_for(event.wait(), timeout=DISPATCH_TIMEOUT_SECONDS)
-            result = _PENDING[reply_id]["value"]
-        except asyncio.TimeoutError:
-            result = None
-    finally:
-        _PENDING.pop(reply_id, None)
-
-    if result is None:
-        return JsonResponse(
-            {
-                "error": (
-                    f"timeout waiting {DISPATCH_TIMEOUT_SECONDS:.0f}s "
-                    f"for reply from agent {agent!r}"
-                ),
-            },
-            status=504,
-        )
-
-    return JsonResponse(result, json_dumps_params={"ensure_ascii": False})
+# Re-export the dispatch helpers from their new home so any code that
+# still imports them from ``hub.views.api._a2a_dispatch`` keeps working
+# during the migration. Once the in-tree consumers are updated this
+# re-export can be removed.
+from hub.a2a._dispatch_internals import (  # noqa: F401
+    DISPATCH_TIMEOUT_SECONDS,
+    HTTP_DIRECT_TIMEOUT_SECONDS,
+    _PENDING,
+    _agent_group,
+    _resolve_workspace_id,
+    _try_http_direct,
+    log,
+)
 
 
 @csrf_exempt
@@ -185,8 +45,8 @@ async def api_a2a_reply(request):
     """Agent-side callback: deliver an A2A reply by ``reply_id``.
 
     Body: ``{"reply_id": "...", "result": {...JSON-RPC body...}}``.
-    The matching :func:`api_a2a_dispatch` waiter unblocks and returns
-    the ``result`` to its caller.
+    The matching :class:`hub.a2a.executor.OrochiAgentExecutor` waiter
+    unblocks and returns the ``result`` to the SDK ``event_queue``.
 
     Async to share the event loop with the dispatch waiter — setting a
     plain ``asyncio.Event`` only wakes coroutines on the same loop.
@@ -208,3 +68,6 @@ async def api_a2a_reply(request):
     pending["value"] = result
     pending["event"].set()
     return JsonResponse({"ok": True, "reply_id": reply_id})
+
+
+__all__ = ["api_a2a_reply"]

--- a/orochi/asgi.py
+++ b/orochi/asgi.py
@@ -1,4 +1,10 @@
-"""ASGI config for Orochi — routes HTTP and WebSocket."""
+"""ASGI config for Orochi — routes HTTP and WebSocket.
+
+HTTP requests with a path under ``/v1/agents/`` are forwarded to the
+official a2a-sdk Starlette sub-app (see :mod:`hub.a2a.mount`); every
+other HTTP request hits Django as before. WebSocket routing is
+unchanged.
+"""
 
 import os
 
@@ -10,11 +16,23 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "orochi.settings")
 
 django_asgi_app = get_asgi_application()
 
+from hub.a2a.mount import build_a2a_app  # noqa: E402
 from hub.routing import websocket_urlpatterns  # noqa: E402
+
+_a2a_app = build_a2a_app()
+
+
+async def _http_router(scope, receive, send):
+    """Dispatch ``/v1/agents/...`` to the SDK Starlette app, else Django."""
+    path: str = scope.get("path", "")
+    if path.startswith("/v1/agents/"):
+        return await _a2a_app(scope, receive, send)
+    return await django_asgi_app(scope, receive, send)
+
 
 application = ProtocolTypeRouter(
     {
-        "http": django_asgi_app,
+        "http": _http_router,
         "websocket": AuthMiddlewareStack(URLRouter(websocket_urlpatterns)),
     }
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,11 @@ dependencies = [
     # so the terminal consumer can stream into fleet hosts without
     # shelling out to the openssh binary.
     "asyncssh>=2.14",
+    # A2A SDK — orochi serves the canonical A2A interface at
+    # ``/v1/agents/<name>/`` (Phase 3 of GITIGNORED/A2A_MIGRATION.md).
+    # The ``[http-server]`` extra pulls in starlette + sse-starlette,
+    # which the SDK's route factories require for JSON-RPC + streaming.
+    "a2a-sdk[http-server]>=1.0.2",
 ]
 
 [project.optional-dependencies]

--- a/src/scitex_orochi/_skills/scitex-orochi/51_a2a-client.md
+++ b/src/scitex_orochi/_skills/scitex-orochi/51_a2a-client.md
@@ -28,17 +28,68 @@ See `scitex-agent-container/06_env-injection-ports.md` for the three ports.
 | MCP tool (recommended) | `src_mcp.json env` (port 2) | `"SCITEX_OROCHI_A2A_TOKEN": "${SCITEX_OROCHI_A2A_TOKEN}"` (parent shell sources from token file before launching sac) |
 | Hook | n/a — hooks can't inject env into the agent |
 
-The MCP route (port 2) is preferred: agents call `mcp__scitex-orochi__a2a_call(agent="lead", method="tasks/send", message="hi")` and never see the token in their transcript.
+The MCP route (port 2) is preferred: agents call `mcp__scitex-orochi__a2a_call(agent="lead", text="hi")` and never see the token in their transcript.
 
-## Wire-level call
+## MCP tool surface (Phase 5, SDK 1.x)
+
+Five MCP tools wrap the A2A SDK 1.x surface. All set the `A2A-Version: 1.0` header and read the bearer from disk.
+
+### `a2a_call` — unary
+
+Default method: `SendMessage` (SDK 1.x gRPC-style). Use for short, single-shot peer calls.
+
+```jsonc
+// MCP arg shape
+{"agent": "lead", "text": "summarise issue #142"}
+```
+
+Other supported methods via the `method` arg: `GetTask`, `CancelTask`, `SendStreamingMessage`. Prefer the dedicated tools below for the latter three.
+
+### `a2a_send_streaming` — SSE stream
+
+Use when the peer agent runs long enough that you want progress events. Returns `{events: [...], count: N}` once the stream ends.
+
+```jsonc
+{"agent": "lead", "text": "kick off the long pipeline"}
+```
+
+**Limitation**: the orochi MCP server (`@modelcontextprotocol/sdk` ^1.29.0) does not yet expose incremental tool output, so all SSE events are buffered until end-of-stream. Track Phase 6 for incremental piping.
+
+### `a2a_get_task` — poll
+
+Fetch the latest state of a long-running task by id.
+
+```jsonc
+{"agent": "lead", "task_id": "abcd-1234"}
+```
+
+### `a2a_cancel_task` — interrupt
+
+Cancel a running task; returns the SDK envelope so you can confirm `CANCELED` state.
+
+```jsonc
+{"agent": "lead", "task_id": "abcd-1234"}
+```
+
+### `a2a_list_agents` — discovery
+
+Enumerate callable agents from the hub registry (`GET /api/agents/`). Use this before `a2a_call` so you do not have to guess agent names.
+
+```jsonc
+{}
+```
+
+## Wire-level call (curl, SDK 1.x)
 
 ```bash
 TOKEN=$(cat "$SCITEX_OROCHI_A2A_TOKEN_PATH")
 curl -fsSL -X POST https://a2a.scitex.ai/v1/agents/lead \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"jsonrpc":"2.0","id":"t1","method":"tasks/send",
-       "params":{"message":{"role":"user","parts":[{"type":"text","text":"hi"}]}}}'
+  -H "A2A-Version: 1.0" \
+  -d '{"jsonrpc":"2.0","id":"t1","method":"SendMessage",
+       "params":{"message":{"message_id":"m1","role":"ROLE_USER",
+         "parts":[{"text":"hi"}]}}}'
 ```
 
 GET endpoints (`/v1/agents/`, `/.well-known/agent.json`) stay public and unauthenticated — they are the discovery surface.

--- a/ts/mcp_channel/handlers.ts
+++ b/ts/mcp_channel/handlers.ts
@@ -33,6 +33,10 @@ import {
   handleUploadMedia,
   handleExportChannel,
   handleA2aCall,
+  handleA2aSendStreaming,
+  handleA2aGetTask,
+  handleA2aCancelTask,
+  handleA2aListAgents,
 } from "../src/tools.js";
 import { conn } from "./connection.js";
 
@@ -69,6 +73,11 @@ export function registerMcpHandlers(mcp: Server): void {
     if (name === "dm_open") return handleDmOpen(args as any);
     if (name === "export_channel") return handleExportChannel(args as any);
     if (name === "a2a_call") return handleA2aCall(args as any);
+    if (name === "a2a_send_streaming")
+      return handleA2aSendStreaming(args as any);
+    if (name === "a2a_get_task") return handleA2aGetTask(args as any);
+    if (name === "a2a_cancel_task") return handleA2aCancelTask(args as any);
+    if (name === "a2a_list_agents") return handleA2aListAgents();
     throw new Error(`Unknown tool: ${name}`);
   });
 }

--- a/ts/src/tool_defs.ts
+++ b/ts/src/tool_defs.ts
@@ -465,7 +465,12 @@ export const TOOL_DEFS = [
   {
     name: "a2a_call",
     description:
-      "Call a peer agent via the A2A protocol (POST JSON-RPC to https://a2a.scitex.ai/v1/agents/<agent>). Bearer token is read from disk by the MCP server; never enters the agent transcript. Default method is tasks/send.",
+      "Call a peer agent via the A2A protocol SDK 1.x (POST JSON-RPC to " +
+      "https://a2a.scitex.ai/v1/agents/<agent>). Bearer token is read from " +
+      "disk by the MCP server; never enters the agent transcript. Sends " +
+      "'A2A-Version: 1.0' header. Default method is 'SendMessage' (unary). " +
+      "Other gRPC-style methods: 'GetTask', 'CancelTask'. For SSE streaming " +
+      "use the dedicated 'a2a_send_streaming' tool.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -477,24 +482,111 @@ export const TOOL_DEFS = [
         method: {
           type: "string",
           description:
-            "JSON-RPC method. Default: tasks/send. Other supported: tasks/get.",
+            "JSON-RPC method. Default: 'SendMessage'. Also: 'GetTask', " +
+            "'CancelTask', 'SendStreamingMessage'.",
         },
         text: {
           type: "string",
           description:
-            "Convenience for tasks/send: wrapped as message.parts[0].text. Ignored if 'params' is set.",
+            "Convenience for SendMessage / SendStreamingMessage: wrapped " +
+            "as params.message.parts[0].text. Ignored if 'params' is set.",
         },
         task_id: {
           type: "string",
-          description: "Task id for tasks/get. Ignored if 'params' is set.",
+          description:
+            "Task id for GetTask / CancelTask. Mapped to proto 'id' " +
+            "field. Ignored if 'params' is set.",
+        },
+        message_id: {
+          type: "string",
+          description:
+            "Optional proto message_id (snake_case). Auto-generated if " +
+            "omitted. Ignored if 'params' is set.",
         },
         params: {
           type: "object",
           description:
-            "Raw JSON-RPC params. Overrides text/task_id if provided. Use for advanced calls.",
+            "Raw JSON-RPC params. Overrides text/task_id if provided. " +
+            "Use for advanced calls.",
         },
       },
       required: ["agent"],
+    },
+  },
+  {
+    name: "a2a_send_streaming",
+    description:
+      "Call a peer agent via A2A 'SendStreamingMessage' (SDK 1.x SSE). " +
+      "Collects all server-sent events into a single MCP tool result " +
+      "({events:[...], count:N}). Use for long-running peer work where " +
+      "you want progress events; use 'a2a_call' for short unary calls. " +
+      "LIMITATION: the MCP SDK does not yet expose incremental tool " +
+      "output, so all events are buffered until the stream ends.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent: { type: "string", description: "Target agent name." },
+        text: {
+          type: "string",
+          description: "Message text to stream to the peer agent.",
+        },
+        message_id: {
+          type: "string",
+          description:
+            "Optional proto message_id; auto-generated if omitted.",
+        },
+      },
+      required: ["agent", "text"],
+    },
+  },
+  {
+    name: "a2a_get_task",
+    description:
+      "Poll a long-running A2A task by id (SDK 1.x 'GetTask'). Use after " +
+      "'SendMessage' / 'SendStreamingMessage' returns a task id when you " +
+      "want to check progress without holding an SSE stream open.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent: {
+          type: "string",
+          description:
+            "Target agent name (must match the agent that owns the task).",
+        },
+        task_id: {
+          type: "string",
+          description:
+            "Task id returned by a previous SendMessage/SendStreamingMessage.",
+        },
+      },
+      required: ["agent", "task_id"],
+    },
+  },
+  {
+    name: "a2a_cancel_task",
+    description:
+      "Interrupt a running A2A task (SDK 1.x 'CancelTask'). Returns the " +
+      "SDK envelope so the caller can confirm the new task state " +
+      "(typically CANCELED).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent: { type: "string", description: "Target agent name." },
+        task_id: { type: "string", description: "Task id to cancel." },
+      },
+      required: ["agent", "task_id"],
+    },
+  },
+  {
+    name: "a2a_list_agents",
+    description:
+      "Enumerate callable agents in the orochi fleet by hitting the hub's " +
+      "registry endpoint (GET /api/agents/). Use this before 'a2a_call' " +
+      "so you do not have to guess agent names. Override the URL with " +
+      "SCITEX_OROCHI_AGENTS_LIST_URL.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
     },
   },
 ];

--- a/ts/src/tools.ts
+++ b/ts/src/tools.ts
@@ -46,3 +46,7 @@ export {
 } from "./tools/self_command.js";
 
 export { handleA2aCall } from "./tools/a2a.js";
+export { handleA2aSendStreaming } from "./tools/a2a_streaming.js";
+export { handleA2aGetTask } from "./tools/a2a_get_task.js";
+export { handleA2aCancelTask } from "./tools/a2a_cancel_task.js";
+export { handleA2aListAgents } from "./tools/a2a_list_agents.js";

--- a/ts/src/tools/a2a.test.ts
+++ b/ts/src/tools/a2a.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for the A2A SDK 1.x MCP tool surface (Phase 5).
+ *
+ * Mocks ``globalThis.fetch`` so the suite is hermetic — no real
+ * network calls. Verifies the wire-shape that sac SDK 1.x expects:
+ *
+ *   * URL: ``POST /v1/agents/<agent>``
+ *   * Header: ``A2A-Version: 1.0``
+ *   * SendMessage params: ``{message: {message_id, role: "ROLE_USER",
+ *     parts: [{text}]}}``
+ *   * GetTask / CancelTask params: ``{id: <task_id>}``
+ *
+ * Run with ``bun test ts/src/tools/a2a.test.ts``.
+ */
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { handleA2aCall } from "./a2a";
+import { handleA2aGetTask } from "./a2a_get_task";
+import { handleA2aCancelTask } from "./a2a_cancel_task";
+import { handleA2aSendStreaming } from "./a2a_streaming";
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function installFetchStub(
+  respond: (call: FetchCall) => Response | Promise<Response>,
+) {
+  const calls: FetchCall[] = [];
+  const original = globalThis.fetch;
+  (globalThis as any).fetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    const url = typeof input === "string" ? input : (input as URL).toString();
+    const call: FetchCall = { url, init };
+    calls.push(call);
+    return respond(call);
+  };
+  return {
+    calls,
+    restore: () => {
+      (globalThis as any).fetch = original;
+    },
+  };
+}
+
+let tmpDir: string;
+let tokenPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "a2a-test-"));
+  tokenPath = join(tmpDir, ".a2a-token");
+  writeFileSync(tokenPath, "test-bearer-xyz\n");
+  process.env.SCITEX_OROCHI_A2A_TOKEN_PATH = tokenPath;
+  process.env.SCITEX_OROCHI_A2A_BASE_URL = "https://a2a.test";
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.SCITEX_OROCHI_A2A_TOKEN_PATH;
+  delete process.env.SCITEX_OROCHI_A2A_BASE_URL;
+});
+
+describe("handleA2aCall (SDK 1.x defaults)", () => {
+  test("default method is SendMessage with proto snake_case + A2A-Version header", async () => {
+    const stub = installFetchStub(
+      () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: "x", result: { ok: true } }),
+          { status: 200 },
+        ),
+    );
+    try {
+      await handleA2aCall({ agent: "lead", text: "hi" });
+      expect(stub.calls).toHaveLength(1);
+      const call = stub.calls[0]!;
+      expect(call.url).toBe("https://a2a.test/v1/agents/lead");
+      const headers = call.init!.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer test-bearer-xyz");
+      expect(headers["A2A-Version"]).toBe("1.0");
+      const body = JSON.parse(call.init!.body as string);
+      expect(body.method).toBe("SendMessage");
+      expect(body.params.message.role).toBe("ROLE_USER");
+      expect(body.params.message.parts[0].text).toBe("hi");
+      expect(typeof body.params.message.message_id).toBe("string");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("explicit GetTask method maps task_id → params.id", async () => {
+    const stub = installFetchStub(
+      () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "x", result: {} }), {
+          status: 200,
+        }),
+    );
+    try {
+      await handleA2aCall({
+        agent: "lead",
+        method: "GetTask",
+        task_id: "task-42",
+      });
+      const body = JSON.parse(stub.calls[0]!.init!.body as string);
+      expect(body.method).toBe("GetTask");
+      expect(body.params).toEqual({ id: "task-42" });
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("non-2xx surface as throw", async () => {
+    const stub = installFetchStub(
+      () => new Response("nope", { status: 503 }),
+    );
+    try {
+      await expect(handleA2aCall({ agent: "lead", text: "x" })).rejects.toThrow(
+        /A2A 503/,
+      );
+    } finally {
+      stub.restore();
+    }
+  });
+});
+
+describe("handleA2aGetTask / handleA2aCancelTask", () => {
+  test("GetTask sends method=GetTask + params.id", async () => {
+    const stub = installFetchStub(
+      () => new Response(JSON.stringify({ result: { task: {} } }), { status: 200 }),
+    );
+    try {
+      await handleA2aGetTask({ agent: "lead", task_id: "abc" });
+      const body = JSON.parse(stub.calls[0]!.init!.body as string);
+      expect(body.method).toBe("GetTask");
+      expect(body.params).toEqual({ id: "abc" });
+      const headers = stub.calls[0]!.init!.headers as Record<string, string>;
+      expect(headers["A2A-Version"]).toBe("1.0");
+    } finally {
+      stub.restore();
+    }
+  });
+
+  test("CancelTask sends method=CancelTask + params.id", async () => {
+    const stub = installFetchStub(
+      () => new Response(JSON.stringify({ result: {} }), { status: 200 }),
+    );
+    try {
+      await handleA2aCancelTask({ agent: "lead", task_id: "abc" });
+      const body = JSON.parse(stub.calls[0]!.init!.body as string);
+      expect(body.method).toBe("CancelTask");
+      expect(body.params).toEqual({ id: "abc" });
+    } finally {
+      stub.restore();
+    }
+  });
+});
+
+describe("handleA2aSendStreaming", () => {
+  test("collects SSE events into MCP tool result", async () => {
+    const sse =
+      "data: {\"event\":\"start\"}\n\n" +
+      "data: {\"event\":\"progress\",\"pct\":50}\n\n" +
+      "data: {\"event\":\"completed\",\"state\":\"COMPLETED\"}\n\n";
+    const stub = installFetchStub(
+      () =>
+        new Response(sse, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+    );
+    try {
+      const out = await handleA2aSendStreaming({
+        agent: "lead",
+        text: "stream",
+      });
+      const body = JSON.parse(stub.calls[0]!.init!.body as string);
+      expect(body.method).toBe("SendStreamingMessage");
+      expect(body.params.message.role).toBe("ROLE_USER");
+      const parsed = JSON.parse(out.content[0]!.text);
+      expect(parsed.count).toBe(3);
+      expect(parsed.events[2].event).toBe("completed");
+    } finally {
+      stub.restore();
+    }
+  });
+});

--- a/ts/src/tools/a2a.ts
+++ b/ts/src/tools/a2a.ts
@@ -1,5 +1,5 @@
 /**
- * A2A protocol client tool — call peer agents via JSON-RPC.
+ * A2A protocol client tool — call peer agents via JSON-RPC (SDK 1.x).
  *
  * Posts to `https://a2a.scitex.ai/v1/agents/<agent>` with the bearer
  * read from the per-agent `.a2a-token` file (path injected via
@@ -8,9 +8,16 @@
  * Bearer never enters the agent transcript: the MCP server reads it
  * from disk per call and includes it in the outbound HTTP request.
  *
+ * SDK 1.x alignment (Phase 5 of A2A_MIGRATION.md):
+ *   - default method → ``SendMessage`` (not legacy ``tasks/send``)
+ *   - polling      → ``GetTask`` (params: ``{id}``)
+ *   - proto snake_case message fields (``message_id``, ``task_id``)
+ *   - ``A2A-Version: 1.0`` header on every outbound request
+ *
  * Cross-refs:
  *   - skill: scitex-orochi/_skills/scitex-orochi/51_a2a-client.md
- *   - master nav: scitex-orochi/GITIGNORED/A2A_PROTOCOL_SUPPORT.md
+ *   - master nav: scitex-orochi/GITIGNORED/A2A_MIGRATION.md (Phase 5)
+ *   - sac SDK reference: /tmp/wt-sac-a2a/tests/test_a2a_server.py
  */
 import { readFileSync } from "node:fs";
 
@@ -23,9 +30,10 @@ interface A2aCallArgs {
   text?: string;
   params?: Record<string, unknown>;
   task_id?: string;
+  message_id?: string;
 }
 
-function readBearer(): string {
+export function readBearer(): string {
   const path = process.env.SCITEX_OROCHI_A2A_TOKEN_PATH;
   if (!path) {
     throw new Error(
@@ -40,19 +48,37 @@ function readBearer(): string {
   }
 }
 
+export function a2aBaseUrl(): string {
+  return (process.env.SCITEX_OROCHI_A2A_BASE_URL ?? DEFAULT_BASE).replace(
+    /\/+$/,
+    "",
+  );
+}
+
+export function a2aHeaders(bearer: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${bearer}`,
+    "Content-Type": "application/json",
+    "A2A-Version": "1.0",
+  };
+}
+
 function buildParams(args: A2aCallArgs): Record<string, unknown> {
   if (args.params) return args.params;
-  const method = args.method ?? "tasks/send";
-  if (method === "tasks/send") {
+  const method = args.method ?? "SendMessage";
+  if (method === "SendMessage" || method === "SendStreamingMessage") {
     const text = args.text ?? "";
     return {
       message: {
-        role: "user",
-        parts: [{ type: "text", text }],
+        message_id: args.message_id ?? `mcp-msg-${Date.now()}`,
+        role: "ROLE_USER",
+        parts: [{ text }],
       },
     };
   }
-  if (method === "tasks/get") {
+  if (method === "GetTask" || method === "CancelTask") {
+    // SDK 1.x: GetTask/CancelTask take ``{id}``; we accept ``task_id`` from
+    // the caller and map it to the proto-style ``id`` field.
     return { id: args.task_id ?? "" };
   }
   return {};
@@ -64,11 +90,8 @@ export async function handleA2aCall(args: A2aCallArgs): Promise<{
   if (!args || !args.agent) {
     throw new Error("a2a_call requires 'agent' argument");
   }
-  const method = args.method ?? "tasks/send";
-  const baseUrl = (
-    process.env.SCITEX_OROCHI_A2A_BASE_URL ?? DEFAULT_BASE
-  ).replace(/\/+$/, "");
-  const url = `${baseUrl}/v1/agents/${encodeURIComponent(args.agent)}`;
+  const method = args.method ?? "SendMessage";
+  const url = `${a2aBaseUrl()}/v1/agents/${encodeURIComponent(args.agent)}`;
   const bearer = readBearer();
   const body = JSON.stringify({
     jsonrpc: "2.0",
@@ -83,10 +106,7 @@ export async function handleA2aCall(args: A2aCallArgs): Promise<{
   try {
     resp = await fetch(url, {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${bearer}`,
-        "Content-Type": "application/json",
-      },
+      headers: a2aHeaders(bearer),
       body,
       signal: ctrl.signal,
     });

--- a/ts/src/tools/a2a_cancel_task.ts
+++ b/ts/src/tools/a2a_cancel_task.ts
@@ -1,0 +1,53 @@
+/**
+ * A2A ``CancelTask`` tool — interrupt a running task (SDK 1.x).
+ *
+ * Phase 5 of A2A_MIGRATION.md. Maps the MCP ``task_id`` arg to the
+ * proto ``id`` field. Returns the SDK envelope verbatim so the caller
+ * can inspect the new task state (typically ``CANCELED``).
+ */
+import { a2aBaseUrl, a2aHeaders, readBearer } from "./a2a.js";
+
+const HTTP_TIMEOUT_MS = 15_000;
+
+interface A2aCancelTaskArgs {
+  agent: string;
+  task_id: string;
+}
+
+export async function handleA2aCancelTask(args: A2aCancelTaskArgs): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  if (!args || !args.agent) {
+    throw new Error("a2a_cancel_task requires 'agent' argument");
+  }
+  if (!args.task_id) {
+    throw new Error("a2a_cancel_task requires 'task_id' argument");
+  }
+  const url = `${a2aBaseUrl()}/v1/agents/${encodeURIComponent(args.agent)}`;
+  const bearer = readBearer();
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: `mcp-cancel-${Date.now()}`,
+    method: "CancelTask",
+    params: { id: args.task_id },
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), HTTP_TIMEOUT_MS);
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "POST",
+      headers: a2aHeaders(bearer),
+      body,
+      signal: ctrl.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`A2A ${resp.status} from ${url}: ${text.slice(0, 500)}`);
+  }
+  return { content: [{ type: "text", text }] };
+}

--- a/ts/src/tools/a2a_get_task.ts
+++ b/ts/src/tools/a2a_get_task.ts
@@ -1,0 +1,55 @@
+/**
+ * A2A ``GetTask`` tool — poll a long-running task by id (SDK 1.x).
+ *
+ * Phase 5 of A2A_MIGRATION.md. Companion to ``a2a_send_streaming`` /
+ * ``a2a_call``: once a peer agent returns a task id, callers use this
+ * to fetch the latest task state (status + artifacts) without holding
+ * the SSE stream open.
+ */
+import { a2aBaseUrl, a2aHeaders, readBearer } from "./a2a.js";
+
+const HTTP_TIMEOUT_MS = 15_000;
+
+interface A2aGetTaskArgs {
+  agent: string;
+  task_id: string;
+}
+
+export async function handleA2aGetTask(args: A2aGetTaskArgs): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  if (!args || !args.agent) {
+    throw new Error("a2a_get_task requires 'agent' argument");
+  }
+  if (!args.task_id) {
+    throw new Error("a2a_get_task requires 'task_id' argument");
+  }
+  const url = `${a2aBaseUrl()}/v1/agents/${encodeURIComponent(args.agent)}`;
+  const bearer = readBearer();
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: `mcp-get-${Date.now()}`,
+    method: "GetTask",
+    // SDK 1.x: GetTask params take ``{id}`` (proto field name).
+    params: { id: args.task_id },
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), HTTP_TIMEOUT_MS);
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "POST",
+      headers: a2aHeaders(bearer),
+      body,
+      signal: ctrl.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`A2A ${resp.status} from ${url}: ${text.slice(0, 500)}`);
+  }
+  return { content: [{ type: "text", text }] };
+}

--- a/ts/src/tools/a2a_list_agents.ts
+++ b/ts/src/tools/a2a_list_agents.ts
@@ -1,0 +1,52 @@
+/**
+ * A2A ``list_agents`` tool — enumerate callable agents (SDK 1.x).
+ *
+ * Hits the orochi hub registry endpoint so the LLM does not have to
+ * guess agent names before issuing ``a2a_call`` /
+ * ``a2a_send_streaming``.
+ *
+ * URL choice: ``GET /api/agents/`` is the canonical hub endpoint that
+ * powers the Agents tab (see ``hub/urls.py:112`` →
+ * ``views.api_agents``). The orochi A2A surface at
+ * ``/v1/agents/`` (sac-side AgentCard discovery) is the public
+ * equivalent on the cloud side; for the MCP sidecar we prefer the hub
+ * registry because it is the authoritative source of liveness +
+ * workspace scoping (and the bearer model already authenticates the
+ * sidecar to the hub, no second token needed).
+ *
+ * Override via ``SCITEX_OROCHI_AGENTS_LIST_URL`` if a deployment puts
+ * the registry behind a different path.
+ */
+import { buildHttpBase, buildFetchHeaders } from "../config.js";
+
+const HTTP_TIMEOUT_MS = 10_000;
+
+export async function handleA2aListAgents(): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  const override = process.env.SCITEX_OROCHI_AGENTS_LIST_URL;
+  const base = buildHttpBase().replace(/\/+$/, "");
+  const url = override && override.trim().length > 0
+    ? override
+    : `${base}/api/agents/`;
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), HTTP_TIMEOUT_MS);
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "GET",
+      headers: buildFetchHeaders({ Accept: "application/json" }),
+      signal: ctrl.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(
+      `a2a_list_agents ${resp.status} from ${url}: ${text.slice(0, 500)}`,
+    );
+  }
+  return { content: [{ type: "text", text }] };
+}

--- a/ts/src/tools/a2a_streaming.ts
+++ b/ts/src/tools/a2a_streaming.ts
@@ -1,0 +1,122 @@
+/**
+ * A2A streaming tool — ``SendStreamingMessage`` over SSE.
+ *
+ * Phase 5 of A2A_MIGRATION.md. Posts to
+ * ``POST /v1/agents/<agent>`` with method ``SendStreamingMessage`` and
+ * accumulates the SSE event stream into a single MCP tool result.
+ *
+ * Limitation: the MCP TypeScript SDK (``@modelcontextprotocol/sdk``
+ * ^1.29.0) used by this server returns tool results synchronously
+ * from a single ``CallToolRequestSchema`` handler — there is no
+ * incremental-output API exposed here. So we collect all SSE events
+ * in memory and return a JSON array of events at end-of-stream.
+ *
+ * If/when the MCP SDK exposes streaming tool output cleanly, this
+ * function should pipe events as they arrive. Tracked alongside Phase 6
+ * (push-notification MCP wiring).
+ */
+import { a2aBaseUrl, a2aHeaders, readBearer } from "./a2a.js";
+
+const HTTP_TIMEOUT_MS = 60_000; // streaming may take longer than unary
+const MAX_EVENTS = 256; // safety cap so a runaway agent can't OOM the sidecar
+
+interface A2aStreamArgs {
+  agent: string;
+  text: string;
+  message_id?: string;
+}
+
+export async function handleA2aSendStreaming(args: A2aStreamArgs): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+}> {
+  if (!args || !args.agent) {
+    throw new Error("a2a_send_streaming requires 'agent' argument");
+  }
+  const text = args.text ?? "";
+  const url = `${a2aBaseUrl()}/v1/agents/${encodeURIComponent(args.agent)}`;
+  const bearer = readBearer();
+  const body = JSON.stringify({
+    jsonrpc: "2.0",
+    id: `mcp-stream-${Date.now()}`,
+    method: "SendStreamingMessage",
+    params: {
+      message: {
+        message_id: args.message_id ?? `mcp-stream-msg-${Date.now()}`,
+        role: "ROLE_USER",
+        parts: [{ text }],
+      },
+    },
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), HTTP_TIMEOUT_MS);
+  let resp: Response;
+  try {
+    resp = await fetch(url, {
+      method: "POST",
+      headers: { ...a2aHeaders(bearer), Accept: "text/event-stream" },
+      body,
+      signal: ctrl.signal,
+    });
+  } catch (e) {
+    clearTimeout(timer);
+    throw e;
+  }
+
+  if (!resp.ok) {
+    clearTimeout(timer);
+    const errText = await resp.text();
+    throw new Error(
+      `A2A ${resp.status} from ${url}: ${errText.slice(0, 500)}`,
+    );
+  }
+  if (!resp.body) {
+    clearTimeout(timer);
+    throw new Error(`A2A streaming response from ${url} has no body`);
+  }
+
+  const events: unknown[] = [];
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    while (events.length < MAX_EVENTS) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      // SSE frames are separated by blank lines; each frame may have
+      // multiple ``data:`` lines. We extract one JSON object per
+      // ``data:`` line (matching sac's test client).
+      let nl: number;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        const line = buf.slice(0, nl).replace(/\r$/, "");
+        buf = buf.slice(nl + 1);
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice("data:".length).trim();
+        if (!payload) continue;
+        try {
+          events.push(JSON.parse(payload));
+        } catch {
+          events.push({ raw: payload });
+        }
+        if (events.length >= MAX_EVENTS) break;
+      }
+    }
+  } finally {
+    clearTimeout(timer);
+    try {
+      reader.releaseLock();
+    } catch {
+      // ignore
+    }
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ events, count: events.length }, null, 2),
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- ``a2a_call`` updated: default method ``SendMessage`` (was ``tasks/send``); proto snake_case params; ``A2A-Version: 1.0`` header.
- 4 new MCP tools exposing SDK 1.x capabilities to Claude Code clients:
  - ``a2a_send_streaming`` — SSE-based ``SendStreamingMessage``
  - ``a2a_get_task`` — poll long-running tasks
  - ``a2a_cancel_task`` — interrupt running tasks
  - ``a2a_list_agents`` — enumerate orochi-registered agents
- Skill doc ``51_a2a-client.md`` updated with per-tool surface.

## Test plan
- [x] ``bun test src/tools/a2a.test.ts`` — 6 pass / 0 fail / 20 expects
- [x] No Python (``hub/``, ``src/``) changes

## Known limitation
- ``a2a_send_streaming`` buffers SSE events (cap 256) until end-of-stream because ``@modelcontextprotocol/sdk@1.29`` doesn't expose incremental tool output. Documented in tool description; future Phase 6 if/when MCP SDK adds streaming.

## Dependency
Lands **after** orochi Phase 3 PR (#374) is merged + deployed — needs the new ``/v1/agents/<name>/`` URL live to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)