### PR TITLE
chore(lint): fix ruff I001/F401 in src/ and tests/ (make CI lint pass)

### DIFF
--- a/src/scitex_orochi/__init__.py
+++ b/src/scitex_orochi/__init__.py
@@ -1,7 +1,8 @@
 """Orochi -- Agent Communication Hub for the SciTeX ecosystem."""
 
 try:
-    from importlib.metadata import version as _v, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _v
     try:
         __version__ = _v("scitex-orochi")
     except PackageNotFoundError:

--- a/tests/test_hostname_aliases_config.py
+++ b/tests/test_hostname_aliases_config.py
@@ -5,10 +5,8 @@ Tests the YAML-reading logic in isolation — no Django infrastructure needed.
 
 from __future__ import annotations
 
-import os
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 
 def _load_hostname_aliases_impl(config_path: str) -> dict:

--- a/tests/test_orochi_slurm_resources.py
+++ b/tests/test_orochi_slurm_resources.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import patch
 
-from scitex_orochi import _resources, _orochi_slurm
+from scitex_orochi import _orochi_slurm, _resources
 
 # ---------------------------------------------------------------------------
 # Low-level parser tests

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -2,6 +2,7 @@
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
 from pathlib import Path
+
 from scitex_dev._skills_quality_pytest import make_skill_quality_tests
 
 test_skills_quality = make_skill_quality_tests(


### PR DESCRIPTION
## Summary

- Remove 2 unused imports from `tests/test_hostname_aliases_config.py` (unused `os`, `patch`)
- Sort import blocks in `src/scitex_orochi/__init__.py`, `tests/test_orochi_slurm_resources.py`, `tests/test_skills_quality.py`

After this PR, `ruff check src/ tests/` passes clean with 0 errors — turning the advisory lint gate into a real pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)