### PR TITLE
fix(mcp-sidecar): exponential backoff reconnect on hub recovery (FR-K)

### DIFF
--- a/src/scitex_orochi/__init__.py
+++ b/src/scitex_orochi/__init__.py
@@ -1,7 +1,8 @@
 """Orochi -- Agent Communication Hub for the SciTeX ecosystem."""
 
 try:
-    from importlib.metadata import version as _v, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _v
     try:
         __version__ = _v("scitex-orochi")
     except PackageNotFoundError:

--- a/tests/test_hostname_aliases_config.py
+++ b/tests/test_hostname_aliases_config.py
@@ -5,10 +5,8 @@ Tests the YAML-reading logic in isolation — no Django infrastructure needed.
 
 from __future__ import annotations
 
-import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 
 def _load_hostname_aliases_impl(config_path: str) -> dict:

--- a/tests/test_orochi_slurm_resources.py
+++ b/tests/test_orochi_slurm_resources.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import patch
 
-from scitex_orochi import _resources, _orochi_slurm
+from scitex_orochi import _orochi_slurm, _resources
 
 # ---------------------------------------------------------------------------
 # Low-level parser tests

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -2,6 +2,7 @@
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
 from pathlib import Path
+
 from scitex_dev._skills_quality_pytest import make_skill_quality_tests
 
 test_skills_quality = make_skill_quality_tests(

--- a/ts/mcp_channel/connection.test.ts
+++ b/ts/mcp_channel/connection.test.ts
@@ -1,0 +1,56 @@
+/**
+ * FR-K (lead msg#22969): MCP sidecar should auto-reconnect on hub
+ * recovery with exponential backoff, capped at 5min, retried indefinitely.
+ *
+ * Background: 2026-04-29 mba disk-full incident took the hub down ~21h.
+ * The pre-FR-K reconnect was a flat 3s setTimeout — fine for short
+ * blips, but during a 21h outage it would re-attempt ~25k times and
+ * gave operators no clear "we are back" signal in the agent's pane.
+ *
+ * These tests cover the pure backoff-scheduling helper. The full
+ * reconnect loop integration is exercised by the manual acceptance
+ * test (kill hub, restart, verify MCP tools recover without manual
+ * /mcp reconnect) — too WS-stateful to mock cleanly.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { RECONNECT_BACKOFF_MS, reconnectBackoffMs } from "./connection.js";
+
+describe("reconnectBackoffMs", () => {
+  test("first attempt waits 5s", () => {
+    expect(reconnectBackoffMs(1)).toBe(5_000);
+  });
+
+  test("schedule progresses 5s -> 10s -> 30s -> 60s -> 120s -> 300s", () => {
+    expect(reconnectBackoffMs(1)).toBe(5_000);
+    expect(reconnectBackoffMs(2)).toBe(10_000);
+    expect(reconnectBackoffMs(3)).toBe(30_000);
+    expect(reconnectBackoffMs(4)).toBe(60_000);
+    expect(reconnectBackoffMs(5)).toBe(120_000);
+    expect(reconnectBackoffMs(6)).toBe(300_000);
+  });
+
+  test("clamps at 5min for any attempt past the schedule", () => {
+    expect(reconnectBackoffMs(7)).toBe(300_000);
+    expect(reconnectBackoffMs(100)).toBe(300_000);
+    // 21h outage at 5min cadence is the worst case after the schedule
+    // is exhausted — this is the upper bound we care about.
+    expect(reconnectBackoffMs(10_000)).toBe(300_000);
+  });
+
+  test("treats attempt=0 the same as attempt=1 (defensive)", () => {
+    // Production code increments reconnectAttempts before calling, so 0
+    // shouldn't occur, but the helper must not throw if it does.
+    expect(reconnectBackoffMs(0)).toBe(5_000);
+    expect(reconnectBackoffMs(-1)).toBe(5_000);
+  });
+
+  test("schedule shape is monotonic and capped at 300s", () => {
+    for (let i = 1; i < RECONNECT_BACKOFF_MS.length; i++) {
+      expect(RECONNECT_BACKOFF_MS[i]).toBeGreaterThanOrEqual(
+        RECONNECT_BACKOFF_MS[i - 1],
+      );
+    }
+    expect(Math.max(...RECONNECT_BACKOFF_MS)).toBe(300_000);
+  });
+});

--- a/ts/mcp_channel/connection.ts
+++ b/ts/mcp_channel/connection.ts
@@ -21,7 +21,25 @@ import { handleWsMessage } from "./dispatch.js";
 
 let _ws: WebSocket | null = null;
 let _heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+let _reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let _mcpRef: Server | null = null;
+// FR-K: track whether the most recent disconnect resulted in a reconnect
+// loop so we can emit a single "recovered after outage" line on the next
+// successful onOpen, rather than spamming every reconnect attempt.
+let _priorOutage = false;
+
+// FR-K backoff schedule (ms) — index by reconnectAttempts, clamp at last.
+// Values: 5s, 10s, 30s, 60s, 120s, 300s; subsequent attempts stay at 300s.
+export const RECONNECT_BACKOFF_MS = [
+  5_000, 10_000, 30_000, 60_000, 120_000, 300_000,
+];
+export function reconnectBackoffMs(attempt: number): number {
+  const idx = Math.min(
+    Math.max(attempt - 1, 0),
+    RECONNECT_BACKOFF_MS.length - 1,
+  );
+  return RECONNECT_BACKOFF_MS[idx];
+}
 
 // Lightweight adapter that satisfies the OrochiConnection interface
 // expected by tools.ts (isConnected, state, send, reconnectAttempts, etc.)
@@ -49,6 +67,15 @@ export const conn = {
     }
   },
   connect(): void {
+    // Idempotent: skip if already connected or connecting (FR-K).
+    if (_ws !== null) {
+      dbg(`ws connect skipped (state=${conn.state}, readyState=${_ws.readyState})`);
+      return;
+    }
+    if (_reconnectTimer) {
+      clearTimeout(_reconnectTimer);
+      _reconnectTimer = null;
+    }
     const wsUrl = buildWsUrl();
     dbg(`ws connecting to ${maskUrl(wsUrl)}`);
     conn.state = "connecting";
@@ -76,8 +103,17 @@ export function attachMcp(mcp: Server): void {
 function onOpen(ws: WebSocket): void {
   conn.state = "connected";
   conn.lastConnectedAt = new Date();
+  const _recoveredAttempts = conn.reconnectAttempts;
   conn.reconnectAttempts = 0;
   console.error(`[orochi] ws connected as ${OROCHI_AGENT}`);
+  // FR-K: emit a single, scrape-friendly recovery line if we were in a
+  // reconnect loop. This is what lead's pane needs to see post-outage.
+  if (_priorOutage) {
+    console.error(
+      `[orochi] MCP reconnected at ${new Date().toISOString()} after ${_recoveredAttempts} attempt(s)`,
+    );
+    _priorOutage = false;
+  }
   dbg(`ws open`);
 
   startAppHeartbeat(ws);
@@ -222,8 +258,15 @@ function onClose(code: number, reason: Buffer): void {
     clearInterval(_heartbeatInterval);
     _heartbeatInterval = null;
   }
-  // Simple reconnect after 3s
+  // FR-K: exponential backoff reconnect, capped at 5min, retried indefinitely.
   conn.reconnectAttempts++;
   conn.totalReconnects++;
-  setTimeout(() => conn.connect(), 3000);
+  _priorOutage = true;
+  const _delayMs = reconnectBackoffMs(conn.reconnectAttempts);
+  dbg(`ws reconnect in ${_delayMs}ms (attempt ${conn.reconnectAttempts})`);
+  if (_reconnectTimer) clearTimeout(_reconnectTimer);
+  _reconnectTimer = setTimeout(() => {
+    _reconnectTimer = null;
+    conn.connect();
+  }, _delayMs);
 }


### PR DESCRIPTION
## Summary

- Replace flat 3s `setTimeout` reconnect in `ts/mcp_channel/connection.ts` with exponential backoff `[5, 10, 30, 60, 120, 300]s`, capped at 300s and retried indefinitely.
- Emit a single `MCP reconnected at <iso-ts> after N attempt(s)` line on recovery so operator panes get a clear "we are back" signal.
- `connect()` is now idempotent (skips when `_ws !== null`, clears pending reconnect timer on entry) and the reconnect timer is single-shot.

## Why

2026-04-29 mba disk-full incident took the hub down ~21h. The pre-existing flat 3s loop would have hammered the hub roughly 25k times during recovery and gave no scrape-friendly recovery line. Lead requested FR-K in DM msg#22969 / msg#22973.

## Test plan

- [x] `bun test mcp_channel` — 18/18 pass (5 new for backoff helper, 13 pre-existing)
- [x] `bun build mcp_channel/connection.ts` — clean
- [x] Backoff helper covers schedule, monotonicity, defensive 0/-1 input, and 21h-equivalent clamp
- [ ] **Acceptance (manual, blocks merge)**: kill the hub, restart it, verify the agent's MCP tools recover without manual `/mcp reconnect <name>` and that one `MCP reconnected at <ts> after N attempt(s)` line appears in the agent's pane.
- [ ] Sanity: cold start with the hub down — agent should retry on the backoff schedule rather than the old 3s cadence.

## Notes

- This stops hub-hammering and clarifies the recovery signal; it does **not** address the deferred-tool-cache issue (manual `/mcp reconnect` still required for some agent sessions). That is tracked separately as FR-L.
- Self-referential project: this code path is the channel everyone uses. Recommend dev-mode test before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)