### PR TITLE
feat(daemons): daemon-auditor-haiku Stage 1 — regex layer + shadow posts (FR-M)

### DIFF
--- a/examples/agents/daemon-auditor-haiku.yaml
+++ b/examples/agents/daemon-auditor-haiku.yaml
@@ -1,0 +1,87 @@
+# Template: copy to ~/.scitex/orochi/agents/ and customize.
+#
+# daemon-auditor-haiku — fleet-wide ZOO/banned-phrase auditor (FR-M).
+#
+# Stage 1 ships **regex-only**, posting verdicts to ``#audit-shadow``
+# (or ``#general`` until head-nas provisions ``#audit-shadow``). 24h
+# soak; lead + ywatanabe review false-positives before promoting to
+# Stage 2 (origin react) / Stage 3 (origin react+reply).
+#
+# Pilot uses ``kind: Agent`` with ``worker_role`` label per lead
+# msg#23310 (defer the ``daemon`` kind to a separate
+# scitex-agent-container contributor; rename when that lands).
+apiVersion: cld-agent/v1
+kind: Agent
+metadata:
+  name: daemon-auditor-haiku
+  labels:
+    role: daemon
+    worker_role: daemon-auditor-haiku
+    team: orochi
+    cardinality: "1"
+    machine: CHANGEME
+    capabilities: zoo-audit,banned-phrase-detect,communication-discipline
+spec:
+  runtime: bash
+  workdir: ~/proj/scitex-orochi
+
+  remote:
+    host: CHANGEME_HOST
+    user: CHANGEME_USER
+
+  command:
+    # Long-lived subscriber; the audit loop is event-driven (each
+    # inbound message), not tick-driven, so there's no sleep here.
+    # Container/sac restarts on crash via the ``restart`` block.
+    - bash
+    - -lc
+    - "exec python -m scitex_orochi._daemons._auditor_haiku"
+
+  orochi:
+    enabled: true
+    hosts:
+      - CHANGEME_LAN_IP
+      - CHANGEME_DOMAIN
+    port: 8559
+    token_env: OROCHI_HUB_TOKEN
+    channels:
+      - "#general"
+      - "#heads"
+      - "#ywatanabe"
+    heartbeat_interval: 60
+
+  env:
+    CLAUDE_AGENT_ROLE: daemon
+    CLAUDE_AGENT_ID: daemon-auditor-haiku
+    OROCHI_HUB_HOST: scitex-orochi.com
+    OROCHI_HUB_PORT: "8559"
+    OROCHI_HUB_WS_PATH: /ws/agent/
+    OROCHI_HUB_TOKEN: ""
+
+    # Where verdict lines land. Flip to '#audit-shadow' once head-nas
+    # provisions it (lead msg#23336). Until then, '#general' so the
+    # loop is visible.
+    AUDITOR_PUBLISH_CHANNEL: "#general"
+
+    # Subscribed channels. Keep this in sync with ``orochi.channels``
+    # above — the env list is the operational source of truth, the
+    # ``orochi.channels`` list is for sac registration.
+    AUDITOR_SUBSCRIBE_CHANNELS: "#general,#heads,#ywatanabe"
+
+    # Stage 1: emit PASS lines so soak review has full coverage.
+    # Operator can flip to ``AUDITOR_FAIL_ONLY=1`` if shadow noise
+    # becomes a problem during soak.
+    AUDITOR_EMIT_PASS: "1"
+    AUDITOR_FAIL_ONLY: "0"
+
+  screen:
+    name: daemon-auditor-haiku
+
+  health:
+    enabled: true
+    interval: 60
+    method: multiplexer-alive
+
+  restart:
+    policy: on-failure
+    max_retries: 5

--- a/src/scitex_orochi/_daemons/__init__.py
+++ b/src/scitex_orochi/_daemons/__init__.py
@@ -1,0 +1,16 @@
+"""Sac-managed daemon-agents.
+
+Per lead msg#23306 / msg#23310, fleet daemon-agents are sac-managed
+tmux sessions that wake on a tick (or on inbound messages, in the
+auditor-haiku case), do deterministic work, post a one-line summary
+to ``#daemons`` (or ``#general`` until that channel exists), and
+sleep again. Each tick is a fresh process so context is naturally
+cleared (ZOO#04 cost). This package collects the per-daemon
+implementations.
+
+Daemons:
+    * ``daemon-stale-pr`` — gitea polling for stuck CI-green PRs (FR-N).
+    * ``daemon-auditor-haiku`` — fleet-wide ZOO/banned-phrase auditor
+      (FR-M). Stage 1 ships regex-only with shadow posts to
+      ``#audit-shadow``.
+"""

--- a/src/scitex_orochi/_daemons/_auditor_haiku/__init__.py
+++ b/src/scitex_orochi/_daemons/_auditor_haiku/__init__.py
@@ -1,0 +1,37 @@
+"""``daemon-auditor-haiku`` — fleet-wide ZOO/banned-phrase auditor.
+
+FR-M (lead msg#23289 + msg#23300 + msg#23327). Subscribes to fleet
+channels via :class:`scitex_orochi.OrochiClient`, runs a hybrid
+audit pipeline against each new message (regex layer first for
+zero-false-negative banned-phrase coverage; Haiku second-pass for
+fuzzy rules), and posts a verdict.
+
+Stage gating (msg#23300):
+  Stage 1 — verdicts go *only* to ``#audit-shadow``; origin
+            channels are not touched. 24h soak; lead + ywatanabe
+            review false-positives.
+  Stage 2 — react ⭕️/❌ on the origin message; no reply.
+  Stage 3 — full ⭕️/❌ + reply with violation cite + suggested
+            rephrase.
+
+This package ships **Stage 1** behaviour. The stage is selected at
+deploy time via the ``DAEMON_AUDITOR_STAGE`` env var (default ``1``).
+"""
+
+from scitex_orochi._daemons._auditor_haiku._rules import (
+    AuditFinding,
+    AuditVerdict,
+    Rule,
+    RuleHit,
+    apply_regex_rules,
+    default_rules,
+)
+
+__all__ = [
+    "AuditFinding",
+    "AuditVerdict",
+    "Rule",
+    "RuleHit",
+    "apply_regex_rules",
+    "default_rules",
+]

