### PR TITLE
fix(ui): wall-clock into brand header, improve contrast (todo#360)

### DIFF
--- a/hub/static/hub/style/style-base.css
+++ b/hub/static/hub/style/style-base.css
@@ -139,10 +139,10 @@ body {
 }
 .wall-clock {
   font-size: 11px;
-  color: #888;
-  text-align: center;
+  color: #b0b0b0;
   font-family: "Consolas", "Monaco", monospace;
-  padding: 2px 0 4px;
+  padding: 0 4px;
+  white-space: nowrap;
 }
 .sidebar-brand .header-icon {
   height: 100px;

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -101,8 +101,8 @@
                 <span class="brand-product-inline" title="SciTeX Orochi">Orochi</span>
                 <span class="brand-version" id="orochi-version"></span>
                 <span id="conn-status" class="status conn-down" title="connecting"></span>
+                <span id="wall-clock" class="wall-clock"></span>
             </div>
-            <div id="wall-clock" class="wall-clock"></div>
             <!-- hook-bypass: inline-style -->
             <div class="sidebar-sections">
                 <h2 class="collapsible-heading channels-heading"


### PR DESCRIPTION
## Summary
- Moves `#wall-clock` inside the `.sidebar-brand-compact` flex row (was outside as a standalone block div below the brand)
- Increases color contrast: `#888` → `#b0b0b0` for readable timestamp on dark sidebar
- Removes now-redundant `text-align: center` and block padding (clock is now an inline flex item)
- Adds `white-space: nowrap` so the timestamp stays on one line

## Test plan
- [ ] Sidebar shows timestamp inline with Orochi brand row
- [ ] Timestamp color is readable against dark sidebar background
- [ ] Timestamp updates every second

Closes todo#360

🤖 Generated with [Claude Code](https://claude.com/claude-code)