### PR TITLE
feat(daemons): daemon-stale-pr — gitea polling daemon for stuck CI-green PRs (FR-N)

### DIFF
--- a/examples/agents/daemon-stale-pr.yaml
+++ b/examples/agents/daemon-stale-pr.yaml
@@ -1,0 +1,81 @@
+# Template: copy to ~/.scitex/orochi/agents/ and customize.
+#
+# daemon-stale-pr — gitea polling daemon (FR-N, lead msg#23297 + msg#23310).
+#
+# Pattern: sac-managed tmux session running a sleep-loop wrapper that
+# tick every ``tick_interval_s``, polls gitea for stuck CI-green PRs,
+# DMs the suggested merger, and posts a one-line tick summary to
+# ``publish_channel``. Each tick is a fresh subprocess invocation of
+# ``python -m scitex_orochi._daemons._stale_pr --once`` so context is
+# naturally cleared (ZOO#04 cost).
+#
+# Pilot uses ``kind: Agent`` with ``worker_role`` label (lead msg#23310
+# decision: defer the ``daemon`` kind to a separate scitex-agent-container
+# contributor; rename when that lands).
+apiVersion: cld-agent/v1
+kind: Agent
+metadata:
+  name: daemon-stale-pr
+  labels:
+    role: daemon
+    worker_role: daemon-stale-pr
+    team: orochi
+    cardinality: "1"
+    # The host that has the gitea_token + hub_token in env. Today this
+    # is whichever host runs the cron scheduler; the daemon is
+    # location-independent so any host with creds works.
+    machine: CHANGEME
+    capabilities: gitea-poll,pr-merge-routing
+spec:
+  runtime: bash
+  workdir: ~/proj/scitex-orochi
+
+  remote:
+    host: CHANGEME_HOST
+    user: CHANGEME_USER
+
+  command:
+    # The wrapper IS the daemon — sleep-loop in-process so the tmux
+    # pane stays attached and prints each tick. ``--once`` is for
+    # smoke testing; production omits it and lets the loop run.
+    - bash
+    - -lc
+    - "exec python -m scitex_orochi._daemons._stale_pr --config ~/.scitex/orochi/daemons.yaml"
+
+  orochi:
+    enabled: true
+    hosts:
+      - CHANGEME_LAN_IP
+      - CHANGEME_DOMAIN
+    port: 8559
+    token_env: OROCHI_HUB_TOKEN
+    # Subscribe-side: the daemon doesn't read inbound messages, but
+    # registering with the hub puts it on the agents dashboard so
+    # operators can see it's alive.
+    channels:
+      - "#daemons"
+    heartbeat_interval: 60
+
+  env:
+    CLAUDE_AGENT_ROLE: daemon
+    CLAUDE_AGENT_ID: daemon-stale-pr
+    OROCHI_HUB_URL: "https://scitex-orochi.com"
+    # Set in deployment env, not here. Daemon will WARN-and-skip-post
+    # if either is empty so the loop still runs read-only.
+    OROCHI_HUB_TOKEN: ""
+    OROCHI_GITEA_TOKEN: ""
+
+  screen:
+    name: daemon-stale-pr
+
+  health:
+    enabled: true
+    interval: 60
+    # The daemon prints "[tick @ ts] ..." each tick, so multiplexer
+    # liveness + recent stdout is sufficient signal. A future v2 can
+    # check the JSONL log tail for stale ticks.
+    method: multiplexer-alive
+
+  restart:
+    policy: on-failure
+    max_retries: 5

--- a/examples/daemons.yaml.example
+++ b/examples/daemons.yaml.example
@@ -1,0 +1,52 @@
+# ~/.scitex/orochi/daemons.yaml — config for sac-managed daemon-agents.
+#
+# Template: copy to ``~/.scitex/orochi/daemons.yaml`` and edit. Secrets
+# (tokens) live in env, never here:
+#   OROCHI_GITEA_TOKEN   — gitea API token, read-only suffices
+#   OROCHI_HUB_TOKEN     — orochi hub token used for /api/messages POSTs
+#   OROCHI_HUB_URL       — overridden by ``hub_url`` below if set
+
+# ---------------------------------------------------------------------------
+# daemon-stale-pr (FR-N) — gitea polling daemon for stuck CI-green PRs
+# ---------------------------------------------------------------------------
+daemon-stale-pr:
+  # Gitea endpoint. The daemon caches no responses, so a temporary
+  # 5xx is recoverable on the next tick.
+  gitea_base_url: https://gitea.scitex.ai
+  gitea_owner: scitex
+
+  # Watched repos. Add/remove freely — nothing else needs updating.
+  repos:
+    - scitex-orochi
+    - scitex-agent-container
+    - scitex
+    - scitex-app
+
+  # Per-repo merger DM target. Use the orochi agent name (e.g.
+  # ``head-mba``) or a human name — the hub will route either way.
+  # Repos missing from this map produce a warning, never a crash.
+  repo_to_merger:
+    scitex-orochi: head-mba
+    scitex-agent-container: head-mba
+    scitex: mgr-scitex
+    scitex-app: head-nas
+
+  # Sender identity used in the canonical DM channel id. Must match
+  # ``CLAUDE_AGENT_ID`` in the agent yaml so cross-host attribution
+  # is consistent.
+  sender: daemon-stale-pr
+
+  # Hub for /api/messages POSTs. Falls back to env ``OROCHI_HUB_URL``
+  # if empty.
+  hub_url: https://scitex-orochi.com
+
+  # Where the per-tick summary lands. Until mgr-auth provisions
+  # ``#daemons``, leave this on ``#general`` so the loop is visible.
+  publish_channel: "#general"
+
+  # Stale-PR rule:
+  threshold_s: 3600.0     # min PR age before considered stale
+  redm_after_s: 3600.0    # debounce: re-DM no sooner than this
+
+  # Loop cadence.
+  tick_interval_s: 600.0

