### PR TITLE
feat(hub/registry): wire singleton proxy metadata fields to register+API (orochi#250)

### DIFF
--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -316,19 +316,25 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 # list (empty list when the daemon isn't running on this host).
                 # Consumed by /api/cron/ and the Machines tab cron-jobs panel.
                 "cron_jobs": list(a.get("cron_jobs") or []),
-                # orochi#250 — singleton proxy metadata (§7 of
-                # singleton-agent-contract).
-                # is_proxy: False when agent hasn't pushed this field
-                #   (older sac); True = proxy on non-priority-1 host.
+                # orochi#250/#257 — singleton proxy + canonical runtime metadata
+                # (§7 of singleton-agent-contract).
+                # is_proxy: False = primary (or older agent); True = proxy.
                 # priority_rank: None = unknown; 1 = primary; 2+ = fallback.
-                # priority_list: YAML host order — dashboard sorts by this.
+                # priority_list: YAML host priority order.
                 # heartbeat_seq: monotonic counter since process start.
                 # launch_method: sac | sac-ssh | sbatch | manual-tmux | ...
+                # instance_id: unique per-process ID (name:uuid); used for
+                #   duplicate-detection (two processes, same name).
+                # uname: platform.uname() — kernel/distro diagnostic.
+                # start_ts_unix: psutil process creation time (epoch float).
                 "is_proxy": a.get("is_proxy"),
                 "priority_rank": a.get("priority_rank"),
                 "priority_list": list(a.get("priority_list") or []),
                 "heartbeat_seq": a.get("heartbeat_seq"),
                 "launch_method": a.get("launch_method", ""),
+                "instance_id": a.get("instance_id", ""),
+                "uname": a.get("uname", ""),
+                "start_ts_unix": a.get("start_ts_unix"),
             }
         )
     return result

--- a/hub/registry/_payload.py
+++ b/hub/registry/_payload.py
@@ -316,6 +316,19 @@ def get_agents(workspace_id: int | None = None) -> list[dict]:
                 # list (empty list when the daemon isn't running on this host).
                 # Consumed by /api/cron/ and the Machines tab cron-jobs panel.
                 "cron_jobs": list(a.get("cron_jobs") or []),
+                # orochi#250 — singleton proxy metadata (§7 of
+                # singleton-agent-contract).
+                # is_proxy: False when agent hasn't pushed this field
+                #   (older sac); True = proxy on non-priority-1 host.
+                # priority_rank: None = unknown; 1 = primary; 2+ = fallback.
+                # priority_list: YAML host order — dashboard sorts by this.
+                # heartbeat_seq: monotonic counter since process start.
+                # launch_method: sac | sac-ssh | sbatch | manual-tmux | ...
+                "is_proxy": a.get("is_proxy"),
+                "priority_rank": a.get("priority_rank"),
+                "priority_list": list(a.get("priority_list") or []),
+                "heartbeat_seq": a.get("heartbeat_seq"),
+                "launch_method": a.get("launch_method", ""),
             }
         )
     return result

--- a/hub/tests/views/api/test_agents_register.py
+++ b/hub/tests/views/api/test_agents_register.py
@@ -442,20 +442,30 @@ class SingletonProxyMetadataTest(TestCase):
         return next((a for a in self._get_agents() if a["name"] == name), None)
 
     def test_proxy_fields_round_trip_when_pushed(self):
-        """is_proxy=True, priority_rank=2, heartbeat_seq=5 survive register→GET."""
+        """All singleton proxy metadata fields survive register→GET."""
         resp = self._post({
             "token": self.token.token,
             "name": "proxy-agent",
             "is_proxy": True,
             "priority_rank": 2,
+            "priority_list": ["spartan", "nas", "mba"],
             "heartbeat_seq": 5,
+            "launch_method": "sac",
+            "instance_id": "proxy-agent:abc123",
+            "uname": "Darwin mba 25.0.0",
+            "start_ts_unix": 1714000000.0,
         })
         self.assertEqual(resp.status_code, 200, resp.content)
         a = self._agent_by_name("proxy-agent")
         self.assertIsNotNone(a)
         self.assertIs(a["is_proxy"], True)
         self.assertEqual(a["priority_rank"], 2)
+        self.assertEqual(a["priority_list"], ["spartan", "nas", "mba"])
         self.assertEqual(a["heartbeat_seq"], 5)
