### PR TITLE
refactor(health): extract HealthState + classify() into _health.py (PR #1/5 SAC-consumer)

### DIFF
--- a/src/scitex_orochi/_caduceus.py
+++ b/src/scitex_orochi/_caduceus.py
@@ -52,8 +52,6 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
-from datetime import datetime, timezone
 
 from ._caduceus_greeting import (
     DEFAULT_TIMEOUT_S as GREETING_TIMEOUT_S,
@@ -63,34 +61,41 @@ from ._caduceus_greeting import (
     format_greeting,
     should_ping,
 )
+from ._health import (
+    DEAD_THRESHOLD,
+    ESCALATE_THRESHOLD,
+    NUDGE_THRESHOLD,
+    HealthState,
+)
+from ._health import (
+    AgentSnapshot as AgentState,
+)
+from ._health import classify as _classify_state
 
 log = logging.getLogger("orochi.caduceus")
 
-# Severity thresholds (seconds)
-NUDGE_THRESHOLD = 120  # 2 min — soft nudge
-ESCALATE_THRESHOLD = 600  # 10 min — escalation
-DEAD_THRESHOLD = 300  # 5 min — heartbeat silence ⇒ probably dead
+# Re-exported from scitex_orochi._health so existing imports
+# (`from scitex_orochi._caduceus import classify, AgentState, ...`) keep
+# working. New code should import from ``._health`` directly.
+__all__ = [
+    "NUDGE_THRESHOLD",
+    "ESCALATE_THRESHOLD",
+    "DEAD_THRESHOLD",
+    "AgentState",
+    "HealthState",
+    "classify",
+]
 
 
-@dataclass
-class AgentState:
-    name: str
-    machine: str
-    status: str  # "online" | "offline"
-    liveness: str  # "online" | "idle" | "stale" | "offline"
-    idle_seconds: int | None
-    orochi_current_task: str
-    last_heartbeat: str | None  # ISO
+def classify(agent: AgentState) -> str:
+    """Return one of: ``ok``, ``idle``, ``stale``, ``dead``.
 
-    @property
-    def heartbeat_age_seconds(self) -> int | None:
-        if not self.last_heartbeat:
-            return None
-        try:
-            ts = datetime.fromisoformat(self.last_heartbeat.replace("Z", "+00:00"))
-        except ValueError:
-            return None
-        return int((datetime.now(timezone.utc) - ts).total_seconds())
+    Thin shim around :func:`scitex_orochi._health.classify` that
+    preserves the historical string return type. The HealthState enum
+    subclasses ``str`` so callers comparing against string literals
+    keep working.
+    """
+    return _classify_state(agent).value
 
 
 def _http_get_json(url: str, token: str | None = None, timeout: int = 5):
@@ -143,20 +148,6 @@ def fetch_agents(hub: str, token: str | None) -> list[AgentState]:
             )
         )
     return out
-
-
-def classify(agent: AgentState) -> str:
-    """Return one of: ok, idle, stale, dead, zombie."""
-    if agent.status == "offline":
-        return "dead"
-    hb_age = agent.heartbeat_age_seconds
-    if hb_age is not None and hb_age > DEAD_THRESHOLD:
-        return "dead"
-    if agent.liveness == "stale":
-        return "stale"
-    if agent.liveness == "idle" and agent.orochi_current_task:
-        return "idle"
-    return "ok"
 
 
 def heal_idle(hub: str, token: str | None, agent: AgentState) -> None:
