### PR TITLE
docs(readme): replace ghost .env.example ref + clarify dual-transport ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ pip install scitex-orochi
 scitex-orochi serve
 ```
 
-WebSocket endpoint: `ws://localhost:9559` | Dashboard: `http://localhost:8559`
+`scitex-orochi serve` starts the standalone hub on **WS `ws://localhost:9559`** + **Dashboard `http://localhost:8559`** (two ports). The Django ASGI production path (used by the public site and by agents that auto-connect via `spec.orochi.enabled: true`) unifies both on **port `8559`** with WS at **`/ws/agent/`** — that is what agents register against by default. Use the standalone hub for local development and the Django path for production; see [Getting Started](docs/getting-started.md) for which to pick.
 
 See [Getting Started](docs/getting-started.md) for prerequisites, Docker deploy, heartbeat-push, MCP channel setup, and agent definitions.
 
@@ -192,8 +192,8 @@ See [Getting Started](docs/getting-started.md) for prerequisites, Docker deploy,
 ## Environment Variables
 
 `scitex-orochi` reads its configuration from `SCITEX_OROCHI_*` environment
-variables (see [`.env.example`](.env.example) for the full list and
-defaults). Common ones:
+variables. The full list is documented in
+[`docs/configuration.md`](docs/configuration.md); the most common ones:
 
 | Variable | Purpose | Default |
 |----------|---------|---------|


### PR DESCRIPTION
## Summary

Two doc-vs-code drifts surfaced by the 2026-06-01 audit:

**1. `.env.example` link goes to a 404.** `README.md:195` reads:
> see [`.env.example`](.env.example) for the full list and defaults

The file does not exist in the repo. The full SCITEX_OROCHI_* documentation lives in `docs/configuration.md`. Point the link there.

**2. Standalone-vs-Django port confusion.** `README.md:186` read:
> WebSocket endpoint: `ws://localhost:9559` | Dashboard: `http://localhost:8559`

This is only true for the standalone hub (`scitex-orochi serve`). The Django ASGI production path — which is what agents with `spec.orochi.enabled: true` auto-connect against (see `_agent_container_bridge/spec.py:24`, default `port=8559`, `ws_path=/ws/agent/`) — unifies WS+HTTP on port 8559. Operators wiring agent onboarding to `:9559` fail silently because no agent ever lands there.

Clarify which mode runs which ports and what each is for.

## Changes

- `README.md` only: +3/-3.

## Test plan

- [x] `git diff` confined to `README.md`
- [x] `docs/configuration.md` exists (verified)
- [ ] CI green