### PR TITLE
feat(mentions): fire PWA web push on @mention DM fan-out (todo#308)

### DIFF
--- a/hub/mentions.py
+++ b/hub/mentions.py
@@ -468,6 +468,21 @@ def expand_mentions_and_notify(
             except Exception:
                 log.exception("mention-push: group_send failed for %s", dm_name)
 
+        # Fire PWA web push so ywatanabe gets an active notification even
+        # when the app tab is closed (todo#308). Best-effort — never blocks.
+        try:
+            from hub.push import send_push_to_subscribers_async
+
+            send_push_to_subscribers_async(
+                workspace_id=workspace.id,
+                channel=dm_name,
+                sender=sender_username,
+                text=text,
+                message_id=dm_msg.id,
+            )
+        except Exception:
+            log.debug("mention-push: web push skipped for %s", target_username)
+
         notifications.append(
             {
                 "recipient": target_username,


### PR DESCRIPTION
## Summary
- Fire send_push_to_subscribers_async() after DM message is created for @mention fan-out
- Delivers browser push notifications to subscribed devices when an agent receives an @mention
- Wrapped in try/except so push failures never block the DM creation path

Clean cherry-pick onto main (previous PR #419 closed — had 274 extra commits from old branch base).

Closes ywatanabe1989/todo#308

Generated with Claude Code