### PR TITLE
fix(mentions): @channel-name mention — autocomplete, link chip, and subscriber fan-out

### DIFF
--- a/hub/frontend/src/chat/chat-markdown.ts
+++ b/hub/frontend/src/chat/chat-markdown.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { escapeHtml } from "../app/utils";
 import { cachedMemberNames } from "../mention";
+import { _channelPrefs } from "../app/members";
 
 /* Chat module -- markdown / mention / link / code-block content rendering.
  * Extracted from appendMessage() so chat-render.js stays under the JS
@@ -176,6 +177,21 @@ export function _processMessageMarkdown(content) {
           "</span>"
         );
       }
+      /* Channel-name mention (#168): @general → channel-link chip so
+       * clicking it switches to that channel (same behavior as #general links). */
+      var chKey = "#" + name;
+      if (_channelPrefs && (_channelPrefs[chKey] !== undefined || _channelPrefs[name] !== undefined)) {
+        return (
+          prefix +
+          '<a href="#" class="channel-link mention-channel-chip" data-channel="' +
+          escapeHtml(chKey) +
+          '" title="Switch to ' +
+          escapeHtml(chKey) +
+          '">@' +
+          escapeHtml(name) +
+          "</a>"
+        );
+      }
       return prefix + '<span class="mention-highlight">@' + name + "</span>";
     },
   );
