### PR TITLE
chore: declare project-type [pip, django, deferred] for scitex-orochi

### DIFF
--- a/.scitex/dev/config.yaml
+++ b/.scitex/dev/config.yaml
@@ -3,7 +3,14 @@
 # `[tool.hatch.build.targets.wheel] packages` ships `src/scitex_orochi`,
 # `hub`, and `orochi` as separate wheel components. Plus `ts/` for
 # TypeScript source bundled into the wheel's `_ts/`.
+#
+# It is ALSO a Django app (`manage.py`, `orochi/` settings, websockets,
+# daemons, cron, dashboard) — hence `django`. The `config/`+`apps/`
+# "apps and config" migration (ADR 0002) is tracked separately; until it
+# lands, `deferred` opts out of the not-yet-canonical PS-103 reminders
+# while `audit-django` reports the DJ-* gaps.
 
 project-type:
   - pip
+  - django
   - deferred


### PR DESCRIPTION
scitex-orochi is a Django app (has `manage.py`, `orochi/` settings, websockets, daemons, cron, dashboard) but `.scitex/dev/config.yaml` only declared `[pip, deferred]`.

Adds `django` so `scitex-dev ecosystem audit-all` applies the DJ-* "apps and config" standard (ADR 0002) to orochi, mirroring scitex-hub which is already `[pip, django, deferred]`.

`deferred` is retained until the `config/`+`apps/` migration (Phase 1) lands — it opts out of the not-yet-canonical PS-103 reminders while `audit-django` reports the concrete DJ-* gaps (currently DJ-101 missing `config/`, DJ-201 missing `apps/`).

Metadata-only; no code/runtime change.