### PR TITLE
test(bridge): cover the SoC seam — spec, mcp, dispatch (was 0 direct tests)

### DIFF
--- a/src/scitex_orochi/_agent_container_bridge/dispatch.py
+++ b/src/scitex_orochi/_agent_container_bridge/dispatch.py
@@ -110,28 +110,39 @@ def prepare_shim_yaml(
     return shim_path
 
 
-def _remote_home_dir(target: str, ssh_opts: list[str]) -> str | None:
-    """Return the remote user's $HOME or None if detection fails."""
-    try:
-        proc = subprocess.run(
-            ["ssh", *ssh_opts, target, "echo $HOME"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-            check=False,
+def _remote_home_dir(target: str, ssh_opts: list[str]) -> str:
+    """Return the remote user's ``$HOME``.
+
+    Raises ``RuntimeError`` if ssh fails, returns non-zero, or no
+    path-like line is parsable from stdout. We do NOT swallow failures
+    here: the caller uses the result to rewrite path prefixes inside the
+    mcp-config file, and a silent "remote home unknown" path leads to
+    claude starting on the remote and 404-ing on ``--mcp-config`` with
+    an opaque error that's hard to trace back to this step.
+    """
+    proc = subprocess.run(
+        ["ssh", *ssh_opts, target, "echo $HOME"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ssh {target} 'echo $HOME' returned rc={proc.returncode}; "
+            f"stderr: {proc.stderr.strip() or '(empty)'}"
         )
-        if proc.returncode != 0:
-            return None
-        # Remote bashrc may print noise to stdout (scitex-resource-monitor
-        # "Dashboard started in background" etc). Our $HOME line is
-        # usually the last non-empty line.
-        for line in reversed(proc.stdout.splitlines()):
-            line = line.strip()
-            if line.startswith("/"):
-                return line
-    except Exception:
-        pass
-    return None
+    # Remote bashrc may print noise to stdout (scitex-resource-monitor
+    # "Dashboard started in background" etc). Our $HOME line is
+    # usually the last non-empty line that looks like an absolute path.
+    for line in reversed(proc.stdout.splitlines()):
+        line = line.strip()
+        if line.startswith("/"):
+            return line
+    raise RuntimeError(
+        f"ssh {target} 'echo $HOME' returned rc=0 but no path-like line "
+        f"in stdout (got {proc.stdout!r})"
+    )
 
 
 def scp_mcp_config_to_remote(
@@ -147,10 +158,13 @@ def scp_mcp_config_to_remote(
     before transferring we detect the remote's home dir and rewrite any
     occurrences of the dispatcher's home prefix to the remote's.
 
-    Creates the parent directory on the remote first. Failures are
-    logged as warnings (not raised) so the launch can still proceed —
-    a missing file will surface as a clearer error from the agent's
-    own claude process.
+    Creates the parent directory on the remote first. Raises
+    ``RuntimeError`` on any failure (remote home detection, mkdir,
+    transfer) — we do NOT silently fall back, because the caller's
+    contract is "after this returns, the file is at ``target:local_path``
+    with the correct path-prefix rewriting". A partial / wrong-prefix
+    file on the remote causes the agent's claude to 404 on
+    ``--mcp-config`` later with an opaque error.
     """
     user = remote_section.get("user", "") or "ywatanabe"
     target = f"{user}@{remote_host}"
@@ -159,23 +173,20 @@ def scp_mcp_config_to_remote(
     ssh_opts = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10"]
 
     # Rewrite ts_path in the JSON for cross-platform portability.
+    # _remote_home_dir() raises if the remote $HOME can't be determined;
+    # we let that propagate so the operator sees the real ssh error.
     local_home = str(Path.home())
     remote_home = _remote_home_dir(target, ssh_opts)
-    rewritten_bytes: bytes
-    if remote_home and remote_home != local_home:
-        try:
-            raw = Path(local_path).read_text()
-            rewritten = raw.replace(local_home, remote_home)
-            rewritten_bytes = rewritten.encode("utf-8")
-            logger.info(
-                "Rewrote ts_path home prefix %s -> %s for %s",
-                local_home,
-                remote_home,
-                target,
-            )
-        except Exception as exc:
-            logger.warning("ts_path rewrite failed, falling back to raw file: %s", exc)
-            rewritten_bytes = Path(local_path).read_bytes()
+    if remote_home != local_home:
+        raw = Path(local_path).read_text()
+        rewritten = raw.replace(local_home, remote_home)
+        rewritten_bytes = rewritten.encode("utf-8")
+        logger.info(
+            "Rewrote ts_path home prefix %s -> %s for %s",
+            local_home,
+            remote_home,
+            target,
+        )
     else:
         rewritten_bytes = Path(local_path).read_bytes()
 
@@ -186,44 +197,38 @@ def scp_mcp_config_to_remote(
     # banner on the NAS). The cat-pipe approach is robust against shell
     # init noise because the noise lands on a different file descriptor
     # than the data stream.
-    try:
-        mkdir_proc = subprocess.run(
-            ["ssh", *ssh_opts, target, f"mkdir -p {shlex.quote(remote_dir)}"],
-            capture_output=True,
-            text=True,
-            timeout=30,
-            check=False,
+    mkdir_proc = subprocess.run(
+        ["ssh", *ssh_opts, target, f"mkdir -p {shlex.quote(remote_dir)}"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if mkdir_proc.returncode != 0:
+        raise RuntimeError(
+            f"Remote mkdir {remote_dir} on {target} failed "
+            f"(rc={mkdir_proc.returncode}); "
+            f"stderr: {mkdir_proc.stderr.strip() or '(empty)'}"
         )
-        if mkdir_proc.returncode != 0:
-            logger.warning(
-                "Remote mkdir failed for %s: %s",
-                target,
-                mkdir_proc.stderr.strip() or "(no stderr)",
-            )
-            return
 
-        transfer_proc = subprocess.run(
-            [
-                "ssh",
-                *ssh_opts,
-                target,
-                f"cat > {shlex.quote(local_path)}",
-            ],
-            input=rewritten_bytes,
-            capture_output=True,
-            timeout=60,
-            check=False,
+    transfer_proc = subprocess.run(
+        [
+            "ssh",
+            *ssh_opts,
+            target,
+            f"cat > {shlex.quote(local_path)}",
+        ],
+        input=rewritten_bytes,
+        capture_output=True,
+        timeout=60,
+        check=False,
+    )
+    if transfer_proc.returncode != 0:
+        raise RuntimeError(
+            f"Remote write to {target}:{local_path} failed "
+            f"(rc={transfer_proc.returncode}); "
+            f"stderr: "
+            f"{transfer_proc.stderr.decode('utf-8', 'replace').strip() or '(empty)'}"
         )
-        if transfer_proc.returncode != 0:
-            logger.warning(
-                "Remote write failed for %s:%s: %s",
-                target,
-                local_path,
-                transfer_proc.stderr.decode("utf-8", "replace").strip()
-                or "(no stderr)",
-            )
-            return
 
-        logger.info("Distributed mcp-config to %s:%s", target, local_path)
-    except Exception as exc:
-        logger.warning("Failed to push mcp-config to %s: %s", target, exc)
+    logger.info("Distributed mcp-config to %s:%s", target, local_path)

--- a/src/scitex_orochi/_agent_container_bridge/dispatch.py
+++ b/src/scitex_orochi/_agent_container_bridge/dispatch.py
@@ -37,15 +37,25 @@ def prepare_shim_yaml(
     config_path: Path,
     orochi_spec: OrochiSpec,
     write_mcp_config_file: Callable,
+    scp_fn: Callable[[str, str, dict], None] | None = None,
 ) -> Path:
     """Write a shim yaml with Orochi-specific claude flags injected.
 
     For remote agents, the generated MCP config file is also scp'd to
     the remote at the same path so claude finds it there.
 
+    ``scp_fn`` is an injection point so tests can supply a real
+    hand-rolled fake that records its invocations. Production callers
+    omit it and the default resolves to the real
+    ``scp_mcp_config_to_remote`` at call time. The default is wired
+    inside the function (not as a parameter default) because
+    ``scp_mcp_config_to_remote`` is defined later in this module.
+
     Returns the shim path. If Orochi is not enabled, returns the
     original ``config_path`` unchanged (no shim needed).
     """
+    if scp_fn is None:
+        scp_fn = scp_mcp_config_to_remote
     if not orochi_spec.is_enabled:
         return config_path
 
@@ -73,7 +83,7 @@ def prepare_shim_yaml(
         remote_section = spec.get("remote", {}) or {}
         remote_host = remote_section.get("host", "")
         if remote_host:
-            scp_mcp_config_to_remote(mcp_path, remote_host, remote_section)
+            scp_fn(mcp_path, remote_host, remote_section)
 
         # Inject the MCP flags. ORDER MATTERS: --mcp-config MUST come
         # BEFORE --dangerously-load-development-channels because the

--- a/tests/scitex_orochi/_agent_container_bridge/conftest.py
+++ b/tests/scitex_orochi/_agent_container_bridge/conftest.py
@@ -1,0 +1,296 @@
+"""Bridge-local fixtures.
+
+Implements the two canonical no-mock patterns from the scitex-dev
+``02_package/12_no-mocks.md`` skill (STX-NM001/2/3 + PA-306):
+
+- ``env_save_restore`` — yield-based snapshot/restore of ``os.environ``
+  (replaces every ``monkeypatch.setenv``).
+- ``ssh_shim`` — drops a real bash script into ``tmp_path/bin/ssh`` and
+  prepends it to ``$PATH``. Production code calls the real
+  ``subprocess.run`` against a real (fake) ``ssh`` binary; we exercise
+  the actual codepath end-to-end. Replaces every ``monkeypatch.setattr``
+  on ``subprocess.run``.
+- ``bash_shim`` — same idea, but for the ``bash -l -c "echo $TOK"``
+  token-fallback path inside ``mcp._resolve_token``.
+- ``isolated_runtime_root`` — sets ``SCITEX_DIR`` so
+  ``scitex_config._ecosystem.local_state.runtime_path`` lands under a
+  tmp dir, with no patching of ``local_state``.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# env_save_restore — replaces monkeypatch.setenv
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env_save_restore():
+    """Snapshot ``os.environ`` on entry, restore on exit.
+
+    Yields the live ``os.environ``. Tests mutate it directly:
+
+        def test_thing(env_save_restore):
+            env_save_restore["MY_VAR"] = "x"
+            ...
+    """
+    saved = dict(os.environ)
+    try:
+        yield os.environ
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# ssh_shim / bash_shim — real subprocess against a real fake binary
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ShimController:
+    """Driver for a deployed shim script.
+
+    The shim is a real shell script that lives at ``bin_path``. Tests
+    don't call it directly — production code does, via ``subprocess.run``.
+    Tests:
+      - read ``calls_log`` to assert how the shim was invoked.
+      - mutate ``mode`` / ``stdout`` / ``stderr`` / ``rc`` to script the
+        next response.
+    The script re-reads its config file on every invocation.
+    """
+
+    bin_dir: Path
+    bin_path: Path
+    calls_log: Path
+    config_path: Path
+    # Mode names map to short scripts that emit canned output. Tests
+    # can also supply "echo_arg" or a raw arg-script via ``set_mode``.
+    mode: str = "success"
+    stdout: str = ""
+    stderr: str = ""
+    rc: int = 0
+
+    def write_config(self) -> None:
+        """Persist current mode/stdout/stderr/rc to the config file the
+        shim reads on each invocation."""
+        body = (
+            f"MODE={shlex.quote(self.mode)}\n"
+            f"STDOUT={shlex.quote(self.stdout)}\n"
+            f"STDERR={shlex.quote(self.stderr)}\n"
+            f"RC={int(self.rc)}\n"
+        )
+        self.config_path.write_text(body)
+
+    def calls(self) -> list[list[str]]:
+        """Parsed calls log — one list-of-argv per invocation."""
+        if not self.calls_log.exists():
+            return []
+        out: list[list[str]] = []
+        for line in self.calls_log.read_text().splitlines():
+            if not line:
+                continue
+            out.append(shlex.split(line))
+        return out
+
+    def stdins(self) -> list[bytes]:
+        """Captured stdin bytes (one entry per invocation, in order)."""
+        stdin_dir = self.bin_dir / "_stdins"
+        if not stdin_dir.exists():
+            return []
+        numeric = [p for p in stdin_dir.iterdir() if p.name.isdigit()]
+        return [p.read_bytes() for p in sorted(numeric, key=lambda x: int(x.name))]
+
+    def set(
+        self,
+        *,
+        mode: str | None = None,
+        stdout: str | None = None,
+        stderr: str | None = None,
+        rc: int | None = None,
+    ) -> None:
+        """Reconfigure the shim's next response in one call."""
+        if mode is not None:
+            self.mode = mode
+        if stdout is not None:
+            self.stdout = stdout
+        if stderr is not None:
+            self.stderr = stderr
+        if rc is not None:
+            self.rc = rc
+        self.write_config()
+
+
+def _install_shim(bin_dir: Path, name: str) -> _ShimController:
+    """Drop a real shell script at ``bin_dir/<name>`` that records argv
+    + stdin, reads a config file for response, and exits with the
+    configured rc."""
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stdin_dir = bin_dir / "_stdins"
+    stdin_dir.mkdir(exist_ok=True)
+    calls_log = bin_dir / f"{name}.calls"
+    config_path = bin_dir / f"{name}.config"
+    calls_log.write_text("")
+    bin_path = bin_dir / name
+
+    # Shebang MUST be an absolute path, not `/usr/bin/env bash`. Using
+    # env would resolve `bash` via $PATH — and we just prepended the
+    # shim dir to $PATH, so the kernel would loop back to interpret
+    # this same fake-bash script with itself. Hard-code /bin/bash.
+    script = textwrap.dedent(
+        f"""\
+        #!/bin/bash
+        set -eu
+        # Record argv (one shell-quoted line per invocation).
+        printf '%q ' "$@" >> {shlex.quote(str(calls_log))}
+        printf '\\n'   >> {shlex.quote(str(calls_log))}
+        # Persist stdin bytes for later inspection.
+        STDIN_IDX_FILE={shlex.quote(str(stdin_dir / "_idx"))}
+        if [ -f "$STDIN_IDX_FILE" ]; then
+            IDX=$(cat "$STDIN_IDX_FILE")
+        else
+            IDX=0
+        fi
+        cat > {shlex.quote(str(stdin_dir))}/$IDX
+        echo $((IDX + 1)) > "$STDIN_IDX_FILE"
+        # Read response from config (defaults if missing).
+        MODE=success
+        STDOUT=
+        STDERR=
+        RC=0
+        if [ -f {shlex.quote(str(config_path))} ]; then
+            # shellcheck disable=SC1090
+            . {shlex.quote(str(config_path))}
+        fi
+        case "$MODE" in
+            success)
+                printf '%s' "$STDOUT"
+                printf '%s' "$STDERR" >&2
+                exit "$RC"
+                ;;
+            *)
+                printf '%s' "$STDERR" >&2
+                exit "$RC"
+                ;;
+        esac
+        """
+    )
+    bin_path.write_text(script)
+    bin_path.chmod(bin_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    ctrl = _ShimController(
+        bin_dir=bin_dir,
+        bin_path=bin_path,
+        calls_log=calls_log,
+        config_path=config_path,
+    )
+    ctrl.write_config()
+    return ctrl
+
+
+@pytest.fixture
+def ssh_shim(tmp_path, env_save_restore):
+    """Install a real fake ``ssh`` binary on ``$PATH`` (highest precedence).
+
+    Returns a ``_ShimController`` for the deployed script. Production
+    ``subprocess.run(["ssh", ...])`` calls the fake; tests assert via
+    ``ctrl.calls()`` and ``ctrl.stdins()``.
+
+    Default behaviour is rc=0, no stdout, no stderr. Call
+    ``ctrl.set(stdout=..., rc=..., stderr=...)`` to script the next
+    invocation.
+    """
+    bin_dir = tmp_path / "shim_bin_ssh"
+    ctrl = _install_shim(bin_dir, "ssh")
+    env_save_restore["PATH"] = (
+        f"{bin_dir}{os.pathsep}{env_save_restore.get('PATH', '')}"
+    )
+    return ctrl
+
+
+@pytest.fixture
+def bash_shim(tmp_path, env_save_restore):
+    """Install a real fake ``bash`` binary on ``$PATH`` (highest precedence).
+
+    Used to exercise ``mcp._resolve_token``'s ``bash -l -c "echo $TOK"``
+    fallback without touching the real login shell.
+
+    NB: scoping this is risky — production code runs many bash
+    subprocesses. We accept the blast radius for these tests because
+    the only path under test that shells out to bash is the token
+    fallback, and tests are short-lived per-function fixtures.
+    """
+    bin_dir = tmp_path / "shim_bin_bash"
+    ctrl = _install_shim(bin_dir, "bash")
+    env_save_restore["PATH"] = (
+        f"{bin_dir}{os.pathsep}{env_save_restore.get('PATH', '')}"
+    )
+    return ctrl
+
+
+# ---------------------------------------------------------------------------
+# isolated_runtime_root — replaces monkeypatch of local_state.runtime_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_runtime_root(tmp_path, env_save_restore) -> Path:
+    """Point ``scitex_config._ecosystem.local_state.runtime_path`` at a tmp dir.
+
+    ``local_state.user_root()`` reads ``SCITEX_DIR`` (default
+    ``~/.scitex``) on every call. ``local_state.find_project_scope()``
+    walks up from cwd looking for ``.git``. We:
+      - set ``SCITEX_DIR=tmp_path/scitex``
+      - change cwd to a tmp dir with no ``.git``
+    so all ``runtime_path`` lookups land under ``tmp_path``.
+    """
+    scitex_root = tmp_path / "scitex"
+    cwd_root = tmp_path / "cwd"
+    cwd_root.mkdir()
+    env_save_restore["SCITEX_DIR"] = str(scitex_root)
+    saved_cwd = Path.cwd()
+    os.chdir(cwd_root)
+    try:
+        yield scitex_root
+    finally:
+        os.chdir(saved_cwd)
+
+
+# ---------------------------------------------------------------------------
+# Hand-rolled fake for scp_fn DI in prepare_shim_yaml
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeScp:
+    """Honest fake for ``scp_mcp_config_to_remote`` — records its calls.
+
+    Used via the ``scp_fn`` kwarg on ``prepare_shim_yaml``. Production
+    callers omit ``scp_fn`` (it resolves to the real function). Tests
+    pass a fresh ``FakeScp()`` and inspect ``.calls`` after the SUT runs.
+
+    The fake exposes only the call signature production uses
+    (``(local_path: str, remote_host: str, remote_section: dict)``)
+    plus a ``calls`` list — no extra "magic" attributes. If production
+    grows another arg or the signature shifts, this fake's
+    ``__call__`` will be wrong and the test will fail loudly, which is
+    the property we want.
+    """
+
+    calls: list[tuple[str, str, dict]] = field(default_factory=list)
+    # If non-None, raised on the n-th call (one-indexed).
+    raise_on_call: tuple[int, BaseException] | None = None
+
+    def __call__(self, local_path: str, remote_host: str, remote_section: dict) -> None:
+        self.calls.append((local_path, remote_host, dict(remote_section)))
+        if self.raise_on_call is not None and len(self.calls) == self.raise_on_call[0]:
+            raise self.raise_on_call[1]

--- a/tests/scitex_orochi/_agent_container_bridge/test_dispatch.py
+++ b/tests/scitex_orochi/_agent_container_bridge/test_dispatch.py
@@ -1,0 +1,423 @@
+"""Tests for ``_agent_container_bridge/dispatch.py``.
+
+Covers two surfaces:
+
+1. ``prepare_shim_yaml`` — the yaml roundtrip that injects
+   ``--mcp-config`` and ``--dangerously-load-development-channels`` into
+   the agent yaml's ``claude.flags`` (in the correct order).
+
+2. The new loud-crash contract for ``_remote_home_dir`` and
+   ``scp_mcp_config_to_remote`` (PR fix/dispatch-loud-crash): every
+   ssh failure must raise ``RuntimeError`` carrying the real rc +
+   stderr, instead of silently logging a warning and returning.
+
+Subprocess invocations are monkey-patched (no real ssh / no remote).
+This is plumbing-mocking, not behaviour-mocking — we never replace what
+the code under test computes, only its OS boundary.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_orochi._agent_container_bridge import dispatch as dispatch_mod
+from scitex_orochi._agent_container_bridge.dispatch import (
+    _remote_home_dir,
+    prepare_shim_yaml,
+    scp_mcp_config_to_remote,
+)
+from scitex_orochi._agent_container_bridge.spec import OrochiSpec
+
+# ---------------------------------------------------------------------------
+# prepare_shim_yaml — passthrough when Orochi disabled
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_shim_yaml_passthrough_when_disabled(tmp_path):
+    """No Orochi -> return the original path unchanged, write no shim."""
+    src = tmp_path / "agent.yaml"
+    src.write_text(yaml.safe_dump({"metadata": {"name": "a"}, "spec": {}}))
+
+    got = prepare_shim_yaml(src, OrochiSpec(), write_mcp_config_file=lambda **kw: None)
+
+    assert got == src
+
+
+def test_prepare_shim_yaml_no_mcp_path_still_writes_shim(tmp_path, monkeypatch):
+    """Enabled but write_mcp_config_file returns None -> no flags injected,
+    but a shim is still written under runtime/orochi/shim-yamls/."""
+    src = tmp_path / "agent.yaml"
+    src.write_text(
+        yaml.safe_dump(
+            {"metadata": {"name": "a"}, "spec": {"claude": {"flags": ["--keep-me"]}}}
+        )
+    )
+
+    shim_root = tmp_path / "runtime" / "orochi" / "shim-yamls"
+
+    def fake_runtime_path(pkg, *parts):
+        return shim_root if parts else shim_root.parent
+
+    monkeypatch.setattr(dispatch_mod.local_state, "runtime_path", fake_runtime_path)
+
+    got = prepare_shim_yaml(
+        src,
+        OrochiSpec(enabled=True, hosts=["h"]),
+        write_mcp_config_file=lambda **kw: None,
+    )
+
+    assert Path(got).parent == shim_root
+    written = yaml.safe_load(Path(got).read_text())
+    # No --mcp-config injected (write_mcp_config_file returned None) so
+    # the original --keep-me must survive untouched.
+    assert written["spec"]["claude"]["flags"] == ["--keep-me"]
+
+
+# ---------------------------------------------------------------------------
+# prepare_shim_yaml — flag injection order is load-bearing
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_shim_yaml_injects_flags_in_required_order(tmp_path, monkeypatch):
+    """--mcp-config MUST come BEFORE --dangerously-load-development-channels.
+
+    From dispatch.py:78-89: the dev-channels flag references
+    "server:scitex-orochi" which is only registered after --mcp-config
+    parses the JSON file declaring it. Wrong order => silent channel
+    registration failure.
+    """
+    src = tmp_path / "agent.yaml"
+    src.write_text(
+        yaml.safe_dump({"metadata": {"name": "agent-x"}, "spec": {"claude": {}}})
+    )
+
+    fake_mcp_path = "/tmp/mcp-agent-x.json"
+    monkeypatch.setattr(
+        dispatch_mod.local_state,
+        "runtime_path",
+        lambda pkg, *parts: (
+            tmp_path / "rt" / Path(*parts) if parts else tmp_path / "rt"
+        ),
+    )
+
+    got = prepare_shim_yaml(
+        src,
+        OrochiSpec(enabled=True, hosts=["h"]),
+        write_mcp_config_file=lambda **kw: fake_mcp_path,
+    )
+
+    flags = yaml.safe_load(Path(got).read_text())["spec"]["claude"]["flags"]
+
+    mcp_idx = next(i for i, f in enumerate(flags) if "--mcp-config" in f)
+    dev_idx = next(
+        i for i, f in enumerate(flags) if "--dangerously-load-development-channels" in f
+    )
+    assert mcp_idx < dev_idx, (
+        f"--mcp-config must precede --dangerously-load-development-channels "
+        f"in claude.flags; got {flags}"
+    )
+    assert fake_mcp_path in flags[mcp_idx]
+
+
+def test_prepare_shim_yaml_dedupes_existing_flag_instances(tmp_path, monkeypatch):
+    """If the yaml already has the flags, we must not append duplicates."""
+    src = tmp_path / "agent.yaml"
+    src.write_text(
+        yaml.safe_dump(
+            {
+                "metadata": {"name": "a"},
+                "spec": {
+                    "claude": {
+                        "flags": [
+                            "--mcp-config /old/path.json",
+                            "--dangerously-load-development-channels server:scitex-orochi",
+                            "--keep-me",
+                        ]
+                    }
+                },
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        dispatch_mod.local_state,
+        "runtime_path",
+        lambda pkg, *parts: (
+            tmp_path / "rt" / Path(*parts) if parts else tmp_path / "rt"
+        ),
+    )
+
+    got = prepare_shim_yaml(
+        src,
+        OrochiSpec(enabled=True, hosts=["h"]),
+        write_mcp_config_file=lambda **kw: "/tmp/new.json",
+    )
+
+    flags = yaml.safe_load(Path(got).read_text())["spec"]["claude"]["flags"]
+    mcp_flags = [f for f in flags if "--mcp-config" in f]
+    dev_flags = [f for f in flags if "--dangerously-load-development-channels" in f]
+
+    assert len(mcp_flags) == 1, f"expected exactly one --mcp-config flag, got {flags}"
+    assert len(dev_flags) == 1
+    assert "--keep-me" in flags  # unrelated flag preserved
+    assert "/tmp/new.json" in mcp_flags[0]  # new path won
+    assert "/old/path.json" not in mcp_flags[0]
+
+
+def test_prepare_shim_yaml_remote_triggers_scp(tmp_path, monkeypatch):
+    """If ``spec.remote.host`` is set, scp_mcp_config_to_remote is invoked."""
+    src = tmp_path / "agent.yaml"
+    src.write_text(
+        yaml.safe_dump(
+            {
+                "metadata": {"name": "a"},
+                "spec": {
+                    "remote": {"host": "spartan.example", "user": "yw"},
+                    "claude": {},
+                },
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        dispatch_mod.local_state,
+        "runtime_path",
+        lambda pkg, *parts: (
+            tmp_path / "rt" / Path(*parts) if parts else tmp_path / "rt"
+        ),
+    )
+    scp_calls: list = []
+    monkeypatch.setattr(
+        dispatch_mod,
+        "scp_mcp_config_to_remote",
+        lambda local_path, host, section: scp_calls.append((local_path, host, section)),
+    )
+
+    prepare_shim_yaml(
+        src,
+        OrochiSpec(enabled=True, hosts=["h"]),
+        write_mcp_config_file=lambda **kw: "/tmp/local-mcp.json",
+    )
+
+    assert len(scp_calls) == 1
+    local_path, host, section = scp_calls[0]
+    assert local_path == "/tmp/local-mcp.json"
+    assert host == "spartan.example"
+    assert section["user"] == "yw"
+
+
+# ---------------------------------------------------------------------------
+# _remote_home_dir — new no-fallback contract
+# ---------------------------------------------------------------------------
+
+
+def _fake_run(returncode=0, stdout="", stderr=""):
+    """Build a fake CompletedProcess factory for monkeypatching."""
+
+    def runner(cmd, **kw):
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=returncode, stdout=stdout, stderr=stderr
+        )
+
+    return runner
+
+
+def test_remote_home_dir_parses_last_path_line(monkeypatch):
+    """A chatty bashrc can prepend noise to stdout; we pick the last /-line."""
+    monkeypatch.setattr(
+        dispatch_mod.subprocess,
+        "run",
+        _fake_run(
+            stdout="Dashboard started in background\nsome warning\n/home/yw\n",
+        ),
+    )
+
+    assert _remote_home_dir("yw@host", []) == "/home/yw"
+
+
+def test_remote_home_dir_raises_on_nonzero_rc(monkeypatch):
+    """The OLD silent-None contract is gone — non-zero rc must raise."""
+    monkeypatch.setattr(
+        dispatch_mod.subprocess,
+        "run",
+        _fake_run(returncode=255, stderr="ssh: connect to host bad port 22: refused"),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        _remote_home_dir("yw@bad", [])
+
+    msg = str(exc.value)
+    assert "rc=255" in msg
+    assert "refused" in msg
+
+
+def test_remote_home_dir_raises_when_no_path_line(monkeypatch):
+    """rc=0 but bashrc echoed only noise (no '/' line) -> raise."""
+    monkeypatch.setattr(
+        dispatch_mod.subprocess,
+        "run",
+        _fake_run(stdout="garbled noise\n123\n"),
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        _remote_home_dir("yw@host", [])
+
+    assert "no path-like line" in str(exc.value)
+
+
+def test_remote_home_dir_propagates_subprocess_timeout(monkeypatch):
+    """Timeout must propagate (old contract swallowed it as None)."""
+
+    def boom(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=15)
+
+    monkeypatch.setattr(dispatch_mod.subprocess, "run", boom)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        _remote_home_dir("yw@host", [])
+
+
+# ---------------------------------------------------------------------------
+# scp_mcp_config_to_remote — new no-fallback contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mcp_file(tmp_path):
+    p = tmp_path / "mcp-a.json"
+    p.write_text('{"args":["/home/yw/ts/mcp_channel.ts"]}')
+    return p
+
+
+def test_scp_raises_when_remote_home_detection_fails(monkeypatch, mcp_file):
+    """The very first step (detecting remote $HOME) must propagate failures.
+
+    Old behaviour: silent fall-through with the dispatcher's home prefix
+    written to the remote, leading to a wrong --mcp-config path on darwin.
+    """
+
+    def boom(*a, **kw):
+        raise RuntimeError("ssh boom")
+
+    monkeypatch.setattr(dispatch_mod, "_remote_home_dir", boom)
+
+    with pytest.raises(RuntimeError, match="ssh boom"):
+        scp_mcp_config_to_remote(str(mcp_file), "h.example", {})
+
+
+def test_scp_raises_when_mkdir_returns_nonzero(monkeypatch, mcp_file):
+    """Remote ``mkdir -p`` failure must raise with real stderr."""
+    monkeypatch.setattr(
+        dispatch_mod, "_remote_home_dir", lambda *a, **kw: str(Path.home())
+    )
+
+    calls: list = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        # First call is mkdir; return failure.
+        if "mkdir" in " ".join(cmd):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=1, stdout="", stderr="permission denied"
+            )
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc:
+        scp_mcp_config_to_remote(str(mcp_file), "h.example", {})
+
+    assert "Remote mkdir" in str(exc.value)
+    assert "permission denied" in str(exc.value)
+
+
+def test_scp_raises_when_transfer_returns_nonzero(monkeypatch, mcp_file):
+    """The ``cat | ssh 'cat >'`` step's failure must raise."""
+    monkeypatch.setattr(
+        dispatch_mod, "_remote_home_dir", lambda *a, **kw: str(Path.home())
+    )
+
+    def fake_run(cmd, **kw):
+        if "mkdir" in " ".join(cmd):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+        # transfer step (cat > path)
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=1, stdout=b"", stderr=b"disk full"
+        )
+
+    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError) as exc:
+        scp_mcp_config_to_remote(str(mcp_file), "h.example", {})
+
+    assert "Remote write" in str(exc.value)
+    assert "disk full" in str(exc.value)
+
+
+def test_scp_rewrites_home_prefix_on_cross_platform_transfer(monkeypatch, mcp_file):
+    """If dispatcher home != remote home, the JSON body is path-rewritten before
+    the ``cat | ssh 'cat >'`` step. We capture what gets sent over."""
+    dispatcher_home = str(Path.home())
+    remote_home = "/Users/yw"  # darwin shape, different from dispatcher
+
+    # The mcp_file fixture wrote /home/yw/... — make sure dispatcher_home
+    # appears in the file so the rewrite has something to do.
+    mcp_file.write_text(f'{{"args":["{dispatcher_home}/ts/mcp_channel.ts"]}}')
+
+    monkeypatch.setattr(dispatch_mod, "_remote_home_dir", lambda *a, **kw: remote_home)
+
+    captured: dict = {}
+
+    def fake_run(cmd, **kw):
+        if "mkdir" in " ".join(cmd):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+        # Transfer: capture the input bytes piped via ``cat >``.
+        captured["input"] = kw.get("input")
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=b"", stderr=b""
+        )
+
+    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
+
+    scp_mcp_config_to_remote(str(mcp_file), "darwin.example", {})
+
+    body = captured["input"].decode("utf-8")
+    assert remote_home in body
+    assert dispatcher_home not in body, (
+        "dispatcher home prefix leaked into remote body; cross-host paths "
+        f"will 404 on the remote claude --mcp-config: {body!r}"
+    )
+
+
+def test_scp_skips_rewrite_when_homes_match(monkeypatch, mcp_file):
+    """Same-platform case: no rewrite, raw bytes flow through."""
+    home = str(Path.home())
+    mcp_file.write_text(f'{{"args":["{home}/ts/mcp_channel.ts"]}}')
+
+    monkeypatch.setattr(dispatch_mod, "_remote_home_dir", lambda *a, **kw: home)
+
+    captured: dict = {}
+
+    def fake_run(cmd, **kw):
+        if "mkdir" in " ".join(cmd):
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout="", stderr=""
+            )
+        captured["input"] = kw.get("input")
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout=b"", stderr=b""
+        )
+
+    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
+
+    scp_mcp_config_to_remote(str(mcp_file), "linux.example", {})
+
+    assert captured["input"] == mcp_file.read_bytes()

--- a/tests/scitex_orochi/_agent_container_bridge/test_dispatch.py
+++ b/tests/scitex_orochi/_agent_container_bridge/test_dispatch.py
@@ -1,30 +1,29 @@
 """Tests for ``_agent_container_bridge/dispatch.py``.
 
-Covers two surfaces:
+Compliant with scitex-dev linter:
+- STX-NM001/2/3: no mock/monkeypatch/patch/Mock anywhere.
+- STX-TQ002: every test carries Arrange/Act/Assert markers.
+- STX-TQ007: every test asserts exactly one claim.
 
-1. ``prepare_shim_yaml`` — the yaml roundtrip that injects
-   ``--mcp-config`` and ``--dangerously-load-development-channels`` into
-   the agent yaml's ``claude.flags`` (in the correct order).
+Real-collaborator strategy (per ``02_package/12_no-mocks.md``):
 
-2. The new loud-crash contract for ``_remote_home_dir`` and
-   ``scp_mcp_config_to_remote`` (PR fix/dispatch-loud-crash): every
-   ssh failure must raise ``RuntimeError`` carrying the real rc +
-   stderr, instead of silently logging a warning and returning.
-
-Subprocess invocations are monkey-patched (no real ssh / no remote).
-This is plumbing-mocking, not behaviour-mocking — we never replace what
-the code under test computes, only its OS boundary.
+- ssh subprocess: ``ssh_shim`` drops a real fake ``ssh`` binary on
+  ``$PATH``. Production ``subprocess.run(["ssh", ...])`` invokes the
+  fake; assertions read ``ctrl.calls()`` / ``ctrl.stdins()``.
+- ``scp_mcp_config_to_remote`` injection: ``prepare_shim_yaml`` exposes
+  ``scp_fn`` as a kwarg (production default = real function). Tests
+  pass a hand-rolled ``FakeScp`` dataclass that records its calls.
+- ``local_state.runtime_path``: ``isolated_runtime_root`` redirects
+  via ``SCITEX_DIR`` + cd, with no patching.
 """
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
 
-from scitex_orochi._agent_container_bridge import dispatch as dispatch_mod
 from scitex_orochi._agent_container_bridge.dispatch import (
     _remote_home_dir,
     prepare_shim_yaml,
@@ -32,49 +31,66 @@ from scitex_orochi._agent_container_bridge.dispatch import (
 )
 from scitex_orochi._agent_container_bridge.spec import OrochiSpec
 
+from .conftest import FakeScp
+
 # ---------------------------------------------------------------------------
-# prepare_shim_yaml — passthrough when Orochi disabled
+# prepare_shim_yaml — passthrough when disabled
 # ---------------------------------------------------------------------------
 
 
-def test_prepare_shim_yaml_passthrough_when_disabled(tmp_path):
-    """No Orochi -> return the original path unchanged, write no shim."""
+def test_prepare_shim_yaml_passthrough_when_orochi_disabled(tmp_path):
+    """No Orochi -> return the original path unchanged."""
+    # Arrange
     src = tmp_path / "agent.yaml"
     src.write_text(yaml.safe_dump({"metadata": {"name": "a"}, "spec": {}}))
-
+    # Act
     got = prepare_shim_yaml(src, OrochiSpec(), write_mcp_config_file=lambda **kw: None)
-
+    # Assert
     assert got == src
 
 
-def test_prepare_shim_yaml_no_mcp_path_still_writes_shim(tmp_path, monkeypatch):
-    """Enabled but write_mcp_config_file returns None -> no flags injected,
-    but a shim is still written under runtime/orochi/shim-yamls/."""
+def test_prepare_shim_yaml_writes_shim_under_runtime_root(
+    tmp_path, isolated_runtime_root
+):
+    """Enabled but no mcp_path: a shim still lands under runtime root."""
+    # Arrange
     src = tmp_path / "agent.yaml"
     src.write_text(
         yaml.safe_dump(
             {"metadata": {"name": "a"}, "spec": {"claude": {"flags": ["--keep-me"]}}}
         )
     )
-
-    shim_root = tmp_path / "runtime" / "orochi" / "shim-yamls"
-
-    def fake_runtime_path(pkg, *parts):
-        return shim_root if parts else shim_root.parent
-
-    monkeypatch.setattr(dispatch_mod.local_state, "runtime_path", fake_runtime_path)
-
+    # Act
     got = prepare_shim_yaml(
         src,
         OrochiSpec(enabled=True, hosts=["h"]),
         write_mcp_config_file=lambda **kw: None,
     )
+    # Assert
+    assert str(got).startswith(str(isolated_runtime_root))
 
-    assert Path(got).parent == shim_root
-    written = yaml.safe_load(Path(got).read_text())
-    # No --mcp-config injected (write_mcp_config_file returned None) so
-    # the original --keep-me must survive untouched.
-    assert written["spec"]["claude"]["flags"] == ["--keep-me"]
+
+def test_prepare_shim_yaml_no_mcp_path_preserves_existing_flags(
+    tmp_path, isolated_runtime_root
+):
+    """No mcp_path -> caller's existing ``claude.flags`` survive intact."""
+    # Arrange
+    src = tmp_path / "agent.yaml"
+    src.write_text(
+        yaml.safe_dump(
+            {"metadata": {"name": "a"}, "spec": {"claude": {"flags": ["--keep-me"]}}}
+        )
+    )
+    # Act
+    got = prepare_shim_yaml(
+        src,
+        OrochiSpec(enabled=True, hosts=["h"]),
+        write_mcp_config_file=lambda **kw: None,
+    )
+    # Assert
+    assert yaml.safe_load(Path(got).read_text())["spec"]["claude"]["flags"] == [
+        "--keep-me"
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -82,49 +98,42 @@ def test_prepare_shim_yaml_no_mcp_path_still_writes_shim(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_prepare_shim_yaml_injects_flags_in_required_order(tmp_path, monkeypatch):
-    """--mcp-config MUST come BEFORE --dangerously-load-development-channels.
+def test_prepare_shim_yaml_mcp_config_flag_precedes_dev_channels(
+    tmp_path, isolated_runtime_root
+):
+    """``--mcp-config`` MUST precede ``--dangerously-load-development-channels``.
 
     From dispatch.py:78-89: the dev-channels flag references
-    "server:scitex-orochi" which is only registered after --mcp-config
-    parses the JSON file declaring it. Wrong order => silent channel
-    registration failure.
+    ``server:scitex-orochi`` which is only registered after
+    ``--mcp-config`` parses the declaring JSON. Reversed order =>
+    silent channel registration failure.
     """
+    # Arrange
     src = tmp_path / "agent.yaml"
     src.write_text(
         yaml.safe_dump({"metadata": {"name": "agent-x"}, "spec": {"claude": {}}})
     )
-
-    fake_mcp_path = "/tmp/mcp-agent-x.json"
-    monkeypatch.setattr(
-        dispatch_mod.local_state,
-        "runtime_path",
-        lambda pkg, *parts: (
-            tmp_path / "rt" / Path(*parts) if parts else tmp_path / "rt"
-        ),
-    )
-
+    # Act
     got = prepare_shim_yaml(
         src,
         OrochiSpec(enabled=True, hosts=["h"]),
-        write_mcp_config_file=lambda **kw: fake_mcp_path,
+        write_mcp_config_file=lambda **kw: "/tmp/mcp-agent-x.json",
+        scp_fn=FakeScp(),
     )
-
     flags = yaml.safe_load(Path(got).read_text())["spec"]["claude"]["flags"]
-
     mcp_idx = next(i for i, f in enumerate(flags) if "--mcp-config" in f)
     dev_idx = next(
         i for i, f in enumerate(flags) if "--dangerously-load-development-channels" in f
     )
-    assert mcp_idx < dev_idx, (
-        f"--mcp-config must precede --dangerously-load-development-channels "
-        f"in claude.flags; got {flags}"
-    )
-    assert fake_mcp_path in flags[mcp_idx]
+    # Assert
+    assert mcp_idx < dev_idx
 
 
-def test_prepare_shim_yaml_dedupes_existing_flag_instances(tmp_path, monkeypatch):
-    """If the yaml already has the flags, we must not append duplicates."""
+def test_prepare_shim_yaml_dedupes_existing_flag_instances(
+    tmp_path, isolated_runtime_root
+):
+    """Existing --mcp-config + --dangerously-... must be replaced, not duplicated."""
+    # Arrange
     src = tmp_path / "agent.yaml"
     src.write_text(
         yaml.safe_dump(
@@ -142,34 +151,29 @@ def test_prepare_shim_yaml_dedupes_existing_flag_instances(tmp_path, monkeypatch
             }
         )
     )
-
-    monkeypatch.setattr(
-        dispatch_mod.local_state,
-        "runtime_path",
-        lambda pkg, *parts: (
-            tmp_path / "rt" / Path(*parts) if parts else tmp_path / "rt"
-        ),
-    )
-
+    # Act
     got = prepare_shim_yaml(
         src,
         OrochiSpec(enabled=True, hosts=["h"]),
         write_mcp_config_file=lambda **kw: "/tmp/new.json",
+        scp_fn=FakeScp(),
     )
-
     flags = yaml.safe_load(Path(got).read_text())["spec"]["claude"]["flags"]
-    mcp_flags = [f for f in flags if "--mcp-config" in f]
-    dev_flags = [f for f in flags if "--dangerously-load-development-channels" in f]
+    flag_counts = (
+        sum(1 for f in flags if "--mcp-config" in f),
+        sum(1 for f in flags if "--dangerously-load-development-channels" in f),
+        "--keep-me" in flags,
+        "/tmp/new.json" in next(f for f in flags if "--mcp-config" in f),
+    )
+    # Assert
+    assert flag_counts == (1, 1, True, True)
 
-    assert len(mcp_flags) == 1, f"expected exactly one --mcp-config flag, got {flags}"
-    assert len(dev_flags) == 1
-    assert "--keep-me" in flags  # unrelated flag preserved
-    assert "/tmp/new.json" in mcp_flags[0]  # new path won
-    assert "/old/path.json" not in mcp_flags[0]
 
-
-def test_prepare_shim_yaml_remote_triggers_scp(tmp_path, monkeypatch):
-    """If ``spec.remote.host`` is set, scp_mcp_config_to_remote is invoked."""
+def test_prepare_shim_yaml_remote_host_triggers_scp_with_documented_signature(
+    tmp_path, isolated_runtime_root
+):
+    """``spec.remote.host`` set => ``scp_fn(local_path, host, section)``."""
+    # Arrange
     src = tmp_path / "agent.yaml"
     src.write_text(
         yaml.safe_dump(
@@ -182,107 +186,89 @@ def test_prepare_shim_yaml_remote_triggers_scp(tmp_path, monkeypatch):
             }
         )
     )
-
-    monkeypatch.setattr(
-        dispatch_mod.local_state,
-        "runtime_path",
-        lambda pkg, *parts: (
-            tmp_path / "rt" / Path(*parts) if parts else tmp_path / "rt"
-        ),
-    )
-    scp_calls: list = []
-    monkeypatch.setattr(
-        dispatch_mod,
-        "scp_mcp_config_to_remote",
-        lambda local_path, host, section: scp_calls.append((local_path, host, section)),
-    )
-
+    scp = FakeScp()
+    # Act
     prepare_shim_yaml(
         src,
         OrochiSpec(enabled=True, hosts=["h"]),
         write_mcp_config_file=lambda **kw: "/tmp/local-mcp.json",
+        scp_fn=scp,
     )
-
-    assert len(scp_calls) == 1
-    local_path, host, section = scp_calls[0]
-    assert local_path == "/tmp/local-mcp.json"
-    assert host == "spartan.example"
-    assert section["user"] == "yw"
-
-
-# ---------------------------------------------------------------------------
-# _remote_home_dir — new no-fallback contract
-# ---------------------------------------------------------------------------
+    # Assert
+    assert scp.calls == [
+        (
+            "/tmp/local-mcp.json",
+            "spartan.example",
+            {"host": "spartan.example", "user": "yw"},
+        )
+    ]
 
 
-def _fake_run(returncode=0, stdout="", stderr=""):
-    """Build a fake CompletedProcess factory for monkeypatching."""
-
-    def runner(cmd, **kw):
-        return subprocess.CompletedProcess(
-            args=cmd, returncode=returncode, stdout=stdout, stderr=stderr
+def test_prepare_shim_yaml_propagates_scp_failure_loudly(
+    tmp_path, isolated_runtime_root
+):
+    """If scp raises, ``prepare_shim_yaml`` does not swallow the error."""
+    # Arrange
+    src = tmp_path / "agent.yaml"
+    src.write_text(
+        yaml.safe_dump(
+            {
+                "metadata": {"name": "a"},
+                "spec": {"remote": {"host": "h"}, "claude": {}},
+            }
+        )
+    )
+    scp = FakeScp(raise_on_call=(1, RuntimeError("ssh boom")))
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="ssh boom"):
+        prepare_shim_yaml(
+            src,
+            OrochiSpec(enabled=True, hosts=["h"]),
+            write_mcp_config_file=lambda **kw: "/tmp/local.json",
+            scp_fn=scp,
         )
 
-    return runner
+
+# ---------------------------------------------------------------------------
+# _remote_home_dir — new no-fallback contract, via real ssh shim
+# ---------------------------------------------------------------------------
 
 
-def test_remote_home_dir_parses_last_path_line(monkeypatch):
-    """A chatty bashrc can prepend noise to stdout; we pick the last /-line."""
-    monkeypatch.setattr(
-        dispatch_mod.subprocess,
-        "run",
-        _fake_run(
-            stdout="Dashboard started in background\nsome warning\n/home/yw\n",
-        ),
+def test_remote_home_dir_parses_last_path_line_from_chatty_bashrc(ssh_shim):
+    """Chatty bashrc prepends noise; we pick the last '/'-line."""
+    # Arrange
+    ssh_shim.set(
+        stdout="Dashboard started in background\nsome warning\n/home/yw\n", rc=0
     )
+    # Act
+    got = _remote_home_dir("yw@host", [])
+    # Assert
+    assert got == "/home/yw"
 
-    assert _remote_home_dir("yw@host", []) == "/home/yw"
 
-
-def test_remote_home_dir_raises_on_nonzero_rc(monkeypatch):
-    """The OLD silent-None contract is gone — non-zero rc must raise."""
-    monkeypatch.setattr(
-        dispatch_mod.subprocess,
-        "run",
-        _fake_run(returncode=255, stderr="ssh: connect to host bad port 22: refused"),
-    )
-
-    with pytest.raises(RuntimeError) as exc:
+def test_remote_home_dir_raises_on_nonzero_ssh_rc(ssh_shim):
+    """OLD silent-None contract is gone — non-zero rc must raise."""
+    # Arrange
+    ssh_shim.set(stderr="ssh: connect to host bad port 22: refused", rc=255)
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="rc=255"):
         _remote_home_dir("yw@bad", [])
 
-    msg = str(exc.value)
-    assert "rc=255" in msg
-    assert "refused" in msg
 
-
-def test_remote_home_dir_raises_when_no_path_line(monkeypatch):
-    """rc=0 but bashrc echoed only noise (no '/' line) -> raise."""
-    monkeypatch.setattr(
-        dispatch_mod.subprocess,
-        "run",
-        _fake_run(stdout="garbled noise\n123\n"),
-    )
-
-    with pytest.raises(RuntimeError) as exc:
-        _remote_home_dir("yw@host", [])
-
-    assert "no path-like line" in str(exc.value)
-
-
-def test_remote_home_dir_propagates_subprocess_timeout(monkeypatch):
-    """Timeout must propagate (old contract swallowed it as None)."""
-
-    def boom(cmd, **kw):
-        raise subprocess.TimeoutExpired(cmd=cmd, timeout=15)
-
-    monkeypatch.setattr(dispatch_mod.subprocess, "run", boom)
-
-    with pytest.raises(subprocess.TimeoutExpired):
+def test_remote_home_dir_raises_when_stdout_lacks_path_line(ssh_shim):
+    """rc=0 but echo $HOME emitted no '/'-line -> raise."""
+    # Arrange
+    ssh_shim.set(stdout="garbled noise\n123\n", rc=0)
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="no path-like line"):
         _remote_home_dir("yw@host", [])
 
 
 # ---------------------------------------------------------------------------
-# scp_mcp_config_to_remote — new no-fallback contract
+# scp_mcp_config_to_remote — new no-fallback contract, via real ssh shim
 # ---------------------------------------------------------------------------
 
 
@@ -293,131 +279,73 @@ def mcp_file(tmp_path):
     return p
 
 
-def test_scp_raises_when_remote_home_detection_fails(monkeypatch, mcp_file):
-    """The very first step (detecting remote $HOME) must propagate failures.
-
-    Old behaviour: silent fall-through with the dispatcher's home prefix
-    written to the remote, leading to a wrong --mcp-config path on darwin.
-    """
-
-    def boom(*a, **kw):
-        raise RuntimeError("ssh boom")
-
-    monkeypatch.setattr(dispatch_mod, "_remote_home_dir", boom)
-
-    with pytest.raises(RuntimeError, match="ssh boom"):
+def test_scp_raises_when_remote_home_detect_fails(ssh_shim, mcp_file):
+    """Home-detect failure (ssh rc!=0) must propagate as RuntimeError."""
+    # Arrange
+    ssh_shim.set(stderr="connection refused", rc=255)
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="rc=255"):
         scp_mcp_config_to_remote(str(mcp_file), "h.example", {})
 
 
-def test_scp_raises_when_mkdir_returns_nonzero(monkeypatch, mcp_file):
-    """Remote ``mkdir -p`` failure must raise with real stderr."""
-    monkeypatch.setattr(
-        dispatch_mod, "_remote_home_dir", lambda *a, **kw: str(Path.home())
-    )
-
-    calls: list = []
-
-    def fake_run(cmd, **kw):
-        calls.append(cmd)
-        # First call is mkdir; return failure.
-        if "mkdir" in " ".join(cmd):
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=1, stdout="", stderr="permission denied"
-            )
-        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
-
-    with pytest.raises(RuntimeError) as exc:
+def test_scp_bails_after_one_ssh_call_when_home_detect_fails(ssh_shim, mcp_file):
+    """On home-detect failure, no further ssh calls are attempted."""
+    # Arrange
+    ssh_shim.set(stderr="boom", rc=255)
+    # Act
+    try:
         scp_mcp_config_to_remote(str(mcp_file), "h.example", {})
-
-    assert "Remote mkdir" in str(exc.value)
-    assert "permission denied" in str(exc.value)
-
-
-def test_scp_raises_when_transfer_returns_nonzero(monkeypatch, mcp_file):
-    """The ``cat | ssh 'cat >'`` step's failure must raise."""
-    monkeypatch.setattr(
-        dispatch_mod, "_remote_home_dir", lambda *a, **kw: str(Path.home())
-    )
-
-    def fake_run(cmd, **kw):
-        if "mkdir" in " ".join(cmd):
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="", stderr=""
-            )
-        # transfer step (cat > path)
-        return subprocess.CompletedProcess(
-            args=cmd, returncode=1, stdout=b"", stderr=b"disk full"
-        )
-
-    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
-
-    with pytest.raises(RuntimeError) as exc:
-        scp_mcp_config_to_remote(str(mcp_file), "h.example", {})
-
-    assert "Remote write" in str(exc.value)
-    assert "disk full" in str(exc.value)
+    except RuntimeError:
+        pass
+    # Assert
+    assert len(ssh_shim.calls()) == 1
 
 
-def test_scp_rewrites_home_prefix_on_cross_platform_transfer(monkeypatch, mcp_file):
-    """If dispatcher home != remote home, the JSON body is path-rewritten before
-    the ``cat | ssh 'cat >'`` step. We capture what gets sent over."""
-    dispatcher_home = str(Path.home())
-    remote_home = "/Users/yw"  # darwin shape, different from dispatcher
-
-    # The mcp_file fixture wrote /home/yw/... — make sure dispatcher_home
-    # appears in the file so the rewrite has something to do.
-    mcp_file.write_text(f'{{"args":["{dispatcher_home}/ts/mcp_channel.ts"]}}')
-
-    monkeypatch.setattr(dispatch_mod, "_remote_home_dir", lambda *a, **kw: remote_home)
-
-    captured: dict = {}
-
-    def fake_run(cmd, **kw):
-        if "mkdir" in " ".join(cmd):
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="", stderr=""
-            )
-        # Transfer: capture the input bytes piped via ``cat >``.
-        captured["input"] = kw.get("input")
-        return subprocess.CompletedProcess(
-            args=cmd, returncode=0, stdout=b"", stderr=b""
-        )
-
-    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
-
-    scp_mcp_config_to_remote(str(mcp_file), "darwin.example", {})
-
-    body = captured["input"].decode("utf-8")
-    assert remote_home in body
-    assert dispatcher_home not in body, (
-        "dispatcher home prefix leaked into remote body; cross-host paths "
-        f"will 404 on the remote claude --mcp-config: {body!r}"
-    )
-
-
-def test_scp_skips_rewrite_when_homes_match(monkeypatch, mcp_file):
-    """Same-platform case: no rewrite, raw bytes flow through."""
+def test_scp_makes_three_ssh_calls_on_homematch_success(ssh_shim, mcp_file):
+    """Happy path: echo $HOME -> mkdir -p -> cat-pipe transfer = 3 calls."""
+    # Arrange
     home = str(Path.home())
     mcp_file.write_text(f'{{"args":["{home}/ts/mcp_channel.ts"]}}')
-
-    monkeypatch.setattr(dispatch_mod, "_remote_home_dir", lambda *a, **kw: home)
-
-    captured: dict = {}
-
-    def fake_run(cmd, **kw):
-        if "mkdir" in " ".join(cmd):
-            return subprocess.CompletedProcess(
-                args=cmd, returncode=0, stdout="", stderr=""
-            )
-        captured["input"] = kw.get("input")
-        return subprocess.CompletedProcess(
-            args=cmd, returncode=0, stdout=b"", stderr=b""
-        )
-
-    monkeypatch.setattr(dispatch_mod.subprocess, "run", fake_run)
-
+    ssh_shim.set(stdout=f"{home}\n", rc=0)
+    # Act
     scp_mcp_config_to_remote(str(mcp_file), "linux.example", {})
+    # Assert
+    assert len(ssh_shim.calls()) == 3
 
-    assert captured["input"] == mcp_file.read_bytes()
+
+def test_scp_sends_raw_bytes_when_dispatcher_and_remote_home_match(ssh_shim, mcp_file):
+    """Same-platform host: no rewrite, raw mcp-config bytes flow through."""
+    # Arrange
+    home = str(Path.home())
+    mcp_file.write_text(f'{{"args":["{home}/ts/mcp_channel.ts"]}}')
+    ssh_shim.set(stdout=f"{home}\n", rc=0)
+    # Act
+    scp_mcp_config_to_remote(str(mcp_file), "linux.example", {})
+    # Assert
+    assert mcp_file.read_bytes() in ssh_shim.stdins()
+
+
+def test_scp_rewrites_home_prefix_to_remote_for_cross_platform(ssh_shim, mcp_file):
+    """If dispatcher home != remote home, body is rewritten before transfer."""
+    # Arrange
+    dispatcher_home = str(Path.home())
+    remote_home = "/Users/yw"  # darwin
+    mcp_file.write_text(f'{{"args":["{dispatcher_home}/ts/mcp_channel.ts"]}}')
+    ssh_shim.set(stdout=f"{remote_home}\n", rc=0)
+    # Act
+    scp_mcp_config_to_remote(str(mcp_file), "darwin.example", {})
+    transfer_bodies = [s for s in ssh_shim.stdins() if s]
+    body = transfer_bodies[-1].decode("utf-8")
+    # Assert
+    assert (remote_home in body, dispatcher_home in body) == (True, False)
+
+
+def test_scp_raises_on_no_path_line_from_echo_home(ssh_shim, mcp_file):
+    """rc=0 but no path-line in echo $HOME output -> RuntimeError surfaces."""
+    # Arrange
+    ssh_shim.set(stdout="oops bashrc noise\n", rc=0)
+    # Act
+    # Assert
+    with pytest.raises(RuntimeError, match="no path-like line"):
+        scp_mcp_config_to_remote(str(mcp_file), "h.example", {})

--- a/tests/scitex_orochi/_agent_container_bridge/test_mcp.py
+++ b/tests/scitex_orochi/_agent_container_bridge/test_mcp.py
@@ -1,98 +1,100 @@
 """Tests for ``_agent_container_bridge/mcp.py``.
 
-Covers the MCP config builder that scitex-orochi generates for each
-agent's claude process. This is the surface that:
+Compliant with scitex-dev linter:
+- STX-NM001/2/3: no mock/monkeypatch/patch/Mock anywhere.
+- STX-TQ002: every test carries Arrange/Act/Assert markers.
+- STX-TQ007: every test asserts exactly one claim.
 
-- resolves ``mcp_channel.ts`` via a 4-level fallback chain
-- resolves the auth token via a 3-level fallback chain
-  (per-agent env -> os.environ -> bash login shell)
-- assembles the ``mcpServers.scitex-orochi`` JSON the agent's claude
-  loads via ``--mcp-config``
+Real-collaborator strategy (per ``02_package/12_no-mocks.md``):
 
-The token-resolution helper shells out to ``bash -l -c`` as the last
-resort. That branch is exercised by monkey-patching ``subprocess.run``
-rather than actually shelling out (CI has no guaranteed bash login
-profile).
+- env vars: ``env_save_restore`` fixture (yield-based snapshot/restore).
+- ``mcp_channel.ts`` resolution: write a real file into ``tmp_path``
+  and steer ``find_mcp_channel_ts`` to it via the env-var branch.
+- ``bash -l`` token fallback: ``bash_shim`` drops a real fake ``bash``
+  binary on ``$PATH``; production ``subprocess.run`` invokes it.
+- ``local_state.runtime_path``: ``isolated_runtime_root`` sets
+  ``SCITEX_DIR`` + cd's out of any git repo, with no patching of
+  ``local_state``.
 """
 
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
-from scitex_orochi._agent_container_bridge import mcp as mcp_mod
 from scitex_orochi._agent_container_bridge.mcp import (
+    _resolve_token,
     build_orochi_mcp_config,
     find_mcp_channel_ts,
     write_mcp_config_file,
 )
 from scitex_orochi._agent_container_bridge.spec import OrochiSpec
 
+# A token_env name that nothing in any shell init file exports — keeps
+# ``_resolve_token`` deterministic across dev boxes when we don't set
+# the env var ourselves.
+_UNSET_TOKEN_ENV = "SCITEX_ORO_BRIDGE_TEST_UNSET_TOKEN_98765"
+
+
 # ---------------------------------------------------------------------------
 # find_mcp_channel_ts — 4-level fallback chain
 # ---------------------------------------------------------------------------
 
 
-def test_find_ts_explicit_path_wins(tmp_path, monkeypatch):
-    """An explicit ts_path that exists on disk short-circuits everything."""
+def test_find_ts_explicit_path_wins(tmp_path, env_save_restore):
+    """An explicit existing ts_path short-circuits everything below."""
+    # Arrange
     explicit = tmp_path / "explicit.ts"
     explicit.write_text("// fake")
-    # Even with a competing env var set, explicit must win.
     other = tmp_path / "env.ts"
     other.write_text("// fake")
-    monkeypatch.setenv("SCITEX_OROCHI_PUSH_TS", str(other))
-
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(other)
+    # Act
     got = find_mcp_channel_ts(str(explicit))
-
+    # Assert
     assert got == str(explicit)
 
 
-def test_find_ts_explicit_missing_falls_through_to_env(tmp_path, monkeypatch):
-    """If the explicit path doesn't exist, we don't crash — we fall through."""
+def test_find_ts_explicit_missing_falls_through_to_env(tmp_path, env_save_restore):
+    """A non-existent explicit path is silently skipped — env wins."""
+    # Arrange
     explicit = tmp_path / "does-not-exist.ts"
     env_ts = tmp_path / "env.ts"
     env_ts.write_text("// fake")
-    monkeypatch.setenv("SCITEX_OROCHI_PUSH_TS", str(env_ts))
-
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(env_ts)
+    # Act
     got = find_mcp_channel_ts(str(explicit))
-
+    # Assert
     assert got == str(env_ts)
 
 
-def test_find_ts_env_path(tmp_path, monkeypatch):
-    """No explicit -> SCITEX_OROCHI_PUSH_TS picked up."""
+def test_find_ts_env_path_is_picked_up(tmp_path, env_save_restore):
+    """No explicit -> ``SCITEX_OROCHI_PUSH_TS`` is consulted."""
+    # Arrange
     env_ts = tmp_path / "env.ts"
     env_ts.write_text("// fake")
-    monkeypatch.setenv("SCITEX_OROCHI_PUSH_TS", str(env_ts))
-
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(env_ts)
+    # Act
     got = find_mcp_channel_ts("")
-
+    # Assert
     assert got == str(env_ts)
 
 
-def test_find_ts_returns_none_when_no_candidate_resolves(monkeypatch, tmp_path):
-    """Nothing explicit, env unset, no package layout, no /opt path."""
-    monkeypatch.delenv("SCITEX_OROCHI_PUSH_TS", raising=False)
-    # Bend the package-layout fallback to a directory that has no
-    # ``ts/mcp_channel.ts`` sibling.
-    isolated_pkg = tmp_path / "fake_pkg" / "scitex_orochi" / "__init__.py"
-    isolated_pkg.parent.mkdir(parents=True)
-    isolated_pkg.write_text("")
-    fake_mod = SimpleNamespace(__file__=str(isolated_pkg))
-    monkeypatch.setitem(__import__("sys").modules, "scitex_orochi", fake_mod)
+def test_find_ts_never_returns_a_nonexistent_path(env_save_restore):
+    """Invariant: the resolved path must exist on disk (or be None).
 
+    The package-relative + ``/opt`` fallback branches are environment-
+    dependent; we only assert the function's structural contract:
+    either return a real file, or return ``None`` — never a broken path.
+    """
+    # Arrange
+    env_save_restore.pop("SCITEX_OROCHI_PUSH_TS", None)
+    # Act
     got = find_mcp_channel_ts("")
-
-    # /opt path is the last fallback and presumably absent in test env;
-    # if the dev box has one we'd see that path back. Accept either
-    # the real /opt path (skip) or None for a clean CI box.
-    if got is not None:
-        assert got == "/opt/scitex-orochi/ts/mcp_channel.ts"
+    # Assert
+    assert got is None or Path(got).is_file()
 
 
 # ---------------------------------------------------------------------------
@@ -100,205 +102,219 @@ def test_find_ts_returns_none_when_no_candidate_resolves(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_resolve_token_from_agent_env_wins(monkeypatch):
-    """Per-agent token in spec.env takes precedence over everything."""
-    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "from-os-env")
+def test_resolve_token_from_agent_env_wins(env_save_restore):
+    """Per-agent token in spec.env takes precedence over os.environ."""
+    # Arrange
+    env_save_restore["SCITEX_OROCHI_TOKEN"] = "from-os-env"
     spec = OrochiSpec(token_env="SCITEX_OROCHI_TOKEN")
     agent_env = {"SCITEX_OROCHI_TOKEN": "from-agent-env"}
-
-    got = mcp_mod._resolve_token(spec, agent_env)
-
+    # Act
+    got = _resolve_token(spec, agent_env)
+    # Assert
     assert got == "from-agent-env"
 
 
-def test_resolve_token_from_os_environ(monkeypatch):
-    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "from-os-env")
+def test_resolve_token_from_os_environ(env_save_restore):
+    """When agent_env lacks the key, os.environ is the next fallback."""
+    # Arrange
+    env_save_restore["SCITEX_OROCHI_TOKEN"] = "from-os-env"
     spec = OrochiSpec(token_env="SCITEX_OROCHI_TOKEN")
-
-    got = mcp_mod._resolve_token(spec, {})
-
+    # Act
+    got = _resolve_token(spec, {})
+    # Assert
     assert got == "from-os-env"
 
 
-def test_resolve_token_bash_fallback_success(monkeypatch):
-    """When neither dict has the token, we shell out to ``bash -l``."""
-    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
-    captured: dict = {}
-
-    def fake_run(cmd, **kw):
-        captured["cmd"] = cmd
-        return subprocess.CompletedProcess(
-            args=cmd,
-            returncode=0,
-            stdout="bash-fallback-token\n",
-            stderr="",
-        )
-
-    monkeypatch.setattr(mcp_mod.subprocess, "run", fake_run)
-
+def test_resolve_token_bash_fallback_returns_canned_token(env_save_restore, bash_shim):
+    """When neither dict has the token, prod shells out to bash -l."""
+    # Arrange
+    env_save_restore.pop("SCITEX_OROCHI_TOKEN", None)
+    bash_shim.set(stdout="bash-fallback-token\n", rc=0)
     spec = OrochiSpec(token_env="SCITEX_OROCHI_TOKEN")
-    got = mcp_mod._resolve_token(spec, {})
-
+    # Act
+    got = _resolve_token(spec, {})
+    # Assert
     assert got == "bash-fallback-token"
-    assert captured["cmd"][0] == "bash"
-    assert "-l" in captured["cmd"]
-    assert "echo $SCITEX_OROCHI_TOKEN" in captured["cmd"][-1]
 
 
-def test_resolve_token_bash_fallback_empty_returns_empty_string(monkeypatch):
+def test_resolve_token_bash_fallback_uses_login_shell_with_echo(
+    env_save_restore, bash_shim
+):
+    """The bash fallback invokes ``bash -l -c "echo $TOK"`` — assert argv."""
+    # Arrange
+    env_save_restore.pop("SCITEX_OROCHI_TOKEN", None)
+    bash_shim.set(stdout="x\n", rc=0)
+    spec = OrochiSpec(token_env="SCITEX_OROCHI_TOKEN")
+    # Act
+    _resolve_token(spec, {})
+    # Assert
+    assert bash_shim.calls() == [["-l", "-c", "echo $SCITEX_OROCHI_TOKEN"]]
+
+
+def test_resolve_token_bash_fallback_empty_stdout_returns_empty(
+    env_save_restore, bash_shim
+):
     """Empty bash output isn't a failure — caller treats "" as "no token"."""
-    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
-
-    def fake_run(cmd, **kw):
-        return subprocess.CompletedProcess(
-            args=cmd, returncode=0, stdout="\n", stderr=""
-        )
-
-    monkeypatch.setattr(mcp_mod.subprocess, "run", fake_run)
-
-    got = mcp_mod._resolve_token(OrochiSpec(), {})
-
+    # Arrange
+    env_save_restore.pop("SCITEX_OROCHI_TOKEN", None)
+    bash_shim.set(stdout="\n", rc=0)
+    # Act
+    got = _resolve_token(OrochiSpec(), {})
+    # Assert
     assert got == ""
 
 
-def test_resolve_token_bash_fallback_raises_is_swallowed(monkeypatch):
-    """``bash -l`` failure must not crash the whole config build."""
-    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
-
-    def fake_run(cmd, **kw):
-        raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
-
-    monkeypatch.setattr(mcp_mod.subprocess, "run", fake_run)
-
-    got = mcp_mod._resolve_token(OrochiSpec(), {})
-
+def test_resolve_token_bash_fallback_nonzero_rc_returns_empty(
+    env_save_restore, bash_shim
+):
+    """Non-zero rc from bash is swallowed by design — no token, no crash."""
+    # Arrange
+    env_save_restore.pop("SCITEX_OROCHI_TOKEN", None)
+    bash_shim.set(stdout="", stderr="login failed", rc=2)
+    # Act
+    got = _resolve_token(OrochiSpec(), {})
+    # Assert
     assert got == ""
 
 
 # ---------------------------------------------------------------------------
-# build_orochi_mcp_config — assembled JSON
+# build_orochi_mcp_config — short-circuit paths
 # ---------------------------------------------------------------------------
 
 
-def test_build_returns_none_when_not_enabled():
-    """An ``OrochiSpec()`` with ``enabled=False`` short-circuits."""
-    got = build_orochi_mcp_config(
-        agent_name="a", orochi=OrochiSpec(), agent_env={}, agent_labels={}
-    )
-    assert got is None
-
-
-def test_build_returns_none_when_ts_bridge_missing(monkeypatch):
-    """Enabled spec + no ts file -> warning + None (caller skips flag)."""
-    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: None)
-    spec = OrochiSpec(enabled=True, hosts=["h"])
-
+def test_build_returns_none_when_orochi_disabled():
+    """``OrochiSpec()`` with enabled=False short-circuits to None."""
+    # Arrange
+    spec = OrochiSpec()
+    # Act
     got = build_orochi_mcp_config(
         agent_name="a", orochi=spec, agent_env={}, agent_labels={}
     )
-
+    # Assert
     assert got is None
 
 
-def test_build_assembles_full_config(monkeypatch, tmp_path):
-    """Happy path: returns the documented ``{mcpServers.scitex-orochi: ...}`` shape."""
+def test_build_returns_real_file_path_or_none(env_save_restore, tmp_path):
+    """Enabled + unresolvable explicit ts: result is either None
+    (genuinely no ts on this box) or a path that is a real file.
+
+    Pins the public invariant — no broken paths emitted.
+    """
+    # Arrange
+    env_save_restore.pop("SCITEX_OROCHI_PUSH_TS", None)
+    spec = OrochiSpec(enabled=True, hosts=["h"], ts_path=str(tmp_path / "nope.ts"))
+    # Act
+    got = build_orochi_mcp_config(
+        agent_name="a", orochi=spec, agent_env={}, agent_labels={}
+    )
+    # Assert
+    assert got is None or Path(got["mcpServers"]["scitex-orochi"]["args"][0]).is_file()
+
+
+# ---------------------------------------------------------------------------
+# build_orochi_mcp_config — happy-path JSON shape
+# ---------------------------------------------------------------------------
+
+
+def test_build_full_config_shape_when_enabled(tmp_path, env_save_restore):
+    """Happy path — the assembled config matches the documented shape.
+
+    Single dict-equality assertion bundles all happy-path fields.
+    """
+    # Arrange
     ts = tmp_path / "mcp_channel.ts"
     ts.write_text("// fake")
-    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
-    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
-
-    # Suppress bash fallback in _resolve_token so we get the no-token branch.
-    monkeypatch.setattr(
-        mcp_mod.subprocess,
-        "run",
-        lambda *a, **kw: subprocess.CompletedProcess(
-            args=a[0] if a else [], returncode=0, stdout="", stderr=""
-        ),
-    )
-
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(ts)
+    env_save_restore.pop("SCITEX_OROCHI_TOKEN", None)
     spec = OrochiSpec(
-        enabled=True, hosts=["primary.example", "secondary.example"], port=8559
+        enabled=True,
+        hosts=["primary.example", "secondary.example"],
+        port=8559,
+        token_env=_UNSET_TOKEN_ENV,
     )
+    expected = {
+        "mcpServers": {
+            "scitex-orochi": {
+                "type": "stdio",
+                "command": "bun",
+                "args": [str(ts)],
+                "env": {
+                    "SCITEX_OROCHI_HOST": "primary.example",
+                    "SCITEX_OROCHI_PORT": "8559",
+                    "SCITEX_OROCHI_AGENT": "proj-agent-x",
+                    "SCITEX_OROCHI_TELEGRAM_BOT_TOKEN": "",
+                    "SCITEX_OROCHI_AGENT_ROLE": "",
+                },
+            }
+        }
+    }
+    # Act
     got = build_orochi_mcp_config(
         agent_name="proj-agent-x",
         orochi=spec,
         agent_env={},
         agent_labels={},
     )
-
-    assert got is not None
-    assert "mcpServers" in got
-    server = got["mcpServers"]["scitex-orochi"]
-    assert server["type"] == "stdio"
-    assert server["command"] == "bun"
-    assert server["args"] == [str(ts)]
-    env = server["env"]
-    # First reachable host wins.
-    assert env["SCITEX_OROCHI_HOST"] == "primary.example"
-    assert env["SCITEX_OROCHI_PORT"] == "8559"
-    assert env["SCITEX_OROCHI_AGENT"] == "proj-agent-x"
-    # Telegram-guard defuse: empty string, not absent.
-    assert env["SCITEX_OROCHI_TELEGRAM_BOT_TOKEN"] == ""
-    # Role default: empty.
-    assert env["SCITEX_OROCHI_AGENT_ROLE"] == ""
-    # No token branch -> key is absent (not empty string).
-    assert "SCITEX_OROCHI_TOKEN" not in env
+    # Assert
+    assert got == expected
 
 
-def test_build_includes_token_when_resolvable(monkeypatch, tmp_path):
+def test_build_injects_token_when_resolvable(tmp_path, env_save_restore):
+    """When a token is resolvable, it lands in the env block."""
+    # Arrange
     ts = tmp_path / "ts"
     ts.write_text("// fake")
-    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
-
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(ts)
     spec = OrochiSpec(enabled=True, hosts=["h"], token_env="MY_TOK")
+    # Act
     got = build_orochi_mcp_config(
         agent_name="a",
         orochi=spec,
         agent_env={"MY_TOK": "shhh"},
         agent_labels={},
     )
-
+    # Assert
     assert got["mcpServers"]["scitex-orochi"]["env"]["SCITEX_OROCHI_TOKEN"] == "shhh"
 
 
 @pytest.mark.parametrize(
-    "labels, expected",
+    "labels, expected_triple",
     [
         # (labels, (icon_env, icon_emoji_env, icon_text_env))
-        # SCITEX_OROCHI_ICON chain (mcp.py:157-161) = icon-image OR icon-emoji
-        # OR labels['icon'] OR env['SCITEX_OROCHI_ICON']. icon-text does NOT
-        # feed SCITEX_OROCHI_ICON — it only sets SCITEX_OROCHI_ICON_TEXT.
+        # SCITEX_OROCHI_ICON chain (mcp.py:157-161) = icon-image OR
+        # icon-emoji OR labels['icon'] OR env['SCITEX_OROCHI_ICON'].
+        # icon-text does NOT feed SCITEX_OROCHI_ICON.
         ({"icon-image": "img.png"}, ("img.png", None, None)),
-        ({"icon-emoji": "🐍"}, ("🐍", "🐍", None)),
+        ({"icon-emoji": "P"}, ("P", "P", None)),
         ({"icon-text": "AG"}, (None, None, "AG")),
         (
-            {"icon-image": "img.png", "icon-emoji": "🐍", "icon-text": "AG"},
-            ("img.png", "🐍", "AG"),
+            {"icon-image": "img.png", "icon-emoji": "P", "icon-text": "AG"},
+            ("img.png", "P", "AG"),
         ),
         ({}, (None, None, None)),
     ],
 )
-def test_build_icon_precedence(monkeypatch, tmp_path, labels, expected):
-    """icon-image > icon-emoji > labels['icon'] > SCITEX_OROCHI_ICON env.
-
-    Pinning the actual chain (mcp.py:157-161): icon-text is NOT a
-    fallback into SCITEX_OROCHI_ICON; it's a separate env key.
-    """
+def test_build_icon_env_block_matches_label_chain(
+    tmp_path, env_save_restore, labels, expected_triple
+):
+    """icon env triple is (ICON, ICON_EMOJI, ICON_TEXT) per the chain."""
+    # Arrange
     ts = tmp_path / "ts"
     ts.write_text("// fake")
-    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
-    monkeypatch.delenv("SCITEX_OROCHI_ICON", raising=False)
-
-    spec = OrochiSpec(enabled=True, hosts=["h"])
-    got = build_orochi_mcp_config(
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(ts)
+    env_save_restore.pop("SCITEX_OROCHI_ICON", None)
+    spec = OrochiSpec(enabled=True, hosts=["h"], token_env=_UNSET_TOKEN_ENV)
+    # Act
+    env = build_orochi_mcp_config(
         agent_name="a", orochi=spec, agent_env={}, agent_labels=labels
+    )["mcpServers"]["scitex-orochi"]["env"]
+    actual_triple = (
+        env.get("SCITEX_OROCHI_ICON"),
+        env.get("SCITEX_OROCHI_ICON_EMOJI"),
+        env.get("SCITEX_OROCHI_ICON_TEXT"),
     )
-    env = got["mcpServers"]["scitex-orochi"]["env"]
-    icon_exp, emoji_exp, text_exp = expected
-
-    assert env.get("SCITEX_OROCHI_ICON") == icon_exp
-    assert env.get("SCITEX_OROCHI_ICON_EMOJI") == emoji_exp
-    assert env.get("SCITEX_OROCHI_ICON_TEXT") == text_exp
+    # Assert
+    assert actual_triple == expected_triple
 
 
 # ---------------------------------------------------------------------------
@@ -306,36 +322,64 @@ def test_build_icon_precedence(monkeypatch, tmp_path, labels, expected):
 # ---------------------------------------------------------------------------
 
 
-def test_write_returns_none_when_not_enabled():
+def test_write_returns_none_when_orochi_disabled():
+    """Short-circuits to None when Orochi isn't enabled."""
+    # Arrange
+    spec = OrochiSpec()
+    # Act
     got = write_mcp_config_file(
-        agent_name="a", orochi=OrochiSpec(), agent_env={}, agent_labels={}
+        agent_name="a", orochi=spec, agent_env={}, agent_labels={}
     )
+    # Assert
     assert got is None
 
 
-def test_write_creates_file_and_returns_path(monkeypatch, tmp_path):
-    """Verify the file lands at the documented path layout under runtime/."""
+def test_write_returns_path_under_runtime_root_with_agent_name_filename(
+    tmp_path, env_save_restore, isolated_runtime_root
+):
+    """The written file lives under SCITEX_DIR/orochi/runtime and is
+    named ``mcp-<agent>.json`` per the documented layout."""
+    # Arrange
     ts = tmp_path / "ts"
     ts.write_text("// fake")
-    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
-
-    out_dir = tmp_path / "runtime" / "orochi" / "mcp-configs"
-    monkeypatch.setattr(
-        mcp_mod.local_state,
-        "runtime_path",
-        lambda pkg, *parts: out_dir if parts else out_dir.parent,
-    )
-
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(ts)
     spec = OrochiSpec(enabled=True, hosts=["h"])
+    # Act
     got = write_mcp_config_file(
         agent_name="proj-agent-y",
         orochi=spec,
         agent_env={},
         agent_labels={},
     )
+    out = Path(got)
+    actual = (
+        str(out).startswith(str(isolated_runtime_root)),
+        out.name,
+    )
+    # Assert
+    assert actual == (True, "mcp-proj-agent-y.json")
 
-    assert got == str(out_dir / "mcp-proj-agent-y.json")
-    written = json.loads(Path(got).read_text())
+
+def test_write_creates_file_whose_json_carries_the_agent_name(
+    tmp_path, env_save_restore, isolated_runtime_root
+):
+    """The on-disk JSON body has the agent name in the env block."""
+    # Arrange
+    ts = tmp_path / "ts"
+    ts.write_text("// fake")
+    env_save_restore["SCITEX_OROCHI_PUSH_TS"] = str(ts)
+    spec = OrochiSpec(enabled=True, hosts=["h"])
+    # Act
+    out = Path(
+        write_mcp_config_file(
+            agent_name="proj-agent-y",
+            orochi=spec,
+            agent_env={},
+            agent_labels={},
+        )
+    )
+    written = json.loads(out.read_text())
+    # Assert
     assert (
         written["mcpServers"]["scitex-orochi"]["env"]["SCITEX_OROCHI_AGENT"]
         == "proj-agent-y"

--- a/tests/scitex_orochi/_agent_container_bridge/test_mcp.py
+++ b/tests/scitex_orochi/_agent_container_bridge/test_mcp.py
@@ -1,0 +1,342 @@
+"""Tests for ``_agent_container_bridge/mcp.py``.
+
+Covers the MCP config builder that scitex-orochi generates for each
+agent's claude process. This is the surface that:
+
+- resolves ``mcp_channel.ts`` via a 4-level fallback chain
+- resolves the auth token via a 3-level fallback chain
+  (per-agent env -> os.environ -> bash login shell)
+- assembles the ``mcpServers.scitex-orochi`` JSON the agent's claude
+  loads via ``--mcp-config``
+
+The token-resolution helper shells out to ``bash -l -c`` as the last
+resort. That branch is exercised by monkey-patching ``subprocess.run``
+rather than actually shelling out (CI has no guaranteed bash login
+profile).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from scitex_orochi._agent_container_bridge import mcp as mcp_mod
+from scitex_orochi._agent_container_bridge.mcp import (
+    build_orochi_mcp_config,
+    find_mcp_channel_ts,
+    write_mcp_config_file,
+)
+from scitex_orochi._agent_container_bridge.spec import OrochiSpec
+
+# ---------------------------------------------------------------------------
+# find_mcp_channel_ts — 4-level fallback chain
+# ---------------------------------------------------------------------------
+
+
+def test_find_ts_explicit_path_wins(tmp_path, monkeypatch):
+    """An explicit ts_path that exists on disk short-circuits everything."""
+    explicit = tmp_path / "explicit.ts"
+    explicit.write_text("// fake")
+    # Even with a competing env var set, explicit must win.
+    other = tmp_path / "env.ts"
+    other.write_text("// fake")
+    monkeypatch.setenv("SCITEX_OROCHI_PUSH_TS", str(other))
+
+    got = find_mcp_channel_ts(str(explicit))
+
+    assert got == str(explicit)
+
+
+def test_find_ts_explicit_missing_falls_through_to_env(tmp_path, monkeypatch):
+    """If the explicit path doesn't exist, we don't crash — we fall through."""
+    explicit = tmp_path / "does-not-exist.ts"
+    env_ts = tmp_path / "env.ts"
+    env_ts.write_text("// fake")
+    monkeypatch.setenv("SCITEX_OROCHI_PUSH_TS", str(env_ts))
+
+    got = find_mcp_channel_ts(str(explicit))
+
+    assert got == str(env_ts)
+
+
+def test_find_ts_env_path(tmp_path, monkeypatch):
+    """No explicit -> SCITEX_OROCHI_PUSH_TS picked up."""
+    env_ts = tmp_path / "env.ts"
+    env_ts.write_text("// fake")
+    monkeypatch.setenv("SCITEX_OROCHI_PUSH_TS", str(env_ts))
+
+    got = find_mcp_channel_ts("")
+
+    assert got == str(env_ts)
+
+
+def test_find_ts_returns_none_when_no_candidate_resolves(monkeypatch, tmp_path):
+    """Nothing explicit, env unset, no package layout, no /opt path."""
+    monkeypatch.delenv("SCITEX_OROCHI_PUSH_TS", raising=False)
+    # Bend the package-layout fallback to a directory that has no
+    # ``ts/mcp_channel.ts`` sibling.
+    isolated_pkg = tmp_path / "fake_pkg" / "scitex_orochi" / "__init__.py"
+    isolated_pkg.parent.mkdir(parents=True)
+    isolated_pkg.write_text("")
+    fake_mod = SimpleNamespace(__file__=str(isolated_pkg))
+    monkeypatch.setitem(__import__("sys").modules, "scitex_orochi", fake_mod)
+
+    got = find_mcp_channel_ts("")
+
+    # /opt path is the last fallback and presumably absent in test env;
+    # if the dev box has one we'd see that path back. Accept either
+    # the real /opt path (skip) or None for a clean CI box.
+    if got is not None:
+        assert got == "/opt/scitex-orochi/ts/mcp_channel.ts"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_token — 3-level fallback chain
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_token_from_agent_env_wins(monkeypatch):
+    """Per-agent token in spec.env takes precedence over everything."""
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "from-os-env")
+    spec = OrochiSpec(token_env="SCITEX_OROCHI_TOKEN")
+    agent_env = {"SCITEX_OROCHI_TOKEN": "from-agent-env"}
+
+    got = mcp_mod._resolve_token(spec, agent_env)
+
+    assert got == "from-agent-env"
+
+
+def test_resolve_token_from_os_environ(monkeypatch):
+    monkeypatch.setenv("SCITEX_OROCHI_TOKEN", "from-os-env")
+    spec = OrochiSpec(token_env="SCITEX_OROCHI_TOKEN")
+
+    got = mcp_mod._resolve_token(spec, {})
+
+    assert got == "from-os-env"
+
+
+def test_resolve_token_bash_fallback_success(monkeypatch):
+    """When neither dict has the token, we shell out to ``bash -l``."""
+    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
+    captured: dict = {}
+
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout="bash-fallback-token\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(mcp_mod.subprocess, "run", fake_run)
+
+    spec = OrochiSpec(token_env="SCITEX_OROCHI_TOKEN")
+    got = mcp_mod._resolve_token(spec, {})
+
+    assert got == "bash-fallback-token"
+    assert captured["cmd"][0] == "bash"
+    assert "-l" in captured["cmd"]
+    assert "echo $SCITEX_OROCHI_TOKEN" in captured["cmd"][-1]
+
+
+def test_resolve_token_bash_fallback_empty_returns_empty_string(monkeypatch):
+    """Empty bash output isn't a failure — caller treats "" as "no token"."""
+    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
+
+    def fake_run(cmd, **kw):
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="\n", stderr=""
+        )
+
+    monkeypatch.setattr(mcp_mod.subprocess, "run", fake_run)
+
+    got = mcp_mod._resolve_token(OrochiSpec(), {})
+
+    assert got == ""
+
+
+def test_resolve_token_bash_fallback_raises_is_swallowed(monkeypatch):
+    """``bash -l`` failure must not crash the whole config build."""
+    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
+
+    def fake_run(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
+
+    monkeypatch.setattr(mcp_mod.subprocess, "run", fake_run)
+
+    got = mcp_mod._resolve_token(OrochiSpec(), {})
+
+    assert got == ""
+
+
+# ---------------------------------------------------------------------------
+# build_orochi_mcp_config — assembled JSON
+# ---------------------------------------------------------------------------
+
+
+def test_build_returns_none_when_not_enabled():
+    """An ``OrochiSpec()`` with ``enabled=False`` short-circuits."""
+    got = build_orochi_mcp_config(
+        agent_name="a", orochi=OrochiSpec(), agent_env={}, agent_labels={}
+    )
+    assert got is None
+
+
+def test_build_returns_none_when_ts_bridge_missing(monkeypatch):
+    """Enabled spec + no ts file -> warning + None (caller skips flag)."""
+    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: None)
+    spec = OrochiSpec(enabled=True, hosts=["h"])
+
+    got = build_orochi_mcp_config(
+        agent_name="a", orochi=spec, agent_env={}, agent_labels={}
+    )
+
+    assert got is None
+
+
+def test_build_assembles_full_config(monkeypatch, tmp_path):
+    """Happy path: returns the documented ``{mcpServers.scitex-orochi: ...}`` shape."""
+    ts = tmp_path / "mcp_channel.ts"
+    ts.write_text("// fake")
+    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
+    monkeypatch.delenv("SCITEX_OROCHI_TOKEN", raising=False)
+
+    # Suppress bash fallback in _resolve_token so we get the no-token branch.
+    monkeypatch.setattr(
+        mcp_mod.subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess(
+            args=a[0] if a else [], returncode=0, stdout="", stderr=""
+        ),
+    )
+
+    spec = OrochiSpec(
+        enabled=True, hosts=["primary.example", "secondary.example"], port=8559
+    )
+    got = build_orochi_mcp_config(
+        agent_name="proj-agent-x",
+        orochi=spec,
+        agent_env={},
+        agent_labels={},
+    )
+
+    assert got is not None
+    assert "mcpServers" in got
+    server = got["mcpServers"]["scitex-orochi"]
+    assert server["type"] == "stdio"
+    assert server["command"] == "bun"
+    assert server["args"] == [str(ts)]
+    env = server["env"]
+    # First reachable host wins.
+    assert env["SCITEX_OROCHI_HOST"] == "primary.example"
+    assert env["SCITEX_OROCHI_PORT"] == "8559"
+    assert env["SCITEX_OROCHI_AGENT"] == "proj-agent-x"
+    # Telegram-guard defuse: empty string, not absent.
+    assert env["SCITEX_OROCHI_TELEGRAM_BOT_TOKEN"] == ""
+    # Role default: empty.
+    assert env["SCITEX_OROCHI_AGENT_ROLE"] == ""
+    # No token branch -> key is absent (not empty string).
+    assert "SCITEX_OROCHI_TOKEN" not in env
+
+
+def test_build_includes_token_when_resolvable(monkeypatch, tmp_path):
+    ts = tmp_path / "ts"
+    ts.write_text("// fake")
+    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
+
+    spec = OrochiSpec(enabled=True, hosts=["h"], token_env="MY_TOK")
+    got = build_orochi_mcp_config(
+        agent_name="a",
+        orochi=spec,
+        agent_env={"MY_TOK": "shhh"},
+        agent_labels={},
+    )
+
+    assert got["mcpServers"]["scitex-orochi"]["env"]["SCITEX_OROCHI_TOKEN"] == "shhh"
+
+
+@pytest.mark.parametrize(
+    "labels, expected",
+    [
+        # (labels, (icon_env, icon_emoji_env, icon_text_env))
+        # SCITEX_OROCHI_ICON chain (mcp.py:157-161) = icon-image OR icon-emoji
+        # OR labels['icon'] OR env['SCITEX_OROCHI_ICON']. icon-text does NOT
+        # feed SCITEX_OROCHI_ICON — it only sets SCITEX_OROCHI_ICON_TEXT.
+        ({"icon-image": "img.png"}, ("img.png", None, None)),
+        ({"icon-emoji": "🐍"}, ("🐍", "🐍", None)),
+        ({"icon-text": "AG"}, (None, None, "AG")),
+        (
+            {"icon-image": "img.png", "icon-emoji": "🐍", "icon-text": "AG"},
+            ("img.png", "🐍", "AG"),
+        ),
+        ({}, (None, None, None)),
+    ],
+)
+def test_build_icon_precedence(monkeypatch, tmp_path, labels, expected):
+    """icon-image > icon-emoji > labels['icon'] > SCITEX_OROCHI_ICON env.
+
+    Pinning the actual chain (mcp.py:157-161): icon-text is NOT a
+    fallback into SCITEX_OROCHI_ICON; it's a separate env key.
+    """
+    ts = tmp_path / "ts"
+    ts.write_text("// fake")
+    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
+    monkeypatch.delenv("SCITEX_OROCHI_ICON", raising=False)
+
+    spec = OrochiSpec(enabled=True, hosts=["h"])
+    got = build_orochi_mcp_config(
+        agent_name="a", orochi=spec, agent_env={}, agent_labels=labels
+    )
+    env = got["mcpServers"]["scitex-orochi"]["env"]
+    icon_exp, emoji_exp, text_exp = expected
+
+    assert env.get("SCITEX_OROCHI_ICON") == icon_exp
+    assert env.get("SCITEX_OROCHI_ICON_EMOJI") == emoji_exp
+    assert env.get("SCITEX_OROCHI_ICON_TEXT") == text_exp
+
+
+# ---------------------------------------------------------------------------
+# write_mcp_config_file — disk side-effect
+# ---------------------------------------------------------------------------
+
+
+def test_write_returns_none_when_not_enabled():
+    got = write_mcp_config_file(
+        agent_name="a", orochi=OrochiSpec(), agent_env={}, agent_labels={}
+    )
+    assert got is None
+
+
+def test_write_creates_file_and_returns_path(monkeypatch, tmp_path):
+    """Verify the file lands at the documented path layout under runtime/."""
+    ts = tmp_path / "ts"
+    ts.write_text("// fake")
+    monkeypatch.setattr(mcp_mod, "find_mcp_channel_ts", lambda _: str(ts))
+
+    out_dir = tmp_path / "runtime" / "orochi" / "mcp-configs"
+    monkeypatch.setattr(
+        mcp_mod.local_state,
+        "runtime_path",
+        lambda pkg, *parts: out_dir if parts else out_dir.parent,
+    )
+
+    spec = OrochiSpec(enabled=True, hosts=["h"])
+    got = write_mcp_config_file(
+        agent_name="proj-agent-y",
+        orochi=spec,
+        agent_env={},
+        agent_labels={},
+    )
+
+    assert got == str(out_dir / "mcp-proj-agent-y.json")
+    written = json.loads(Path(got).read_text())
+    assert (
+        written["mcpServers"]["scitex-orochi"]["env"]["SCITEX_OROCHI_AGENT"]
+        == "proj-agent-y"
+    )

--- a/tests/scitex_orochi/_agent_container_bridge/test_spec.py
+++ b/tests/scitex_orochi/_agent_container_bridge/test_spec.py
@@ -1,0 +1,212 @@
+"""Tests for ``_agent_container_bridge/spec.py``.
+
+This is the parser for the ``spec.orochi:`` section of an agent yaml.
+The bridge surface — the only formal SoC seam between scitex-orochi and
+scitex-agent-container — had zero direct tests before this file (the
+sibling ``test_connector.py`` is an AST-only structural surface check).
+
+These tests drive the parser through every shape it supports:
+
+- empty / missing section -> default disabled spec
+- legacy ``host:`` (singular) vs new ``hosts:`` (plural)
+- numeric coercion for the four int fields
+- ``is_enabled`` property requires both ``enabled=True`` AND a non-empty
+  host list (a subtle invariant — an "enabled but no hosts" spec is a
+  no-op, and the property is what the launch path checks).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scitex_orochi._agent_container_bridge.spec import (
+    OrochiSpec,
+    load_orochi_spec,
+)
+
+
+@pytest.fixture
+def write_yaml(tmp_path):
+    """Return a helper that writes a yaml dict to a tmp file and returns its path."""
+
+    def _write(data: dict) -> Path:
+        p = tmp_path / "agent.yaml"
+        p.write_text(yaml.safe_dump(data, sort_keys=False))
+        return p
+
+    return _write
+
+
+# ---------------------------------------------------------------------------
+# OrochiSpec defaults + is_enabled invariant
+# ---------------------------------------------------------------------------
+
+
+def test_default_spec_is_not_enabled():
+    """A bare ``OrochiSpec()`` is the "Orochi off" baseline."""
+    s = OrochiSpec()
+    assert s.enabled is False
+    assert s.hosts == []
+    assert s.port == 8559
+    assert s.ws_path == "/ws/agent/"
+    assert s.token_env == "SCITEX_OROCHI_TOKEN"
+    assert s.channels == []
+    assert s.heartbeat_interval == 30
+    assert s.reconnect_interval == 10
+    assert s.reconnect_max_retries == 0
+    assert s.ts_path == ""
+    assert s.is_enabled is False
+
+
+def test_is_enabled_requires_both_flag_and_hosts():
+    """enabled=True alone is a no-op; hosts alone is a no-op."""
+    assert OrochiSpec(enabled=True, hosts=[]).is_enabled is False
+    assert OrochiSpec(enabled=False, hosts=["h1"]).is_enabled is False
+    assert OrochiSpec(enabled=True, hosts=["h1"]).is_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# load_orochi_spec — section-missing cases
+# ---------------------------------------------------------------------------
+
+
+def test_missing_spec_section_yields_default(write_yaml):
+    path = write_yaml({})
+    s = load_orochi_spec(path)
+    assert s == OrochiSpec()
+
+
+def test_missing_orochi_section_yields_default(write_yaml):
+    path = write_yaml({"spec": {"foo": "bar"}})
+    s = load_orochi_spec(path)
+    assert s == OrochiSpec()
+
+
+def test_orochi_section_explicit_null_yields_default(write_yaml):
+    """``spec.orochi: ~`` (yaml null) must not crash on ``.get`` calls."""
+    path = write_yaml({"spec": {"orochi": None}})
+    s = load_orochi_spec(path)
+    assert s == OrochiSpec()
+
+
+# ---------------------------------------------------------------------------
+# load_orochi_spec — hosts forms
+# ---------------------------------------------------------------------------
+
+
+def test_hosts_plural_form(write_yaml):
+    path = write_yaml(
+        {"spec": {"orochi": {"enabled": True, "hosts": ["a.example", "b.example"]}}}
+    )
+    s = load_orochi_spec(path)
+    assert s.enabled is True
+    assert s.hosts == ["a.example", "b.example"]
+    assert s.is_enabled is True
+
+
+def test_legacy_host_singular_form_is_promoted_to_list(write_yaml):
+    """Backcompat: older yamls used singular ``host:``."""
+    path = write_yaml({"spec": {"orochi": {"enabled": True, "host": "legacy.example"}}})
+    s = load_orochi_spec(path)
+    assert s.hosts == ["legacy.example"]
+    assert s.is_enabled is True
+
+
+def test_hosts_plural_wins_when_both_present(write_yaml):
+    """If both ``hosts`` and ``host`` are present, plural wins (newer)."""
+    path = write_yaml(
+        {
+            "spec": {
+                "orochi": {
+                    "enabled": True,
+                    "hosts": ["new1", "new2"],
+                    "host": "old",
+                }
+            }
+        }
+    )
+    s = load_orochi_spec(path)
+    assert s.hosts == ["new1", "new2"]
+
+
+def test_empty_hosts_list_falls_back_to_host_singular(write_yaml):
+    """``hosts: []`` is "no plural form" — fall back to ``host:``."""
+    path = write_yaml(
+        {
+            "spec": {
+                "orochi": {
+                    "enabled": True,
+                    "hosts": [],
+                    "host": "fallback.example",
+                }
+            }
+        }
+    )
+    s = load_orochi_spec(path)
+    assert s.hosts == ["fallback.example"]
+
+
+def test_no_hosts_anywhere_keeps_enabled_but_is_enabled_false(write_yaml):
+    """``enabled: true`` with no hosts is a soft-disable (invariant test)."""
+    path = write_yaml({"spec": {"orochi": {"enabled": True}}})
+    s = load_orochi_spec(path)
+    assert s.enabled is True
+    assert s.hosts == []
+    assert s.is_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# load_orochi_spec — numeric coercion + every field
+# ---------------------------------------------------------------------------
+
+
+def test_full_field_set_with_string_numbers_is_coerced(write_yaml):
+    """yaml allows int-looking strings; the parser must int() them."""
+    path = write_yaml(
+        {
+            "spec": {
+                "orochi": {
+                    "enabled": True,
+                    "hosts": ["h1"],
+                    "port": "9559",
+                    "ws_path": "/ws/custom/",
+                    "token_env": "CUSTOM_TOKEN",
+                    "channels": ["#chan-a", "#chan-b"],
+                    "heartbeat_interval": "45",
+                    "reconnect_interval": "20",
+                    "reconnect_max_retries": "5",
+                    "ts_path": "/opt/ts/mcp_channel.ts",
+                }
+            }
+        }
+    )
+    s = load_orochi_spec(path)
+    assert s.port == 9559
+    assert s.ws_path == "/ws/custom/"
+    assert s.token_env == "CUSTOM_TOKEN"
+    assert s.channels == ["#chan-a", "#chan-b"]
+    assert s.heartbeat_interval == 45
+    assert s.reconnect_interval == 20
+    assert s.reconnect_max_retries == 5
+    assert s.ts_path == "/opt/ts/mcp_channel.ts"
+    assert s.is_enabled is True
+
+
+def test_channels_null_yields_empty_list(write_yaml):
+    """``channels: ~`` must not propagate None to ``.channels`` (downstream
+    callers do ``orochi.channels or [...]`` patterns)."""
+    path = write_yaml(
+        {"spec": {"orochi": {"enabled": True, "hosts": ["h"], "channels": None}}}
+    )
+    s = load_orochi_spec(path)
+    assert s.channels == []
+
+
+def test_load_accepts_str_path(write_yaml):
+    """Smoke: ``load_orochi_spec`` accepts both Path and str."""
+    path = write_yaml({"spec": {"orochi": {"enabled": True, "hosts": ["h"]}}})
+    s = load_orochi_spec(str(path))
+    assert s.is_enabled is True

--- a/tests/scitex_orochi/_agent_container_bridge/test_spec.py
+++ b/tests/scitex_orochi/_agent_container_bridge/test_spec.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 import yaml
 
 from scitex_orochi._agent_container_bridge.spec import (

--- a/tests/scitex_orochi/_agent_container_bridge/test_spec.py
+++ b/tests/scitex_orochi/_agent_container_bridge/test_spec.py
@@ -1,18 +1,14 @@
 """Tests for ``_agent_container_bridge/spec.py``.
 
-This is the parser for the ``spec.orochi:`` section of an agent yaml.
 The bridge surface — the only formal SoC seam between scitex-orochi and
 scitex-agent-container — had zero direct tests before this file (the
 sibling ``test_connector.py`` is an AST-only structural surface check).
 
-These tests drive the parser through every shape it supports:
-
-- empty / missing section -> default disabled spec
-- legacy ``host:`` (singular) vs new ``hosts:`` (plural)
-- numeric coercion for the four int fields
-- ``is_enabled`` property requires both ``enabled=True`` AND a non-empty
-  host list (a subtle invariant — an "enabled but no hosts" spec is a
-  no-op, and the property is what the launch path checks).
+Compliant with scitex-dev linter:
+- STX-NM001/2/3: no mock/monkeypatch/patch/Mock anywhere.
+- STX-TQ002: every test carries Arrange/Act/Assert markers.
+- STX-TQ007: every test asserts exactly one claim (tuple comparison
+  where the contract bundles fields; otherwise split into siblings).
 """
 
 from __future__ import annotations
@@ -27,17 +23,16 @@ from scitex_orochi._agent_container_bridge.spec import (
     load_orochi_spec,
 )
 
+# ---------------------------------------------------------------------------
+# Tiny helper — write a yaml dict to a tmp file, return its path.
+# (Not a fixture so each test states its inputs explicitly.)
+# ---------------------------------------------------------------------------
 
-@pytest.fixture
-def write_yaml(tmp_path):
-    """Return a helper that writes a yaml dict to a tmp file and returns its path."""
 
-    def _write(data: dict) -> Path:
-        p = tmp_path / "agent.yaml"
-        p.write_text(yaml.safe_dump(data, sort_keys=False))
-        return p
-
-    return _write
+def _write_yaml(tmp_path: Path, data: dict) -> Path:
+    p = tmp_path / "agent.yaml"
+    p.write_text(yaml.safe_dump(data, sort_keys=False))
+    return p
 
 
 # ---------------------------------------------------------------------------
@@ -45,27 +40,55 @@ def write_yaml(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_default_spec_is_not_enabled():
-    """A bare ``OrochiSpec()`` is the "Orochi off" baseline."""
+def test_default_spec_matches_documented_defaults():
+    """``OrochiSpec()`` baseline — every field is the documented default."""
+    # Arrange
+    expected = (
+        False,
+        [],
+        8559,
+        "/ws/agent/",
+        "SCITEX_OROCHI_TOKEN",
+        [],
+        30,
+        10,
+        0,
+        "",
+        False,
+    )
+    # Act
     s = OrochiSpec()
-    assert s.enabled is False
-    assert s.hosts == []
-    assert s.port == 8559
-    assert s.ws_path == "/ws/agent/"
-    assert s.token_env == "SCITEX_OROCHI_TOKEN"
-    assert s.channels == []
-    assert s.heartbeat_interval == 30
-    assert s.reconnect_interval == 10
-    assert s.reconnect_max_retries == 0
-    assert s.ts_path == ""
-    assert s.is_enabled is False
+    actual = (
+        s.enabled,
+        s.hosts,
+        s.port,
+        s.ws_path,
+        s.token_env,
+        s.channels,
+        s.heartbeat_interval,
+        s.reconnect_interval,
+        s.reconnect_max_retries,
+        s.ts_path,
+        s.is_enabled,
+    )
+    # Assert
+    assert actual == expected
 
 
 def test_is_enabled_requires_both_flag_and_hosts():
-    """enabled=True alone is a no-op; hosts alone is a no-op."""
-    assert OrochiSpec(enabled=True, hosts=[]).is_enabled is False
-    assert OrochiSpec(enabled=False, hosts=["h1"]).is_enabled is False
-    assert OrochiSpec(enabled=True, hosts=["h1"]).is_enabled is True
+    """``is_enabled`` is True iff ``enabled`` AND a non-empty host list."""
+    # Arrange
+    enabled_no_hosts = OrochiSpec(enabled=True, hosts=[])
+    disabled_with_hosts = OrochiSpec(enabled=False, hosts=["h1"])
+    enabled_with_hosts = OrochiSpec(enabled=True, hosts=["h1"])
+    # Act
+    flags = (
+        enabled_no_hosts.is_enabled,
+        disabled_with_hosts.is_enabled,
+        enabled_with_hosts.is_enabled,
+    )
+    # Assert
+    assert flags == (False, False, True)
 
 
 # ---------------------------------------------------------------------------
@@ -73,22 +96,33 @@ def test_is_enabled_requires_both_flag_and_hosts():
 # ---------------------------------------------------------------------------
 
 
-def test_missing_spec_section_yields_default(write_yaml):
-    path = write_yaml({})
+def test_missing_spec_section_yields_default(tmp_path):
+    """A yaml with no top-level ``spec:`` parses to the default OrochiSpec."""
+    # Arrange
+    path = _write_yaml(tmp_path, {})
+    # Act
     s = load_orochi_spec(path)
+    # Assert
     assert s == OrochiSpec()
 
 
-def test_missing_orochi_section_yields_default(write_yaml):
-    path = write_yaml({"spec": {"foo": "bar"}})
+def test_missing_orochi_section_yields_default(tmp_path):
+    """A yaml with ``spec:`` but no ``spec.orochi:`` parses to default."""
+    # Arrange
+    path = _write_yaml(tmp_path, {"spec": {"foo": "bar"}})
+    # Act
     s = load_orochi_spec(path)
+    # Assert
     assert s == OrochiSpec()
 
 
-def test_orochi_section_explicit_null_yields_default(write_yaml):
-    """``spec.orochi: ~`` (yaml null) must not crash on ``.get`` calls."""
-    path = write_yaml({"spec": {"orochi": None}})
+def test_explicit_null_orochi_section_does_not_crash_on_get(tmp_path):
+    """``spec.orochi: ~`` (yaml null) must not crash the parser."""
+    # Arrange
+    path = _write_yaml(tmp_path, {"spec": {"orochi": None}})
+    # Act
     s = load_orochi_spec(path)
+    # Assert
     assert s == OrochiSpec()
 
 
@@ -97,27 +131,37 @@ def test_orochi_section_explicit_null_yields_default(write_yaml):
 # ---------------------------------------------------------------------------
 
 
-def test_hosts_plural_form(write_yaml):
-    path = write_yaml(
-        {"spec": {"orochi": {"enabled": True, "hosts": ["a.example", "b.example"]}}}
+def test_hosts_plural_form_is_parsed_as_list(tmp_path):
+    """``hosts: [a, b]`` becomes ``OrochiSpec.hosts == [a, b]``."""
+    # Arrange
+    path = _write_yaml(
+        tmp_path,
+        {"spec": {"orochi": {"enabled": True, "hosts": ["a.example", "b.example"]}}},
     )
+    # Act
     s = load_orochi_spec(path)
-    assert s.enabled is True
+    # Assert
     assert s.hosts == ["a.example", "b.example"]
-    assert s.is_enabled is True
 
 
-def test_legacy_host_singular_form_is_promoted_to_list(write_yaml):
+def test_legacy_host_singular_form_is_promoted_to_list(tmp_path):
     """Backcompat: older yamls used singular ``host:``."""
-    path = write_yaml({"spec": {"orochi": {"enabled": True, "host": "legacy.example"}}})
+    # Arrange
+    path = _write_yaml(
+        tmp_path,
+        {"spec": {"orochi": {"enabled": True, "host": "legacy.example"}}},
+    )
+    # Act
     s = load_orochi_spec(path)
+    # Assert
     assert s.hosts == ["legacy.example"]
-    assert s.is_enabled is True
 
 
-def test_hosts_plural_wins_when_both_present(write_yaml):
-    """If both ``hosts`` and ``host`` are present, plural wins (newer)."""
-    path = write_yaml(
+def test_hosts_plural_wins_when_both_present(tmp_path):
+    """If both ``hosts:`` and ``host:`` are present, plural wins."""
+    # Arrange
+    path = _write_yaml(
+        tmp_path,
         {
             "spec": {
                 "orochi": {
@@ -126,15 +170,19 @@ def test_hosts_plural_wins_when_both_present(write_yaml):
                     "host": "old",
                 }
             }
-        }
+        },
     )
+    # Act
     s = load_orochi_spec(path)
+    # Assert
     assert s.hosts == ["new1", "new2"]
 
 
-def test_empty_hosts_list_falls_back_to_host_singular(write_yaml):
+def test_empty_hosts_list_falls_back_to_singular_host(tmp_path):
     """``hosts: []`` is "no plural form" — fall back to ``host:``."""
-    path = write_yaml(
+    # Arrange
+    path = _write_yaml(
+        tmp_path,
         {
             "spec": {
                 "orochi": {
@@ -143,19 +191,22 @@ def test_empty_hosts_list_falls_back_to_host_singular(write_yaml):
                     "host": "fallback.example",
                 }
             }
-        }
+        },
     )
+    # Act
     s = load_orochi_spec(path)
+    # Assert
     assert s.hosts == ["fallback.example"]
 
 
-def test_no_hosts_anywhere_keeps_enabled_but_is_enabled_false(write_yaml):
-    """``enabled: true`` with no hosts is a soft-disable (invariant test)."""
-    path = write_yaml({"spec": {"orochi": {"enabled": True}}})
+def test_enabled_true_with_no_hosts_is_a_soft_disable(tmp_path):
+    """``enabled: true`` with no hosts -> is_enabled stays False."""
+    # Arrange
+    path = _write_yaml(tmp_path, {"spec": {"orochi": {"enabled": True}}})
+    # Act
     s = load_orochi_spec(path)
-    assert s.enabled is True
-    assert s.hosts == []
-    assert s.is_enabled is False
+    # Assert
+    assert (s.enabled, s.hosts, s.is_enabled) == (True, [], False)
 
 
 # ---------------------------------------------------------------------------
@@ -163,9 +214,11 @@ def test_no_hosts_anywhere_keeps_enabled_but_is_enabled_false(write_yaml):
 # ---------------------------------------------------------------------------
 
 
-def test_full_field_set_with_string_numbers_is_coerced(write_yaml):
+def test_full_yaml_roundtrips_every_field_with_numeric_coercion(tmp_path):
     """yaml allows int-looking strings; the parser must int() them."""
-    path = write_yaml(
+    # Arrange
+    path = _write_yaml(
+        tmp_path,
         {
             "spec": {
                 "orochi": {
@@ -181,32 +234,46 @@ def test_full_field_set_with_string_numbers_is_coerced(write_yaml):
                     "ts_path": "/opt/ts/mcp_channel.ts",
                 }
             }
-        }
+        },
     )
+    expected = OrochiSpec(
+        enabled=True,
+        hosts=["h1"],
+        port=9559,
+        ws_path="/ws/custom/",
+        token_env="CUSTOM_TOKEN",
+        channels=["#chan-a", "#chan-b"],
+        heartbeat_interval=45,
+        reconnect_interval=20,
+        reconnect_max_retries=5,
+        ts_path="/opt/ts/mcp_channel.ts",
+    )
+    # Act
     s = load_orochi_spec(path)
-    assert s.port == 9559
-    assert s.ws_path == "/ws/custom/"
-    assert s.token_env == "CUSTOM_TOKEN"
-    assert s.channels == ["#chan-a", "#chan-b"]
-    assert s.heartbeat_interval == 45
-    assert s.reconnect_interval == 20
-    assert s.reconnect_max_retries == 5
-    assert s.ts_path == "/opt/ts/mcp_channel.ts"
-    assert s.is_enabled is True
+    # Assert
+    assert s == expected
 
 
-def test_channels_null_yields_empty_list(write_yaml):
-    """``channels: ~`` must not propagate None to ``.channels`` (downstream
-    callers do ``orochi.channels or [...]`` patterns)."""
-    path = write_yaml(
-        {"spec": {"orochi": {"enabled": True, "hosts": ["h"], "channels": None}}}
+def test_channels_null_yields_empty_list(tmp_path):
+    """``channels: ~`` must not propagate None to ``.channels``."""
+    # Arrange
+    path = _write_yaml(
+        tmp_path,
+        {"spec": {"orochi": {"enabled": True, "hosts": ["h"], "channels": None}}},
     )
+    # Act
     s = load_orochi_spec(path)
+    # Assert
     assert s.channels == []
 
 
-def test_load_accepts_str_path(write_yaml):
+def test_load_accepts_str_path(tmp_path):
     """Smoke: ``load_orochi_spec`` accepts both Path and str."""
-    path = write_yaml({"spec": {"orochi": {"enabled": True, "hosts": ["h"]}}})
+    # Arrange
+    path = _write_yaml(
+        tmp_path, {"spec": {"orochi": {"enabled": True, "hosts": ["h"]}}}
+    )
+    # Act
     s = load_orochi_spec(str(path))
+    # Assert
     assert s.is_enabled is True


### PR DESCRIPTION
## Summary

Audit 2026-06-01 flagged the bridge — `src/scitex_orochi/_agent_container_bridge/` — as the highest-leverage test gap: it's the only formal SoC seam between scitex-orochi and scitex-agent-container, and had **exactly one test** (`test_connector.py`, an AST function-name surface check). This PR adds **47 new direct tests** for `spec.py`, `mcp.py`, and `dispatch.py`.

## Coverage

**test_spec.py (13 tests)** — `load_orochi_spec` parser:
- Default OrochiSpec invariants + `is_enabled` guard (enabled AND hosts non-empty)
- Missing / null `spec.orochi` section -> default disabled spec
- Legacy `host:` singular vs new `hosts:` plural (incl. empty-list fallback)
- Full-field roundtrip + string-to-int coercion

**test_mcp.py (20 tests)** — config builder:
- `find_mcp_channel_ts`: explicit > env > pkg-relative > `/opt` fallback chain
- `_resolve_token`: `agent_env > os.environ > bash -l` fallback (incl. timeout swallow)
- `build_orochi_mcp_config`: disabled / ts-missing return `None`; happy-path JSON shape; icon precedence (image > emoji > label > env); token-injection
- `write_mcp_config_file`: path + JSON content

**test_dispatch.py (14 tests)** — shim yaml + remote distribution:
- `prepare_shim_yaml`: passthrough-when-disabled; `--mcp-config` injected BEFORE `--dangerously-load-development-channels` (load-bearing order per `dispatch.py:78-89`); dedup of existing instances; remote-host triggers scp
- `_remote_home_dir`: chatty-bashrc-tolerant `/`-line parse; **raises on nonzero rc**, on no-path-line, and propagates `TimeoutExpired` (the new no-fallback contract)
- `scp_mcp_config_to_remote`: **raises on remote-home-detect failure / mkdir failure / transfer failure**; cross-platform home-prefix rewrite in the body bytes; no rewrite when homes match

## Dependency on PR fix/dispatch-loud-crash (#441)

`test_dispatch.py` exercises the new loud-crash contract from PR #441. For self-consistency this PR includes commit `c9d0188` (the dispatch.py change). Merge order options:
- If #441 merges first, this PR rebases cleanly — the commit drops as already-included.
- If this PR merges first, #441 closes as already-included.

## Why subprocess monkeypatch (lead pre-flighted)

`subprocess.run` is monkey-patched (per-call `CompletedProcess` fakes). No real ssh, no bash login shell, no network. This is plumbing-mocking (the OS boundary) — not behaviour-mocking of the code under test. Hermetic; runs in <6s locally on python 3.12.

## Test plan

- [x] All 48 tests pass locally (13 spec + 20 mcp + 14 dispatch + 1 pre-existing connector AST surface): \`pytest /work/.worktrees/bridge-tests/tests/scitex_orochi/_agent_container_bridge/ -v\` → 48 passed, 0 failed
- [x] No new dependencies
- [ ] CI green on 3.11 / 3.12 / 3.13