--- a/src/scitex_orochi/_daemons/__init__.py
+++ b/src/scitex_orochi/_daemons/__init__.py
@@ -1,0 +1,11 @@
+"""Sac-managed daemon-agents.
+
+Per lead msg#23306 / msg#23310, fleet daemon-agents are sac-managed
+tmux sessions that wake on a tick, do deterministic work, post a
+one-line summary to ``#daemons`` (or ``#general`` until that channel
+exists), and sleep again. Each tick is a fresh process so context is
+naturally cleared (ZOO#04 cost). This package collects the per-daemon
+implementations.
+
+Pilot daemon: ``daemon-stale-pr`` (FR-N).
+"""

--- a/src/scitex_orochi/_daemons/_stale_pr/__init__.py
+++ b/src/scitex_orochi/_daemons/_stale_pr/__init__.py
@@ -1,0 +1,27 @@
+"""``daemon-stale-pr`` — gitea polling daemon for stuck CI-green PRs.
+
+FR-N (lead msg#23297 + msg#23310). Polls the configured gitea repos
+every ``tick_interval_s``, finds PRs that are ``mergeable=True`` with
+all CI checks ``success`` and age > threshold, and DMs the suggested
+merger (head-{host} per repo) at most once per debounce window.
+
+Public surface:
+    * :func:`is_stale` — pure predicate over a PR + commit-status pair
+    * :func:`select_stale_for_dm` — wrap :func:`is_stale` + state debounce
+    * :class:`StalePrState` — JSON-backed last-notified-at store
+    * :func:`run_tick` — one wrapper tick (used by ``__main__``)
+"""
+
+from scitex_orochi._daemons._stale_pr._check import (
+    StalePrFinding,
+    is_stale,
+    select_stale_for_dm,
+)
+from scitex_orochi._daemons._stale_pr._state import StalePrState
+
+__all__ = [
+    "StalePrFinding",
+    "is_stale",
+    "select_stale_for_dm",
+    "StalePrState",
+]

--- a/src/scitex_orochi/_daemons/_stale_pr/__main__.py
+++ b/src/scitex_orochi/_daemons/_stale_pr/__main__.py
@@ -1,0 +1,58 @@
+"""``python -m scitex_orochi._daemons._stale_pr`` entry point."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from scitex_orochi._daemons._stale_pr._state import StalePrState
+from scitex_orochi._daemons._stale_pr._wrapper import StalePrConfig, run_loop
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="daemon-stale-pr",
+        description=(
+            "Sac-managed daemon-agent that polls gitea for stuck CI-green "
+            "PRs and DMs the suggested merger. Tick interval and repo "
+            "list come from --config (default: "
+            "~/.scitex/orochi/daemons.yaml)."
+        ),
+    )
+    p.add_argument(
+        "--config",
+        type=Path,
+        default=Path.home() / ".scitex" / "orochi" / "daemons.yaml",
+        help="Path to daemons.yaml.",
+    )
+    p.add_argument(
+        "--once",
+        action="store_true",
+        help="Run a single tick and exit (smoke test).",
+    )
+    p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    cfg = StalePrConfig.from_env_and_yaml(args.config)
+    state = StalePrState()
+    state.load()
+    run_loop(cfg, state, max_ticks=1 if args.once else None)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_orochi/_daemons/_stale_pr/_check.py
+++ b/src/scitex_orochi/_daemons/_stale_pr/_check.py
@@ -1,0 +1,174 @@
+"""Pure stale-PR predicates and finding-selection.
+
+Kept I/O-free so the rules are unit-testable without a gitea mock —
+the wrapper supplies fetched PR + status payloads as plain dicts.
+
+Spec recap (lead msg#23297):
+  Stale PR := mergeable=True ∧ all-CI=success ∧ age > threshold_s
+
+Selection rule (debounce):
+  A finding is dispatched only if no DM was sent for the same PR
+  identifier within the last ``redm_after_s`` window.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class StalePrFinding:
+    """A stale PR ready to dispatch a DM about.
+
+    The ``key`` field is the stable identifier used for debounce
+    state; ``repo + number`` works across PR title edits and force-pushes.
+    """
+
+    repo: str
+    number: int
+    sha: str
+    age_seconds: float
+    title: str
+    author: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.repo}#{self.number}"
+
+
+def _parse_iso8601(value: str) -> datetime:
+    """Tolerant ISO-8601 parser — handles trailing ``Z`` and offsets.
+
+    Gitea returns ``2026-04-29T12:34:56Z`` for created_at; Python's
+    ``fromisoformat`` only accepts ``Z`` from 3.11 on. We're already
+    on 3.11 per pyproject, so this is straight-through.
+    """
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def is_stale(
+    pr: Mapping,
+    combined_status: Mapping,
+    *,
+    threshold_s: float,
+    now_ts: float | None = None,
+) -> bool:
+    """Return True iff this PR meets the stale-merge criteria.
+
+    Parameters
+    ----------
+    pr
+        Gitea ``GET /repos/.../pulls`` element. Required keys:
+        ``mergeable`` (bool), ``created_at`` (ISO-8601 str).
+    combined_status
+        Gitea ``GET /repos/.../commits/<sha>/status`` payload. Required
+        key: ``state`` ∈ {``success``, ``pending``, ``failure``,
+        empty-string for "no checks reported"}.
+    threshold_s
+        Minimum PR age (seconds since ``created_at``) before staleness
+        kicks in. The original FR-N spec said 1h.
+    now_ts
+        Override "current time" for tests. Defaults to ``time.time()``.
+
+    Notes
+    -----
+    A PR with no CI configured returns ``state=""`` from gitea — we
+    treat that as "no checks reported" rather than success, because
+    rubber-stamping a PR that *should* have had CI is exactly the
+    failure mode the auditor (close-evidence-gate) catches separately.
+    """
+    if not pr.get("mergeable"):
+        return False
+    if combined_status.get("state") != "success":
+        return False
+    created_raw = pr.get("created_at")
+    if not created_raw:
+        return False
+    created_dt = _parse_iso8601(created_raw)
+    now = now_ts if now_ts is not None else time.time()
+    age = now - created_dt.timestamp()
+    return age > threshold_s
+
+
+def _to_finding(pr: Mapping, repo: str, *, now_ts: float) -> StalePrFinding:
+    created_dt = _parse_iso8601(pr["created_at"])
+    return StalePrFinding(
+        repo=repo,
+        number=int(pr["number"]),
+        sha=str(pr.get("head", {}).get("sha", "")),
+        age_seconds=now_ts - created_dt.timestamp(),
+        title=str(pr.get("title", "")),
+        author=str(pr.get("user", {}).get("login", "")),
+    )
+
+
+@dataclass
+class _DebounceView:
+    """The minimum surface of :class:`StalePrState` this module needs.
+
+    Defined as a Protocol-shaped dataclass so the ``select`` function
+    can be unit-tested with a plain ``dict`` instead of touching the
+    filesystem.
+    """
+
+    last_notified_ts: dict[str, float] = field(default_factory=dict)
+
+
+def select_stale_for_dm(
+    stale_findings: Iterable[StalePrFinding],
+    state: _DebounceView,
+    *,
+    redm_after_s: float,
+    now_ts: float | None = None,
+) -> list[StalePrFinding]:
+    """Filter findings down to those that should actually trigger a DM.
+
+    Debounce rule: a key is suppressed if its last notification was
+    less than ``redm_after_s`` ago. The state is *not* mutated here —
+    the wrapper records the dispatch only after the DM POST succeeds,
+    so a transient hub outage doesn't silently swallow an alert.
+    """
+    now = now_ts if now_ts is not None else time.time()
+    out: list[StalePrFinding] = []
+    for f in stale_findings:
+        last = state.last_notified_ts.get(f.key)
+        if last is None or (now - last) >= redm_after_s:
+            out.append(f)
+    return out
+
+
+def findings_from_payload(
+    pulls: Iterable[Mapping],
+    status_lookup: Mapping[str, Mapping],
+    repo: str,
+    *,
+    threshold_s: float,
+    now_ts: float | None = None,
+) -> list[StalePrFinding]:
+    """Convenience: walk a ``GET /pulls`` list, attach combined status,
+    and produce findings for the stale subset.
+
+    ``status_lookup`` is keyed by head SHA so the wrapper can fetch
+    once per PR and reuse the dict across reruns within a tick.
+    """
+    now = now_ts if now_ts is not None else time.time()
+    out: list[StalePrFinding] = []
+    for pr in pulls:
+        sha = pr.get("head", {}).get("sha", "")
+        status = status_lookup.get(sha, {})
+        if is_stale(pr, status, threshold_s=threshold_s, now_ts=now):
+            out.append(_to_finding(pr, repo, now_ts=now))
+    return out
+
+
+__all__ = [
+    "StalePrFinding",
+    "is_stale",
+    "select_stale_for_dm",
+    "findings_from_payload",
+    "_DebounceView",
+    "_parse_iso8601",
+]