@@ -185,10 +201,29 @@ export function _processMessageMarkdown(content) {
     .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "<em>$1</em>")
     .replace(/`([^`]+)`/g, '<code class="inline-code">$1</code>')
     .replace(/\n/g, "<br>")
-    .replace(
-      /(#(?:general|todo|research|deploy|telegram|orchestrator))\b/g,
-      '<span class="channel-highlight">$1</span>',
-    )
+    /* #channel-name links — dynamic from _channelPrefs (#168).
+     * Renders as a clickable .channel-link chip for any known channel. */
+    .replace(/(^|[^&\w])(#[\w\-\/]+)\b/g, function (_m, lead, hash) {
+      var key = hash.charAt(0) === "#" ? hash : "#" + hash;
+      if (_channelPrefs && (_channelPrefs[key] !== undefined || _channelPrefs[hash.slice(1)] !== undefined)) {
+        return (
+          lead +
+          '<a href="#" class="channel-link channel-highlight" data-channel="' +
+          escapeHtml(key) +
+          '" title="Switch to ' +
+          escapeHtml(key) +
+          '">' +
+          escapeHtml(hash) +
+          "</a>"
+        );
+      }
+      /* Fallback: still highlight hardcoded well-known channel names even
+       * when _channelPrefs hasn't loaded yet. */
+      if (/^#(?:general|todo|research|deploy|telegram|orchestrator)$/.test(key)) {
+        return lead + '<span class="channel-highlight">' + escapeHtml(hash) + "</span>";
+      }
+      return _m;
+    })
     /* Cross-repo references: `owner/repo#N` → GitHub issue link.
      * Bare `#N` is intentionally NOT linked (see top-of-file note / #275). */
     .replace(

--- a/hub/frontend/src/mention.ts
+++ b/hub/frontend/src/mention.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import { apiUrl, escapeHtml, isAgentInactive } from "./app/utils";
+import { _channelPrefs } from "./app/members";
 
 /* Mention autocomplete module */
 /* globals: escapeHtml, getAgentColor, (globalThis as any).cachedAgentNames, apiUrl, isAgentInactive */
@@ -109,7 +110,8 @@ export function positionMentionDropdown(inputEl) {
   }
 }
 
-export function showMentionDropdown(specialItems, agentItems) {
+export function showMentionDropdown(specialItems, agentItems, channelItems?) {
+  channelItems = channelItems || [];
   var msgInput = document.getElementById("msg-input");
   var inputHasFocus = msgInput && document.activeElement === msgInput;
   var savedStart = inputHasFocus ? msgInput.selectionStart : 0;
@@ -134,7 +136,7 @@ export function showMentionDropdown(specialItems, agentItems) {
       "</div>";
   });
 
-  if (specialItems.length > 0 && agentItems.length > 0) {
+  if (specialItems.length > 0 && (agentItems.length > 0 || channelItems.length > 0)) {
     html += '<div class="mention-divider"></div>';
   }
 
@@ -155,6 +157,24 @@ export function showMentionDropdown(specialItems, agentItems) {
       '"></span>' +
       escapeHtml(display) +
       (showFull ? '<span class="mention-desc">' + escapeHtml(name) + '</span>' : '') +
+      "</div>";
+  });
+
+  if ((agentItems.length > 0) && channelItems.length > 0) {
+    html += '<div class="mention-divider"></div>';
+  }
+
+  var chOffset = offset + agentItems.length;
+  channelItems.forEach(function (chName, i) {
+    html +=
+      '<div class="mention-item mention-channel' +
+      (chOffset + i === 0 ? " selected" : "") +
+      '" data-name="' +
+      escapeHtml(chName) +
+      '">' +
+      '<span class="mention-dot mention-dot-channel">#</span>' +
+      escapeHtml(chName) +
+      '<span class="mention-desc">channel</span>' +
       "</div>";
   });
 
@@ -242,11 +262,27 @@ export function handleMentionInput(e) {
       return item.name;
     });
 
-  if (matchedSpecial.length === 0 && matchedAgents.length === 0) {
+  /* Channel name completions — strip leading # so @general matches "general" */
+  var channelKeys = _channelPrefs ? Object.keys(_channelPrefs) : [];
+  var matchedChannels = channelKeys
+    .filter(function (ch) {
+      if (!ch || ch.startsWith("dm:")) return false;
+      /* Bare name without # for matching (e.g. "general", "proj-foo") */
+      var bare = ch.charAt(0) === "#" ? ch.slice(1) : ch;
+      return _mention__fuzzyMatch(info.query, bare) !== -1;
+    })
+    .map(function (ch) {
+      return ch.charAt(0) === "#" ? ch.slice(1) : ch;
+    })
+    /* Deduplicate and sort */
+    .filter(function (v, i, a) { return a.indexOf(v) === i; })
+    .slice(0, 6);
+
+  if (matchedSpecial.length === 0 && matchedAgents.length === 0 && matchedChannels.length === 0) {
     hideMentionDropdown();
     return;
   }
-  showMentionDropdown(matchedSpecial, matchedAgents);
+  showMentionDropdown(matchedSpecial, matchedAgents, matchedChannels);
 }
 
 export function handleMentionKeydown(e) {

--- a/hub/mentions.py
+++ b/hub/mentions.py
@@ -189,8 +189,26 @@ def resolve_mention_targets(
         # creating ghost DMs to non-existent principals.
         if User.objects.filter(username=agent_username).exists():
             _add(agent_username)
-        elif User.objects.filter(username=token).exists():
+            continue
+        if User.objects.filter(username=token).exists():
             _add(token)
+            continue
+        # Channel-name mention: @general → all subscribers of #general.
+        # Normalise to #token and look up ChannelMembership rows so that
+        # ``@general`` pings everyone subscribed to #general. Fail-soft:
+        # unrecognised tokens are silently skipped (same as before).
+        from hub.models import Channel, ChannelMembership
+
+        ch_name = f"#{token}" if not token.startswith("#") else token
+        try:
+            ch = Channel.objects.get(workspace_id=workspace_id, name=ch_name)
+            for uname in (
+                ChannelMembership.objects.filter(channel=ch)
+                .values_list("user__username", flat=True)
+            ):
+                _add(uname)
+        except Channel.DoesNotExist:
+            pass
 
     return result
 


### PR DESCRIPTION
## Summary
- `@general` in the composer now triggers autocomplete with matching channel names
- Sent `@channel-name` renders as a clickable `.channel-link` chip (same as `#channel-name`)
- `@channel-name` fans out a DM notification to all subscribers of that channel
- `#channel-name` in message text now renders as a clickable link for ALL known channels (not just the hardcoded list of 6)
- All 32 existing mention tests pass

Closes #168

## Test plan
- [ ] Type `@gen` in composer → dropdown shows `#general` as a channel completion
- [ ] Select it → `@general` inserted; sent message renders as a clickable chip
- [ ] Click the chip → switches to `#general`
- [ ] Sending `@general` delivers a DM to all subscribers of #general
- [ ] `#proj-foo` in a message body renders as a clickable link when that channel exists
- [ ] Existing agent @mention behavior unchanged
- [ ] `python manage.py test hub.tests.test_mention_expansion` → 32 tests OK ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)