### PR TITLE
fix(test): de-flake (Available Now) suffix probe + stop scheduler thread under tests

### DIFF
--- a/apps/hub/apps.py
+++ b/apps/hub/apps.py
@@ -95,9 +95,23 @@ class HubConfig(AppConfig):
 
     def ready(self):
         # Importing the module registers the post_save handlers.
+        from django.conf import settings
+
         from apps.hub import signals  # noqa: F401
 
         # Start scheduled-action background thread (issue #95).
+        #
+        # Skipped under the test suite: the long-lived loop queries
+        # ``ScheduledAction`` on its own connection, but the Django/pytest test
+        # runner creates and tears down an ephemeral per-run database around it.
+        # The thread then races that lifecycle and intermittently raises
+        # ``no such table: hub_scheduledaction`` / ``database is locked``. The
+        # ``RUN_BACKGROUND_SCHEDULER`` setting (False under tests by default,
+        # see ``settings_shared``) gates it; operators can still force it via
+        # ``SCITEX_OROCHI_RUN_SCHEDULER``.
+        if not getattr(settings, "RUN_BACKGROUND_SCHEDULER", True):
+            return
+
         # Guard against double-start during Django auto-reload.
         if os.environ.get("RUN_MAIN") != "true" and not os.environ.get(
             "SCHEDULER_STARTED"

--- a/config/settings/settings_shared.py
+++ b/config/settings/settings_shared.py
@@ -88,6 +88,30 @@ SECRET_KEY = os.environ.get(
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() in ("true", "1", "yes")
 
+# ``TESTING`` is True whenever the process is running the Django/pytest test
+# suite. The Django test runner injects ``test`` into ``sys.argv``; pytest sets
+# ``PYTEST_CURRENT_TEST`` once a test starts but, more reliably for app-ready
+# time, runs under a ``pytest``-named entrypoint. We detect both so background
+# workers (e.g. the scheduled-action thread started in ``HubConfig.ready``)
+# never race the ephemeral, per-run test database.
+import sys as _sys  # noqa: E402
+
+TESTING = (
+    "test" in _sys.argv
+    or "PYTEST_CURRENT_TEST" in os.environ
+    or os.path.basename(_sys.argv[0] if _sys.argv else "").startswith("pytest")
+)
+
+# Whether ``HubConfig.ready`` should spin up the scheduled-action background
+# thread. Off under tests by default (the per-run test DB is created/destroyed
+# out from under a long-lived thread, which surfaces as transient
+# ``no such table: hub_scheduledaction`` / ``database is locked`` errors).
+# Operators can force-enable/disable via the env var.
+RUN_BACKGROUND_SCHEDULER = os.environ.get(
+    "SCITEX_OROCHI_RUN_SCHEDULER",
+    "false" if TESTING else "true",
+).lower() in ("true", "1", "yes")
+
 ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(",")
 
 CSRF_TRUSTED_ORIGINS = [

--- a/src/scitex_orochi/_cli/_help_availability.py
+++ b/src/scitex_orochi/_cli/_help_availability.py
@@ -384,6 +384,7 @@ class AvailabilityAnnotatedGroup(click.Group):
                 host=host,
                 port=port,
                 probe_map=self._availability_probe_map,
+                total_budget_s=mod.TOTAL_BUDGET_S,
                 hub_prober=mod.probe_hub,
                 daemon_prober=mod.probe_local_daemon,
             )

--- a/tests/integration/cli/test_help_availability.py
+++ b/tests/integration/cli/test_help_availability.py
@@ -42,6 +42,38 @@ def _clear_cache() -> None:
     reset_probe_cache()
 
 
+@pytest.fixture(autouse=True)
+def _generous_probe_budget() -> None:
+    """Pin a generous total probe budget for the deterministic suffix tests.
+
+    The suffix-presence/absence tests below drive the real ``format_commands``
+    rendering path with hand-substituted, effectively-instant probe functions,
+    so the ``(Available Now)`` suffix must depend *only* on the reachability
+    those probes report — never on wall-clock timing.
+
+    With the production default of 100 ms, however, the parallel probe pool in
+    ``format_commands`` is still gated by a wall-clock deadline. On a
+    heavily-loaded CI runner, thread-scheduling jitter can let that deadline
+    elapse before every (instant) probe future is collected, so an arbitrary
+    noun (observed in CI: ``push``) is force-marked unreachable and silently
+    loses its suffix — a genuine nondeterministic CI flake unrelated to the
+    code under test.
+
+    Raising the module-level budget for the duration of each test removes that
+    timing race without weakening any assertion: the reachability values are
+    still whatever the test's probe functions return. The dedicated
+    ``test_run_probes_*`` timing tests call ``run_probes`` directly with an
+    explicit budget and are unaffected. This is a real attribute swap with a
+    save/restore teardown — no mock object is involved.
+    """
+    original = ha.TOTAL_BUDGET_S
+    ha.TOTAL_BUDGET_S = 30.0
+    try:
+        yield
+    finally:
+        ha.TOTAL_BUDGET_S = original
+
+
 # ---------------------------------------------------------------------------
 # Builder: a minimal click group that mirrors the real registration shape
 # ---------------------------------------------------------------------------
@@ -84,8 +116,9 @@ def test_suffix_appears_when_hub_reachable() -> None:
     root = _build_group()
     runner = CliRunner()
 
-    with patch.object(ha, "probe_hub", return_value=True), patch.object(
-        ha, "probe_local_daemon", return_value=True
+    with (
+        patch.object(ha, "probe_hub", return_value=True),
+        patch.object(ha, "probe_local_daemon", return_value=True),
     ):
         result = runner.invoke(root, ["--help"], obj={"host": "h", "port": 9559})
 
@@ -107,8 +140,9 @@ def test_suffix_absent_when_hub_unreachable() -> None:
     root = _build_group()
     runner = CliRunner()
 
-    with patch.object(ha, "probe_hub", return_value=False), patch.object(
-        ha, "probe_local_daemon", return_value=False
+    with (
+        patch.object(ha, "probe_hub", return_value=False),
+        patch.object(ha, "probe_local_daemon", return_value=False),
     ):
         result = runner.invoke(root, ["--help"], obj={"host": "h", "port": 9559})
 
@@ -125,8 +159,9 @@ def test_pure_local_never_gets_suffix() -> None:
     root = _build_group()
     runner = CliRunner()
 
-    with patch.object(ha, "probe_hub", return_value=True), patch.object(
-        ha, "probe_local_daemon", return_value=True
+    with (
+        patch.object(ha, "probe_hub", return_value=True),
+        patch.object(ha, "probe_local_daemon", return_value=True),
     ):
         result = runner.invoke(root, ["--help"], obj={"host": "h", "port": 9559})
 
@@ -146,8 +181,9 @@ def test_daemon_probe_independent_of_hub() -> None:
     runner = CliRunner()
 
     # Hub down but daemon up -> cron should be annotated; agent should not.
-    with patch.object(ha, "probe_hub", return_value=False), patch.object(
-        ha, "probe_local_daemon", return_value=True
+    with (
+        patch.object(ha, "probe_hub", return_value=False),
+        patch.object(ha, "probe_local_daemon", return_value=True),
     ):
         result = runner.invoke(root, ["--help"], obj={"host": "h", "port": 9559})
 
@@ -296,18 +332,15 @@ def test_step_b_noun_suffix_present_when_hub_reachable(noun: str) -> None:
     from scitex_orochi._cli._main import orochi
 
     runner = CliRunner()
-    with patch.object(ha, "probe_hub", return_value=True), patch.object(
-        ha, "probe_local_daemon", return_value=True
+    with (
+        patch.object(ha, "probe_hub", return_value=True),
+        patch.object(ha, "probe_local_daemon", return_value=True),
     ):
         result = runner.invoke(orochi, ["--help"], obj={"host": "h", "port": 9559})
 
     assert result.exit_code == 0, result.output
     line = next(
-        (
-            ln
-            for ln in result.output.splitlines()
-            if ln.lstrip().startswith(noun + " ")
-        ),
+        (ln for ln in result.output.splitlines() if ln.lstrip().startswith(noun + " ")),
         "",
     )
     assert AVAILABLE_SUFFIX in line, (
@@ -323,23 +356,19 @@ def test_step_b_noun_suffix_absent_when_hub_unreachable(noun: str) -> None:
     from scitex_orochi._cli._main import orochi
 
     runner = CliRunner()
-    with patch.object(ha, "probe_hub", return_value=False), patch.object(
-        ha, "probe_local_daemon", return_value=False
+    with (
+        patch.object(ha, "probe_hub", return_value=False),
+        patch.object(ha, "probe_local_daemon", return_value=False),
     ):
         result = runner.invoke(orochi, ["--help"], obj={"host": "h", "port": 9559})
 
     assert result.exit_code == 0, result.output
     line = next(
-        (
-            ln
-            for ln in result.output.splitlines()
-            if ln.lstrip().startswith(noun + " ")
-        ),
+        (ln for ln in result.output.splitlines() if ln.lstrip().startswith(noun + " ")),
         "",
     )
     assert AVAILABLE_SUFFIX not in line, (
-        f"{noun!r} must NOT show the suffix when hub is unreachable; "
-        f"got line {line!r}"
+        f"{noun!r} must NOT show the suffix when hub is unreachable; got line {line!r}"
     )
 
 
@@ -350,18 +379,15 @@ def test_step_b_pure_local_noun_never_annotated(noun: str) -> None:
     from scitex_orochi._cli._main import orochi
 
     runner = CliRunner()
-    with patch.object(ha, "probe_hub", return_value=True), patch.object(
-        ha, "probe_local_daemon", return_value=True
+    with (
+        patch.object(ha, "probe_hub", return_value=True),
+        patch.object(ha, "probe_local_daemon", return_value=True),
     ):
         result = runner.invoke(orochi, ["--help"], obj={"host": "h", "port": 9559})
 
     assert result.exit_code == 0, result.output
     line = next(
-        (
-            ln
-            for ln in result.output.splitlines()
-            if ln.lstrip().startswith(noun + " ")
-        ),
+        (ln for ln in result.output.splitlines() if ln.lstrip().startswith(noun + " ")),
         "",
     )
     assert AVAILABLE_SUFFIX not in line, (


### PR DESCRIPTION
Fixes the two pre-existing, environment-coupled test failures on `develop` (they predate the v0.16.4 audit work) so the `test` CI workflow goes fully green.

## 1. `test_help_availability::test_step_b_noun_suffix_present_when_hub_reachable[push]` (in CI `test` workflow)
**Root cause:** a wall-clock timing race, not a code bug. The mocked-probe suffix tests drive the real `format_commands` rendering path, whose parallel probe pool is gated by a 100 ms `TOTAL_BUDGET_S` deadline. Even though the probes are mocked to return instantly, under a loaded CI runner thread-scheduling jitter can let that 100 ms deadline elapse before every probe future is collected — `run_probes` then force-marks an arbitrary noun (observed: `push`) unreachable and strips its `(Available Now)` suffix. Reproduced deterministically: with probe latency above the budget the old 100 ms path drops the suffix 8/8 runs; raising the budget holds 0/8.

**Fix (no faking):**
- `format_commands` now reads `TOTAL_BUDGET_S` from the module at call time (consistent with how it already resolves `probe_hub`/`probe_local_daemon`), making the budget the single source of truth and runtime-configurable.
- The suffix-presence/absence tests pin a generous budget via a save/restore autouse fixture, so the **deterministic mocked reachability** — not wall-clock timing — decides the suffix. The dedicated `test_run_probes_*` timing tests pass an explicit budget and are unaffected.

## 2. `no such table: hub_scheduledaction` (Django `apps/hub` test suite)
**Root cause:** `HubConfig.ready()` unconditionally started the scheduled-action daemon thread, **including inside the test runner**. The long-lived loop queries `ScheduledAction` on its own connection while the Django/pytest runner creates and destroys an ephemeral per-run database around it — intermittently raising `no such table: hub_scheduledaction` / `database is locked` (visible as `Scheduler loop error` in test logs).

**Fix:** gate the thread on a new `RUN_BACKGROUND_SCHEDULER` setting — `False` under tests by default (via a `TESTING` probe in `settings_shared`), overridable through `SCITEX_OROCHI_RUN_SCHEDULER`. Production `runserver`/asgi behaviour is unchanged (verified: `TESTING=False`, scheduler enabled under `runserver`). After the fix the `Scheduler loop error` / `database is locked` log lines disappear from the `apps.hub` cron and auto_dispatch test runs.

## Verification
- `test_step_b_noun_suffix_present_when_hub_reachable[push]`: **was FAILED → now PASSED** (all 10 nouns green; full `test_help_availability.py` = 29 passed, run 5×).
- Scheduler-thread races: gone from `apps.hub.tests.views.api.test_cron` (16 OK) and `apps.hub.tests.test_auto_dispatch`.
- Full `pytest tests/ -m "not llm_eval"` (CI scope): 692 passed, 1 skipped, 1 xfailed. The only failure is `tests/develop/test_audit.py::test_audit_all_clean`, which is environment-coupled (resolves config from the local ECOSYSTEM registry path + the locally-installed `scitex-dev` rule set) and **passes in CI** — not in scope here and unrelated to these changes.
- Note: a separate, unrelated pre-existing assertion failure exists in the Django suite (`test_auto_dispatch::test_text_includes_per_host_gh_command`, a gh-command-text assertion) — out of scope for these two targeted failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)