### PR TITLE
docs(readme): correct sac/orochi boundary — sac is cross-host (fleet/peer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ reads agent status, sac never imports orochi.
 | MCP channel server (in-session push)     | **orochi**                           |
 | Container lifecycle (start/stop/send)    | **sac**                              |
 | Health checks, restart policies          | **sac**                              |
+| Fleet/peer orchestration (cross-host launch, peer registry, singleton reconcile) | **sac** |
 | Telegram bridge + alerting               | **claude-code-telegrammer**          |
 
-Rule: **orochi knows messages + people across hosts; sac knows containers + sessions on one host.** sac never imports orochi.
+Rule: **orochi owns the cross-host messaging + visibility layer (people + messages); sac owns the cross-host execution + lifecycle layer (agents + containers, local and peer hosts).** Both span hosts — the boundary is *comms vs execution*, not *fleet vs single-host*. sac never imports orochi.
 
 See [Architecture](docs/architecture.md) for the server topology,
 status-collection flow, and snake fleet roles.


### PR DESCRIPTION
## Summary

The README rule line **"sac knows containers + sessions on one host"** predates sac's fleet/peer expansion and is now inaccurate. sac ships cross-host primitives:

- `sac host add-peer / list-peers / remove-peer` — cross-host listen-bearer registry
- `sac peer post-turn AGENT TEXT` — A2A outbound (loopback or cross-host)
- `sac fleet launch PEER <name>...` — rsync specs to PEER, start remotely
- `sac fleet notify done|blocker|status` — agent→lead push (ADR-0013)
- `sac registry reconcile` — singleton placement reconcile across fleet
- `sac host probe-hub` — WSL → fleet-hub layered connectivity probe

The real boundary between sac and orochi is **comms vs execution**, not **fleet vs single-host** — both span hosts.

## Changes

1. New table row: "Fleet/peer orchestration (cross-host launch, peer registry, singleton reconcile)" → **sac**.
2. Rule line updated to reflect comms-vs-execution boundary.

## Not changed

- SOC itself (sac never imports orochi). Verified: `grep -rEn 'from scitex_orochi\|import scitex_orochi' scitex-agent-container/src/` → 0 hits. This is doc drift, not a code change.
- Diagram "apptainer runtime · per host" + "Claude agents (one per host)" stay — those literal claims (an apptainer container runs on one host; a claude process runs on one host) remain accurate.

## Test plan

- [x] `git diff` confined to README.md
- [ ] CI green