### PR TITLE
feat(export): add Copy to clipboard button in channel export modal (todo#200)

### DIFF
--- a/hub/frontend/src/app/agent-actions.ts
+++ b/hub/frontend/src/app/agent-actions.ts
@@ -135,6 +135,49 @@ export function doChannelExport() {
   closeChannelExport();
 }
 
+export function doCopyChannelExport(btnEl?) {
+  var modal = document.getElementById("channel-export-modal");
+  if (!modal) return;
+  var ch = modal.getAttribute("data-channel");
+  var from = (document.getElementById("ch-export-from") as HTMLInputElement)?.value;
+  var to = (document.getElementById("ch-export-to") as HTMLInputElement)?.value;
+  var fmt = (document.getElementById("ch-export-format") as HTMLSelectElement)?.value || "md";
+  if (!ch) { alert("No channel selected."); return; }
+  var chatId = ch.replace(/^#/, "");
+  var url = "/api/channels/" + encodeURIComponent(chatId) + "/export/?format=" + encodeURIComponent(fmt);
+  if (from) url += "&from=" + encodeURIComponent(from);
+  if (to) url += "&to=" + encodeURIComponent(to);
+  if (token) url += "&token=" + encodeURIComponent(token);
+  fetch(url, { credentials: "same-origin" })
+    .then(function (r) { return r.text(); })
+    .then(function (text) {
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text);
+      }
+      /* Fallback for non-secure contexts */
+      var ta = document.createElement("textarea");
+      ta.value = text;
+      ta.style.position = "fixed";
+      ta.style.opacity = "0";
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      ta.remove();
+    })
+    .then(function () {
+      if (btnEl) {
+        var prev = btnEl.textContent;
+        btnEl.textContent = "Copied!";
+        setTimeout(function () { btnEl.textContent = prev; }, 1500);
+      }
+      closeChannelExport();
+    })
+    .catch(function (err) {
+      console.error("Export copy failed:", err);
+      alert("Copy failed: " + String(err));
+    });
+}
+
 /* ── Drag-and-drop reordering for sidebar channel sections (msg#10370) ──
  * Works within a section (Starred ↔ Starred, Channels ↔ Channels).
  * Cross-section drops are ignored (star toggle is the way to move between sections).

--- a/hub/frontend/src/window-bridge.ts
+++ b/hub/frontend/src/window-bridge.ts
@@ -6,7 +6,7 @@
 
 import { openAvatarPicker, openHumanAvatarPicker, openHumanAvatarTextEditor } from "./agent-icons";
 import { purgeStaleAgents, toggleClaudeMd } from "./agents-tab/overview";
-import { closeChannelExport, doChannelExport, openChannelExport } from "./app/agent-actions";
+import { closeChannelExport, doCopyChannelExport, doChannelExport, openChannelExport } from "./app/agent-actions";
 import { closeChannelTopicEdit, closeMembersPanel, openChannelTopicEdit, saveChannelTopic, toggleMembersPanel } from "./app/members";
 import { killAgent, restartAgent, togglePinAgent } from "./app/sidebar-agents";
 import { escapeHtml } from "./app/utils";
@@ -34,6 +34,7 @@ Object.assign(window, {
   copyThreadPermalink,
   copyToken,
   deleteMessage,
+  doCopyChannelExport,
   doChannelExport,
   escapeHtml,
   filesClearSelection,

--- a/hub/static/hub/style/style-menus.css
+++ b/hub/static/hub/style/style-menus.css
@@ -320,3 +320,16 @@
   color: #ccc;
   border-color: #3a5a6a;
 }
+.ch-export-copy {
+  background: #1a5c3a;
+  border: none;
+  border-radius: 4px;
+  color: #f8f7f5;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 7px 16px;
+  font-weight: bold;
+}
+.ch-export-copy:hover {
+  background: #1e7048;
+}

--- a/hub/templates/hub/dashboard.html
+++ b/hub/templates/hub/dashboard.html
@@ -595,6 +595,7 @@
                 </label>
             </div>
             <div class="ch-export-footer">
+                <button type="button" class="ch-export-copy" onclick="doCopyChannelExport(this)">&#128203; Copy</button>
                 <button type="button" class="ch-export-download" onclick="doChannelExport()">&#10515; Download</button>
                 <button type="button" class="ch-export-cancel" onclick="closeChannelExport()">Cancel</button>
             </div>


### PR DESCRIPTION
## Summary
- Add Copy button alongside Download in channel export modal footer
- doCopyChannelExport(btnEl): fetches export URL, copies text to clipboard
- Clipboard fallback using textarea + execCommand for non-HTTPS contexts
- Button text changes to 'Copied!' for 1.5s then reverts
- CSS: .ch-export-copy (green-tinted, matching Download button style)

Clean cherry-pick onto main (previous PR #420 closed — had 274 extra commits from old branch base).

Closes ywatanabe1989/todo#200

Generated with Claude Code