### PR TITLE
feat(hub): on-demand message translation via Claude API (todo#409 Phase 1)

### DIFF
--- a/hub/frontend/src/chat/chat-actions.ts
+++ b/hub/frontend/src/chat/chat-actions.ts
@@ -170,6 +170,73 @@ export function handleMessageDelete(event) {
   }
 }
 
+/* --- On-demand translation (todo#409 Phase 1) --- */
+
+export function translateMessage(msgId, targetLang?) {
+  var lang = targetLang || "en";
+  fetch(apiUrl("/api/messages/" + msgId + "/translate/"), {
+    method: "POST",
+    headers: orochiHeaders(),
+    credentials: "same-origin",
+    body: JSON.stringify({ target_lang: lang }),
+  })
+    .then(function (res) {
+      return res.json().then(function (d) {
+        return { ok: res.ok, data: d };
+      });
+    })
+    .then(function ({ ok, data }) {
+      if (!ok) {
+        _showTranslateOverlay(msgId, null, data.error || "Translation failed");
+        return;
+      }
+      _showTranslateOverlay(msgId, data.translated_text, null);
+    })
+    .catch(function (e) {
+      _showTranslateOverlay(msgId, null, "Translation error: " + e);
+    });
+  /* Optimistic spinner while waiting */
+  _showTranslateOverlay(msgId, null, "Translating…");
+}
+
+function _showTranslateOverlay(msgId, text, error) {
+  var existing = document.querySelector('.msg-translate-overlay[data-msg-id="' + msgId + '"]');
+  if (existing) existing.remove();
+
+  var el = document.querySelector('.msg[data-msg-id="' + msgId + '"]');
+  if (!el) return;
+
+  var overlay = document.createElement("div");
+  overlay.className = "msg-translate-overlay";
+  overlay.setAttribute("data-msg-id", String(msgId));
+
+  if (error) {
+    overlay.innerHTML =
+      '<div class="msg-translate-error">' + escapeHtml(error) + "</div>" +
+      '<button class="msg-translate-close" type="button" onclick="this.parentNode.remove()">×</button>';
+  } else {
+    overlay.innerHTML =
+      '<div class="msg-translate-text">' +
+      escapeHtml(text || "").replace(/\n/g, "<br>") +
+      "</div>" +
+      '<button class="msg-translate-close" type="button" onclick="this.parentNode.remove()">×</button>';
+  }
+  el.appendChild(overlay);
+  /* Dismiss on outside click */
+  setTimeout(function () {
+    document.addEventListener(
+      "click",
+      function onOutside(ev) {
+        if (!overlay.contains(ev.target as Node)) {
+          overlay.remove();
+          document.removeEventListener("click", onOutside, true);
+        }
+      },
+      true,
+    );
+  }, 50);
+}
+
 /* Timestamps are now absolute (YYYY-MM-DD HH:mm:ss), no periodic refresh needed */
 
 /* --- Long-press context menu (mobile) ---

--- a/hub/frontend/src/chat/chat-render.ts
+++ b/hub/frontend/src/chat/chat-render.ts
@@ -239,6 +239,11 @@ export function appendMessage(msg) {
         msg.id +
         ')">&#10005;</button>'
       : "") +
+    (msg.id
+      ? '<button class="msg-translate-btn" type="button" title="Translate message" onclick="translateMessage(' +
+        msg.id +
+        ')">&#127760;</button>'
+      : "") +
     (function () {
       var tc = msg.thread_count || 0;
       if (!msg.id || tc === 0) return "";

--- a/hub/frontend/src/window-bridge.ts
+++ b/hub/frontend/src/window-bridge.ts
@@ -10,7 +10,7 @@ import { closeChannelExport, doChannelExport, openChannelExport } from "./app/ag
 import { closeChannelTopicEdit, closeMembersPanel, openChannelTopicEdit, saveChannelTopic, toggleMembersPanel } from "./app/members";
 import { killAgent, restartAgent, togglePinAgent } from "./app/sidebar-agents";
 import { escapeHtml } from "./app/utils";
-import { deleteMessage, startEditMessage } from "./chat/chat-actions";
+import { deleteMessage, startEditMessage, translateMessage } from "./chat/chat-actions";
 import { jumpToMsg } from "./chat/chat-attachments";
 import { chatFilterApply } from "./chat/chat-state";
 import { closeImgViewer, filesSetQuery, filesSetView, filesTogglePreview, imgViewerNav, openImgViewer } from "./files-tab/files-tab-core";
@@ -59,6 +59,7 @@ Object.assign(window, {
   saveChannelTopic,
   sendThreadReply,
   startEditMessage,
+  translateMessage,
   toggleClaudeMd,
   toggleMembersPanel,
   togglePinAgent,

--- a/hub/static/hub/style/style-agents.css
+++ b/hub/static/hub/style/style-agents.css
@@ -185,7 +185,8 @@
 }
 
 .msg-edit-btn,
-.msg-delete-btn {
+.msg-delete-btn,
+.msg-translate-btn {
   position: absolute;
   bottom: 6px;
   background: #1a1a1a;
@@ -211,8 +212,13 @@
   right: 114px;
 }
 
+.msg-translate-btn {
+  right: 150px;
+}
+
 .msg:hover .msg-edit-btn,
-.msg:hover .msg-delete-btn {
+.msg:hover .msg-delete-btn,
+.msg:hover .msg-translate-btn {
   opacity: 1;
 }
 
@@ -277,6 +283,47 @@
 .msg-edit-cancel:hover {
   background: #333;
   color: #f8f7f5;
+}
+
+.msg-translate-btn:hover {
+  background: #222;
+  color: #74b9ff;
+  border-color: #74b9ff;
+}
+
+/* Translation overlay */
+.msg-translate-overlay {
+  position: relative;
+  margin-top: 6px;
+  background: #1a1f2e;
+  border: 1px solid #2c3e6b;
+  border-radius: 6px;
+  padding: 8px 32px 8px 10px;
+  color: #b0c4ff;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.msg-translate-error {
+  color: #e74c3c;
+  font-style: italic;
+}
+
+.msg-translate-close {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  background: transparent;
+  border: none;
+  color: #555;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 0 2px;
+  line-height: 1;
+}
+
+.msg-translate-close:hover {
+  color: #999;
 }
 
 /* Delete animation */

