### PR TITLE
fix(voice): Alt+Enter targets correct composer when thread panel is open (todo#380)

### DIFF
--- a/hub/frontend/src/voice-input.ts
+++ b/hub/frontend/src/voice-input.ts
@@ -208,6 +208,20 @@ import { activeTab } from "./tabs";
       }
     }
     if (!input) {
+      /* Bug #380 fix: when focus is anywhere inside .thread-panel (not
+       * just the textarea), target the thread reply composer so voice
+       * goes to the right surface even when a button/link stole focus. */
+      if (focused && focused.closest && focused.closest(".thread-panel")) {
+        var threadInput = document.getElementById("thread-input");
+        if (threadInput) {
+          input = threadInput;
+          try {
+            (threadInput as HTMLElement).focus();
+          } catch (_ignored) {}
+        }
+      }
+    }
+    if (!input) {
       var canvasCompose = document.getElementById("topo-channel-compose");
       if (canvasCompose) {
         var composeTa = canvasCompose.querySelector(
@@ -326,11 +340,17 @@ import { activeTab } from "./tabs";
         return;
       }
       if (e.key === "Enter" && (e.ctrlKey || e.altKey)) {
-        /* Skip if focus is in thread panel — thread's own keydown handler manages this */
         var focused = document.activeElement;
         var inThread =
           focused && focused.closest && focused.closest(".thread-panel");
-        if (inThread) return;
+        /* Skip only when the focused element IS the thread textarea — the
+         * composer's local keydown handler (localVoiceChord:true) fires
+         * in that case and prevents double-toggle via stopPropagation.
+         * When focus is on a non-textarea inside the thread panel (e.g.
+         * a button or link), the local handler did NOT fire — fall
+         * through to _toggleVoice() so it can redirect to #thread-input.
+         * Bug #380 fix. */
+        if (inThread && focused && focused.id === "thread-input") return;
         /* Skip if focus is in canvas compose popup — its own keydown handler
          * intercepts Ctrl+Enter (for voice) / plain Enter (for send). */
         var inCanvasCompose =
@@ -341,7 +361,14 @@ import { activeTab } from "./tabs";
         var inTopoGroupCompose =
           focused && focused.closest && focused.closest(".topo-compose-modal");
         if (inTopoGroupCompose) return;
-        if (typeof activeTab !== "undefined" && activeTab === "chat") {
+        /* Allow when chat tab is active OR when thread panel is open
+         * (thread replies are accessible from any tab). _toggleVoice()
+         * bails safely when there's nothing to dictate into.
+         * Bug #380 fix: thread open → voice targets thread composer. */
+        var threadOpen = !!(globalThis as any).threadPanelParentId;
+        var chatTabActive =
+          typeof activeTab !== "undefined" && activeTab === "chat";
+        if (chatTabActive || threadOpen) {
           e.preventDefault();
           _toggleVoice();
         }


### PR DESCRIPTION
## Summary
- When focus is on a button/link inside `.thread-panel` (not the textarea), Alt+Enter now correctly targets `#thread-input` instead of doing nothing
- Alt+Enter now fires when thread panel is open (`globalThis.threadPanelParentId` set) regardless of which tab is active
- `_toggleVoice()` gets an explicit fallback: any element focused inside `.thread-panel` → target `#thread-input`

## Bug fixes (both from todo#380 comments, ywatanabe msg#10404)
1. **Bug 1 (intermittent activation)**: When focus drifted to a button/link in thread panel, the global handler bailed (old `inThread` return) but the composer's local handler never fired. Fixed by narrowing the early-return to only when `focused.id === 'thread-input'`.
2. **Bug 2 (wrong target)**: Thread panel open + Alt+Enter now always goes to thread composer. Previously only worked when chat tab was active.

## Test plan
- [ ] Open thread panel → click thread header button → press Alt+Enter → voice starts on thread input
- [ ] Chat tab active, thread panel open → Alt+Enter → voice targets thread composer
- [ ] Agents tab active, thread panel open → Alt+Enter → voice targets thread composer
- [ ] No thread panel, chat tab active → Alt+Enter → voice targets main `#msg-input`
- [ ] No thread panel, other tab active → Alt+Enter → no-op (bails safely)

Closes todo#380 bugs (v0.11.53+ target per issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)