### PR TITLE
feat(agents-tab): surface recent tool activity in detail panel (todo#418)

### DIFF
--- a/hub/frontend/src/agents-tab/detail.ts
+++ b/hub/frontend/src/agents-tab/detail.ts
@@ -8,6 +8,7 @@ import {
   livenessColor,
 } from "./state";
 import { escapeHtml, isAgentInactive } from "../app/utils";
+import { _renderHookPanels } from "../activity-tab/hooks-panel";
 
 /* Agents Tab — per-agent detail view + indicator lamps + pane-state badge.
  * Depends on state.js (livenessColor, _fmtDuration, _agentDetailCache,
@@ -655,12 +656,25 @@ export function _renderAgentDetail(a) {
       "</div>";
   }
 
+  /* Hook-event panels — recent tool calls, prompts, Agent calls.
+   * Populated from scitex-agent-container ring buffer (PreToolUse /
+   * PostToolUse / UserPromptSubmit). Collapses to empty string when no
+   * hook data is available so legacy agents stay tidy (todo#418). */
+  var hooksHtml = _renderHookPanels(
+    d.sac_hooks_recent_tools || a.sac_hooks_recent_tools || [],
+    d.sac_hooks_recent_prompts || a.sac_hooks_recent_prompts || [],
+    d.sac_hooks_agent_calls || a.sac_hooks_agent_calls || [],
+    d.sac_hooks_background_tasks || a.sac_hooks_background_tasks || [],
+    d.sac_hooks_tool_counts || a.sac_hooks_tool_counts || {},
+  );
+
   return (
     '<div class="agent-detail-view">' +
     headerHtml +
     subagentsHtml +
     channelsHtml +
     stateHtml +
+    hooksHtml +
     fileTabsHtml +
     setupAuditHtml +
     mcpHtml +


### PR DESCRIPTION
## Summary

- Imports `_renderHookPanels` from `activity-tab/hooks-panel` into `agents-tab/detail.ts`
- Adds `hooksHtml` computation in `_renderAgentDetail()` feeding `sac_hooks_recent_tools`, `sac_hooks_recent_prompts`, `sac_hooks_agent_calls`, `sac_hooks_background_tasks`, `sac_hooks_tool_counts`
- Injects `hooksHtml` into the detail panel HTML between `stateHtml` and `fileTabsHtml`
- The data was already in the `/api/agents/` payload; it was simply not wired into the Agents tab's per-agent card

The Activity tab already renders this data via the same `_renderHookPanels` function. This change adds the same view to the Agents tab so agents' recent tool calls are visible at a glance alongside their pane state, channels, and metadata.

## Test plan

- [x] `npm run build` in `hub/frontend` — TypeScript clean, 117 modules
- [x] `pytest -x -q` — 636 tests pass

Closes #418 (partial — pane state badge + last-action timestamp were already present; this adds the expandable tool activity section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)