### PR TITLE
fix(liveness): classify limit_reached pane state as idle, not stale

### DIFF
--- a/docs/observability/drop-detection.md
+++ b/docs/observability/drop-detection.md
@@ -32,8 +32,8 @@ elif pane in ("stale", "auth_error"):
     liveness = "stale"
 elif pane == "idle":
     liveness = "idle"
-elif pane in ("y_n_prompt", "compose_pending_unsent", ...):
-    liveness = "idle"          # waiting — not stuck
+elif pane in ("y_n_prompt", "compose_pending_unsent", "limit_reached", ...):
+    liveness = "idle"          # waiting / rate-limited — not stuck
 elif idle_seconds > 600:       # >10 min no action
     liveness = "stale"
 elif idle_seconds > 120:       # >2 min

--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -104,8 +104,9 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 "bypass_permissions_prompt",
                 "dev_channels_prompt",
                 "y_n_prompt",
+                "limit_reached",
             ):
-                liveness = "idle"  # awaiting input — not stuck
+                liveness = "idle"  # awaiting input / rate-limited — not stuck
             elif idle_seconds is not None:
                 if idle_seconds > 600:
                     liveness = "stale"  # >10min silent — probably stuck

--- a/hub/tests/views/api/test_liveness_pane_state.py
+++ b/hub/tests/views/api/test_liveness_pane_state.py
@@ -1,0 +1,93 @@
+"""Tests for pane_state → liveness classification in GET /api/agents/.
+
+Ensures the liveness classifier in hub/registry/_payload.py maps
+each recognised pane_state value to the correct liveness label.
+"""
+
+import time
+
+from django.test import Client, TestCase
+
+from hub.models import Workspace, WorkspaceMember, WorkspaceToken
+from hub.registry import _agents as _reg
+from hub.registry import register_agent
+
+
+class LivenessPaneStateTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="lps-test-ws")
+        self.token = WorkspaceToken.objects.create(workspace=self.ws, label="ci")
+        from django.contrib.auth.models import User
+
+        self.user = User.objects.create_user(username="lps-tester", password="x")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.user, role="member"
+        )
+        _reg.clear()
+
+    def _register(self, name, **extra):
+        register_agent(name, workspace_id=self.ws.id, info={"machine": "lps-host", **extra})
+
+    def _inject(self, name, **fields):
+        if name in _reg:
+            _reg[name].update(fields)
+
+    def _get(self):
+        self.client.force_login(self.user)
+        return self.client.get(
+            "/api/agents/", HTTP_HOST=f"{self.ws.name}.lvh.me"
+        )
+
+    def _liveness_for(self, name):
+        data = self._get().json()
+        for a in data:
+            if a["name"] == name:
+                return a["liveness"]
+        return None
+
+    def test_running_pane_state_is_online(self):
+        self._register("a-running")
+        self._inject("a-running", orochi_pane_state="running", last_action=time.time())
+        self.assertEqual(self._liveness_for("a-running"), "online")
+
+    def test_stale_pane_state_is_stale(self):
+        self._register("a-stale")
+        self._inject("a-stale", orochi_pane_state="stale", last_action=time.time())
+        self.assertEqual(self._liveness_for("a-stale"), "stale")
+
+    def test_y_n_prompt_pane_state_is_idle(self):
+        self._register("a-ynprompt")
+        self._inject("a-ynprompt", orochi_pane_state="y_n_prompt", last_action=time.time())
+        self.assertEqual(self._liveness_for("a-ynprompt"), "idle")
+
+    def test_compose_pending_pane_state_is_idle(self):
+        self._register("a-compose")
+        self._inject("a-compose", orochi_pane_state="compose_pending_unsent", last_action=time.time())
+        self.assertEqual(self._liveness_for("a-compose"), "idle")
+
+    def test_bypass_permissions_pane_state_is_idle(self):
+        self._register("a-bypass")
+        self._inject("a-bypass", orochi_pane_state="bypass_permissions_prompt", last_action=time.time())
+        self.assertEqual(self._liveness_for("a-bypass"), "idle")
+
+    def test_limit_reached_pane_state_is_idle(self):
+        """limit_reached = Anthropic rate-limit visible; agent is alive but
+        temporarily blocked — must be classified as idle, not stale."""
+        self._register("a-limited")
+        self._inject(
+            "a-limited",
+            orochi_pane_state="limit_reached",
+            last_action=time.time() - 700,
+        )
+        self.assertEqual(self._liveness_for("a-limited"), "idle")
+
+    def test_unknown_pane_state_falls_through_to_time_based(self):
+        """Unrecognised pane state falls back to idle_seconds heuristic."""
+        self._register("a-unknown")
+        self._inject(
+            "a-unknown",
+            orochi_pane_state="some_future_state",
+            last_action=time.time() - 700,
+        )
+        self.assertEqual(self._liveness_for("a-unknown"), "stale")


### PR DESCRIPTION
## Summary

- `limit_reached` (Anthropic rate-limit warning in terminal) was not in the recognised pane_state set, causing it to fall through to the `idle_seconds` heuristic
- After >10 min of rate-limiting, the agent appeared `stale` on the dashboard — triggering false-positive `subagent_stuck` alerts
- Fix: add `limit_reached` to the `idle` pane states alongside `y_n_prompt`, `compose_pending_unsent`, etc.

## Test plan

- [x] 5 new tests in `hub/tests/views/api/test_liveness_pane_state.py`: running→online, stale→stale, y_n_prompt→idle, `limit_reached→idle`, unknown→stale (time-based fallthrough)
- [x] Updated `docs/observability/drop-detection.md` classification table

🤖 Generated with [Claude Code](https://claude.com/claude-code)