### PR TITLE
feat(caduceus): Phase 2 pong reader — REST history poll + _scan_pongs (todo#467)

### DIFF
--- a/src/scitex_orochi/_caduceus.py
+++ b/src/scitex_orochi/_caduceus.py
@@ -234,6 +234,62 @@ def register_self(hub: str, token: str | None, name: str, machine: str) -> bool:
     return False
 
 
+def _poll_channel_history(
+    hub: str,
+    token: str | None,
+    channel: str,
+    since_iso: str | None = None,
+    limit: int = 50,
+) -> list[dict]:
+    """Fetch recent messages from a channel via REST history endpoint.
+
+    Returns a list of message dicts with at least ``content`` and ``ts``
+    keys. Empty list on any error (best-effort; never raises).
+    """
+    import urllib.parse
+
+    ch = channel.lstrip("#")
+    url = f"{hub.rstrip('/')}/api/history/{urllib.parse.quote(ch, safe='')}/"
+    params: dict[str, str] = {"limit": str(limit)}
+    if since_iso:
+        params["since"] = since_iso
+    if token:
+        params["token"] = token
+    url += "?" + urllib.parse.urlencode(params)
+    data = _http_get_json(url)
+    if not isinstance(data, list):
+        return []
+    return data
+
+
+def _scan_pongs(
+    messages: list[dict],
+    state: GreetingState,
+    now: float,
+) -> int:
+    """Feed channel messages into greeting state to match pongs.
+
+    Each message's ``content`` field is checked for ``[pong:<hex>]`` tokens.
+    Matched pongs are consumed from the in-flight table and the agent's
+    conversational status is updated to "healthy". Returns the count of
+    pongs matched.
+    """
+    matched = 0
+    for msg in messages:
+        body = msg.get("content") or ""
+        ping = state.record_reply(body, now)
+        if ping is not None:
+            rtt = now - ping.sent_ts
+            log.info(
+                "pong received: agent=%s nonce=%s rtt=%.1fs",
+                ping.agent,
+                ping.nonce,
+                rtt,
+            )
+            matched += 1
+    return matched
+
+
 def greeting_scan(
     hub: str,
     token: str | None,
@@ -243,20 +299,39 @@ def greeting_scan(
     channel: str,
     interval_s: int,
     timeout_s: int,
+    last_poll_iso: list[str | None] | None = None,
 ) -> None:
     """One tick of the conversational round-trip health check (todo#168).
 
-    1. Sweep expired in-flight greetings → mark owners inbound-deaf.
-    2. For every agent in the roster, decide if they're due for a ping.
-    3. Post the greeting, remember ``(agent, nonce, sent_ts)``.
+    1. Pull recent channel history and feed pongs into ``state`` (Phase 2).
+    2. Sweep expired in-flight greetings → mark owners inbound-deaf.
+    3. For every agent in the roster, decide if they're due for a ping.
+    4. Post the greeting, remember ``(agent, nonce, sent_ts)``.
 
-    Matching incoming pongs happens out-of-band — a separate code path
-    watches ``#<channel>`` traffic and calls
-    ``state.record_reply(body, now)`` per inbound message. That path
-    lives in the MCP-bridge verifier (sidecar lane, Phase 2); for now
-    the caller can call ``state.record_reply`` manually in tests.
+    ``last_poll_iso`` is a one-element list used as a mutable cell so
+    the caller can pass a persistent reference across ticks. The value
+    is updated to the current timestamp after each poll so the next call
+    only fetches messages posted since the last scan.
     """
     now = time.time()
+
+    # Phase 2 — poll channel history and match pongs before sweeping.
+    # last_poll_iso is a one-element mutable cell so the caller can share
+    # state across loop iterations without an extra field on GreetingState.
+    if last_poll_iso is None:
+        last_poll_iso = [None]
+    try:
+        messages = _poll_channel_history(
+            hub, token, channel, since_iso=last_poll_iso[0], limit=100
+        )
+        if messages:
+            _scan_pongs(messages, state, now)
+    except Exception as exc:
+        log.debug("pong poll error: %s", exc)
+    from datetime import datetime
+    from datetime import timezone as _tz
+    last_poll_iso[0] = datetime.now(_tz.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")
+
     expired = state.sweep_expired(now)
     for ping in expired:
         label = state.conversational_status(ping.agent)
@@ -306,6 +381,9 @@ def loop(
     last_action_ts: dict[str, float] = {}
     last_greeting_ts: dict[str, float] = {}
     greeting_state = GreetingState()
+    # Mutable one-element cell shared across greeting_scan() calls so each
+    # poll only fetches messages posted since the previous scan (Phase 2).
+    last_poll_iso: list[str | None] = [None]
     self_host = (
         os.environ.get("SCITEX_OROCHI_CADUCEUS_HOST")
         or os.environ.get("SCITEX_OROCHI_MACHINE")
@@ -361,6 +439,7 @@ def loop(
                     channel=greeting_channel,
                     interval_s=greeting_interval_s,
                     timeout_s=greeting_timeout_s,
+                    last_poll_iso=last_poll_iso,
                 )
             except Exception as e:  # never let greeting errors kill the loop
                 log.warning("greeting_scan error: %s", e)

--- a/tests/test_caduceus_greeting.py
+++ b/tests/test_caduceus_greeting.py
@@ -241,3 +241,127 @@ def test_default_timeout_matches_rule_13():
     # fleet-communication-discipline.md §13. Do not relax without
     # explicit ywatanabe sign-off.
     assert DEFAULT_TIMEOUT_S == 60
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — pong reader (_scan_pongs / _poll_channel_history) — todo#467
+# ---------------------------------------------------------------------------
+
+class TestScanPongs:
+    """Tests for the REST history → GreetingState bridge (todo#467 Phase 2)."""
+
+    def test_scan_pongs_matches_pong_in_history(self):
+        from scitex_orochi._caduceus import _scan_pongs
+
+        state = GreetingState()
+        _, nonce = format_greeting("head-mba")
+        state.register_ping("head-mba", nonce, sent_ts=0.0, timeout_s=60)
+
+        messages = [{"content": f"[pong:{nonce}]", "ts": "2026-04-30T00:00:01Z"}]
+        matched = _scan_pongs(messages, state, now=5.0)
+
+        assert matched == 1
+        assert state.conversational_status("head-mba") == "healthy"
+        # Consumed from in-flight
+        assert ("head-mba", nonce) not in state.in_flight
+
+    def test_scan_pongs_ignores_unknown_nonces(self):
+        from scitex_orochi._caduceus import _scan_pongs
+
+        state = GreetingState()
+        messages = [{"content": "[pong:deadbeef]", "ts": "2026-04-30T00:00:01Z"}]
+        matched = _scan_pongs(messages, state, now=5.0)
+        assert matched == 0
+
+    def test_scan_pongs_handles_empty_list(self):
+        from scitex_orochi._caduceus import _scan_pongs
+
+        state = GreetingState()
+        assert _scan_pongs([], state, now=0.0) == 0
+
+    def test_scan_pongs_handles_missing_content_field(self):
+        from scitex_orochi._caduceus import _scan_pongs
+
+        state = GreetingState()
+        messages = [{"ts": "2026-04-30T00:00:01Z"}]  # no 'content' key
+        assert _scan_pongs(messages, state, now=0.0) == 0
+
+    def test_scan_pongs_matches_pong_with_surrounding_text(self):
+        from scitex_orochi._caduceus import _scan_pongs
+
+        state = GreetingState()
+        _, nonce = format_greeting("fleet-lead")
+        state.register_ping("fleet-lead", nonce, sent_ts=0.0, timeout_s=60)
+
+        messages = [{"content": f"Sure, [pong:{nonce}] — working on it.", "ts": "2026-04-30T00:00:01Z"}]
+        matched = _scan_pongs(messages, state, now=2.0)
+        assert matched == 1
+        assert state.conversational_status("fleet-lead") == "healthy"
+
+
+class TestPollChannelHistoryUrl:
+    """Tests that _poll_channel_history builds the URL correctly (mocked)."""
+
+    def test_channel_name_is_url_encoded(self, monkeypatch):
+        from scitex_orochi import _caduceus
+
+        captured = {}
+
+        def fake_http_get(url, token=None, timeout=5):
+            captured["url"] = url
+            return []
+
+        monkeypatch.setattr(_caduceus, "_http_get_json", fake_http_get)
+        _caduceus._poll_channel_history(
+            hub="https://hub.example.com",
+            token=None,
+            channel="#general",
+            since_iso=None,
+            limit=20,
+        )
+        assert "/api/history/general/" in captured["url"]
+        assert "limit=20" in captured["url"]
+
+    def test_since_parameter_included(self, monkeypatch):
+        from scitex_orochi import _caduceus
+
+        captured = {}
+
+        def fake_http_get(url, token=None, timeout=5):
+            captured["url"] = url
+            return []
+
+        monkeypatch.setattr(_caduceus, "_http_get_json", fake_http_get)
+        _caduceus._poll_channel_history(
+            hub="https://hub.example.com",
+            token=None,
+            channel="#agent",
+            since_iso="2026-04-30T12:00:00.000000",
+            limit=50,
+        )
+        assert "since=" in captured["url"]
+
+    def test_returns_empty_on_non_list_response(self, monkeypatch):
+        from scitex_orochi import _caduceus
+
+        monkeypatch.setattr(_caduceus, "_http_get_json", lambda *a, **kw: {"error": "oops"})
+        result = _caduceus._poll_channel_history("https://hub.example.com", None, "#general")
+        assert result == []
+
+    def test_token_included_in_url(self, monkeypatch):
+        from scitex_orochi import _caduceus
+
+        captured = {}
+
+        def fake_http_get(url, token=None, timeout=5):
+            captured["url"] = url
+            return []
+
+        monkeypatch.setattr(_caduceus, "_http_get_json", fake_http_get)
+        _caduceus._poll_channel_history(
+            hub="https://hub.example.com",
+            token="secret",
+            channel="#ywatanabe",
+            limit=10,
+        )
+        assert "token=secret" in captured["url"]


### PR DESCRIPTION
## Summary

- Adds `_poll_channel_history()` — fetches `/api/history/<channel>/` via the existing `_http_get_json` helper, supporting `since` (incremental) and `limit` params
- Adds `_scan_pongs()` — iterates message history and feeds each body into `GreetingState.record_reply()`, completing the conversational health round-trip
- Updates `greeting_scan()` to poll history at each tick using a `last_poll_iso: list[str|None]` mutable cell for incremental fetch
- Updates `loop()` to create and thread the cell through

## Test plan

- [x] `TestScanPongs` — 5 tests: pong matching, unknown nonces, empty list, missing content field, surrounding text in message body
- [x] `TestPollChannelHistoryUrl` — 4 tests: URL encoding of channel name, `since` param included, non-list response returns `[]`, token param included
- [x] All 645 tests pass (`pytest -x -q`)

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)