### PR TITLE
feat(fleet-watch): fleet-mesh-audit.sh + pane_tail_block_clean fix (#387)

### DIFF
--- a/scripts/client/fleet-watch/fleet_watch.sh
+++ b/scripts/client/fleet-watch/fleet_watch.sh
@@ -123,9 +123,9 @@ classify_orochi_pane_state() {
     command -v jq >/dev/null 2>&1 || return 0
     [ -s "$curr" ] || return 0
 
-    # Pull every (agent, orochi_pane_tail_block) pair we can find. Both schemas:
-    #   snapshot --json: .agent + .agent_meta.orochi_pane_tail_block          (single)
-    #   probe_remote.sh fallback: .agents_meta.<name>.orochi_pane_tail_block  (map)
+    # Pull every (agent, pane_tail_block) pair we can find. Both schemas:
+    #   snapshot --json: .agent + (.agent_meta.pane_tail_block_clean // .agent_meta.pane_tail_block)          (single)
+    #   probe_remote.sh fallback: .agents_meta.<name>.pane_tail_block  (map)
     local pairs
     pairs=$(jq -r '
         def pair($name; $block):
@@ -133,7 +133,7 @@ classify_orochi_pane_state() {
             else "\($name)\t\($block | tostring | @base64)" end;
         (
             (if .agent != null and (.agent_meta? // null) != null
-              then pair(.agent; .agent_meta.orochi_pane_tail_block)
+              then pair(.agent; (.agent_meta.pane_tail_block_clean // .agent_meta.pane_tail_block))
               else empty end),
             (
                 (.agents_meta // {})
@@ -152,7 +152,7 @@ classify_orochi_pane_state() {
                 else "\($name)\t\($block | tostring | @base64)" end;
             (
                 (if .agent != null and (.agent_meta? // null) != null
-                  then pair(.agent; .agent_meta.orochi_pane_tail_block)
+                  then pair(.agent; (.agent_meta.pane_tail_block_clean // .agent_meta.pane_tail_block))
                   else empty end),
                 (
                     (.agents_meta // {})

--- a/scripts/client/fleet-watch/pane_state.py
+++ b/scripts/client/fleet-watch/pane_state.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 import json
 import re
 import sys
-from dataclasses import dataclass, asdict, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 # Mirror of --ecc-state-detection-buffer-size (elisp). The canonical

--- a/tests/test_orochi_slurm_resources.py
+++ b/tests/test_orochi_slurm_resources.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 from scitex_orochi import _orochi_slurm, _resources
 
 # ---------------------------------------------------------------------------
@@ -198,9 +200,6 @@ def test_collect_metrics_merges_orochi_slurm_override():
     assert metrics["orochi_slurm_total_jobs"] == 3
     # Disk is NOT touched by orochi_slurm — local /proc value still present
     # (skip assertion on exact value; just require key exists when available)
-
-
-import pytest
 
 
 @pytest.mark.skipif(

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -1,8 +1,9 @@
 """Enforces SciTeX skills quality checklist §1–§4.
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
-import pytest
 from pathlib import Path
+
+import pytest
 
 try:
     from scitex_dev._skills_quality_pytest import make_skill_quality_tests


### PR DESCRIPTION
Supersedes #125. Adds fleet-mesh-audit.sh to scripts/client/fleet-watch/ and fixes stuck-detection to use pane_tail_block_clean.