### PR TITLE
feat(chat): clicking a message card opens its thread panel

### DIFF
--- a/hub/frontend/src/chat/chat-actions.ts
+++ b/hub/frontend/src/chat/chat-actions.ts
@@ -477,3 +477,36 @@ document.addEventListener("click", function (e) {
     if (typeof fetchStats === "function") fetchStats();
   }
 });
+
+/* Message card click → open thread panel (#242) */
+document.addEventListener("click", function (e) {
+  var target = e.target as Element;
+  /* Skip interactive children so buttons/links still work */
+  var node: Element | null = target;
+  while (node && node !== document.body) {
+    var tag = node.tagName;
+    if (
+      tag === "BUTTON" ||
+      tag === "A" ||
+      tag === "INPUT" ||
+      tag === "TEXTAREA" ||
+      tag === "SELECT"
+    ) {
+      return;
+    }
+    if (node.classList && node.classList.contains("msg-edit-container")) {
+      return;
+    }
+    node = node.parentElement;
+  }
+  var msgEl = target.closest && target.closest(".msg");
+  if (!msgEl) return;
+  if (msgEl.classList.contains("msg-system")) return;
+  var idStr = msgEl.getAttribute("data-msg-id");
+  if (!idStr) return;
+  var msgId = parseInt(idStr, 10);
+  if (!msgId) return;
+  if (typeof openThreadForMessage === "function") {
+    openThreadForMessage(msgId);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds a delegated `click` listener on `document` that detects clicks on `.msg` cards
- Skips interactive children (button, a, input, textarea, select, `.msg-edit-container`) so existing buttons/links still work
- Calls `openThreadForMessage(msgId)` — same function used by the long-press "Reply" action on touch devices
- No change to system messages (`.msg-system` is excluded)

Closes #242

## Test plan
- [ ] Click a message body → thread panel opens on the right
- [ ] Click the "Reply in thread" button → still works (button is excluded from card-click)
- [ ] Click the reaction button → still works
- [ ] Click a link inside a message → navigates, no thread opens
- [ ] Click a system message → nothing happens
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)