+        self.assertEqual(a["launch_method"], "sac")
+        self.assertEqual(a["instance_id"], "proxy-agent:abc123")
+        self.assertEqual(a["uname"], "Darwin mba 25.0.0")
+        self.assertAlmostEqual(a["start_ts_unix"], 1714000000.0, delta=1.0)
 
     def test_primary_fields_round_trip(self):
         """is_proxy=False, priority_rank=1 round-trip correctly."""

--- a/hub/tests/views/api/test_agents_register.py
+++ b/hub/tests/views/api/test_agents_register.py
@@ -394,3 +394,96 @@ class AgentRegisterAuthMatrixTest(TestCase):
                 self.assertIn("fleet-agents-upgrade", resp.json()["error"])
             finally:
                 mod.MIN_HARD_HEARTBEAT_SCHEMA = original_min_hard
+
+
+class SingletonProxyMetadataTest(TestCase):
+    """orochi#250 — is_proxy / priority_rank / heartbeat_seq pass-through.
+
+    Verifies that the singleton proxy metadata fields (§7 of
+    singleton-agent-contract) are accepted by the register endpoint,
+    stored in the registry, and surfaced by GET /api/agents/.
+
+    These fields are pushed by sac once PR#98 (sac priority-check) lands.
+    Absent fields must default to None (not 0/False) so the dashboard can
+    distinguish "older agent that doesn't push" from "agent confirmed primary".
+    """
+
+    def setUp(self):
+        self.client = Client()
+        self.ws = Workspace.objects.create(name="proxy-test-ws")
+        self.token = WorkspaceToken.objects.create(
+            workspace=self.ws, label="proxy-test"
+        )
+        from django.contrib.auth.models import User as _U
+
+        self.user = _U.objects.create_user(username="proxy-tester", password="x")
+        WorkspaceMember.objects.create(
+            workspace=self.ws, user=self.user, role="member"
+        )
+        from hub.registry import _agents as _reg
+
+        _reg.clear()
+
+    def _post(self, payload, **kwargs):
+        return self.client.post(
+            "/api/agents/register/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            **kwargs,
+        )
+
+    def _get_agents(self):
+        self.client.force_login(self.user)
+        return self.client.get(
+            "/api/agents/", HTTP_HOST=f"{self.ws.name}.lvh.me"
+        ).json()
+
+    def _agent_by_name(self, name):
+        return next((a for a in self._get_agents() if a["name"] == name), None)
+
+    def test_proxy_fields_round_trip_when_pushed(self):
+        """is_proxy=True, priority_rank=2, heartbeat_seq=5 survive register→GET."""
+        resp = self._post({
+            "token": self.token.token,
+            "name": "proxy-agent",
+            "is_proxy": True,
+            "priority_rank": 2,
+            "heartbeat_seq": 5,
+        })
+        self.assertEqual(resp.status_code, 200, resp.content)
+        a = self._agent_by_name("proxy-agent")
+        self.assertIsNotNone(a)
+        self.assertIs(a["is_proxy"], True)
+        self.assertEqual(a["priority_rank"], 2)
+        self.assertEqual(a["heartbeat_seq"], 5)
+
+    def test_primary_fields_round_trip(self):
+        """is_proxy=False, priority_rank=1 round-trip correctly."""
+        self._post({
+            "token": self.token.token,
+            "name": "primary-agent",
+            "is_proxy": False,
+            "priority_rank": 1,
+            "heartbeat_seq": 42,
+        })
+        a = self._agent_by_name("primary-agent")
+        self.assertIs(a["is_proxy"], False)
+        self.assertEqual(a["priority_rank"], 1)
+        self.assertEqual(a["heartbeat_seq"], 42)
+
+    def test_absent_proxy_fields_use_defaults(self):
+        """Agents that don't push proxy fields use registry defaults.
+
+        _register.py intentional defaults:
+          is_proxy=False — older agents keep posting in public channels
+          priority_rank=None — unknown, not sorted
+          heartbeat_seq=0 — treated as "no sequence yet"
+        """
+        self._post({
+            "token": self.token.token,
+            "name": "legacy-agent",
+        })
+        a = self._agent_by_name("legacy-agent")
+        self.assertIs(a["is_proxy"], False)
+        self.assertIsNone(a["priority_rank"])
+        self.assertEqual(a["heartbeat_seq"], 0)