--- a/hub/tests/views/api/test_message_translate.py
+++ b/hub/tests/views/api/test_message_translate.py
@@ -1,0 +1,86 @@
+"""Tests for POST /api/messages/<id>/translate/ (todo#409 Phase 1)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth.models import User
+from django.test import Client, TestCase
+
+from hub.models import Channel, Message, Workspace, WorkspaceMember
+
+
+def _ws_host(ws):
+    return f"{ws.name}.lvh.me"
+
+
+class MessageTranslateTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.user = User.objects.create_user(username="tester", password="pass")
+        self.ws = Workspace.objects.create(name="tr-ws")
+        WorkspaceMember.objects.create(workspace=self.ws, user=self.user, role="member")
+        self.ch = Channel.objects.create(workspace=self.ws, name="#general")
+        self.msg = Message.objects.create(
+            workspace=self.ws,
+            channel=self.ch,
+            sender="tester",
+            content="こんにちは世界",
+        )
+        self.client.login(username="tester", password="pass")
+
+    def _post(self, msg_id, body=None):
+        return self.client.post(
+            f"/api/messages/{msg_id}/translate/",
+            data=json.dumps(body or {"target_lang": "en"}),
+            content_type="application/json",
+            HTTP_HOST=_ws_host(self.ws),
+        )
+
+    def test_no_api_key_returns_503(self):
+        with patch.dict("os.environ", {}, clear=True):
+            import importlib
+            import hub.views.api._translate as m
+            importlib.reload(m)
+        resp = self._post(self.msg.id)
+        self.assertEqual(resp.status_code, 503)
+
+    def test_requires_auth(self):
+        self.client.logout()
+        resp = self._post(self.msg.id)
+        self.assertEqual(resp.status_code, 401)
+
+    def test_404_for_missing_message(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "content": [{"text": "Hello world"}]
+        }
+        with patch("hub.views.api._translate.httpx.post", return_value=mock_resp):
+            with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
+                resp = self._post(99999)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_successful_translation(self):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "content": [{"text": "Hello world"}]
+        }
+        with patch("hub.views.api._translate.httpx.post", return_value=mock_resp):
+            with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
+                resp = self._post(self.msg.id, {"target_lang": "en"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["translated_text"], "Hello world")
+        self.assertEqual(data["target_lang"], "en")
+        self.assertEqual(data["original_text"], "こんにちは世界")
+
+    def test_api_error_returns_502(self):
+        import httpx as _httpx
+        mock_resp = MagicMock()
+        mock_resp.status_code = 429
+        exc = _httpx.HTTPStatusError("rate limit", request=MagicMock(), response=mock_resp)
+        with patch("hub.views.api._translate.httpx.post", side_effect=exc):
+            with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-test"}):
+                resp = self._post(self.msg.id)
+        self.assertEqual(resp.status_code, 502)

--- a/hub/urls.py
+++ b/hub/urls.py
@@ -227,6 +227,11 @@ urlpatterns = [
         views.api_message_detail,
         name="api-message-detail",
     ),
+    path(
+        "api/messages/<int:message_id>/translate/",
+        views.api_message_translate,
+        name="api-message-translate",
+    ),
     path("api/releases/", views.api_releases, name="api-releases"),
     path(
         "api/repo/<str:owner>/<str:repo>/changelog/",

--- a/hub/urls_workspace.py
+++ b/hub/urls_workspace.py
@@ -159,6 +159,16 @@ urlpatterns = [
     path("api/media/", views.api_media, name="api-media"),
     path("api/members/", views.api_members, name="api-members"),
     path("api/reactions/", views.api_reactions, name="api-reactions"),
+    path(
+        "api/messages/<int:message_id>/",
+        views.api_message_detail,
+        name="api-message-detail",
+    ),
+    path(
+        "api/messages/<int:message_id>/translate/",
+        views.api_message_translate,
+        name="api-message-translate",
+    ),
     path("api/releases/", views.api_releases, name="api-releases"),
     path(
         "api/repo/<str:owner>/<str:repo>/changelog/",

--- a/hub/views/__init__.py
+++ b/hub/views/__init__.py
@@ -35,6 +35,7 @@ from hub.views.api import (  # noqa: F401
     api_media,
     api_members,
     api_message_detail,
+    api_message_translate,
     api_messages,
     api_my_subscriptions,
     api_push_subscribe,

--- a/hub/views/api/__init__.py
+++ b/hub/views/api/__init__.py
@@ -62,6 +62,7 @@ from hub.views.api._misc import (
     api_watchdog_alerts,
 )
 from hub.views.api._reactions import api_message_detail, api_reactions
+from hub.views.api._translate import api_message_translate
 from hub.views.api._releases import api_releases, api_repo_changelog
 from hub.views.api._resources import api_resources
 
@@ -100,6 +101,7 @@ __all__ = [
     "api_media",
     "api_members",
     "api_message_detail",
+    "api_message_translate",
     "api_messages",
     "api_my_subscriptions",
     "api_push_subscribe",

--- a/hub/views/api/_translate.py
+++ b/hub/views/api/_translate.py
@@ -1,0 +1,98 @@
+"""On-demand message translation via Claude API (todo#409 Phase 1).
+
+POST /api/messages/<id>/translate/
+Body: {"target_lang": "en"}  (default: "en")
+Returns: {"translated_text": "...", "source_lang": "auto", "target_lang": "en"}
+
+Uses ANTHROPIC_API_KEY.  Returns 503 if the key is absent.
+Does NOT cache — translations are on-demand and ephemeral for Phase 1.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods
+
+from hub.models import Message, WorkspaceMember, WorkspaceToken
+from hub.views.api._channels import get_workspace
+
+_ANTHROPIC_API = "https://api.anthropic.com/v1/messages"
+_TRANSLATE_MODEL = "claude-haiku-4-5-20251001"
+
+
+@csrf_exempt
+@require_http_methods(["POST"])
+def api_message_translate(request, message_id):
+    """POST /api/messages/<id>/translate/ — translate a single message."""
+    # Auth — token or session (checked before API key to avoid leaking config)
+    token_str = request.GET.get("token") or request.POST.get("token")
+    if token_str:
+        try:
+            wks_token = WorkspaceToken.objects.select_related("workspace").get(token=token_str)
+            workspace = wks_token.workspace
+        except WorkspaceToken.DoesNotExist:
+            return JsonResponse({"error": "invalid token"}, status=401)
+    elif request.user and request.user.is_authenticated:
+        workspace = get_workspace(request)
+    else:
+        return JsonResponse({"error": "auth required"}, status=401)
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return JsonResponse({"error": "translation unavailable (no API key)"}, status=503)
+
+    try:
+        msg = Message.objects.get(id=message_id, workspace=workspace, deleted_at__isnull=True)
+    except Message.DoesNotExist:
+        return JsonResponse({"error": "message not found"}, status=404)
+
+    try:
+        body = json.loads(request.body or b"{}")
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "invalid json"}, status=400)
+
+    target_lang = body.get("target_lang", "en").strip()[:10]  # cap length
+    original_text = msg.content
+
+    prompt = (
+        f"Translate the following text to {target_lang}. "
+        "Return only the translated text with no explanation. "
+        "Preserve technical terms, code blocks (```...```), URLs, "
+        "filenames, and proper nouns exactly as written.\n\n"
+        f"{original_text}"
+    )
+
+    try:
+        resp = httpx.post(
+            _ANTHROPIC_API,
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "content-type": "application/json",
+            },
+            json={
+                "model": _TRANSLATE_MODEL,
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+            timeout=15.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        translated = data["content"][0]["text"].strip()
+    except httpx.HTTPStatusError as e:
+        return JsonResponse({"error": f"translation API error: {e.response.status_code}"}, status=502)
+    except (httpx.RequestError, KeyError, IndexError, ValueError) as e:
+        return JsonResponse({"error": f"translation failed: {type(e).__name__}"}, status=502)
+
+    return JsonResponse({
+        "translated_text": translated,
+        "original_text": original_text,
+        "target_lang": target_lang,
+        "source_lang": "auto",
+    })


### PR DESCRIPTION
## Summary
- New `POST /api/messages/<id>/translate/` endpoint using Anthropic claude-haiku-4-5 via httpx
- Translate button (🌐) in each chat message renders dismissible overlay with translated text
- Auth check precedes API key check; returns 401 / 503 / 404 / 502 / 200 as appropriate

## Test plan
- [x] `test_requires_auth` → 401 when logged out
- [x] `test_no_api_key_returns_503` → 503 when `ANTHROPIC_API_KEY` absent
- [x] `test_404_for_missing_message` → 404 for unknown message ID
- [x] `test_api_error_returns_502` → 502 on upstream HTTP error
- [x] `test_successful_translation` → 200 with `translated_text`, `original_text`, `target_lang`

Closes ywatanabe1989/todo#409

🤖 Generated with [Claude Code](https://claude.com/claude-code)