### PR TITLE
feat(agents-tab): show account credential badge next to agent name (todo#354)

### DIFF
--- a/hub/frontend/src/agents-tab/overview.ts
+++ b/hub/frontend/src/agents-tab/overview.ts
@@ -204,6 +204,18 @@ export function buildAgentRow(a) {
     ')">' +
     pinIcon +
     "</button>";
+  /* Account badge — shows username part of OAuth email (todo#354).
+   * Falls back through: orochi_account_email → account_email → oauth_email */
+  var _rawAcct =
+    a.orochi_account_email || a.account_email || a.oauth_email || "";
+  var _acctUser = _rawAcct ? _rawAcct.replace(/@.*$/, "") : "";
+  var acctBadgeHtml = _acctUser
+    ? ' <span class="agent-badge agent-badge-account" title="Claude credential: ' +
+      escapeHtml(_rawAcct) +
+      '">' +
+      escapeHtml(_acctUser) +
+      "</span>"
+    : "";
   var rowClass =
     "agent-row" +
     (inactive ? " agent-inactive" : "") +
@@ -239,6 +251,7 @@ export function buildAgentRow(a) {
     "</td>" +
     '<td class="agent-id-cell">' +
     escapeHtml(cleanAgentName(a.agent_id || a.name)) +
+    acctBadgeHtml +
     "</td>" +
     "<td>" +
     escapeHtml(a.role || "agent") +

--- a/hub/static/hub/style/style-agents.css
+++ b/hub/static/hub/style/style-agents.css
@@ -98,6 +98,14 @@
   background: rgba(154, 160, 166, 0.08);
   border: 1px solid rgba(154, 160, 166, 0.22);
 }
+/* todo#354 — credential account username shown next to agent name */
+.agent-badge-account {
+  color: #b48eff;
+  background: rgba(180, 142, 255, 0.1);
+  border: 1px solid rgba(180, 142, 255, 0.25);
+  margin-left: 4px;
+  vertical-align: middle;
+}
 .agent-badge-liveness-online {
   color: #4ecdc4;
   border-color: rgba(78, 205, 196, 0.35);


### PR DESCRIPTION
## Summary
- Adds small purple badge displaying OAuth username next to agent name in Agents tab table
- Reads from `orochi_account_email` → `account_email` → `oauth_email` (falls back gracefully)
- Tooltip shows full email on hover
- Hidden when no account data present yet
- CSS: `.agent-badge-account` (purple, consistent with existing badge palette)

## Why
With 2 Claude accounts rotating (ywata1989 / wyusuuke), ywatanabe needs to see at a glance which agent is on which account (ywatanabe msg#9504).

## Files
- `hub/frontend/src/agents-tab/overview.ts` — buildAgentRow: extract username from email, render badge in agent-id-cell
- `hub/static/hub/style/style-agents.css` — .agent-badge-account rule

## Test plan
- [ ] Open Agents tab — agents reporting account_email show `[ywata1989]` or `[wyusuuke]` badge
- [ ] Agents without account data show no badge (no broken display)
- [ ] Hover over badge → tooltip shows full email

Closes ywatanabe1989/todo#354

🤖 Generated with Claude Code