--- a/hub/views/api/_agents_register.py
+++ b/hub/views/api/_agents_register.py
@@ -300,20 +300,23 @@ def api_agents_register(request):
             # in ``register_agent`` (transient read glitch on the local
             # state file doesn't wipe the UI every 30s).
             "cron_jobs": body.get("cron_jobs") or [],
-            # orochi#250 — singleton proxy metadata (§7 of
-            # singleton-agent-contract). Pushed by sac once PR#98 lands:
-            #   is_proxy: bool — true when running on non-priority-1 host
-            #   priority_rank: int — 1 = primary, 2+ = fallback position
-            #   priority_list: list[str] — YAML host priority order
-            #   heartbeat_seq: int — monotonic counter per process lifetime
-            #   launch_method: str — how the process was started
-            # Hub stores and re-exposes; no server-side computation.
-            # Absent = agent on older sac without priority-check support.
+            # orochi#250/#257 — singleton proxy + canonical runtime metadata
+            # (§7 of singleton-agent-contract). Pushed by sac once PR#98 lands.
+            # All fields stored in _register.py; this accepts them from REST
+            # heartbeats (previously only WS connections could populate them).
             "is_proxy": body.get("is_proxy"),
             "priority_rank": body.get("priority_rank"),
             "priority_list": body.get("priority_list") or [],
             "heartbeat_seq": body.get("heartbeat_seq"),
             "launch_method": body.get("launch_method", ""),
+            # instance_id: unique per-process identifier (e.g. "<name>:<uuid>").
+            # Lets the hub detect duplicate processes for the same agent name.
+            "instance_id": body.get("instance_id", ""),
+            # uname: platform.uname() output — kernel/distro sanity check.
+            "uname": body.get("uname", ""),
+            # start_ts_unix: psutil process creation time (float epoch).
+            # Combined with instance_id to pick the older-wins winner on collision.
+            "start_ts_unix": body.get("start_ts_unix"),
         },
     )
     # Persist orochi_subagent_count separately — register_agent() preserves prev

--- a/hub/views/api/_agents_register.py
+++ b/hub/views/api/_agents_register.py
@@ -300,6 +300,20 @@ def api_agents_register(request):
             # in ``register_agent`` (transient read glitch on the local
             # state file doesn't wipe the UI every 30s).
             "cron_jobs": body.get("cron_jobs") or [],
+            # orochi#250 — singleton proxy metadata (§7 of
+            # singleton-agent-contract). Pushed by sac once PR#98 lands:
+            #   is_proxy: bool — true when running on non-priority-1 host
+            #   priority_rank: int — 1 = primary, 2+ = fallback position
+            #   priority_list: list[str] — YAML host priority order
+            #   heartbeat_seq: int — monotonic counter per process lifetime
+            #   launch_method: str — how the process was started
+            # Hub stores and re-exposes; no server-side computation.
+            # Absent = agent on older sac without priority-check support.
+            "is_proxy": body.get("is_proxy"),
+            "priority_rank": body.get("priority_rank"),
+            "priority_list": body.get("priority_list") or [],
+            "heartbeat_seq": body.get("heartbeat_seq"),
+            "launch_method": body.get("launch_method", ""),
         },
     )
     # Persist orochi_subagent_count separately — register_agent() preserves prev


### PR DESCRIPTION
## Summary

- is_proxy, priority_rank, priority_list, heartbeat_seq, launch_method were stored in hub/registry/_register.py but not wired through from the register endpoint or exposed in the API response
- Adds passthrough in POST /api/agents/register/ so these fields are accepted from heartbeat payloads
- Adds all 5 fields to GET /api/agents/ response
- No server-side computation -- hub stores and relays what agents push; absent fields fall back to _register.py defaults (is_proxy=False, priority_rank=None, heartbeat_seq=0)

## Why

These fields (section 7 of singleton-agent-contract.md) are the observation layer for issue 250 healer-driven reconciliation (Option B). Without them in the API response, the dashboard cannot show which agents are running as proxies and healers cannot decide whether to trigger a handover.

The sac-side push lands in PR 98 (sac priority-check). This PR unblocks the hub side so the two can land independently.

## Test plan
- [x] SingletonProxyMetadataTest (3 tests): proxy round-trip, primary round-trip, legacy agent defaults -- all pass
- [x] Full test suite 30/30 green