### PR TITLE
test: fix 6 PS206 smoke tests importing nonexistent public module names

### DIFF
--- a/tests/test_client_subscribe_bits.py
+++ b/tests/test_client_subscribe_bits.py
@@ -1,4 +1,4 @@
-"""Auto-generated smoke test for scitex_orochi.client_subscribe_bits.
+"""Auto-generated smoke test for scitex_orochi._client.
 
 Replaces the prior placeholder-only stub (audit-project PS206). The
 test imports the target module — if the import fails, the test
@@ -14,4 +14,4 @@ import importlib
 
 def test_module_imports():
     """Smoke: target module imports without error."""
-    importlib.import_module('scitex_orochi.client_subscribe_bits')
+    importlib.import_module('scitex_orochi._client')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,4 @@
-"""Auto-generated smoke test for scitex_orochi.server.
+"""Auto-generated smoke test for scitex_orochi._server.
 
 Replaces the prior placeholder-only stub (audit-project PS206). The
 test imports the target module — if the import fails, the test
@@ -14,4 +14,4 @@ import importlib
 
 def test_module_imports():
     """Smoke: target module imports without error."""
-    importlib.import_module('scitex_orochi.server')
+    importlib.import_module('scitex_orochi._server')

--- a/tests/test_skills_quality.py
+++ b/tests/test_skills_quality.py
@@ -1,9 +1,13 @@
-"""Auto-generated smoke test for scitex_orochi.skills_quality.
+"""Auto-generated smoke test for the skills-quality checker.
 
 Replaces the prior placeholder-only stub (audit-project PS206). The
 test imports the target module — if the import fails, the test
 fails. Renames, broken peer deps, or missing optional deps all
 surface here as red, not as a silent skip.
+
+The skills-quality checks for scitex-orochi live in the shared
+``scitex_dev._skills_quality_pytest`` helper (there is no
+``scitex_orochi.skills_quality`` module); import that instead.
 
 If a module legitimately requires an optional dep, that dep should
 be lazy-imported inside the function bodies — not at module top.
@@ -14,4 +18,4 @@ import importlib
 
 def test_module_imports():
     """Smoke: target module imports without error."""
-    importlib.import_module('scitex_orochi.skills_quality')
+    importlib.import_module('scitex_dev._skills_quality_pytest')

--- a/tests/test_telegram_bridge.py
+++ b/tests/test_telegram_bridge.py
@@ -1,4 +1,4 @@
-"""Auto-generated smoke test for scitex_orochi.telegram_bridge.
+"""Auto-generated smoke test for scitex_orochi._telegram_bridge.
 
 Replaces the prior placeholder-only stub (audit-project PS206). The
 test imports the target module — if the import fails, the test
@@ -14,4 +14,4 @@ import importlib
 
 def test_module_imports():
     """Smoke: target module imports without error."""
-    importlib.import_module('scitex_orochi.telegram_bridge')
+    importlib.import_module('scitex_orochi._telegram_bridge')

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,4 +1,4 @@
-"""Auto-generated smoke test for scitex_orochi.web.
+"""Auto-generated smoke test for scitex_orochi._web.
 
 Replaces the prior placeholder-only stub (audit-project PS206). The
 test imports the target module — if the import fails, the test
@@ -14,4 +14,4 @@ import importlib
 
 def test_module_imports():
     """Smoke: target module imports without error."""
-    importlib.import_module('scitex_orochi.web')
+    importlib.import_module('scitex_orochi._web')

--- a/tests/test_workspace_auth.py
+++ b/tests/test_workspace_auth.py
@@ -1,4 +1,4 @@
-"""Auto-generated smoke test for scitex_orochi.workspace_auth.
+"""Auto-generated smoke test for scitex_orochi._workspaces.
 
 Replaces the prior placeholder-only stub (audit-project PS206). The
 test imports the target module — if the import fails, the test
@@ -14,4 +14,4 @@ import importlib
 
 def test_module_imports():
     """Smoke: target module imports without error."""
-    importlib.import_module('scitex_orochi.workspace_auth')
+    importlib.import_module('scitex_orochi._workspaces')


### PR DESCRIPTION
## Root cause

The \`Test\` workflow has been red on \`develop\` for many runs (e.g. runs 26664551345, 26536939304, 26664840486). Six of the failures are deterministic \`ModuleNotFoundError\`s from the audit-generated PS206 import-smoke stubs.

Commit \`46c5627\` (audit-project PS206) replaced six real/placeholder test files with a generic import-smoke stub that derives its import target from the test filename minus the \`test_\` prefix, assuming a **public top-level** module of that exact name. None of the six targets actually exist under that name — they are private (\`_\`-prefixed) or live in another package:

| test file | wrong target | correct target |
|---|---|---|
| \`test_web.py\` | \`scitex_orochi.web\` | \`scitex_orochi._web\` |
| \`test_server.py\` | \`scitex_orochi.server\` | \`scitex_orochi._server\` |
| \`test_telegram_bridge.py\` | \`scitex_orochi.telegram_bridge\` | \`scitex_orochi._telegram_bridge\` |
| \`test_client_subscribe_bits.py\` | \`scitex_orochi.client_subscribe_bits\` | \`scitex_orochi._client\` |
| \`test_workspace_auth.py\` | \`scitex_orochi.workspace_auth\` | \`scitex_orochi._workspaces\` |
| \`test_skills_quality.py\` | \`scitex_orochi.skills_quality\` | \`scitex_dev._skills_quality_pytest\` |

Then \`cc77a89\` hardened these from skip-on-error to hard-fail, turning the latent mismatch into a permanent red.

## Fix

Point each smoke test at the module it was actually meant to exercise (the module its pre-PS206 version imported). Tests-only; no source changes; nothing under \`config/\` or \`apps/\`.

## Verification

\`\`\`
$ python -m pytest tests/test_web.py tests/test_server.py tests/test_skills_quality.py tests/test_telegram_bridge.py tests/test_client_subscribe_bits.py tests/test_workspace_auth.py -q
6 passed
\`\`\`

## Out of scope (not fixed here)

The 7th Test failure, \`tests/develop/test_audit.py::test_audit_all_clean\`, is a broad project-structure audit failure (README badges/sections, loose top-level tests, \`src/\` reorganization, Django root dirs, workflow secret prefixes). It overlaps the in-progress Phase 1 Django apps/config migration and needs a structural decision, so it is intentionally left for that effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)