--- a/src/scitex_orochi/_daemons/_stale_pr/_state.py
+++ b/src/scitex_orochi/_daemons/_stale_pr/_state.py
@@ -1,0 +1,95 @@
+"""JSON-backed last-notified-at store for ``daemon-stale-pr``.
+
+Tiny by design: a flat ``{key -> unix_ts}`` map, atomic-write on
+update, tolerant of corrupt files (treats them as empty so a single
+bad write doesn't lock the daemon out forever — operator can inspect
+the ``.bak`` if needed).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+logger = logging.getLogger("orochi.daemon.stale_pr.state")
+
+DEFAULT_STATE_PATH = (
+    Path.home() / ".scitex" / "orochi" / "state" / "daemon-stale-pr.json"
+)
+
+
+class StalePrState:
+    """Last-notified-at debounce store.
+
+    Not thread-safe — the daemon is a single-threaded sleep loop, so
+    locking would be ceremony. If we ever multi-thread, wrap the
+    mutator methods in a ``threading.Lock``.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or DEFAULT_STATE_PATH
+        self.last_notified_ts: dict[str, float] = {}
+        self._loaded = False
+
+    def load(self) -> None:
+        """Read the state file. Missing or corrupt → empty in-memory map."""
+        self._loaded = True
+        try:
+            raw = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            self.last_notified_ts = {}
+            return
+        except OSError as exc:
+            logger.warning("stale-pr state: read failed %s: %s", self.path, exc)
+            self.last_notified_ts = {}
+            return
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "stale-pr state: corrupt JSON at %s — treating as empty (%s)",
+                self.path,
+                exc,
+            )
+            # Preserve the corrupt file as .bak for forensic inspection
+            # rather than silently overwriting the operator's evidence.
+            try:
+                self.path.replace(self.path.with_suffix(".json.bak"))
+            except OSError:
+                pass
+            self.last_notified_ts = {}
+            return
+        # Defensive: only keep keys whose values look like numbers.
+        cleaned: dict[str, float] = {}
+        for k, v in data.items():
+            try:
+                cleaned[str(k)] = float(v)
+            except (TypeError, ValueError):
+                continue
+        self.last_notified_ts = cleaned
+
+    def save(self) -> None:
+        """Atomic-write the state file."""
+        if not self._loaded:
+            # Avoid clobbering an unread file with an empty map.
+            self.load()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(self.last_notified_ts, sort_keys=True, indent=2),
+            encoding="utf-8",
+        )
+        os.replace(tmp, self.path)
+
+    def record_notified(self, key: str, when: float | None = None) -> None:
+        """Record that a DM was successfully sent for ``key``."""
+        if not self._loaded:
+            self.load()
+        self.last_notified_ts[key] = when if when is not None else time.time()
+        self.save()
+
+
+__all__ = ["StalePrState", "DEFAULT_STATE_PATH"]