--- a/src/scitex_orochi/_daemons/_auditor_haiku/__main__.py
+++ b/src/scitex_orochi/_daemons/_auditor_haiku/__main__.py
@@ -1,0 +1,56 @@
+"""``python -m scitex_orochi._daemons._auditor_haiku`` entry point."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from scitex_orochi._daemons._auditor_haiku._subscriber import (
+    AuditorConfig,
+    run,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="daemon-auditor-haiku",
+        description=(
+            "Stage 1 fleet-wide audit daemon. Subscribes to fleet "
+            "channels, runs the regex rule layer on every inbound "
+            "message, and posts a verdict line to the publish channel "
+            "(default #audit-shadow). All config via env: see "
+            "AuditorConfig.from_env."
+        ),
+    )
+    p.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    cfg = AuditorConfig.from_env()
+    if not cfg.hub_host or not cfg.token:
+        print(
+            "daemon-auditor-haiku: OROCHI_HUB_HOST / OROCHI_HUB_TOKEN unset, "
+            "refusing to start (no shadow target).",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 2
+    asyncio.run(run(cfg))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scitex_orochi/_daemons/_auditor_haiku/_audit.py
+++ b/src/scitex_orochi/_daemons/_auditor_haiku/_audit.py
@@ -1,0 +1,101 @@
+"""Audit pipeline — combines regex layer with the Haiku second-pass.
+
+Stage 1 (this PR) ships **regex-only**: the Haiku second-pass is a
+stub that returns ``UNKNOWN`` so the pipeline maps regex-clean → PASS.
+Stage 1.5 will plug in a real Haiku call; the seam is here so that
+upgrade is a single function swap, not a pipeline rewrite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from scitex_orochi._daemons._auditor_haiku._rules import (
+    AuditFinding,
+    AuditVerdict,
+    Rule,
+    apply_regex_rules,
+)
+
+# Type alias — keeping it as a free function (not a class with state)
+# means the haiku-second-pass stub and the eventual real call have
+# identical signatures, so swapping is a one-line ``haiku_judge=`` arg.
+HaikuJudge = "Callable[[str], AuditVerdict] | None"
+
+
+def _stub_haiku_judge(_text: str) -> AuditVerdict:
+    """Stage 1 placeholder — never escalates a regex-clean message."""
+    return AuditVerdict.UNKNOWN
+
+
+@dataclass(frozen=True)
+class AuditOutcome:
+    """The final verdict the subscriber emits to ``#audit-shadow``.
+
+    ``verdict`` collapses regex + Haiku into ``PASS|FAIL`` (Stage 1
+    treats UNKNOWN as PASS). ``finding`` retains the rich detail so
+    the subscriber can render a rule-by-rule trace in the shadow log.
+    """
+
+    verdict: AuditVerdict
+    finding: AuditFinding
+
+
+def audit_message(
+    text: str,
+    *,
+    rules: tuple[Rule, ...] | None = None,
+    haiku_judge=None,  # HaikuJudge — typed as Callable in Stage 1.5
+) -> AuditOutcome:
+    """Run the hybrid pipeline on a single message.
+
+    The pipeline is: regex first (cheap, deterministic) → Haiku only
+    on regex-clean (UNKNOWN). Once the Haiku second-pass is wired,
+    that order keeps cost minimal while preserving zero-FN coverage
+    of the explicit banned phrases.
+    """
+    finding = apply_regex_rules(text, rules=rules)
+    if finding.verdict == AuditVerdict.FAIL:
+        return AuditOutcome(verdict=AuditVerdict.FAIL, finding=finding)
+    judge = haiku_judge or _stub_haiku_judge
+    haiku_verdict = judge(text)
+    if haiku_verdict == AuditVerdict.FAIL:
+        return AuditOutcome(verdict=AuditVerdict.FAIL, finding=finding)
+    return AuditOutcome(verdict=AuditVerdict.PASS, finding=finding)
+
+
+def render_shadow_line(
+    *,
+    outcome: AuditOutcome,
+    chat_id: str,
+    msg_id: str | int,
+    user: str,
+    text: str,
+    max_excerpt_chars: int = 200,
+) -> str:
+    """Format one audit verdict for posting to ``#audit-shadow``.
+
+    Shape (per lead msg#23300 review-friendly format):
+        ``[verdict=FAIL] in <chat_id> msg#<id> by <user> — rule=<id1,id2> phrase="<spans>" — text="<excerpt>"``
+
+    For PASS verdicts we still emit a line (a quiet one) so the soak
+    review has explicit per-message coverage; absence-of-line would
+    be ambiguous between "auditor saw it and passed" and "auditor
+    missed it entirely".
+    """
+    excerpt = text.strip().replace("\n", " ")
+    if len(excerpt) > max_excerpt_chars:
+        excerpt = excerpt[: max_excerpt_chars - 1] + "…"
+    head = f"[verdict={outcome.verdict.value}] in {chat_id} msg#{msg_id} by {user}"
+    if outcome.verdict == AuditVerdict.FAIL and outcome.finding.hits:
+        rule_ids = ",".join(h.rule_id for h in outcome.finding.hits)
+        spans = ",".join(f'"{h.matched_span}"' for h in outcome.finding.hits)
+        return f'{head} — rule={rule_ids} phrase={spans} — text="{excerpt}"'
+    return f'{head} — text="{excerpt}"'
+
+
+__all__ = [
+    "AuditOutcome",
+    "audit_message",
+    "render_shadow_line",
+]

