### PR TITLE
feat(hub): wire open_agent_calls to hub registry for stuck-subagent detection (orochi#133)

### DIFF
--- a/docs/observability/drop-detection.md
+++ b/docs/observability/drop-detection.md
@@ -109,6 +109,63 @@ When `machine-stale` appears:
 5. If the agent has been stale for >30 min with no apparent cause, file a report in
    `#heads` and DM `lead` with the agent name and last known task.
 
+## Stuck-subagent detection (orochi#133, sac-side LIFO)
+
+Since sac 0.x and orochi#133, the hub gains a second stuck-subagent signal from the
+agent-container event ring-buffer, complementing the hub-side `subagent_active_since`
+timer.
+
+### How it works
+
+scitex-agent-container records every `PreToolUse` / `PostToolUse` hook event in a
+per-agent JSONL ring-buffer (`~/.scitex/agent-container/events/<agent>.jsonl`).
+`event_log.summarize()` performs LIFO matching on `Agent` tool events:
+
+- `Agent` pretool: push to stack.
+- `Agent` posttool: pop from stack (matched = completed).
+- Remaining entries after full scan = **open (potentially stuck) Agent calls**.
+
+The three derived fields emitted by `summarize()` and forwarded to the hub:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `sac_hooks_open_agent_calls` | `list[{ts, input_preview, age_seconds}]` | Unmatched Agent pretool events |
+| `sac_hooks_open_agent_calls_count` | `int` | Number of open calls |
+| `sac_hooks_oldest_open_agent_age_s` | `float \| null` | Age of the oldest open call in seconds |
+
+### Hub integration
+
+The `subagent_stuck` alert payload (`GET /api/watchdog/alerts/`) now includes
+`open_agent_calls_count` and `oldest_open_agent_age_s` alongside the hub-side
+`subagent_active_since` timer:
+
+```json
+{
+  "agent": "head-mba",
+  "kind": "subagent_stuck",
+  "subagent_count": 2,
+  "subagent_stuck_seconds": 720,
+  "open_agent_calls_count": 1,
+  "oldest_open_agent_age_s": 680.3,
+  "suggested_action": "escalate"
+}
+```
+
+Cross-checking both signals reduces false positives: `subagent_count > 0` alone can lag
+if the count hasn't been updated yet; `open_agent_calls_count > 0` confirms the
+agent-container's own ring-buffer also sees an unresolved call.
+
+### Limitations
+
+- The ring-buffer has a 500-line cap; very busy agents that fill the buffer before
+  the posttool event arrives will appear to have open calls that have actually resolved.
+- The LIFO matching assumes Agent calls complete in LIFO order (nested subagent model).
+  Concurrent independent Agent calls will match out-of-order, potentially leaving false
+  open entries. This is a known approximation; the `age_seconds` field lets callers
+  apply an age threshold to filter stale false-positives.
+- `sac_hooks_open_agent_calls_count` is only populated for agents running
+  scitex-agent-container ≥ 0.x with hooks wired. Legacy agents show 0.
+
 ## Future improvements
 
 - **Threshold tuning**: 10-min stale threshold may need per-role adjustment (long

--- a/docs/observability/subagent-metadata.md
+++ b/docs/observability/subagent-metadata.md
@@ -110,8 +110,46 @@ before clearing its subagents, the last-known list remains visible in the detail
 until the next heartbeat or page refresh. This is by design — stale entries signal that
 the parent agent may have wedged mid-task.
 
+## sac hook-event ring-buffer fields (orochi#133)
+
+Since orochi#133, the hub also receives subagent activity signals derived from the
+`scitex-agent-container` hook-event ring-buffer (`~/.scitex/agent-container/events/`).
+These complement the `subagents` list (which requires the agent to explicitly push via
+`POST /api/agents/subagents/`) with passive, event-log-derived signals.
+
+### `sac_hooks_agent_calls`
+
+The last ≤20 `Agent` pretool events recorded by the hook. Each entry:
+
+| Field | Type | Description |
+|---|---|---|
+| `ts` | ISO-8601 | Timestamp of the pretool event |
+| `input_preview` | `str` | Truncated `description` or first 200 chars of `prompt` |
+
+### `sac_hooks_open_agent_calls` (stuck-subagent signal)
+
+Agent pretool events with **no matching posttool** (LIFO matching). An unmatched
+pretool = an Agent call that has not yet returned. Fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `ts` | ISO-8601 | When the Agent call was started |
+| `input_preview` | `str` | Task description |
+| `age_seconds` | `float \| null` | Seconds since the call was started |
+
+Scalar shortcuts also emitted:
+
+| Field | Type | Description |
+|---|---|---|
+| `sac_hooks_open_agent_calls_count` | `int` | Number of open calls |
+| `sac_hooks_oldest_open_agent_age_s` | `float \| null` | Age of oldest open call |
+
+These fields drive the enriched `subagent_stuck` alert in `GET /api/watchdog/alerts/`.
+See [drop-detection.md](./drop-detection.md) for full semantics.
+
 ## See also
 
 - `hub/views/api/_agents.py` — `api_subagents_update` endpoint
 - `hub/frontend/src/agents-tab/detail.ts` — subagent list rendering in detail pane
 - [drop-detection.md](./drop-detection.md) — detecting stuck agents (subagent staleness as a signal)
+- `src/scitex_agent_container/event_log.py` — `_compute_open_agent_calls()` LIFO logic

--- a/docs/observability/tunnel-health.md
+++ b/docs/observability/tunnel-health.md
@@ -105,6 +105,29 @@ to `"offline"`.
 | `stale` | `orochi_pane_state ∈ {stale, auth_error}` OR `idle_seconds ≥ 600` (>10 min) |
 | `offline` | WS session closed |
 
+## sac-side tunnel probe (`probe_cloudflared`)
+
+Since sac 0.x (orochi#133), the `scitex-agent-container` network probe module
+(`src/scitex_agent_container/network_probe.py`) includes a `probe_cloudflared()`
+function that checks whether a `cloudflared tunnel run` process is alive on the local
+host.
+
+The probe uses `pgrep -f "cloudflared tunnel run"` and returns:
+
+| Result | Meaning |
+|---|---|
+| `ok=True`, `extra.pid=<pid>` | cloudflared daemon is running |
+| `ok=False`, `err="cloudflared tunnel run process not found"` | daemon is not running |
+| `ok=False`, `err="pgrep not available on this host"` | host doesn't have pgrep (rare) |
+
+`probe_cloudflared()` runs as the 5th probe in `run_all_probes()` (after dns → gateway →
+tcp → https). Results are logged to
+`~/.scitex/agent-container/logs/network/<agent>.jsonl`.
+
+The hub heartbeat pusher forwards the full `sac status --terse --json` dict (including
+network probe results) via `sac_status`, so tunnel liveness is visible in the
+`/api/agents/` response under `sac_status`.
+
 ## Recovery runbook
 
 When a machine shows red (offline):
@@ -115,6 +138,8 @@ When a machine shows red (offline):
    systemctl status cloudflared
    # or on macOS:
    launchctl list | grep cloudflared
+   # or via sac:
+   scitex-agent-container network-probe <agent>
    ```
 3. If cloudflared is stopped: `sudo systemctl start cloudflared`
 4. If cloudflared is running but agents are offline: start the relevant agents via

--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -252,6 +252,10 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "sac_hooks_recent_prompts": list(a.get("sac_hooks_recent_prompts") or []),
                 "sac_hooks_agent_calls": list(a.get("sac_hooks_agent_calls") or []),
                 "sac_hooks_background_tasks": list(a.get("sac_hooks_background_tasks") or []),
+                # orochi#133 — stuck-subagent detection (sac-side LIFO).
+                "sac_hooks_open_agent_calls": list(a.get("sac_hooks_open_agent_calls") or []),
+                "sac_hooks_open_agent_calls_count": a.get("sac_hooks_open_agent_calls_count") or 0,
+                "sac_hooks_oldest_open_agent_age_s": a.get("sac_hooks_oldest_open_agent_age_s"),
                 "sac_hooks_tool_counts": dict(a.get("sac_hooks_tool_counts") or {}),
                 # Functional-heartbeat shortcuts (derived by
                 # event_log.summarize() in agent-container).

--- a/hub/registry/_register.py
+++ b/hub/registry/_register.py
@@ -263,6 +263,25 @@ def register_agent(name: str, workspace_id: int, info: dict) -> None:
                 if isinstance(info.get("sac_hooks_background_tasks"), (list, tuple))
                 else prev.get("sac_hooks_background_tasks") or []
             ),
+            # orochi#133 — stuck-subagent detection via LIFO open-call tracking.
+            # sac_hooks_open_agent_calls: Agent pretool events with no matching
+            # posttool (potentially stuck subagent). Corroborates the hub-side
+            # subagent_active_since timer for higher-confidence alerts.
+            "sac_hooks_open_agent_calls": (
+                list(info.get("sac_hooks_open_agent_calls"))
+                if isinstance(info.get("sac_hooks_open_agent_calls"), (list, tuple))
+                else prev.get("sac_hooks_open_agent_calls") or []
+            ),
+            "sac_hooks_open_agent_calls_count": (
+                int(info["sac_hooks_open_agent_calls_count"])
+                if info.get("sac_hooks_open_agent_calls_count") is not None
+                else prev.get("sac_hooks_open_agent_calls_count") or 0
+            ),
+            "sac_hooks_oldest_open_agent_age_s": (
+                info.get("sac_hooks_oldest_open_agent_age_s")
+                if info.get("sac_hooks_oldest_open_agent_age_s") is not None
+                else prev.get("sac_hooks_oldest_open_agent_age_s")
+            ),
             "sac_hooks_tool_counts": (
                 dict(info.get("sac_hooks_tool_counts"))
                 if isinstance(info.get("sac_hooks_tool_counts"), dict)

--- a/hub/tests/registry/test_heartbeat.py
+++ b/hub/tests/registry/test_heartbeat.py
@@ -177,6 +177,26 @@ class FunctionalHeartbeatAndHookEventsTest(TestCase):
         self.assertEqual(len(data["sac_hooks_background_tasks"]), 1)
         self.assertEqual(data["sac_hooks_tool_counts"], {"Grep": 1})
 
+    def test_open_agent_calls_round_trip(self):
+        """orochi#133: sac_hooks_open_agent_calls / _count / _oldest_open_agent_age_s
+        round-trip through register and surface in the detail API."""
+        open_calls = [
+            {"ts": "2026-04-29T00:00:00+00:00", "input_preview": "research task", "age_seconds": 120.5},
+        ]
+        self._post(
+            self._base_payload(
+                sac_hooks_open_agent_calls=open_calls,
+                sac_hooks_open_agent_calls_count=1,
+                sac_hooks_oldest_open_agent_age_s=120.5,
+            )
+        )
+        resp = self._get_detail("hb-agent")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["sac_hooks_open_agent_calls"], open_calls)
+        self.assertEqual(data["sac_hooks_open_agent_calls_count"], 1)
+        self.assertAlmostEqual(data["sac_hooks_oldest_open_agent_age_s"], 120.5)
+
     def test_missing_hook_fields_default_to_empty(self):
         """Registering without any hook fields leaves empty defaults —
         legacy agents that haven't wired hooks still register cleanly."""
@@ -188,6 +208,9 @@ class FunctionalHeartbeatAndHookEventsTest(TestCase):
         self.assertEqual(data["sac_hooks_recent_prompts"], [])
         self.assertEqual(data["sac_hooks_agent_calls"], [])
         self.assertEqual(data["sac_hooks_background_tasks"], [])
+        self.assertEqual(data["sac_hooks_open_agent_calls"], [])
+        self.assertEqual(data["sac_hooks_open_agent_calls_count"], 0)
+        self.assertIsNone(data["sac_hooks_oldest_open_agent_age_s"])
         self.assertEqual(data["sac_hooks_tool_counts"], {})
         self.assertEqual(data["sac_hooks_last_tool_at"], "")
         self.assertEqual(data["sac_hooks_last_tool_name"], "")

--- a/hub/tests/views/api/test_watchdog_alerts.py
+++ b/hub/tests/views/api/test_watchdog_alerts.py
@@ -6,6 +6,7 @@ Covers:
 3. Subagent count non-zero for >10 min → alert (kind=subagent_stuck).
 4. Stale agent already emitted should NOT also emit subagent_stuck.
 5. Thresholds block in response includes subagent_stuck_seconds.
+6. subagent_stuck alert includes sac-side open_agent_calls corroboration fields (orochi#133).
 
 Note: ``liveness`` is computed dynamically in ``get_agents()`` from
 ``last_action`` / ``orochi_pane_state``; injecting it directly into
@@ -150,6 +151,42 @@ class WatchdogAlertsTest(TestCase):
         # Only ONE alert despite matching both conditions
         self.assertEqual(data["count"], 1)
         self.assertEqual(data["alerts"][0]["kind"], "agent_stale")
+
+    def test_subagent_stuck_includes_sac_open_calls_corroboration(self):
+        """subagent_stuck alert carries sac-side open_agent_calls fields (orochi#133)."""
+        self._register("agent-sac-corr")
+        self._make_online("agent-sac-corr")
+        self._inject(
+            "agent-sac-corr",
+            orochi_subagent_count=2,
+            subagent_active_since=time.time() - 680,
+            sac_hooks_open_agent_calls_count=1,
+            sac_hooks_oldest_open_agent_age_s=670.5,
+        )
+        resp = self._get()
+        data = resp.json()
+        self.assertEqual(data["count"], 1)
+        alert = data["alerts"][0]
+        self.assertEqual(alert["kind"], "subagent_stuck")
+        self.assertEqual(alert["open_agent_calls_count"], 1)
+        self.assertAlmostEqual(alert["oldest_open_agent_age_s"], 670.5, delta=1.0)
+
+    def test_subagent_stuck_sac_fields_zero_when_absent(self):
+        """subagent_stuck alert defaults sac fields to 0/None when not pushed."""
+        self._register("agent-no-sac")
+        self._make_online("agent-no-sac")
+        self._inject(
+            "agent-no-sac",
+            orochi_subagent_count=1,
+            subagent_active_since=time.time() - 650,
+        )
+        resp = self._get()
+        data = resp.json()
+        self.assertEqual(data["count"], 1)
+        alert = data["alerts"][0]
+        self.assertEqual(alert["kind"], "subagent_stuck")
+        self.assertEqual(alert["open_agent_calls_count"], 0)
+        self.assertIsNone(alert["oldest_open_agent_age_s"])
 
     def test_thresholds_in_response(self):
         resp = self._get()

--- a/hub/views/agent_detail.py
+++ b/hub/views/agent_detail.py
@@ -362,6 +362,10 @@ def api_agent_detail(request, name: str):
         "sac_hooks_recent_prompts": agent.get("sac_hooks_recent_prompts") or [],
         "sac_hooks_agent_calls": agent.get("sac_hooks_agent_calls") or [],
         "sac_hooks_background_tasks": agent.get("sac_hooks_background_tasks") or [],
+        # orochi#133 — stuck-subagent detection.
+        "sac_hooks_open_agent_calls": agent.get("sac_hooks_open_agent_calls") or [],
+        "sac_hooks_open_agent_calls_count": agent.get("sac_hooks_open_agent_calls_count") or 0,
+        "sac_hooks_oldest_open_agent_age_s": agent.get("sac_hooks_oldest_open_agent_age_s"),
         "sac_hooks_tool_counts": agent.get("sac_hooks_tool_counts") or {},
         # Functional-heartbeat shortcuts.
         "sac_hooks_last_tool_at": agent.get("sac_hooks_last_tool_at") or "",

--- a/hub/views/api/_agents_register.py
+++ b/hub/views/api/_agents_register.py
@@ -259,6 +259,10 @@ def api_agents_register(request):
             "sac_hooks_recent_prompts": body.get("sac_hooks_recent_prompts") or [],
             "sac_hooks_agent_calls": body.get("sac_hooks_agent_calls") or [],
             "sac_hooks_background_tasks": body.get("sac_hooks_background_tasks") or [],
+            # orochi#133 — stuck-subagent detection (sac-side LIFO open-call tracking).
+            "sac_hooks_open_agent_calls": body.get("sac_hooks_open_agent_calls") or [],
+            "sac_hooks_open_agent_calls_count": body.get("sac_hooks_open_agent_calls_count") or 0,
+            "sac_hooks_oldest_open_agent_age_s": body.get("sac_hooks_oldest_open_agent_age_s"),
             "sac_hooks_tool_counts": body.get("sac_hooks_tool_counts") or {},
             # Functional-heartbeat shortcuts — last tool use (LLM-level
             # liveness) + last mcp__* tool (proves MCP sidecar route).

--- a/hub/views/api/_misc.py
+++ b/hub/views/api/_misc.py
@@ -171,6 +171,12 @@ def api_watchdog_alerts(request):
         # Case 2: subagent count non-zero for longer than threshold
         subagent_count = int(a.get("orochi_subagent_count") or 0)
         active_since = a.get("subagent_active_since")
+        # orochi#133: corroborate hub-side timer with sac-side LIFO detection.
+        # sac_hooks_open_agent_calls_count > 0 means the agent-container's own
+        # ring-buffer sees an unmatched Agent pretool — higher confidence the
+        # subagent is genuinely stuck (not just a count-update lag).
+        open_calls_count = int(a.get("sac_hooks_open_agent_calls_count") or 0)
+        oldest_open_age = a.get("sac_hooks_oldest_open_agent_age_s")
         if (
             name not in seen
             and subagent_count > 0
@@ -191,6 +197,9 @@ def api_watchdog_alerts(request):
                     "subagent_count": subagent_count,
                     "subagent_active_since": active_since,
                     "subagent_stuck_seconds": stuck_secs,
+                    # sac-side corroboration (0 / None when sac data absent).
+                    "open_agent_calls_count": open_calls_count,
+                    "oldest_open_agent_age_s": oldest_open_age,
                     "suggested_action": "escalate",
                 }
             )

--- a/scripts/client/_collect_agent_metadata/__init__.py
+++ b/scripts/client/_collect_agent_metadata/__init__.py
@@ -23,7 +23,11 @@ from ._classifier import (
 )
 from ._cli import cli_main
 from ._collect import collect, main
-from ._hooks import _HOOK_EVENT_KEYS, _collect_hook_events
+from ._hooks import _SAC_TO_HUB, _collect_hook_events
+
+# Back-compat: callers that iterated _HOOK_EVENT_KEYS as a list of strings now
+# get the hub-side key names (the values of the mapping).
+_HOOK_EVENT_KEYS = tuple(_SAC_TO_HUB.values())
 from ._hostname import _resolve_canonical_hostname
 from ._metrics import collect_machine_metrics, collect_orochi_slurm_status
 from ._multiplexer import _list_local_agents, detect_multiplexer

--- a/scripts/client/_collect_agent_metadata/_hooks.py
+++ b/scripts/client/_collect_agent_metadata/_hooks.py
@@ -5,27 +5,32 @@ from __future__ import annotations
 import json
 import subprocess
 
-_HOOK_EVENT_KEYS = (
-    "sac_hooks_recent_tools",
-    "sac_hooks_recent_prompts",
-    "sac_hooks_tool_counts",
-    "sac_hooks_last_tool_name",
-    "sac_hooks_last_tool_at",
-    "sac_hooks_last_mcp_tool_name",
-    "sac_hooks_last_mcp_tool_at",
-    "sac_hooks_last_action_name",
-    "sac_hooks_last_action_at",
-    "sac_hooks_last_action_outcome",
-    "sac_hooks_last_action_elapsed_s",
-    "sac_hooks_p95_elapsed_s_by_action",
-    # scitex-orochi #132 — subagent activity. sac_hooks_agent_calls is the
-    # projected Agent/Task tool-invocation ring buffer; subagents is
-    # the in-flight list with descriptions; sac_hooks_background_tasks is
-    # run_in_background Bash calls.
-    "sac_hooks_agent_calls",
-    "sac_hooks_background_tasks",
-    "subagents",
-)
+# Mapping: sac status --json key → heartbeat payload key (sac_hooks_ prefix).
+# The sac outputs unprefixed field names; we add sac_hooks_ here so the hub
+# registry can namespace them without coupling to the sac key names.
+_SAC_TO_HUB: dict[str, str] = {
+    "recent_tools": "sac_hooks_recent_tools",
+    "recent_prompts": "sac_hooks_recent_prompts",
+    "tool_counts": "sac_hooks_tool_counts",
+    "last_tool_name": "sac_hooks_last_tool_name",
+    "last_tool_at": "sac_hooks_last_tool_at",
+    "last_mcp_tool_name": "sac_hooks_last_mcp_tool_name",
+    "last_mcp_tool_at": "sac_hooks_last_mcp_tool_at",
+    "last_action_name": "sac_hooks_last_action_name",
+    "last_action_at": "sac_hooks_last_action_at",
+    "last_action_outcome": "sac_hooks_last_action_outcome",
+    "last_action_elapsed_s": "sac_hooks_last_action_elapsed_s",
+    "p95_elapsed_s_by_action": "sac_hooks_p95_elapsed_s_by_action",
+    # scitex-orochi #132 — subagent activity.
+    "agent_calls": "sac_hooks_agent_calls",
+    "background_tasks": "sac_hooks_background_tasks",
+    # scitex-orochi #133 — stuck-subagent detection via LIFO open-call tracking.
+    "open_agent_calls": "sac_hooks_open_agent_calls",
+    "open_agent_calls_count": "sac_hooks_open_agent_calls_count",
+    "oldest_open_agent_age_s": "sac_hooks_oldest_open_agent_age_s",
+    # Pass-through (already has the right name for the hub).
+    "subagents": "subagents",
+}
 
 
 def _collect_hook_events(agent: str) -> dict:
@@ -36,6 +41,11 @@ def _collect_hook_events(agent: str) -> dict:
     pulled these fields from the hook-event ring buffer. Shell-out is
     short-lived (<1 s) and bounded by ``timeout``; on any failure we
     return an empty dict so the rest of the heartbeat still flows.
+
+    The sac ``status --json`` output uses unprefixed field names
+    (``recent_tools``, ``agent_calls``, …). This function re-maps them
+    to the ``sac_hooks_`` namespace expected by the hub registry so the
+    hub can namespace sac data without coupling to sac's key names.
     """
     try:
         proc = subprocess.run(
@@ -49,4 +59,4 @@ def _collect_hook_events(agent: str) -> dict:
         data = json.loads(proc.stdout or "{}")
     except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
         return {}
-    return {k: data[k] for k in _HOOK_EVENT_KEYS if k in data}
+    return {hub_key: data[sac_key] for sac_key, hub_key in _SAC_TO_HUB.items() if sac_key in data}

--- a/scripts/client/_collect_agent_metadata/_push.py
+++ b/scripts/client/_collect_agent_metadata/_push.py
@@ -116,6 +116,10 @@ def _build_payload(meta: dict, tok: str, sac_status: dict | None = None) -> dict
         # active-subagent badge.
         "sac_hooks_agent_calls": meta.get("sac_hooks_agent_calls") or [],
         "sac_hooks_background_tasks": meta.get("sac_hooks_background_tasks") or [],
+        # orochi#133 — stuck-subagent detection (sac-side LIFO open-call tracking).
+        "sac_hooks_open_agent_calls": meta.get("sac_hooks_open_agent_calls") or [],
+        "sac_hooks_open_agent_calls_count": meta.get("sac_hooks_open_agent_calls_count") or 0,
+        "sac_hooks_oldest_open_agent_age_s": meta.get("sac_hooks_oldest_open_agent_age_s"),
         "subagents": meta.get("subagents") or [],
         # scitex-orochi todo#369 — host-level machine metrics (CPU / mem
         # / disk / load) + optional SLURM cluster snapshot. Without

--- a/src/scitex_orochi/_models/heartbeat.py
+++ b/src/scitex_orochi/_models/heartbeat.py
@@ -164,6 +164,10 @@ HEARTBEAT_FIELDS: tuple[HeartbeatField, ...] = (
     HeartbeatField("sac_hooks_recent_prompts", [], "user-prompt events"),
     HeartbeatField("sac_hooks_agent_calls", [], "subagent-spawn events"),
     HeartbeatField("sac_hooks_background_tasks", [], "Background-task events"),
+    # orochi#133 — stuck-subagent detection (sac-side LIFO open-call tracking).
+    HeartbeatField("sac_hooks_open_agent_calls", [], "Agent pretool events with no posttool (potentially stuck)"),
+    HeartbeatField("sac_hooks_open_agent_calls_count", 0, "count of open (unmatched) Agent calls"),
+    HeartbeatField("sac_hooks_oldest_open_agent_age_s", None, "age_seconds of oldest open Agent call"),
     HeartbeatField(
         "sac_hooks_tool_counts", {}, "per-tool count map for the dashboard chip"
     ),

--- a/tests/test_push_payload_sac_status.py
+++ b/tests/test_push_payload_sac_status.py
@@ -34,6 +34,10 @@ _MIN_META = {
     "sac_hooks_recent_prompts": [],
     "sac_hooks_agent_calls": [],
     "sac_hooks_background_tasks": [],
+    # orochi#133 — stuck-subagent detection.
+    "sac_hooks_open_agent_calls": [],
+    "sac_hooks_open_agent_calls_count": 0,
+    "sac_hooks_oldest_open_agent_age_s": None,
     "subagents": [],
     "sac_hooks_tool_counts": {},
     "sac_hooks_p95_elapsed_s_by_action": {},


### PR DESCRIPTION
## Summary

Fix silent data loss in hooks + wire stuck-subagent LIFO detection through hub.

- **Fix _hooks.py**: was looking for sac_hooks_ prefixed keys in sac output but sac uses unprefixed keys (recent_tools, agent_calls). Was silently returning {} on every heartbeat. Replaced _HOOK_EVENT_KEYS tuple with _SAC_TO_HUB mapping dict.
- **Wire open_agent_calls** through full pipeline: _hooks -> _push -> _agents_register -> _register -> _payload -> agent_detail
- **Enrich subagent_stuck alert** with open_agent_calls_count and oldest_open_agent_age_s for sac-side corroboration of hub-side timer

## Test plan
- [x] python manage.py test hub.tests.registry -- 59/59 passing
- [x] python -m pytest tests/test_push_payload_sac_status.py -- 4/4 passing
- [ ] CI green

Generated with Claude Code