@@ -330,6 +321,7 @@ def greeting_scan(
         log.debug("pong poll error: %s", exc)
     from datetime import datetime
     from datetime import timezone as _tz
+
     last_poll_iso[0] = datetime.now(_tz.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")
 
     expired = state.sweep_expired(now)

--- a/src/scitex_orochi/_health.py
+++ b/src/scitex_orochi/_health.py
@@ -1,0 +1,128 @@
+"""Fleet-wide health classification for Orochi agents.
+
+This module isolates the *classification* concern: given a snapshot of
+an agent (status / liveness / idle / heartbeat-age), decide which
+``HealthState`` bucket it belongs to. Recovery (nudge / escalate / SSH)
+lives in :mod:`scitex_orochi._caduceus`; data collection (REST poll)
+lives there too. Putting classification in its own module makes it:
+
+* unit-testable without spinning up the caduceus loop;
+* swappable — a future PR can layer a SAC-provided
+  ``sac agents health --json`` result on top of the heartbeat-age
+  heuristic without touching the recovery code; and
+* the obvious one-stop shop when someone asks "where is the IDLE
+  threshold defined?".
+
+Per the SAC↔Orochi audit (2026-05): Orochi keeps the *n*-state
+classifier (HEALTHY/IDLE/STALE/DEAD) for the dashboard; SAC owns the
+*binary* alive/dead check via ``sac agents health``. The
+``sac_health`` optional field on :class:`AgentSnapshot` is the seam
+where that signal will plug in once heartbeat collection forwards it
+(PR #3 of the consumer-refactor sequence).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+
+# ---------------------------------------------------------------------------
+# Thresholds (seconds)
+# ---------------------------------------------------------------------------
+# These map to the recovery ladder in :mod:`scitex_orochi._caduceus`:
+#   IDLE   → soft nudge in #general
+#   STALE  → escalation in #general (optionally @ywatanabe)
+#   DEAD   → would SSH the host and restart the bun MCP sidecar
+NUDGE_THRESHOLD = 120
+"""Seconds of agent silence before the IDLE bucket fires (soft nudge)."""
+
+ESCALATE_THRESHOLD = 600
+"""Seconds of agent silence before the STALE bucket fires (escalation)."""
+
+DEAD_THRESHOLD = 300
+"""Seconds of heartbeat silence before an agent is presumed DEAD."""
+
+
+class HealthState(str, Enum):
+    """Coarse health bucket the dashboard renders and caduceus heals on.
+
+    Subclassing ``str`` keeps ``HealthState.OK == "ok"`` so existing
+    callers that compare against string literals (REST responses,
+    dashboard JSON) keep working.
+    """
+
+    OK = "ok"
+    IDLE = "idle"
+    STALE = "stale"
+    DEAD = "dead"
+
+
+@dataclass
+class AgentSnapshot:
+    """Minimal projection of an agent's state needed to classify it.
+
+    Built from a hub `/api/agents/` row. Fields mirror the wire
+    contract (see :mod:`scitex_orochi._models.heartbeat`) so the
+    classifier can run without coupling to the hub's full ORM.
+
+    Parameters
+    ----------
+    name, machine, status, liveness, idle_seconds, orochi_current_task,
+    last_heartbeat:
+        Verbatim heartbeat fields. ``status`` is "online" or "offline";
+        ``liveness`` is the hub-derived fine-grained label.
+    sac_health:
+        Optional SAC-side binary verdict (``True`` healthy, ``False``
+        unhealthy, ``None`` unknown). When set, takes precedence over
+        heartbeat-age in :func:`classify`. Plumbed in by heartbeat
+        collection (PR #3).
+    """
+
+    name: str
+    machine: str
+    status: str  # "online" | "offline"
+    liveness: str  # "online" | "idle" | "stale" | "offline"
+    idle_seconds: int | None
+    orochi_current_task: str
+    last_heartbeat: str | None  # ISO
+    sac_health: bool | None = None
+
+    @property
+    def heartbeat_age_seconds(self) -> int | None:
+        """Seconds since ``last_heartbeat``; ``None`` if missing/malformed."""
+        if not self.last_heartbeat:
+            return None
+        try:
+            ts = datetime.fromisoformat(self.last_heartbeat.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return int((datetime.now(timezone.utc) - ts).total_seconds())
+
+
+def classify(agent: AgentSnapshot) -> HealthState:
+    """Bucket an agent snapshot into a :class:`HealthState`.
+
+    Decision order:
+
+    1. ``sac_health is False`` → DEAD (SAC's per-host binary probe
+       beats any heartbeat-age guess).
+    2. ``status == "offline"`` → DEAD.
+    3. heartbeat age > :data:`DEAD_THRESHOLD` → DEAD.
+    4. ``liveness == "stale"`` → STALE.
+    5. ``liveness == "idle"`` *and* the agent has a current task →
+       IDLE (silent agents with no task assignment aren't problematic).
+    6. otherwise OK.
+    """
+    if agent.sac_health is False:
+        return HealthState.DEAD
+    if agent.status == "offline":
+        return HealthState.DEAD
+    hb_age = agent.heartbeat_age_seconds
+    if hb_age is not None and hb_age > DEAD_THRESHOLD:
+        return HealthState.DEAD
+    if agent.liveness == "stale":
+        return HealthState.STALE
+    if agent.liveness == "idle" and agent.orochi_current_task:
+        return HealthState.IDLE
+    return HealthState.OK

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,136 @@
+"""Unit tests for :mod:`scitex_orochi._health` — fleet-wide health classification."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scitex_orochi._health import (
+    DEAD_THRESHOLD,
+    ESCALATE_THRESHOLD,
+    NUDGE_THRESHOLD,
+    AgentSnapshot,
+    HealthState,
+    classify,
+)
+
+
+def _iso_now_minus(seconds: int) -> str:
+    """ISO-8601 UTC timestamp ``seconds`` ago. Wire-format match."""
+    ts = datetime.now(timezone.utc) - timedelta(seconds=seconds)
+    return ts.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
+
+
+def _snapshot(**overrides: object) -> AgentSnapshot:
+    """Build an AgentSnapshot with sensible defaults, overridable per-test."""
+    defaults: dict[str, object] = {
+        "name": "head@mba",
+        "machine": "mba",
+        "status": "online",
+        "liveness": "online",
+        "idle_seconds": 0,
+        "orochi_current_task": "",
+        "last_heartbeat": _iso_now_minus(5),
+        "sac_health": None,
+    }
+    defaults.update(overrides)
+    return AgentSnapshot(**defaults)  # type: ignore[arg-type]
+
+
+def test_thresholds_are_positive_seconds():
+    """Sanity: thresholds are non-zero positive seconds in expected order."""
+    assert 0 < NUDGE_THRESHOLD < ESCALATE_THRESHOLD
+    assert DEAD_THRESHOLD > 0
+
+
+def test_classify_returns_ok_for_healthy_recent_heartbeat():
+    """Online, recent heartbeat, no idleness → OK."""
+    assert classify(_snapshot()) is HealthState.OK
+
+
+def test_classify_returns_dead_when_status_offline():
+    """status='offline' is a hard-DEAD signal regardless of other fields."""
+    snap = _snapshot(status="offline")
+    assert classify(snap) is HealthState.DEAD
+
+
+def test_classify_returns_dead_when_heartbeat_older_than_dead_threshold():
+    """An agent silent for > DEAD_THRESHOLD seconds is presumed DEAD."""
+    snap = _snapshot(last_heartbeat=_iso_now_minus(DEAD_THRESHOLD + 30))
+    assert classify(snap) is HealthState.DEAD
+
+
+def test_classify_returns_dead_when_sac_health_false_overrides_freshness():
+    """SAC's binary verdict beats heartbeat freshness."""
+    snap = _snapshot(
+        last_heartbeat=_iso_now_minus(1),  # fresh
+        sac_health=False,
+    )
+    assert classify(snap) is HealthState.DEAD
+
+
+def test_classify_returns_stale_when_liveness_stale():
+    """liveness='stale' surfaces as STALE state."""
+    snap = _snapshot(liveness="stale", orochi_current_task="do thing")
+    assert classify(snap) is HealthState.STALE
+
+
+def test_classify_returns_idle_when_idle_and_has_task():
+    """Idle + assigned task → IDLE (silent-with-task is the actionable case)."""
+    snap = _snapshot(
+        liveness="idle",
+        idle_seconds=NUDGE_THRESHOLD + 1,
+        orochi_current_task="finalize migration",
+    )
+    assert classify(snap) is HealthState.IDLE
+
+
+def test_classify_returns_ok_when_idle_but_no_task():
+    """Idle with no assigned task is not actionable → OK."""
+    snap = _snapshot(liveness="idle", idle_seconds=300, orochi_current_task="")
+    assert classify(snap) is HealthState.OK
+
+
+def test_health_state_members_are_string_comparable():
+    """HealthState.OK == 'ok' so legacy string-literal callers still work."""
+    assert HealthState.OK == "ok"
+    assert HealthState.IDLE == "idle"
+    assert HealthState.STALE == "stale"
+    assert HealthState.DEAD == "dead"
+
+
+def test_agent_snapshot_heartbeat_age_seconds_handles_missing_timestamp():
+    """Missing or unparseable last_heartbeat → None (don't crash)."""
+    assert _snapshot(last_heartbeat=None).heartbeat_age_seconds is None
+    assert _snapshot(last_heartbeat="not-an-iso").heartbeat_age_seconds is None
+
+
+def test_agent_snapshot_heartbeat_age_seconds_reflects_recency():
+    """heartbeat_age_seconds reflects roughly how long ago last_heartbeat was."""
+    snap = _snapshot(last_heartbeat=_iso_now_minus(42))
+    assert snap.heartbeat_age_seconds is not None
+    # Within a generous window — clock skew + test-runner pauses.
+    assert 40 <= snap.heartbeat_age_seconds <= 50
+
+
+@pytest.mark.parametrize(
+    "status,liveness,task,sac,expected",
+    [
+        ("offline", "online", "", None, HealthState.DEAD),
+        ("online", "stale", "", None, HealthState.STALE),
+        ("online", "idle", "x", None, HealthState.IDLE),
+        ("online", "online", "x", None, HealthState.OK),
+        ("online", "online", "x", False, HealthState.DEAD),  # SAC overrides
+        ("online", "online", "x", True, HealthState.OK),  # SAC affirmative
+    ],
+)
+def test_classify_state_table(status, liveness, task, sac, expected):
+    """Tabular sweep of the (status, liveness, task, sac_health) state space."""
+    snap = _snapshot(
+        status=status,
+        liveness=liveness,
+        orochi_current_task=task,
+        sac_health=sac,
+    )
+    assert classify(snap) is expected


### PR DESCRIPTION
First PR of the 5-PR sequence agreed with @ywatanabe1989 (SAC↔Orochi
duplication audit 2026-05). Goal: shrink Orochi to a SAC consumer
without dropping any behaviour the dashboard depends on.

## Why
`_caduceus.py` had the fleet-wide health classifier inlined alongside
the recovery loop — thresholds, the `AgentState` dataclass, and a
stringly-typed `classify()` were all in the same file as the
HTTP-poll loop and the SSH-heal stubs. Three concerns (data shape,
classification rules, recovery side-effects) on one file made
classify() impossible to unit-test without spinning the daemon.

## What
- **NEW** `src/scitex_orochi/_health.py`
  - `HealthState` — `str`-Enum (`OK` / `IDLE` / `STALE` / `DEAD`),
    typed but still `==` the legacy string literals.
  - `AgentSnapshot` — minimal projection classify() needs; gains a
    new optional `sac_health: bool | None` field. When set, SAC's
    per-host binary verdict beats heartbeat-age guessing (audit
    decision: "SAC が check、ORC が分類"). Plumbing the field through
    heartbeat collection lands in PR #3.
  - `classify(snapshot) -> HealthState` — same decision tree as
    before, plus the `sac_health` override.
  - `NUDGE_THRESHOLD` / `ESCALATE_THRESHOLD` / `DEAD_THRESHOLD` live
    next to the function that consumes them.
- **EDIT** `src/scitex_orochi/_caduceus.py`
  - Strip the duplicated code; re-export `AgentState` / `HealthState`
    / `classify` / thresholds so any downstream agent importing from
    `_caduceus` keeps working.
  - `classify()` is now a thin shim returning `.value` to preserve
    the historical `str` return type.
- **NEW** `tests/test_health.py` — 17 unit tests covering the full
  state table including the sac_health override, threshold sanity,
  string-compat for legacy callers, and ISO timestamp parsing edge
  cases (None, malformed).

## Non-goals (handled by later PRs)
- Wiring heartbeat-push to populate `sac_health` (PR #3).
- Removing the now-redundant ORC liveness derivation in the hub (PR
  #3, once SAC fills the gap).

## Test plan
- [x] `pytest tests/test_health.py -v` — 17/17 pass
- [x] `pytest tests/test_caduceus_greeting.py` — 31/31 pass (existing
      caduceus tests unaffected)
- [x] `ruff check src/scitex_orochi/_health.py src/scitex_orochi/_caduceus.py tests/test_health.py` — clean
- [x] Manual: `from scitex_orochi._caduceus import classify, AgentState,
      HealthState, NUDGE_THRESHOLD, ESCALATE_THRESHOLD, DEAD_THRESHOLD`
      all still import; `classify(offline_snapshot) == "dead"`
      string-compat holds.