--- a/src/scitex_orochi/_daemons/_stale_pr/_wrapper.py
+++ b/src/scitex_orochi/_daemons/_stale_pr/_wrapper.py
@@ -1,0 +1,348 @@
+"""Sleep-loop wrapper for ``daemon-stale-pr``.
+
+Per lead msg#23310: the wrapper is the daemon. Each tick it:
+  1. Echoes ``[tick @ <iso-ts>] checking gitea PRs in <repos>...`` to
+     stdout (visible if an operator attaches the tmux pane).
+  2. Polls each configured repo via :class:`GiteaClient` for open
+     PRs + commit-status.
+  3. Applies the stale predicate, debounces against last-notified
+     state, and DMs the suggested merger via the hub's
+     ``POST /api/messages/`` endpoint.
+  4. Posts a one-line tick summary
+     (``tick=N found=X dispatched=Y``) to ``publish_channel``.
+  5. Sleeps ``tick_interval_s``.
+
+For deterministic-only work like FR-N there's no per-tick ``claude
+-p`` invocation — that pattern is reserved for FR-M (auditor-haiku),
+where rule-judgement *is* the work. The pane visibility requirement
+(operator can attach and read what the daemon "is doing") is
+satisfied by the stdout echoes here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Mapping
+
+from scitex_orochi._daemons._stale_pr._check import (
+    StalePrFinding,
+    findings_from_payload,
+    select_stale_for_dm,
+)
+from scitex_orochi._daemons._stale_pr._state import StalePrState
+from scitex_orochi._gitea import GiteaClient
+
+logger = logging.getLogger("orochi.daemon.stale_pr")
+
+
+@dataclass
+class StalePrConfig:
+    """Per-deployment config — loaded from ``daemons.yaml``.
+
+    The fields below are the v1 contract. Keep this dataclass small
+    and additions backward-compatible (default values) so operators
+    can roll the daemon binary forward without touching their yaml.
+    """
+
+    gitea_base_url: str
+    gitea_token: str
+    gitea_owner: str
+    repos: list[str]
+    repo_to_merger: dict[str, str]
+    sender: str = "daemon-stale-pr"
+    hub_url: str = ""
+    hub_token: str = ""
+    publish_channel: str = "#general"  # flips to #daemons once mgr-auth provisions it
+    threshold_s: float = 3600.0
+    redm_after_s: float = 3600.0
+    tick_interval_s: float = 600.0
+    log_path: Path = field(
+        default_factory=lambda: Path.home()
+        / ".scitex"
+        / "orochi"
+        / "daemon-logs"
+        / "stale-pr-daemon.log"
+    )
+
+    @classmethod
+    def from_env_and_yaml(cls, yaml_path: Path) -> "StalePrConfig":
+        """Compose config from env (secrets) + yaml (everything else).
+
+        Secrets stay in env so they don't end up in a versioned
+        ``daemons.yaml``: ``OROCHI_GITEA_TOKEN``,
+        ``OROCHI_HUB_TOKEN``. The yaml supplies repo lists,
+        merger map, thresholds, the channel name.
+        """
+        import yaml  # type: ignore[import-untyped]
+
+        with yaml_path.open("r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        block = data.get("daemon-stale-pr") or {}
+        return cls(
+            gitea_base_url=block.get("gitea_base_url", "https://gitea.scitex.ai"),
+            gitea_token=os.environ.get("OROCHI_GITEA_TOKEN", ""),
+            gitea_owner=block.get("gitea_owner", "scitex"),
+            repos=list(block.get("repos", [])),
+            repo_to_merger=dict(block.get("repo_to_merger", {})),
+            sender=block.get("sender", "daemon-stale-pr"),
+            hub_url=block.get("hub_url", os.environ.get("OROCHI_HUB_URL", "")),
+            hub_token=os.environ.get("OROCHI_HUB_TOKEN", ""),
+            publish_channel=block.get("publish_channel", "#general"),
+            threshold_s=float(block.get("threshold_s", 3600.0)),
+            redm_after_s=float(block.get("redm_after_s", 3600.0)),
+            tick_interval_s=float(block.get("tick_interval_s", 600.0)),
+        )
+
+
+def _canonical_dm_channel(sender: str, recipient: str) -> str:
+    pair = sorted([sender, recipient])
+    return f"dm:agent:{pair[0]}|agent:{pair[1]}"
+
+
+def _post_message(
+    *,
+    hub_url: str,
+    hub_token: str,
+    channel: str,
+    sender: str,
+    text: str,
+    timeout: float = 10.0,
+) -> bool:
+    """POST a message to the hub's ``/api/messages/`` endpoint.
+
+    Mirrors the pattern in
+    ``_cli/commands/hungry_signal_cmd.py::_send_dm`` — kept inline
+    rather than imported to avoid coupling the daemon to a click
+    sub-command's private helpers. If the hungry-signal helper ever
+    moves to a shared util, switch over.
+    """
+    if not (hub_url and hub_token):
+        logger.warning("post-message: hub_url/hub_token unset, skipping")
+        return False
+    endpoint = hub_url.rstrip("/") + f"/api/messages/?token={hub_token}"
+    payload = {
+        "channel": channel,
+        "sender": sender,
+        "payload": {"channel": channel, "content": text},
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=data,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "scitex-orochi-daemon/1.0",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status in (200, 201)
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as exc:
+        logger.warning("post-message: %s", exc)
+        return False
+
+
+def _format_dm_text(finding: StalePrFinding, hub_pr_url_base: str = "") -> str:
+    age_h = finding.age_seconds / 3600.0
+    url_hint = (
+        f"\n  {hub_pr_url_base.rstrip('/')}/{finding.repo}/pulls/{finding.number}"
+        if hub_pr_url_base
+        else ""
+    )
+    return (
+        f"Stale CI-green PR awaiting merge:\n"
+        f"  {finding.repo}#{finding.number} — {finding.title}\n"
+        f"  author: {finding.author}\n"
+        f"  sha: {finding.sha[:12]}\n"
+        f"  age: {age_h:.1f}h"
+        f"{url_hint}"
+    )
+
+
+def _append_log(log_path: Path, record: dict) -> None:
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"ts": time.time(), **record}, default=str) + "\n")
+    except OSError as exc:
+        logger.warning("append_log: %s", exc)
+
+
+@dataclass
+class TickResult:
+    """Outcome of one tick — returned for tests + summary post."""
+
+    found: int
+    dispatched: int
+    suppressed: int
+    errors: list[str] = field(default_factory=list)
+
+
+async def _fetch_repo_state(
+    client: GiteaClient, owner: str, repo: str
+) -> tuple[list[Mapping], dict[str, Mapping]]:
+    """Pull open PRs + their combined commit-status. One repo's worth."""
+    pulls = await client._request(
+        "GET", f"/repos/{owner}/{repo}/pulls?state=open"
+    )
+    pulls = pulls or []
+    status_lookup: dict[str, Mapping] = {}
+    for pr in pulls:
+        sha = pr.get("head", {}).get("sha")
+        if not sha:
+            continue
+        try:
+            status = await client._request(
+                "GET", f"/repos/{owner}/{repo}/commits/{sha}/status"
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("fetch_repo_state: %s/%s sha=%s: %s", owner, repo, sha, exc)
+            status = {"state": "unknown"}
+        status_lookup[sha] = status or {}
+    return pulls, status_lookup
+
+
+async def run_tick_async(
+    cfg: StalePrConfig,
+    state: StalePrState,
+    *,
+    now_ts: float | None = None,
+) -> TickResult:
+    """One async tick — fetch, classify, debounce, dispatch, log."""
+    now = now_ts if now_ts is not None else time.time()
+    iso = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+    print(
+        f"[tick @ {iso}] checking gitea PRs in {','.join(cfg.repos)}...",
+        flush=True,
+    )
+    all_findings: list[StalePrFinding] = []
+    errors: list[str] = []
+    client = GiteaClient(cfg.gitea_base_url, cfg.gitea_token)
+    try:
+        for repo in cfg.repos:
+            try:
+                pulls, status_lookup = await _fetch_repo_state(
+                    client, cfg.gitea_owner, repo
+                )
+            except Exception as exc:  # noqa: BLE001
+                msg = f"fetch failed for {repo}: {exc}"
+                logger.warning(msg)
+                errors.append(msg)
+                continue
+            findings = findings_from_payload(
+                pulls, status_lookup, repo, threshold_s=cfg.threshold_s, now_ts=now
+            )
+            all_findings.extend(findings)
+    finally:
+        await client.close()
+
+    if not state._loaded:
+        state.load()
+    to_dispatch = select_stale_for_dm(
+        all_findings, state, redm_after_s=cfg.redm_after_s, now_ts=now
+    )
+
+    dispatched = 0
+    for finding in to_dispatch:
+        merger = cfg.repo_to_merger.get(finding.repo)
+        if not merger:
+            errors.append(f"no merger configured for {finding.repo}")
+            continue
+        channel = _canonical_dm_channel(cfg.sender, merger)
+        text = _format_dm_text(finding)
+        ok = _post_message(
+            hub_url=cfg.hub_url,
+            hub_token=cfg.hub_token,
+            channel=channel,
+            sender=cfg.sender,
+            text=text,
+        )
+        if ok:
+            state.record_notified(finding.key, when=now)
+            dispatched += 1
+            print(
+                f"  dispatched DM to {merger} for {finding.key} "
+                f"(age {finding.age_seconds / 3600.0:.1f}h)",
+                flush=True,
+            )
+        else:
+            errors.append(f"DM failed for {finding.key} -> {merger}")
+
+    suppressed = len(all_findings) - len(to_dispatch)
+    summary = f"tick=stale-pr found={len(all_findings)} dispatched={dispatched}"
+    if suppressed:
+        summary += f" suppressed={suppressed}"
+    if errors:
+        summary += f" errors={len(errors)}"
+    print(f"  {summary}", flush=True)
+    _post_message(
+        hub_url=cfg.hub_url,
+        hub_token=cfg.hub_token,
+        channel=cfg.publish_channel,
+        sender=cfg.sender,
+        text=summary,
+    )
+    _append_log(
+        cfg.log_path,
+        {
+            "found": len(all_findings),
+            "dispatched": dispatched,
+            "suppressed": suppressed,
+            "errors": errors,
+        },
+    )
+    return TickResult(
+        found=len(all_findings),
+        dispatched=dispatched,
+        suppressed=suppressed,
+        errors=errors,
+    )
+
+
+def run_loop(
+    cfg: StalePrConfig,
+    state: StalePrState,
+    *,
+    max_ticks: int | None = None,
+) -> None:
+    """Sleep-loop entry point. Blocks until SIGTERM/SIGINT or max_ticks."""
+    print(
+        f"daemon-stale-pr: starting (interval={cfg.tick_interval_s}s, "
+        f"repos={cfg.repos}, publish={cfg.publish_channel})",
+        flush=True,
+    )
+    n = 0
+    while True:
+        try:
+            asyncio.run(run_tick_async(cfg, state))
+        except KeyboardInterrupt:
+            print("daemon-stale-pr: interrupted, exiting", flush=True)
+            break
+        except Exception as exc:  # noqa: BLE001
+            # Never let one bad tick kill the daemon — log and sleep on.
+            logger.exception("tick raised: %s", exc)
+            print(f"  tick error: {exc}", flush=True, file=sys.stderr)
+        n += 1
+        if max_ticks is not None and n >= max_ticks:
+            break
+        time.sleep(cfg.tick_interval_s)
+
+
+__all__ = [
+    "StalePrConfig",
+    "TickResult",
+    "run_tick_async",
+    "run_loop",
+]

--- a/tests/test_daemon_stale_pr_check.py
+++ b/tests/test_daemon_stale_pr_check.py
@@ -1,0 +1,200 @@
+"""Unit tests for ``daemon-stale-pr`` pure predicates (FR-N).
+
+Lead msg#23297 acceptance:
+  * Synthetic gitea mock with 1 stale PR → 1 DM emitted to merger.
+  * Same PR on second run within 1h → no duplicate DM.
+
+The first half is covered by :mod:`test_daemon_stale_pr_wrapper`
+(wrapper integration). These tests pin the rule logic and debounce
+in isolation so a future refactor doesn't drift the meaning of
+"stale".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scitex_orochi._daemons._stale_pr._check import (
+    StalePrFinding,
+    _DebounceView,
+    findings_from_payload,
+    is_stale,
+    select_stale_for_dm,
+)
+
+
+def _iso(dt: datetime) -> str:
+    """Render a UTC datetime in the ``Z``-suffixed shape gitea returns."""
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@pytest.fixture
+def now_dt() -> datetime:
+    return datetime(2026, 4, 29, 19, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def now_ts(now_dt: datetime) -> float:
+    return now_dt.timestamp()
+
+
+def _pr(*, age_minutes: int, mergeable: bool, sha: str = "abc1234") -> dict:
+    created = datetime(2026, 4, 29, 19, 0, 0, tzinfo=timezone.utc) - timedelta(
+        minutes=age_minutes
+    )
+    return {
+        "number": 388,
+        "mergeable": mergeable,
+        "created_at": _iso(created),
+        "title": "fix: example",
+        "user": {"login": "ywatanabe"},
+        "head": {"sha": sha},
+    }
+
+
+class TestIsStale:
+    def test_old_mergeable_green_is_stale(self, now_ts: float) -> None:
+        assert is_stale(
+            _pr(age_minutes=120, mergeable=True),
+            {"state": "success"},
+            threshold_s=3600,
+            now_ts=now_ts,
+        )
+
+    def test_below_threshold_is_not_stale(self, now_ts: float) -> None:
+        assert not is_stale(
+            _pr(age_minutes=30, mergeable=True),
+            {"state": "success"},
+            threshold_s=3600,
+            now_ts=now_ts,
+        )
+
+    def test_unmergeable_is_not_stale(self, now_ts: float) -> None:
+        assert not is_stale(
+            _pr(age_minutes=120, mergeable=False),
+            {"state": "success"},
+            threshold_s=3600,
+            now_ts=now_ts,
+        )
+
+    def test_pending_ci_is_not_stale(self, now_ts: float) -> None:
+        assert not is_stale(
+            _pr(age_minutes=120, mergeable=True),
+            {"state": "pending"},
+            threshold_s=3600,
+            now_ts=now_ts,
+        )
+
+    def test_failure_ci_is_not_stale(self, now_ts: float) -> None:
+        assert not is_stale(
+            _pr(age_minutes=120, mergeable=True),
+            {"state": "failure"},
+            threshold_s=3600,
+            now_ts=now_ts,
+        )
+
+    def test_no_ci_state_is_not_stale(self, now_ts: float) -> None:
+        # Empty state is gitea's "no checks reported" — we conservatively
+        # refuse to call this success (see _check.is_stale docstring).
+        assert not is_stale(
+            _pr(age_minutes=120, mergeable=True),
+            {"state": ""},
+            threshold_s=3600,
+            now_ts=now_ts,
+        )
+
+    def test_missing_created_at_is_not_stale(self, now_ts: float) -> None:
+        bad = _pr(age_minutes=120, mergeable=True)
+        bad.pop("created_at")
+        assert not is_stale(bad, {"state": "success"}, threshold_s=3600, now_ts=now_ts)
+
+
+class TestSelectStaleForDm:
+    def test_first_time_finding_is_dispatched(self, now_ts: float) -> None:
+        f = StalePrFinding(
+            repo="scitex-orochi",
+            number=388,
+            sha="abc",
+            age_seconds=7200,
+            title="x",
+            author="y",
+        )
+        state = _DebounceView()
+        out = select_stale_for_dm([f], state, redm_after_s=3600, now_ts=now_ts)
+        assert out == [f]
+
+    def test_recent_notification_suppresses_redm(self, now_ts: float) -> None:
+        # Acceptance test #2 from FR-N: same PR on second run within 1h
+        # → no duplicate DM.
+        f = StalePrFinding(
+            repo="scitex-orochi",
+            number=388,
+            sha="abc",
+            age_seconds=7200,
+            title="x",
+            author="y",
+        )
+        state = _DebounceView(last_notified_ts={f.key: now_ts - 600})  # 10min ago
+        out = select_stale_for_dm([f], state, redm_after_s=3600, now_ts=now_ts)
+        assert out == []
+
+    def test_old_notification_allows_redm(self, now_ts: float) -> None:
+        f = StalePrFinding(
+            repo="scitex-orochi",
+            number=388,
+            sha="abc",
+            age_seconds=7200,
+            title="x",
+            author="y",
+        )
+        # 2h ago — past the 1h debounce window, so re-DM allowed.
+        state = _DebounceView(last_notified_ts={f.key: now_ts - 7200})
+        out = select_stale_for_dm([f], state, redm_after_s=3600, now_ts=now_ts)
+        assert out == [f]
+
+    def test_does_not_mutate_state(self, now_ts: float) -> None:
+        f = StalePrFinding(
+            repo="x", number=1, sha="a", age_seconds=7200, title="", author=""
+        )
+        state = _DebounceView()
+        select_stale_for_dm([f], state, redm_after_s=3600, now_ts=now_ts)
+        # Wrapper records the dispatch only after the DM POST succeeds —
+        # selection itself must not write to the state, otherwise a
+        # transient hub outage would silently swallow alerts.
+        assert state.last_notified_ts == {}
+
+
+class TestFindingsFromPayload:
+    def test_walks_pulls_and_attaches_status(self, now_ts: float) -> None:
+        pulls = [
+            _pr(age_minutes=120, mergeable=True, sha="aaa1"),
+            _pr(age_minutes=10, mergeable=True, sha="bbb2"),  # too young
+            _pr(age_minutes=120, mergeable=False, sha="ccc3"),  # not mergeable
+        ]
+        # Vary a couple of titles/numbers so duplicates don't shadow.
+        pulls[1]["number"] = 389
+        pulls[2]["number"] = 390
+        status_lookup = {
+            "aaa1": {"state": "success"},
+            "bbb2": {"state": "success"},
+            "ccc3": {"state": "success"},
+        }
+        out = findings_from_payload(
+            pulls,
+            status_lookup,
+            "scitex-orochi",
+            threshold_s=3600,
+            now_ts=now_ts,
+        )
+        assert [(f.repo, f.number, f.sha) for f in out] == [
+            ("scitex-orochi", 388, "aaa1"),
+        ]
+
+    def test_missing_status_treated_as_no_check(self, now_ts: float) -> None:
+        pulls = [_pr(age_minutes=120, mergeable=True, sha="aaa1")]
+        out = findings_from_payload(
+            pulls, {}, "scitex-orochi", threshold_s=3600, now_ts=now_ts
+        )
+        assert out == []

--- a/tests/test_daemon_stale_pr_state.py
+++ b/tests/test_daemon_stale_pr_state.py
@@ -1,0 +1,57 @@
+"""Unit tests for the ``daemon-stale-pr`` JSON state store."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scitex_orochi._daemons._stale_pr._state import StalePrState
+
+
+def test_load_missing_file_is_empty(tmp_path: Path) -> None:
+    state = StalePrState(tmp_path / "missing.json")
+    state.load()
+    assert state.last_notified_ts == {}
+
+
+def test_round_trip(tmp_path: Path) -> None:
+    p = tmp_path / "state.json"
+    a = StalePrState(p)
+    a.load()
+    a.record_notified("scitex-orochi#388", when=1700000000.0)
+    a.record_notified("scitex/orochi-tools#1", when=1700001000.0)
+    b = StalePrState(p)
+    b.load()
+    assert b.last_notified_ts == {
+        "scitex-orochi#388": 1700000000.0,
+        "scitex/orochi-tools#1": 1700001000.0,
+    }
+
+
+def test_corrupt_json_is_quarantined_to_bak(tmp_path: Path) -> None:
+    p = tmp_path / "state.json"
+    p.write_text("{not json")
+    state = StalePrState(p)
+    state.load()
+    assert state.last_notified_ts == {}
+    # Operator should be able to inspect what was clobbered, so we
+    # rename rather than overwrite. The .bak suffix is for forensic
+    # use, not auto-recovery.
+    assert (tmp_path / "state.json.bak").exists()
+
+
+def test_non_numeric_value_dropped(tmp_path: Path) -> None:
+    p = tmp_path / "state.json"
+    p.write_text(json.dumps({"good#1": 1700000000, "bad#1": "wat"}))
+    state = StalePrState(p)
+    state.load()
+    assert state.last_notified_ts == {"good#1": 1700000000.0}
+
+
+def test_save_creates_parent_dirs(tmp_path: Path) -> None:
+    p = tmp_path / "nested" / "deeper" / "state.json"
+    state = StalePrState(p)
+    state.load()
+    state.record_notified("k", when=1.0)
+    assert p.exists()
+    assert json.loads(p.read_text()) == {"k": 1.0}

--- a/tests/test_daemon_stale_pr_wrapper.py
+++ b/tests/test_daemon_stale_pr_wrapper.py
@@ -1,0 +1,172 @@
+"""Wrapper-level tests for ``daemon-stale-pr`` (FR-N).
+
+Covers lead msg#23297 acceptance:
+  1. Synthetic gitea mock with 1 stale PR → 1 DM emitted to merger.
+  2. Same PR on second run within 1h → no duplicate DM.
+
+We patch out the gitea HTTP client and the hub-message poster so the
+test stays sealed (no network, no side files outside ``tmp_path``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from scitex_orochi._daemons._stale_pr import _wrapper as wrapper_mod
+from scitex_orochi._daemons._stale_pr._state import StalePrState
+from scitex_orochi._daemons._stale_pr._wrapper import (
+    StalePrConfig,
+    run_tick_async,
+)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@pytest.fixture
+def now_ts() -> float:
+    return datetime(2026, 4, 29, 19, 0, 0, tzinfo=timezone.utc).timestamp()
+
+
+@pytest.fixture
+def stale_pr_payload(now_ts: float) -> dict:
+    created = datetime.fromtimestamp(now_ts, tz=timezone.utc) - timedelta(hours=2)
+    return {
+        "number": 388,
+        "mergeable": True,
+        "created_at": _iso(created),
+        "title": "fix: example",
+        "user": {"login": "ywatanabe"},
+        "head": {"sha": "abc123def456"},
+    }
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> StalePrConfig:
+    return StalePrConfig(
+        gitea_base_url="https://gitea.example.com",
+        gitea_token="GTOKEN",
+        gitea_owner="scitex",
+        repos=["scitex-orochi"],
+        repo_to_merger={"scitex-orochi": "head-mba"},
+        sender="daemon-stale-pr",
+        hub_url="https://hub.example.com",
+        hub_token="HTOKEN",
+        publish_channel="#general",
+        threshold_s=3600,
+        redm_after_s=3600,
+        tick_interval_s=600,
+        log_path=tmp_path / "stale-pr-daemon.log",
+    )
+
+
+def _async_return(value: Any):
+    async def _coro(*_a, **_kw):
+        return value
+
+    return _coro
+
+
+def test_acceptance_1_one_stale_pr_emits_one_dm(
+    cfg: StalePrConfig,
+    stale_pr_payload: dict,
+    now_ts: float,
+    tmp_path: Path,
+) -> None:
+    state = StalePrState(tmp_path / "state.json")
+
+    fetch_payload = (
+        [stale_pr_payload],
+        {stale_pr_payload["head"]["sha"]: {"state": "success"}},
+    )
+    posts: list[dict] = []
+
+    def fake_post_message(**kwargs):
+        posts.append(kwargs)
+        return True
+
+    with patch.object(
+        wrapper_mod, "_fetch_repo_state", _async_return(fetch_payload)
+    ), patch.object(wrapper_mod, "_post_message", side_effect=fake_post_message):
+        result = asyncio.run(run_tick_async(cfg, state, now_ts=now_ts))
+
+    assert result.found == 1
+    assert result.dispatched == 1
+    assert result.suppressed == 0
+    # Two POSTs: the merger DM + the publish-channel summary.
+    assert len(posts) == 2
+    dm_post = next(p for p in posts if p["channel"].startswith("dm:"))
+    assert dm_post["channel"] == "dm:agent:daemon-stale-pr|agent:head-mba"
+    assert "scitex-orochi#388" in dm_post["text"]
+    summary_post = next(p for p in posts if p["channel"] == "#general")
+    assert "tick=stale-pr" in summary_post["text"]
+    assert "found=1" in summary_post["text"]
+    assert "dispatched=1" in summary_post["text"]
+    # State file must persist the dispatch — otherwise acceptance #2
+    # below would fail because the daemon would re-DM on the next tick.
+    reread = StalePrState(state.path)
+    reread.load()
+    assert "scitex-orochi#388" in reread.last_notified_ts
+
+
+def test_acceptance_2_repeat_within_window_does_not_redm(
+    cfg: StalePrConfig,
+    stale_pr_payload: dict,
+    now_ts: float,
+    tmp_path: Path,
+) -> None:
+    state = StalePrState(tmp_path / "state.json")
+    state.load()
+    state.record_notified("scitex-orochi#388", when=now_ts - 600)  # 10min ago
+
+    fetch_payload = (
+        [stale_pr_payload],
+        {stale_pr_payload["head"]["sha"]: {"state": "success"}},
+    )
+    posts: list[dict] = []
+
+    def fake_post_message(**kwargs):
+        posts.append(kwargs)
+        return True
+
+    with patch.object(
+        wrapper_mod, "_fetch_repo_state", _async_return(fetch_payload)
+    ), patch.object(wrapper_mod, "_post_message", side_effect=fake_post_message):
+        result = asyncio.run(run_tick_async(cfg, state, now_ts=now_ts))
+
+    assert result.found == 1
+    assert result.dispatched == 0
+    assert result.suppressed == 1
+    # Only the publish-channel summary should be posted; no DM.
+    assert all(not p["channel"].startswith("dm:") for p in posts)
+
+
+def test_no_merger_configured_records_error_but_does_not_crash(
+    cfg: StalePrConfig,
+    stale_pr_payload: dict,
+    now_ts: float,
+    tmp_path: Path,
+) -> None:
+    cfg.repo_to_merger = {}  # forget all routes
+    state = StalePrState(tmp_path / "state.json")
+
+    fetch_payload = (
+        [stale_pr_payload],
+        {stale_pr_payload["head"]["sha"]: {"state": "success"}},
+    )
+
+    with patch.object(
+        wrapper_mod, "_fetch_repo_state", _async_return(fetch_payload)
+    ), patch.object(wrapper_mod, "_post_message", return_value=True):
+        result = asyncio.run(run_tick_async(cfg, state, now_ts=now_ts))
+
+    assert result.found == 1
+    assert result.dispatched == 0
+    assert any("no merger configured" in e for e in result.errors)


### PR DESCRIPTION
## Summary

Pilot daemon-agent following lead msg#23310's sac-managed-tmux paradigm:

- Sleep-loop wrapper as the daemon process (no APScheduler, no cron). Each tick is a fresh in-process call so the loop is visible in an attached tmux pane (operator can read what it's doing).
- Per tick: poll configured gitea repos for open PRs + commit status, filter to `mergeable=True AND all-CI=success AND age>1h`, debounce against `~/.scitex/orochi/state/daemon-stale-pr.json`, DM the suggested merger, post a one-line summary (`tick=stale-pr found=X dispatched=Y`) to `publish_channel`.
- `publish_channel` defaults to `#general` until mgr-auth provisions `#daemons` (lead msg#23310 routing).

## Module shape

- `src/scitex_orochi/_daemons/_stale_pr/_check.py` — pure predicates (I/O-free for testability)
- `src/scitex_orochi/_daemons/_stale_pr/_state.py` — JSON-backed last-notified-at store, atomic write, corrupt → `.json.bak` quarantine
- `src/scitex_orochi/_daemons/_stale_pr/_wrapper.py` — async tick + sleep loop, inline `_post_message` mirroring `hungry_signal_cmd`
- `src/scitex_orochi/_daemons/_stale_pr/__main__.py` — `python -m scitex_orochi._daemons._stale_pr`
- `examples/agents/daemon-stale-pr.yaml` — Agent kind + `worker_role: daemon-stale-pr` (one-line rename when sac `daemon` kind lands)
- `examples/daemons.yaml.example` — config schema, secrets stay in env

## Why this lands now

2026-04-29 mba disk-full surfaced a class of issue: PRs sitting CI-green for hours without a merger (lead msg#23297). This makes the failure mode mechanically visible.

## Test plan

- [x] `pytest tests/test_daemon_stale_pr_*.py` — 21/21 pass
- [x] Lead acceptance #1: 1 stale PR → 1 DM emitted to merger (`test_acceptance_1_one_stale_pr_emits_one_dm`)
- [x] Lead acceptance #2: same PR within 1h → no duplicate DM (`test_acceptance_2_repeat_within_window_does_not_redm`)
- [x] No-merger-route safe (`test_no_merger_configured_records_error_but_does_not_crash`)
- [x] State file: corrupt JSON quarantined to `.bak`, non-numeric values dropped, missing-file = empty
- [x] Ruff lint clean
- [ ] **End-to-end (manual, blocks merge)**: live gitea + live hub, deploy as sac-managed tmux session, attach pane, verify per-tick stdout echo + `#general` summary post + DM dispatch.
- [ ] **Channel migration (out of band)**: DM `mgr-auth` to provision `#daemons`; once created, flip `publish_channel: #general → #daemons` in deployment yaml.

## Out of scope

- sac `daemon` kind (lead defers to a separate scitex-agent-container contributor)
- Per-tick `claude -p` invocation — reserved for FR-M (auditor-haiku) where rule-judgement is the work; FR-N is deterministic
- `#daemons` channel creation (mgr-auth admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
