### PR TITLE
feat(mcp): PING sidecar auto-responder in dispatch.ts (todo#424)

### DIFF
--- a/tests/test_orochi_slurm_resources.py
+++ b/tests/test_orochi_slurm_resources.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 from scitex_orochi import _orochi_slurm, _resources
 
 # ---------------------------------------------------------------------------
@@ -198,9 +200,6 @@ def test_collect_metrics_merges_orochi_slurm_override():
     assert metrics["orochi_slurm_total_jobs"] == 3
     # Disk is NOT touched by orochi_slurm — local /proc value still present
     # (skip assertion on exact value; just require key exists when available)
-
-
-import pytest
 
 
 @pytest.mark.skipif(

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -1,8 +1,9 @@
 """Enforces SciTeX skills quality checklist §1–§4.
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
-import pytest
 from pathlib import Path
+
+import pytest
 
 try:
     from scitex_dev._skills_quality_pytest import make_skill_quality_tests

--- a/ts/mcp_channel/dispatch.ts
+++ b/ts/mcp_channel/dispatch.ts
@@ -221,6 +221,36 @@ export async function handleWsMessage(
       }
     }
 
+    // PING sidecar: auto-respond to 1-min liveness pings without waking
+    // Claude. Pattern: ^PING-[a-f0-9]{8}$. Responds "pong PING-<nonce>"
+    // with reply_to=<original msg_id>. Latency <1s. See todo#424.
+    if (/^PING-[a-f0-9]{8}$/.test(content.trim())) {
+      const nonce = content.trim();
+      const pongPayload: Record<string, unknown> = {
+        channel: channel || "#general",
+        text: `pong ${nonce}`,
+        metadata: msgId != null ? { reply_to: String(msgId) } : {},
+      };
+      let sent = false;
+      try {
+        ws.send(
+          JSON.stringify({
+            type: "message",
+            sender: OROCHI_AGENT,
+            payload: pongPayload,
+          }),
+        );
+        sent = true;
+      } catch {}
+      dbg(
+        `ping-sidecar: ${nonce} from ${sender}@${channel} msg_id=${msgId ?? "?"} sent=${sent}`,
+      );
+      console.error(
+        `[orochi] ping-sidecar auto-pong ${nonce} (from=${sender} channel=${channel} sent=${sent})`,
+      );
+      return;
+    }
+
     // @mention filtering: only deliver messages addressed to this agent
     const mentions = content.match(/@(\w[\w-]*)/g);
     if (mentions && mentions.length > 0) {


### PR DESCRIPTION
## Summary

- Adds PING auto-responder to `ts/mcp_channel/dispatch.ts` — the correct location in the new modular architecture
- Intercepts inbound `^PING-[a-f0-9]{8}$` messages after dedup, before @mention filter
- Emits `pong PING-<nonce>` with `reply_to=<msg_id>` directly via `ws.send()`, no Claude round-trip
- Uses `ws` directly (not `conn.send()`) to avoid circular import: `connection.ts → dispatch.ts → connection.ts`

## Supersedes

Closes #122 (feat/mcp-ping-sidecar) — that PR added the same feature to the old monolithic `ts/mcp_channel.ts`. This PR applies the same logic to the new modular structure.

## Test plan

- [ ] CI lint + tests pass
- [ ] Confirm no circular import: `connection.ts` imports `dispatch.ts`; `dispatch.ts` must NOT import `connection.ts`
- [ ] Verify PING-{nonce} from another agent triggers pong response from sidecar without waking Claude