### PR TITLE
fix(cli): hide rename stubs from --help (post-Phase-1d)

### DIFF
--- a/src/scitex_orochi/_cli/_main.py
+++ b/src/scitex_orochi/_cli/_main.py
@@ -131,13 +131,45 @@ def orochi(
 
 
 # ── Register subcommands ────────────────────────────────────────
-# Phase 1d Step C (plan PR #337 §2): the legacy flat verb-noun command
-# names (e.g. ``agent-launch``, ``list-agents``, ``send``) have been
-# removed entirely. Their grace period under interface-cli §5 is over;
-# users who type a removed name now get Click's standard
-# ``Error: No such command 'agent-launch'.`` and exit 2. The canonical
-# noun-verb forms (``agent launch``, ``agent list``, ``message send``,
-# …) are the only entry points.
+# Post-Phase-1d cleanup (PR #347): re-register the 28 legacy flat
+# command names as hidden stubs (hidden=True) so they don't appear in
+# ``--help`` but still give the canonical rename error when invoked
+# (ywatanabe msg#16746). The noun-verb forms remain the only
+# advertised entry points.
+from scitex_orochi._cli._deprecation import make_rename_stub
+
+_RENAMES: list[tuple[str, str]] = [
+    ("agent-launch", "agent launch"),
+    ("agent-restart", "agent restart"),
+    ("agent-status", "agent status"),
+    ("agent-stop", "agent stop"),
+    ("list-agents", "agent list"),
+    ("fleet", "agent fleet-list"),
+    ("launch", "agent launch"),
+    ("stop", "agent stop"),
+    ("send", "message send"),
+    ("listen", "message listen"),
+    ("show-history", "channel history"),
+    ("join", "channel join"),
+    ("list-channels", "channel list"),
+    ("list-members", "channel members"),
+    ("create-invite", "invite create"),
+    ("list-invites", "invite list"),
+    ("create-workspace", "workspace create"),
+    ("delete-workspace", "workspace delete"),
+    ("list-workspaces", "workspace list"),
+    ("show-status", "server status"),
+    ("serve", "server start"),
+    ("deploy", "server deploy"),
+    ("setup-push", "push setup"),
+    ("init", "config init"),
+    ("doctor", "system doctor"),
+    ("login", "auth login"),
+    ("heartbeat-push", "machine heartbeat send"),
+    ("report", "hook report"),
+]
+for _old, _new in _RENAMES:
+    orochi.add_command(make_rename_stub(_old, _new))
 from scitex_orochi._cli.commands.docs_cmd import docs
 from scitex_orochi._cli.commands.skills_cmd import skills
 

--- a/tests/cli/test_phase1d_step_c_rename_functional.py
+++ b/tests/cli/test_phase1d_step_c_rename_functional.py
@@ -70,23 +70,21 @@ def test_new_form_help_is_reachable(new_path: list[str]) -> None:
     assert "Usage:" in result.output
 
 
-def test_legacy_flat_alias_is_unknown_command() -> None:
-    """Representative regression check: a former rename shim
-    (``agent-launch``) is now an unknown command, so Click prints its
-    standard ``No such command`` error and exits non-zero. This locks
-    the post-grace-period contract — no shim, no forward-pointer
-    redirect — without parametrizing across all 28 deleted aliases.
+def test_legacy_flat_alias_hard_errors_with_rename_message() -> None:
+    """Representative regression check: the former flat alias
+    ``agent-launch`` is registered as a hidden stub that emits the
+    canonical rename error and exits 2. Hidden != removed (PR #347).
     """
     runner = CliRunner()
     result = runner.invoke(
         orochi, ["agent-launch"], obj={"host": "127.0.0.1", "port": 9559}
     )
-    assert result.exit_code != 0, (
-        "legacy flat alias `agent-launch` should be an unknown command "
-        f"after shim removal; got exit {result.exit_code}\n"
+    assert result.exit_code == 2, (
+        f"expected exit 2 from hidden rename stub; got {result.exit_code}\n"
         f"output: {result.output}"
     )
-    assert "No such command 'agent-launch'" in result.output, (
-        "expected Click's standard 'No such command' error; got:\n"
-        f"{result.output}"
+    assert (
+        "error: `scitex-orochi agent-launch` was renamed to `scitex-orochi agent launch`."
+    ) in result.output, (
+        f"expected canonical rename error message; got:\n{result.output}"
     )

--- a/tests/test_orochi_slurm_resources.py
+++ b/tests/test_orochi_slurm_resources.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 from scitex_orochi import _orochi_slurm, _resources
 
 # ---------------------------------------------------------------------------
@@ -198,9 +200,6 @@ def test_collect_metrics_merges_orochi_slurm_override():
     assert metrics["orochi_slurm_total_jobs"] == 3
     # Disk is NOT touched by orochi_slurm — local /proc value still present
     # (skip assertion on exact value; just require key exists when available)
-
-
-import pytest
 
 
 @pytest.mark.skipif(

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -1,8 +1,9 @@
 """Enforces SciTeX skills quality checklist §1–§4.
 Canonical: src/scitex/_skills/general/21_scitex-package-quality-checklist.md
 """
-import pytest
 from pathlib import Path
+
+import pytest
 
 try:
     from scitex_dev._skills_quality_pytest import make_skill_quality_tests


### PR DESCRIPTION
Supersedes #347. Cherry-picks the single CLI fix commit onto current develop. Adds make_rename_stub() with hidden=True so the 28 legacy rename stubs are no longer visible in --help.