### PR TITLE
ci: normalize codecov.yml to canonical shape

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,10 @@
-# Codecov config — scitex-orochi.
-#
-# `target: auto` because the package is still ramping up its coverage
-# baseline (the §0 subprocess-coverage wiring just landed). Switch to a
-# fixed ``90%`` target once a coverage-push session has lifted the
-# baseline past that line. See scitex-dev skill leaf
-# 02_package_11_ci-and-codecov.md.
+codecov:
+  require_ci_to_pass: false
+  # Treat develop as the de-facto default branch — main is a stable
+  # release mirror that only fast-forwards from develop, so develop
+  # is where coverage uploads land. This makes the unbranched badge
+  # endpoint (/graph/badge.svg) follow develop's value.
+  branch: develop
 
 coverage:
   status:
@@ -14,7 +14,16 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 1%
+        target: 80%
 
-comment: false
+ignore:
+  - "src/scitex_orochi/_sphinx_html/**"
+  - "src/scitex_orochi/_skills/**"
+  - "src/scitex_orochi/_completion.py"
+  - "src/scitex_orochi/_cli/_completion.py"
+  - "tests/**"
+  - "examples/**"
+
+comment:
+  layout: "diff, files"
+  require_changes: true


### PR DESCRIPTION
Normalizes Codecov config to the canonical ecosystem shape (general/02_package_11_ci-and-codecov.md):

- codecov.branch: develop — unbranched badge follows develop, not the stale main release-mirror
- ignore: _sphinx_html, _skills, _completion, _cli/_completion, tests, examples
- patch target 80%; project target auto/1%
- canonical comment block

The pytest-matrix workflow's codecov-action@v5 upload step is already correct. UNMERGED for review.