--- a/src/scitex_orochi/_daemons/_auditor_haiku/_rules.py
+++ b/src/scitex_orochi/_daemons/_auditor_haiku/_rules.py
@@ -1,0 +1,237 @@
+"""Regex rule layer for ``daemon-auditor-haiku`` (FR-M).
+
+The hybrid pipeline (lead msg#23300) runs this layer first because:
+
+  * Banned phrases are exact-match-able and deserve **zero false
+    negatives** — phrasing the rule as a regex makes the meaning
+    inspectable, version-controllable, and unit-testable.
+  * Each rule carries a ZOO / runbook citation so the verdict shows
+    *why* the message tripped, not just *that* it did. The Stage 3
+    reply will quote this so the offending agent learns the rule.
+
+The Haiku second-pass (separate module) handles the fuzzy ones —
+hypothesis menus, communication-priority gaps, "ywatanabe please run
+X" intent without literal phrase. Those rules need judgement; they
+don't fit a regex without unacceptable false-positive rates.
+
+Self-exclusion is **not** the responsibility of this module — the
+subscriber filters by sender before invoking ``apply_regex_rules``.
+That keeps the rules pure and means tests can assert "if this string
+arrived from this sender, it would fail" without simulating a
+network sender filter.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterable, Pattern
+
+
+class AuditVerdict(str, Enum):
+    """Three-valued verdict — UNKNOWN exists so a regex-pass result
+    can be distinguished from a confidently-clean result. The Haiku
+    second-pass turns UNKNOWN into PASS or FAIL; for Stage 1 we
+    treat UNKNOWN as PASS (regex-only).
+    """
+
+    PASS = "PASS"
+    FAIL = "FAIL"
+    UNKNOWN = "UNKNOWN"
+
+
+@dataclass(frozen=True)
+class Rule:
+    """One regex-checkable rule.
+
+    Attributes
+    ----------
+    rule_id
+        Stable short id used in verdict output and in tests. Don't
+        rename without updating skill docs that quote it.
+    citation
+        Plain-text rule source (ZOO clause, runbook section). Surfaced
+        in the verdict so the auditor's reaction is self-explanatory.
+    pattern
+        Compiled regex. Use ``re.IGNORECASE`` for natural-language
+        phrases; use a tighter pattern for codename-leak rules so a
+        legitimate technical mention with prose around it doesn't trip.
+    suggested_rephrase
+        Reserved for Stage 3 reply text. Stage 1 still records it so
+        the shadow log is self-explanatory.
+    """
+
+    rule_id: str
+    citation: str
+    pattern: Pattern[str]
+    suggested_rephrase: str = ""
+
+
+@dataclass(frozen=True)
+class RuleHit:
+    """A single rule firing on a message — keep the matched span so
+    the shadow log can show *where* the rule tripped, not just *which*."""
+
+    rule_id: str
+    citation: str
+    matched_span: str
+    suggested_rephrase: str
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    """The full verdict for one message.
+
+    A message can trip multiple rules — we surface them all in
+    ``hits`` rather than short-circuiting on first match, because
+    Stage 1 review benefits from knowing the *full* surface area of
+    a violation (training data for tightening Haiku prompts later).
+    """
+
+    verdict: AuditVerdict
+    hits: tuple[RuleHit, ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Default rule set
+# ---------------------------------------------------------------------------
+#
+# Each rule is intentionally small + readable. Adding a rule is one
+# tuple + one test. Removing a rule is the inverse — never delete a
+# rule without deleting its test, otherwise reviewers can't tell why
+# coverage dropped.
+
+# ZOO#08 — agents must not surface "blocker" framing to ywatanabe.
+# Fleet convention: investigate, don't escalate. The phrase "blocker"
+# is a tell that an agent is asking ywatanabe to unblock something
+# they could have unblocked themselves.
+_BANNED_PHRASES_ZOO_08 = re.compile(
+    r"\b("
+    r"blocker"
+    r"|blocked\s+on\s+ywatanabe"
+    r"|should\s+I"
+    r"|may\s+I"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Same rule, JP variant — these phrases convey the same "asking
+# permission" pattern that ZOO#08 prohibits.
+_BANNED_PHRASES_ZOO_08_JP = re.compile(
+    r"(OK\s*ですか|進めますか|よろしいですか|宜しいですか)"
+)
+
+# "no internal codenames" rule — when an agent surfaces a contributor
+# branch name like "c-orochi-foo" or an FR id like "FR-K" *to
+# ywatanabe* (or in his channel) without a plain-language description,
+# he can't tell what the work actually is. The rule fires on the
+# bare codename; the subscriber decides whether the message is
+# *to ywatanabe* before applying.
+_INTERNAL_CODENAMES = re.compile(
+    r"\b("
+    # FR-X / RFC-X / ZOO#NN style identifiers
+    r"FR-[A-Z]+\b"
+    r"|RFC-\d+\b"
+    r"|ZOO#\d+\b"
+    # contributor branch names
+    r"|c-orochi-[a-z0-9-]+"
+    r"|c-sac-[a-z0-9-]+"
+    r"|c-scitex-[a-z0-9-]+"
+    r")",
+)
+
+# "ywatanabe please run X" — agents must not ask ywatanabe to run
+# commands they could have run themselves. The handyman path
+# (``handyman-spartan`` etc.) is the correct route. This is a coarse
+# detector; Haiku second-pass refines.
+_HUMAN_HANDYMAN_BYPASS = re.compile(
+    r"ywatanabe[^\n]{0,80}?\b(please\s+run|run\s+this|execute)\b",
+    re.IGNORECASE,
+)
+
+
+def default_rules() -> tuple[Rule, ...]:
+    """The rule set ``daemon-auditor-haiku`` ships with by default.
+
+    Tests pin every rule's id + citation so a refactor that drops
+    coverage is loud. Don't tighten patterns here without first
+    expanding tests — the cost of a false-negative on a banned phrase
+    is precisely the failure mode this daemon exists to catch.
+    """
+    return (
+        Rule(
+            rule_id="zoo-08-banned-phrase-en",
+            citation="ZOO#08 (humans-out-of-loop): no permission-asking phrases",
+            pattern=_BANNED_PHRASES_ZOO_08,
+            suggested_rephrase=(
+                "State what you're going to do (or what you did), not whether "
+                "ywatanabe should let you. Investigate, don't escalate."
+            ),
+        ),
+        Rule(
+            rule_id="zoo-08-banned-phrase-jp",
+            citation="ZOO#08 (humans-out-of-loop): 「OK ですか」「進めますか」禁止",
+            pattern=_BANNED_PHRASES_ZOO_08_JP,
+            suggested_rephrase=(
+                "許可を聞かず、行動を述べる。investigate-don't-ask。"
+            ),
+        ),
+        Rule(
+            rule_id="no-internal-codenames",
+            citation="no-internal-codenames rule — plain-language to ywatanabe",
+            pattern=_INTERNAL_CODENAMES,
+            suggested_rephrase=(
+                "Pair the codename with a plain-language description "
+                "('FR-K = MCP sidecar reconnect') the first time you "
+                "mention it in a thread."
+            ),
+        ),
+        Rule(
+            rule_id="lead-routes-handyman-bypass",
+            citation="lead-routes-only override — use handyman, not ywatanabe",
+            pattern=_HUMAN_HANDYMAN_BYPASS,
+            suggested_rephrase=(
+                "Route command requests through handyman-<host>. ywatanabe "
+                "is not an actuator."
+            ),
+        ),
+    )
+
+
+def apply_regex_rules(
+    text: str,
+    *,
+    rules: Iterable[Rule] | None = None,
+) -> AuditFinding:
+    """Run every rule and aggregate the hits.
+
+    Returns ``UNKNOWN`` (not ``PASS``) when nothing fires, because the
+    Haiku second-pass may still flag the message. The subscriber maps
+    ``UNKNOWN → PASS`` for Stage 1.
+    """
+    rule_list = tuple(rules) if rules is not None else default_rules()
+    hits: list[RuleHit] = []
+    for rule in rule_list:
+        for m in rule.pattern.finditer(text):
+            hits.append(
+                RuleHit(
+                    rule_id=rule.rule_id,
+                    citation=rule.citation,
+                    matched_span=m.group(0),
+                    suggested_rephrase=rule.suggested_rephrase,
+                )
+            )
+    if hits:
+        return AuditFinding(verdict=AuditVerdict.FAIL, hits=tuple(hits))
+    return AuditFinding(verdict=AuditVerdict.UNKNOWN, hits=())
+
+
+__all__ = [
+    "AuditFinding",
+    "AuditVerdict",
+    "Rule",
+    "RuleHit",
+    "apply_regex_rules",
+    "default_rules",
+]

--- a/src/scitex_orochi/_daemons/_auditor_haiku/_subscriber.py
+++ b/src/scitex_orochi/_daemons/_auditor_haiku/_subscriber.py
@@ -1,0 +1,190 @@
+"""WebSocket subscriber loop for ``daemon-auditor-haiku`` (Stage 1).
+
+Connects via :class:`OrochiClient`, subscribes to the configured
+fleet channels, and for each inbound message:
+
+  1. Skip if ``sender == self`` (self-exclusion — never audit own
+     audit posts; would loop forever).
+  2. Run :func:`audit_message`.
+  3. Post one verdict line to ``publish_channel`` (Stage 1: that's
+     ``#audit-shadow``; falls back to ``#general`` until provisioned).
+  4. Continue.
+
+This is intentionally a long-lived process, *not* fresh-per-tick.
+Lead msg#23300 said "fresh process per message" but lead msg#23310
+clarified that fresh-per-message is the *judgement* path (each
+``claude -p`` invocation), not the subscriber. The subscriber is
+the wrapper. For Stage 1 there's no ``claude -p`` (regex only), so
+the wrapper-as-subscriber is enough; Stage 1.5 will add a fresh
+subprocess spawn inside the audit pipeline when Haiku is wired.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from scitex_orochi._client import OrochiClient
+from scitex_orochi._daemons._auditor_haiku._audit import (
+    AuditOutcome,
+    audit_message,
+    render_shadow_line,
+)
+from scitex_orochi._daemons._auditor_haiku._rules import AuditVerdict, Rule
+
+logger = logging.getLogger("orochi.daemon.auditor_haiku")
+
+
+@dataclass
+class AuditorConfig:
+    """Per-deployment config for ``daemon-auditor-haiku``."""
+
+    agent_name: str = "daemon-auditor-haiku"
+    hub_host: str = ""
+    hub_port: int = 8559
+    ws_path: str = "/ws/agent/"
+    token: str = ""
+
+    # Channels we subscribe to. Stage 1 is conservative: just the
+    # always-on fleet channels. ``#proj-*`` / ``#c-*`` wildcards are
+    # not in the v1 protocol; the operator can extend this list
+    # explicitly per deployment until the hub supports patterns.
+    subscribe_channels: tuple[str, ...] = (
+        "#general",
+        "#heads",
+        "#ywatanabe",
+    )
+
+    # Where verdict lines go. Stage 1: ``#audit-shadow``.
+    publish_channel: str = "#audit-shadow"
+
+    # Verbosity — emit a line for PASS verdicts as well as FAIL.
+    # Lead msg#23300 wanted "log-only ⭕️/❌" so PASS lines exist
+    # for soak review. Operator can flip to FAIL-only after Stage 1.
+    emit_pass: bool = True
+
+    # When set, only post FAIL lines (overrides emit_pass for noise control).
+    fail_only: bool = False
+
+    # Custom rule set; default :func:`default_rules` if None.
+    rules: tuple[Rule, ...] | None = None
+
+    @classmethod
+    def from_env(cls) -> "AuditorConfig":
+        """Compose config from env (the wrapper is launched from a
+        sac-managed yaml that sets these)."""
+        return cls(
+            agent_name=os.environ.get("CLAUDE_AGENT_ID", "daemon-auditor-haiku"),
+            hub_host=os.environ.get("OROCHI_HUB_HOST", ""),
+            hub_port=int(os.environ.get("OROCHI_HUB_PORT", "8559")),
+            ws_path=os.environ.get("OROCHI_HUB_WS_PATH", "/ws/agent/"),
+            token=os.environ.get("OROCHI_HUB_TOKEN", ""),
+            subscribe_channels=tuple(
+                ch.strip()
+                for ch in os.environ.get(
+                    "AUDITOR_SUBSCRIBE_CHANNELS",
+                    "#general,#heads,#ywatanabe",
+                ).split(",")
+                if ch.strip()
+            ),
+            publish_channel=os.environ.get(
+                "AUDITOR_PUBLISH_CHANNEL", "#audit-shadow"
+            ),
+            emit_pass=os.environ.get("AUDITOR_EMIT_PASS", "1") not in ("0", "false"),
+            fail_only=os.environ.get("AUDITOR_FAIL_ONLY", "0") in ("1", "true"),
+        )
+
+
+@dataclass
+class AuditCounters:
+    """Cheap in-process counters for the periodic summary line."""
+
+    seen: int = 0
+    self_excluded: int = 0
+    failed: int = 0
+    passed: int = 0
+
+
+def _should_post(outcome: AuditOutcome, cfg: AuditorConfig) -> bool:
+    if cfg.fail_only and outcome.verdict != AuditVerdict.FAIL:
+        return False
+    if not cfg.emit_pass and outcome.verdict != AuditVerdict.FAIL:
+        return False
+    return True
+
+
+async def _process_one_message(
+    msg,
+    *,
+    cfg: AuditorConfig,
+    client: OrochiClient,
+    counters: AuditCounters,
+) -> None:
+    """Audit a single inbound message and (maybe) post the verdict."""
+    counters.seen += 1
+    sender = getattr(msg, "sender", "") or ""
+    if sender == cfg.agent_name:
+        counters.self_excluded += 1
+        return
+
+    payload = getattr(msg, "payload", {}) or {}
+    chat_id = payload.get("channel", "") or ""
+    text = payload.get("content", "") or ""
+    msg_id = payload.get("metadata", {}).get("msg_id", "?") if isinstance(
+        payload.get("metadata"), dict
+    ) else "?"
+
+    outcome = audit_message(text, rules=cfg.rules)
+    if outcome.verdict == AuditVerdict.FAIL:
+        counters.failed += 1
+    else:
+        counters.passed += 1
+    if not _should_post(outcome, cfg):
+        return
+    line = render_shadow_line(
+        outcome=outcome,
+        chat_id=chat_id,
+        msg_id=msg_id,
+        user=sender,
+        text=text,
+    )
+    try:
+        await client.send(cfg.publish_channel, line)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("auditor: post to %s failed: %s", cfg.publish_channel, exc)
+
+
+async def run(cfg: AuditorConfig) -> AuditCounters:
+    """Connect, subscribe, listen, audit. Returns counters when the
+    connection closes (caller may choose to reconnect)."""
+    counters = AuditCounters()
+    async with OrochiClient(
+        cfg.agent_name,
+        host=cfg.hub_host or None,
+        port=cfg.hub_port,
+        channels=list(cfg.subscribe_channels),
+        token=cfg.token or None,
+        role="daemon",
+        ws_path=cfg.ws_path,
+    ) as client:
+        print(
+            f"daemon-auditor-haiku: connected as {cfg.agent_name}, "
+            f"subscribed to {','.join(cfg.subscribe_channels)}, "
+            f"publishing to {cfg.publish_channel}",
+            flush=True,
+        )
+        async for msg in client.listen():
+            await _process_one_message(
+                msg, cfg=cfg, client=client, counters=counters
+            )
+    return counters
+
+
+__all__ = [
+    "AuditorConfig",
+    "AuditCounters",
+    "_process_one_message",
+    "_should_post",
+    "run",
+]

--- a/tests/test_daemon_auditor_haiku_audit.py
+++ b/tests/test_daemon_auditor_haiku_audit.py
@@ -1,0 +1,99 @@
+"""Pipeline + shadow-line tests for ``daemon-auditor-haiku`` Stage 1."""
+
+from __future__ import annotations
+
+from scitex_orochi._daemons._auditor_haiku._audit import (
+    AuditOutcome,
+    audit_message,
+    render_shadow_line,
+)
+from scitex_orochi._daemons._auditor_haiku._rules import AuditVerdict
+
+
+class TestAuditMessage:
+    def test_regex_fail_short_circuits(self) -> None:
+        # If regex tripped, we don't waste a Haiku call.
+        called = {"haiku": False}
+
+        def haiku(_: str) -> AuditVerdict:
+            called["haiku"] = True
+            return AuditVerdict.PASS
+
+        outcome = audit_message("This is a blocker", haiku_judge=haiku)
+        assert outcome.verdict == AuditVerdict.FAIL
+        assert called["haiku"] is False
+
+    def test_regex_clean_calls_haiku(self) -> None:
+        called = {"haiku": False}
+
+        def haiku(text: str) -> AuditVerdict:
+            called["haiku"] = True
+            return AuditVerdict.UNKNOWN
+
+        outcome = audit_message("All tests pass; pushing.", haiku_judge=haiku)
+        assert outcome.verdict == AuditVerdict.PASS
+        assert called["haiku"] is True
+
+    def test_haiku_can_escalate_to_fail(self) -> None:
+        # Stage 1.5 surface: Haiku catches the regex-clean fuzzy violator.
+        outcome = audit_message(
+            "vague hypothesis menu A/B/C to ywatanabe",
+            haiku_judge=lambda _: AuditVerdict.FAIL,
+        )
+        assert outcome.verdict == AuditVerdict.FAIL
+
+    def test_default_stub_haiku_treats_as_pass(self) -> None:
+        # Stage 1 default — never escalates a regex-clean message.
+        outcome = audit_message("All tests pass; pushing.")
+        assert outcome.verdict == AuditVerdict.PASS
+
+
+class TestRenderShadowLine:
+    def test_fail_line_includes_rule_and_phrase(self) -> None:
+        outcome = audit_message("Should I proceed with FR-K?")
+        line = render_shadow_line(
+            outcome=outcome,
+            chat_id="#general",
+            msg_id=42,
+            user="proj-foo",
+            text="Should I proceed with FR-K?",
+        )
+        assert "verdict=FAIL" in line
+        assert "in #general" in line
+        assert "msg#42" in line
+        assert "by proj-foo" in line
+        assert "rule=" in line
+        # Both rules tripped, so both ids should be cited.
+        assert "zoo-08-banned-phrase-en" in line
+        assert "no-internal-codenames" in line
+
+    def test_pass_line_omits_rule_section(self) -> None:
+        outcome = audit_message("All tests pass; pushing.")
+        line = render_shadow_line(
+            outcome=outcome,
+            chat_id="#general",
+            msg_id=43,
+            user="proj-foo",
+            text="All tests pass; pushing.",
+        )
+        assert "verdict=PASS" in line
+        assert "rule=" not in line
+        assert 'text="All tests pass; pushing."' in line
+
+    def test_long_text_is_truncated(self) -> None:
+        long = "x" * 1000
+        outcome = AuditOutcome(
+            verdict=AuditVerdict.PASS,
+            finding=audit_message(long).finding,
+        )
+        line = render_shadow_line(
+            outcome=outcome,
+            chat_id="#general",
+            msg_id=1,
+            user="u",
+            text=long,
+            max_excerpt_chars=50,
+        )
+        assert line.endswith('…"')
+        # Ellipsis + closing quote, plus the truncated body.
+        assert len(line) < 200

--- a/tests/test_daemon_auditor_haiku_rules.py
+++ b/tests/test_daemon_auditor_haiku_rules.py
@@ -1,0 +1,148 @@
+"""Regex layer tests for ``daemon-auditor-haiku`` (FR-M Stage 1).
+
+Acceptance pin (lead msg#23289):
+  * Synthetic message containing "blocker" → ❌ react + reply citing ZOO#08
+  * Synthetic message containing "FR-K" without plain-language → ❌ react
+  * Clean message → ⭕️ react
+
+The Stage 1 implementation only posts to ``#audit-shadow`` (no origin
+react/reply yet), so these tests pin the *verdict* and *citation* —
+the reaction-layer behaviour is a Stage 2 concern.
+"""
+
+from __future__ import annotations
+
+import re
+
+from scitex_orochi._daemons._auditor_haiku._rules import (
+    AuditVerdict,
+    Rule,
+    apply_regex_rules,
+    default_rules,
+)
+
+
+def _verdict(text: str) -> AuditVerdict:
+    return apply_regex_rules(text).verdict
+
+
+def _hit_rules(text: str) -> set[str]:
+    return {h.rule_id for h in apply_regex_rules(text).hits}
+
+
+class TestZooBannedPhrasesEN:
+    def test_blocker_trips_zoo_08(self) -> None:
+        finding = apply_regex_rules("This is a blocker for the deploy.")
+        assert finding.verdict == AuditVerdict.FAIL
+        assert {h.rule_id for h in finding.hits} == {"zoo-08-banned-phrase-en"}
+        assert "ZOO#08" in finding.hits[0].citation
+
+    def test_blocked_on_ywatanabe_trips(self) -> None:
+        assert _verdict("we're blocked on ywatanabe for sign-off") == AuditVerdict.FAIL
+
+    def test_should_i_trips(self) -> None:
+        assert _verdict("Should I proceed with the migration?") == AuditVerdict.FAIL
+
+    def test_may_i_trips(self) -> None:
+        assert _verdict("May I open the PR now?") == AuditVerdict.FAIL
+
+    def test_unrelated_use_of_block_does_not_trip(self) -> None:
+        # "block" without "blocker" is not the banned phrase. Word-boundary
+        # \b in the regex prevents this from being a substring match.
+        assert _verdict("The function uses a try/except block.") == AuditVerdict.UNKNOWN
+
+
+class TestZooBannedPhrasesJP:
+    def test_ok_desuka_trips(self) -> None:
+        finding = apply_regex_rules("OK ですか？進めて良いですか")
+        assert finding.verdict == AuditVerdict.FAIL
+        assert "zoo-08-banned-phrase-jp" in {h.rule_id for h in finding.hits}
+
+    def test_susume_masuka_trips(self) -> None:
+        assert _verdict("PR を進めますか？") == AuditVerdict.FAIL
+
+    def test_yoroshii_desuka_trips(self) -> None:
+        assert _verdict("merge してよろしいですか") == AuditVerdict.FAIL
+
+
+class TestInternalCodenames:
+    def test_fr_codename_trips(self) -> None:
+        # Lead-spec acceptance #2: FR-K without plain-language description.
+        finding = apply_regex_rules("Working on FR-K now.")
+        assert finding.verdict == AuditVerdict.FAIL
+        assert "no-internal-codenames" in {h.rule_id for h in finding.hits}
+
+    def test_contributor_branch_codename_trips(self) -> None:
+        assert _verdict("pushed c-orochi-stale-pr-daemon") == AuditVerdict.FAIL
+
+    def test_zoo_clause_codename_trips(self) -> None:
+        assert _verdict("per ZOO#08 we should not.") == AuditVerdict.FAIL
+
+    def test_rfc_codename_trips(self) -> None:
+        assert _verdict("see RFC-42 for the design.") == AuditVerdict.FAIL
+
+
+class TestHandymanBypass:
+    def test_ywatanabe_please_run_trips(self) -> None:
+        assert (
+            _verdict("ywatanabe please run the deploy script")
+            == AuditVerdict.FAIL
+        )
+
+    def test_ywatanabe_run_this_trips(self) -> None:
+        assert _verdict("ywatanabe, run this and let me know") == AuditVerdict.FAIL
+
+    def test_ywatanabe_unrelated_does_not_trip(self) -> None:
+        # The rule looks for an action verb following ywatanabe within a
+        # short window. A bare mention should not trip.
+        assert _verdict("ywatanabe asked for a status update.") == AuditVerdict.UNKNOWN
+
+
+class TestCleanMessages:
+    def test_clean_status_message(self) -> None:
+        # Lead-spec acceptance #3: clean message → PASS (UNKNOWN at this
+        # layer; subscriber maps it to PASS).
+        assert _verdict("Tests pass; pushing to develop.") == AuditVerdict.UNKNOWN
+
+    def test_empty_message(self) -> None:
+        assert _verdict("") == AuditVerdict.UNKNOWN
+
+
+class TestMultipleHits:
+    def test_one_message_can_trip_multiple_rules(self) -> None:
+        # A real corpus example — banned phrase + codename leak in the
+        # same message. Both should surface in the verdict.
+        finding = apply_regex_rules(
+            "Should I proceed with FR-K? It's a blocker."
+        )
+        assert finding.verdict == AuditVerdict.FAIL
+        rules_hit = {h.rule_id for h in finding.hits}
+        assert "zoo-08-banned-phrase-en" in rules_hit
+        assert "no-internal-codenames" in rules_hit
+
+
+class TestDefaultRulesShape:
+    def test_every_default_rule_has_id_and_citation(self) -> None:
+        for rule in default_rules():
+            assert rule.rule_id, "rule_id must be non-empty"
+            assert rule.citation, "citation must be non-empty"
+
+    def test_rule_ids_are_unique(self) -> None:
+        ids = [r.rule_id for r in default_rules()]
+        assert len(ids) == len(set(ids))
+
+
+class TestRuleInjection:
+    def test_caller_supplied_rules_replace_default(self) -> None:
+        custom = (
+            Rule(
+                rule_id="custom-foo",
+                citation="local rule",
+                pattern=re.compile(r"foo"),
+                suggested_rephrase="say bar instead",
+            ),
+        )
+        finding = apply_regex_rules("foo bar baz", rules=custom)
+        assert finding.verdict == AuditVerdict.FAIL
+        assert finding.hits[0].rule_id == "custom-foo"
+        assert finding.hits[0].suggested_rephrase == "say bar instead"

--- a/tests/test_daemon_auditor_haiku_subscriber.py
+++ b/tests/test_daemon_auditor_haiku_subscriber.py
@@ -1,0 +1,116 @@
+"""Subscriber-loop tests for ``daemon-auditor-haiku`` Stage 1.
+
+We don't spin up a real WebSocket — that would gold-plate the test.
+Instead we drive ``_process_one_message`` directly with synthetic
+``Message``-shaped objects and assert on what gets posted.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from scitex_orochi._daemons._auditor_haiku._subscriber import (
+    AuditCounters,
+    AuditorConfig,
+    _process_one_message,
+)
+
+
+@dataclass
+class _FakeMessage:
+    sender: str
+    type: str = "message"
+    payload: dict = field(default_factory=dict)
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, str]] = []
+
+    async def send(self, channel: str, content: str, **_: Any) -> None:
+        self.posts.append((channel, content))
+
+
+@pytest.fixture
+def cfg() -> AuditorConfig:
+    return AuditorConfig(
+        agent_name="daemon-auditor-haiku",
+        publish_channel="#audit-shadow",
+        emit_pass=True,
+        fail_only=False,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_self_excludes_own_messages(cfg: AuditorConfig) -> None:
+    client = _FakeClient()
+    counters = AuditCounters()
+    msg = _FakeMessage(
+        sender="daemon-auditor-haiku",
+        payload={"channel": "#audit-shadow", "content": "blocker", "metadata": {}},
+    )
+    _run(_process_one_message(msg, cfg=cfg, client=client, counters=counters))
+    assert client.posts == []
+    assert counters.self_excluded == 1
+    assert counters.failed == 0
+
+
+def test_fail_message_posts_to_shadow(cfg: AuditorConfig) -> None:
+    client = _FakeClient()
+    counters = AuditCounters()
+    msg = _FakeMessage(
+        sender="proj-foo",
+        payload={
+            "channel": "#general",
+            "content": "Should I proceed?",
+            "metadata": {"msg_id": 99},
+        },
+    )
+    _run(_process_one_message(msg, cfg=cfg, client=client, counters=counters))
+    assert len(client.posts) == 1
+    channel, line = client.posts[0]
+    assert channel == "#audit-shadow"
+    assert "verdict=FAIL" in line
+    assert "msg#99" in line
+    assert counters.failed == 1
+
+
+def test_pass_message_emits_pass_line_when_emit_pass(cfg: AuditorConfig) -> None:
+    client = _FakeClient()
+    counters = AuditCounters()
+    msg = _FakeMessage(
+        sender="proj-foo",
+        payload={
+            "channel": "#general",
+            "content": "All tests pass; pushing.",
+            "metadata": {"msg_id": 100},
+        },
+    )
+    _run(_process_one_message(msg, cfg=cfg, client=client, counters=counters))
+    assert len(client.posts) == 1
+    assert "verdict=PASS" in client.posts[0][1]
+    assert counters.passed == 1
+
+
+def test_fail_only_suppresses_pass_lines() -> None:
+    cfg = AuditorConfig(
+        agent_name="daemon-auditor-haiku",
+        publish_channel="#audit-shadow",
+        fail_only=True,
+    )
+    client = _FakeClient()
+    counters = AuditCounters()
+    msg = _FakeMessage(
+        sender="proj-foo",
+        payload={"channel": "#general", "content": "All good.", "metadata": {}},
+    )
+    _run(_process_one_message(msg, cfg=cfg, client=client, counters=counters))
+    assert client.posts == []
+    assert counters.passed == 1


### PR DESCRIPTION
## Summary

Stage 1 of the fleet-wide ZOO/banned-phrase auditor (lead msg#23289 + msg#23300 + msg#23327). Subscribes to fleet channels via `OrochiClient`, runs a regex rule layer on every inbound message, and posts a verdict line to `publish_channel`. Defaults to `#audit-shadow` (env-flippable to `#general` until head-nas provisions the dedicated channel — request out of band, lead msg#23336).

The hybrid pipeline (regex layer + Haiku second-pass) is split here so Stage 1.5 plugs in the Haiku call as a single `haiku_judge=` argument swap; the seam is intentional.

## Module shape

Under `src/scitex_orochi/_daemons/_auditor_haiku/`:

- `_rules.py` — regex `Rule` + `RuleHit` + `AuditFinding` + default rule set:
  - ZOO#08 banned phrases EN: "blocker", "blocked on ywatanabe", "should I", "may I"
  - ZOO#08 banned phrases JP: "OK ですか", "進めますか", "よろしいですか", "宜しいですか"
  - Internal codename leak: `FR-X`, `RFC-N`, `ZOO#N`, `c-orochi-*`, `c-sac-*`, `c-scitex-*`
  - Lead-routes handyman bypass: "ywatanabe ... please run / run this / execute"
- `_audit.py` — pipeline (regex first → Haiku stub on regex-clean) + `render_shadow_line` for `#audit-shadow` output
- `_subscriber.py` — async `OrochiClient` subscribe loop, per-message audit + post; **self-excludes** own posts to avoid audit-of-audit feedback
- `__main__.py` — CLI entry; refuses to start if hub creds missing

Spec at `examples/agents/daemon-auditor-haiku.yaml` using `Agent` kind + `worker_role: daemon-auditor-haiku` (matches FR-N pilot pattern per lead msg#23310; one-line rename when sac `daemon` kind lands).

## Stage gating

| Stage | Behavior | Gate |
|---|---|---|
| 1 (this PR) | Verdicts to `#audit-shadow`; origin untouched | 24h soak; lead+ywatanabe review false-positives |
| 1.5 | + Haiku second-pass (Anthropic SDK, fresh process per msg) | Stage 1 false-positive rate acceptable |
| 2 | Origin react ⭕️/❌; no reply | Stage 1.5 stable |
| 3 | Origin react + reply with rephrase | Stage 2 soak clean |

## Test plan

- [x] `pytest tests/test_daemon_auditor_haiku_*.py` — **32/32 pass**
- [x] Lead acceptance #1: "blocker" → FAIL with ZOO#08 citation (`TestZooBannedPhrasesEN::test_blocker_trips_zoo_08`)
- [x] Lead acceptance #2: bare `FR-K` → FAIL with `no-internal-codenames` citation (`TestInternalCodenames::test_fr_codename_trips`)
- [x] Lead acceptance #3: clean message → PASS (`TestCleanMessages::test_clean_status_message`)
- [x] Self-exclusion: own posts ignored (`test_self_excludes_own_messages`)
- [x] Multi-rule: one message can trip multiple rules, all surfaced (`test_one_message_can_trip_multiple_rules`)
- [x] Custom rule injection works (`test_caller_supplied_rules_replace_default`)
- [x] Ruff lint clean
- [ ] **End-to-end (manual, blocks merge)**: deploy as sac-managed tmux session, attach pane, post a synthetic "blocker" message in `#general`, verify FAIL line lands in `#audit-shadow` (or `#general` until provisioned).
- [ ] **Channel migration**: head-nas provisioning of `#audit-shadow` per lead msg#23336; flip `AUDITOR_PUBLISH_CHANNEL` env in deployed yaml.
- [ ] **Soak review**: 24h shadow soak; lead + ywatanabe sample false-positives, then promote to Stage 1.5 / Stage 2.

## Out of scope

- Stage 2/3 origin react+reply (gated)
- Real Haiku second-pass — needs Anthropic SDK + fresh-process-per-msg wrapper
- Wildcard channel subscriptions (`#proj-*`, `#c-*`) — needs hub protocol extension
- `#audit-shadow` channel creation (head-nas admin)

## Note re: branch overlap

This branch was created off `develop` before FR-N (PR #404) merged, so it adds `src/scitex_orochi/_daemons/__init__.py` again. Trivial rebase once #404 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
