### PR TITLE
feat(daemons): sac inventory reconciler daemon (ADR-0003 Phase 1)

### DIFF
--- a/apps/hub/management/commands/sync_sac_inventory.py
+++ b/apps/hub/management/commands/sync_sac_inventory.py
@@ -1,0 +1,30 @@
+"""Management command — sac inventory reconciler daemon (ADR-0003 Phase 1).
+
+Wraps the async ``run()`` loop in
+``scitex_orochi._daemons._sac_inventory_sync`` so the daemon can be
+launched as a long-running supervised process via::
+
+    python manage.py sync_sac_inventory
+
+See the module docstring of ``_sac_inventory_sync`` for behaviour and
+deferred scope.
+"""
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = (
+        "Run the sac inventory reconciler daemon. Reconciles "
+        "AgentProfile rows against ~/.scitex/agent-container/agents/*/"
+        "spec.yaml every SCITEX_OROCHI_SAC_SYNC_INTERVAL seconds "
+        "(default 300). ADR-0003 Phase 1."
+    )
+
+    def handle(self, *args, **options):
+        # Lazy import — keep Django's management-command boot path
+        # from triggering the daemon module's logger setup until we
+        # actually intend to run.
+        from scitex_orochi._daemons._sac_inventory_sync import main
+
+        return main()

--- a/src/scitex_orochi/_daemons/_sac_inventory_sync.py
+++ b/src/scitex_orochi/_daemons/_sac_inventory_sync.py
@@ -1,0 +1,423 @@
+"""ADR-0003 Phase 1 — sac inventory reconciler daemon.
+
+Per ADR 0003 §Decision 2, sac filesystem inventory is the canonical
+source of truth for which agents exist. This daemon is the single
+highest-leverage change that resolves the operator's "old contributors
+stay in the orochi UI for months after they're gone from sac" complaint
+(operator msg #74) WITHOUT touching any model, requiring a migration,
+or waiting for the (still-to-be-built) sac extension ports of
+Decision 2-B.
+
+SAC v3 dir-as-SSoT
+------------------
+
+Canonical SAC v3 inventory layout (see
+``~/proj/scitex-agent-container/examples/agents/full-agent/spec.yaml``
+lines 1-7 — the format docs are inline in the example):
+
+    <agents_dir>/<name>/spec.yaml
+
+**The directory name IS the agent name.** There is no top-level
+``name:`` field in the YAML — the parent directory is the
+single-source-of-truth ("dir-as-SSoT"). This daemon honours that
+convention: ``_parse_spec`` derives ``name = spec_path.parent.name``
+and never reads a top-level ``name`` key.
+
+The other two top-level keys the reconciler validates are:
+
+* ``apiVersion: scitex-agent-container/v3`` — REQUIRED. Anything else
+  (v1, v2, missing) is logged with the actual value and skipped.
+* ``kind: Agent | AgentProxy`` — REQUIRED. Any other value is logged
+  and skipped.
+
+This Phase-1 daemon does NOT read ``metadata.labels.*`` or any
+``spec.*`` subsection. Future PRs may map ``metadata.labels.role`` /
+``metadata.labels.description`` etc. into orochi-side surfaces, but
+that's out of scope here — the reconciler's only job is "what agents
+exist (per SAC's directory inventory)".
+
+Behaviour
+---------
+
+1. Read ``<agents_dir>/*/spec.yaml`` (``<agents_dir>`` overridable via
+   ``SCITEX_AGENT_CONTAINER_AGENTS_DIR``; default
+   ``~/.scitex/agent-container/agents``).
+2. Parse each ``spec.yaml`` (``yaml.safe_load``). Validate apiVersion
+   and kind; derive name from the parent directory.
+3. For each name in inventory:
+     - upsert an ``AgentProfile`` row (create with ``is_hidden=False``,
+       or — for existing rows — clear ``is_hidden`` if it was set).
+     - **Never clobber operator-set icon fields** (``icon_emoji``,
+       ``icon_image``, ``icon_text``, ``color``). Operators configure
+       those via the dashboard; the reconciler's only mutation on an
+       existing row is the ``is_hidden`` flag.
+4. For each existing ``AgentProfile.name`` NOT in inventory:
+     - set ``is_hidden=True``. **DO NOT delete** — message history
+       must be preserved (ADR §Decision 2 step 1 is explicit).
+5. Sleep ``SCITEX_OROCHI_SAC_SYNC_INTERVAL`` seconds (default 300).
+
+Workspace selection (Phase-1 simplification)
+--------------------------------------------
+
+The live ``AgentProfile`` model is keyed on
+``unique_together = ("workspace", "name")`` (see
+``apps/hub/models/_identity.py:195``). SAC's filesystem inventory has
+no workspace concept. Until a multi-workspace-routing ADR lands, the
+reconciler operates against a single configurable workspace:
+
+* ``SCITEX_OROCHI_SAC_SYNC_WORKSPACE`` env var picks the target name.
+* Default: ``"default"``.
+* The workspace is auto-created on first run via ``get_or_create``.
+
+What this daemon DEFERS
+-----------------------
+
+* **Multi-host inventory.** Single-host first (the dispatcher host);
+  ADR §Decision 2 step 1 explicitly defers fleet inventory to a
+  follow-up ADR.
+* **ContainerAgent migration** (ADR §Decision 2 steps 2-3). This
+  daemon does NOT touch the ``ContainerAgent`` model or its REST
+  surface.
+* **In-memory ``hub.registry._agents`` rename to
+  ``_session_cache``** (ADR §Decision 2 step 3).
+* **``metadata.labels.*`` mapping** into orochi-side metadata
+  (description, role, capabilities).
+
+Wiring
+------
+
+* ``run()`` — top-level async coroutine; the daemon body.
+* ``main()`` — sync wrapper, ``asyncio.run(run())``. Called by the
+  Django management command at
+  ``apps/hub/management/commands/sync_sac_inventory.py``
+  (``python manage.py sync_sac_inventory``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+# Module-level logger — matches the project pattern
+# (``logging.getLogger("orochi.<scope>")``; cf. ``apps/hub/apps.py``,
+# ``src/scitex_orochi/_daemons/_stale_pr/_wrapper.py:45``).
+logger = logging.getLogger("orochi.daemon.sac_inventory_sync")
+
+
+# ---------------------------------------------------------------------------
+# Defaults / env vars
+# ---------------------------------------------------------------------------
+
+#: Hard-coded fallback when ``SCITEX_AGENT_CONTAINER_AGENTS_DIR`` is unset.
+#: Matches the ADR-0003 §Decision 2 example path.
+DEFAULT_AGENTS_DIR = "~/.scitex/agent-container/agents"
+
+#: Tick interval in seconds (overridable via env).
+DEFAULT_INTERVAL_S = 300
+
+#: Workspace the reconciler upserts AgentProfile rows into. See module
+#: docstring "Workspace selection".
+DEFAULT_WORKSPACE_NAME = "default"
+
+#: SAC apiVersion prefix the reconciler accepts. v1/v2 specs are
+#: warned + skipped (kept readable but not synced).
+_REQUIRED_API_VERSION_PREFIX = "scitex-agent-container/v3"
+
+#: SAC kinds the reconciler accepts. Other kinds are warned + skipped.
+_ACCEPTED_KINDS = frozenset({"Agent", "AgentProxy"})
+
+_ENV_AGENTS_DIR = "SCITEX_AGENT_CONTAINER_AGENTS_DIR"
+_ENV_INTERVAL = "SCITEX_OROCHI_SAC_SYNC_INTERVAL"
+_ENV_WORKSPACE = "SCITEX_OROCHI_SAC_SYNC_WORKSPACE"
+
+
+# ---------------------------------------------------------------------------
+# Inventory parsing
+# ---------------------------------------------------------------------------
+
+
+def _resolve_agents_dir() -> Path:
+    """Return the sac agents inventory directory.
+
+    Reads ``SCITEX_AGENT_CONTAINER_AGENTS_DIR`` first; falls back to
+    ``~/.scitex/agent-container/agents``. ``~`` is expanded.
+    """
+    raw = os.environ.get(_ENV_AGENTS_DIR, DEFAULT_AGENTS_DIR)
+    return Path(raw).expanduser()
+
+
+def _iter_spec_files(agents_dir: Path) -> Iterable[Path]:
+    """Yield each ``<agents_dir>/<name>/spec.yaml`` that exists.
+
+    Per SAC v3 dir-as-SSoT, the canonical layout is one directory per
+    agent with a ``spec.yaml`` inside. The directory name is the agent
+    name (see module docstring).
+    """
+    if not agents_dir.exists() or not agents_dir.is_dir():
+        logger.warning(
+            "sac agents dir does not exist: %s (env=%s)",
+            agents_dir,
+            _ENV_AGENTS_DIR,
+        )
+        return
+    for child in sorted(agents_dir.iterdir()):
+        if not child.is_dir():
+            continue
+        spec = child / "spec.yaml"
+        if spec.is_file():
+            yield spec
+
+
+def _parse_spec(spec_path: Path) -> dict | None:
+    """Parse a single ``spec.yaml`` and return ``{"name": <dir_name>}``,
+    or ``None`` if the file is malformed or fails apiVersion/kind
+    validation.
+
+    Per SAC v3 dir-as-SSoT, the agent name is derived from
+    ``spec_path.parent.name`` — there is NO top-level ``name:`` field
+    in the canonical v3 YAML.
+
+    Validation rules (warn+skip on mismatch):
+        * ``apiVersion`` must start with ``"scitex-agent-container/v3"``.
+        * ``kind`` must be ``"Agent"`` or ``"AgentProxy"``.
+    """
+    try:
+        with spec_path.open("r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+    except (yaml.YAMLError, OSError) as exc:
+        # Per the test contract: bad yaml does not crash the pass; it
+        # is logged and skipped.
+        logger.warning("skipping malformed spec %s: %s", spec_path, exc)
+        return None
+
+    if not isinstance(raw, dict):
+        logger.warning(
+            "skipping spec %s: top-level is not a mapping (got %s)",
+            spec_path,
+            type(raw).__name__,
+        )
+        return None
+
+    api_version = raw.get("apiVersion")
+    if not isinstance(api_version, str) or not api_version.startswith(
+        _REQUIRED_API_VERSION_PREFIX
+    ):
+        logger.warning(
+            "skipping spec %s: unsupported apiVersion=%r (require prefix %r)",
+            spec_path,
+            api_version,
+            _REQUIRED_API_VERSION_PREFIX,
+        )
+        return None
+
+    kind = raw.get("kind")
+    if kind not in _ACCEPTED_KINDS:
+        logger.warning(
+            "skipping spec %s: unsupported kind=%r (accept %s)",
+            spec_path,
+            kind,
+            sorted(_ACCEPTED_KINDS),
+        )
+        return None
+
+    name = spec_path.parent.name
+    if not name or not name.strip():
+        # Defensive: shouldn't happen given _iter_spec_files only yields
+        # children of agents_dir, but guard anyway.
+        logger.warning("skipping spec %s: empty directory name", spec_path)
+        return None
+
+    return {"name": name.strip()}
+
+
+def _read_inventory(agents_dir: Path) -> dict[str, dict]:
+    """Read the full inventory keyed by agent name.
+
+    Malformed individual files are logged + skipped; the rest of the
+    pass proceeds.
+    """
+    inventory: dict[str, dict] = {}
+    for spec_path in _iter_spec_files(agents_dir):
+        parsed = _parse_spec(spec_path)
+        if parsed is None:
+            continue
+        inventory[parsed["name"]] = parsed
+    return inventory
+
+
+# ---------------------------------------------------------------------------
+# DB reconciliation
+# ---------------------------------------------------------------------------
+
+
+def _resolve_workspace():
+    """Return the Workspace the reconciler should write into.
+
+    Lazy import of Django models so this module can be imported (e.g.
+    for unit-testing the yaml-parse helpers) without Django being
+    set up. See module docstring "Workspace selection" for the
+    Phase-1 simplification rationale.
+    """
+    from apps.hub.models import Workspace
+
+    name = os.environ.get(_ENV_WORKSPACE, DEFAULT_WORKSPACE_NAME)
+    workspace, _ = Workspace.objects.get_or_create(
+        name=name,
+        defaults={"description": f"Auto-created by sac inventory reconciler ({name})"},
+    )
+    return workspace
+
+
+def reconcile_once(agents_dir: Path | None = None) -> dict[str, int]:
+    """Run a single reconcile pass synchronously.
+
+    Returns a small dict of counters (useful for tests + tick logs):
+        {"present": N, "created": M, "hidden": H, "unhidden": U}
+
+    Synchronous because Django ORM is sync; the async ``run()`` loop
+    drives this in a thread (asyncio.to_thread) so the event loop
+    doesn't block on DB I/O.
+
+    NOTE: on existing rows, the ONLY field this function mutates is
+    ``is_hidden``. Operator-set icon fields (``icon_emoji``,
+    ``icon_image``, ``icon_text``, ``color``) are never touched.
+    """
+    agents_dir = agents_dir or _resolve_agents_dir()
+    inventory = _read_inventory(agents_dir)
+
+    # Lazy import — see _resolve_workspace.
+    from apps.hub.models import AgentProfile
+
+    workspace = _resolve_workspace()
+
+    counters = {"present": 0, "created": 0, "hidden": 0, "unhidden": 0}
+
+    # ----- upsert each name that IS in inventory -----------------------
+    for name in inventory:
+        counters["present"] += 1
+        # On create, set ONLY workspace + name + is_hidden. Icons are
+        # operator-managed via the dashboard; the reconciler must not
+        # supply defaults (it would lock in empty values on the first
+        # pass and then the no-clobber rule below would prevent the
+        # operator's later edits from taking effect — wait, that's not
+        # true because save-from-dashboard is a direct field write. But
+        # symmetrically: the reconciler has no opinion on icons. Don't
+        # set them.).
+        profile, created = AgentProfile.objects.get_or_create(
+            workspace=workspace,
+            name=name,
+            defaults={"is_hidden": False},
+        )
+        if created:
+            counters["created"] += 1
+            continue
+
+        # Existing row: the ONLY mutation is unhiding if it was hidden.
+        # Icons / health fields are deliberately untouched.
+        if profile.is_hidden:
+            profile.is_hidden = False
+            profile.save(update_fields=["is_hidden", "updated_at"])
+            counters["unhidden"] += 1
+
+    # ----- hide each existing row whose name is NOT in inventory -------
+    # Note: scoped to the configured workspace. DO NOT delete.
+    stale_qs = AgentProfile.objects.filter(workspace=workspace).exclude(
+        name__in=list(inventory.keys())
+    )
+    for profile in stale_qs:
+        if not profile.is_hidden:
+            profile.is_hidden = True
+            profile.save(update_fields=["is_hidden", "updated_at"])
+            counters["hidden"] += 1
+
+    logger.info(
+        "sac inventory reconcile pass: %s",
+        " ".join(f"{k}={v}" for k, v in counters.items()),
+    )
+    return counters
+
+
+# ---------------------------------------------------------------------------
+# Async daemon loop
+# ---------------------------------------------------------------------------
+
+
+def _resolve_interval_s() -> int:
+    raw = os.environ.get(_ENV_INTERVAL)
+    if not raw:
+        return DEFAULT_INTERVAL_S
+    try:
+        v = int(raw)
+        return v if v > 0 else DEFAULT_INTERVAL_S
+    except ValueError:
+        logger.warning(
+            "ignoring non-integer %s=%r; falling back to %ds",
+            _ENV_INTERVAL,
+            raw,
+            DEFAULT_INTERVAL_S,
+        )
+        return DEFAULT_INTERVAL_S
+
+
+async def run(max_ticks: int | None = None) -> None:
+    """Run the reconciler loop forever (or for ``max_ticks`` iterations).
+
+    The ``max_ticks`` knob exists for ``--once`` smoke tests and for
+    future integration tests that want to drive the loop deterministically.
+    Production use is ``max_ticks=None``.
+    """
+    interval_s = _resolve_interval_s()
+    agents_dir = _resolve_agents_dir()
+    logger.info(
+        "sac inventory reconciler starting: agents_dir=%s interval=%ss",
+        agents_dir,
+        interval_s,
+    )
+
+    tick = 0
+    while True:
+        tick += 1
+        try:
+            # ORM is sync; offload so the event loop stays responsive
+            # when the daemon eventually lands alongside other async
+            # daemons in the same process.
+            await asyncio.to_thread(reconcile_once, agents_dir)
+        except Exception:  # pragma: no cover — last-ditch crash guard
+            # NEVER let a single bad pass kill the daemon. Log and
+            # keep ticking; the operator's worst-case is "stale UI",
+            # not "no reconciler at all".
+            logger.exception("sac inventory reconcile pass failed (tick=%d)", tick)
+
+        if max_ticks is not None and tick >= max_ticks:
+            return
+
+        await asyncio.sleep(interval_s)
+
+
+def main() -> int:
+    """Sync entry point. Wired by the Django management command at
+    ``apps/hub/management/commands/sync_sac_inventory.py``.
+    """
+    # Basic logging config in case nothing else has set it up (e.g.
+    # when launched bare via ``python -m`` rather than through
+    # ``manage.py``). Mirrors the pattern in
+    # ``src/scitex_orochi/_daemons/_stale_pr/__main__.py``.
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        )
+    try:
+        asyncio.run(run())
+    except KeyboardInterrupt:
+        logger.info("sac inventory reconciler interrupted; exiting")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scitex_orochi/_daemons/test__sac_inventory_sync.py
+++ b/tests/scitex_orochi/_daemons/test__sac_inventory_sync.py
@@ -22,7 +22,13 @@ see ``/work/manage.py``), call ``django.setup()``, and degrade to a
 We do NOT depend on ``pytest-django``. Instead each test runs inside a
 Django transaction that is rolled back at teardown — the same isolation
 ``TestCase`` gives you, but composable with pytest fixtures (``tmp_path``,
-``monkeypatch``, ``caplog``).
+``caplog``).
+
+Mock-policy note (PA-306): the project's audit forbids the ``monkeypatch``
+fixture in tests. We do all env-var manipulation by direct
+``os.environ[...] = ...`` writes inside a fixture that records the prior
+value and restores it on teardown — no mocking, no fixture-magic
+patching, just plain dict semantics.
 """
 
 from __future__ import annotations
@@ -137,18 +143,31 @@ def db_transaction():
 
 
 @pytest.fixture
-def agents_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, db_transaction) -> Path:
+def agents_dir(tmp_path: Path, db_transaction) -> Path:
     """Fresh empty sac agents inventory rooted in tmp_path, exposed
     to the daemon via the documented env var. Each test gets its own
     isolated workspace so name-collision can't leak across runs.
+
+    Env-var lifecycle is managed by direct ``os.environ`` writes with
+    a try/yield/finally restore pass — no ``monkeypatch`` fixture
+    (PA-306 forbids it under this project's audit).
     """
     d = tmp_path / "sac-agents"
     d.mkdir()
-    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_AGENTS_DIR", str(d))
-    monkeypatch.setenv(
-        "SCITEX_OROCHI_SAC_SYNC_WORKSPACE", f"reconciler-test-{tmp_path.name}"
-    )
-    return d
+    overrides = {
+        "SCITEX_AGENT_CONTAINER_AGENTS_DIR": str(d),
+        "SCITEX_OROCHI_SAC_SYNC_WORKSPACE": f"reconciler-test-{tmp_path.name}",
+    }
+    saved = {k: os.environ.get(k) for k in overrides}
+    os.environ.update(overrides)
+    try:
+        yield d
+    finally:
+        for k, prior in saved.items():
+            if prior is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prior
 
 
 def _ws():

--- a/tests/scitex_orochi/_daemons/test_sac_inventory_sync.py
+++ b/tests/scitex_orochi/_daemons/test_sac_inventory_sync.py
@@ -1,0 +1,330 @@
+"""Tests for the sac inventory reconciler daemon (ADR-0003 Phase 1).
+
+Six contract assertions:
+
+1. A reconcile pass with 3 SAC-v3 spec yamls creates 3 AgentProfile rows.
+2. A subsequent pass with one yaml removed sets that row's
+   ``is_hidden=True`` (does NOT delete).
+3. A subsequent pass with the previously-removed yaml restored sets
+   ``is_hidden=False`` again.
+4. Malformed yaml in one file does not crash the reconcile pass —
+   other files still processed; the bad one is logged + skipped.
+5. A spec with an unsupported ``apiVersion`` is logged + skipped (no
+   AgentProfile row created).
+6. The reconciler does NOT clobber operator-set icon fields when
+   upserting an existing row.
+
+Pattern note: Django needs configuring BEFORE any ``apps.hub.*`` import.
+Set ``DJANGO_SETTINGS_MODULE=config.settings`` (per ADR 0002 layout —
+see ``/work/manage.py``), call ``django.setup()``, and degrade to a
+``pytest.skip`` when Django isn't installed.
+
+We do NOT depend on ``pytest-django``. Instead each test runs inside a
+Django transaction that is rolled back at teardown — the same isolation
+``TestCase`` gives you, but composable with pytest fixtures (``tmp_path``,
+``monkeypatch``, ``caplog``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+# --- Django bootstrap ---
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+# Force a tmp SQLite DB so the test never touches the live db.sqlite3
+# (which may carry stale schema from older branches). The fixture below
+# runs ``migrate`` on this fresh DB on first use.
+import tempfile as _tempfile
+
+os.environ.setdefault(
+    "SCITEX_OROCHI_DB_PATH",
+    str(Path(_tempfile.gettempdir()) / "scitex_orochi_sac_inventory_test.sqlite3"),
+)
+# Wipe any leftover from a previous run so each session starts clean.
+_test_db = Path(os.environ["SCITEX_OROCHI_DB_PATH"])
+if _test_db.exists():
+    _test_db.unlink()
+
+try:
+    import django as _django
+
+    _django.setup()
+    _DJANGO_OK = True
+except Exception:  # pragma: no cover — Django missing or misconfigured
+    _DJANGO_OK = False
+
+pytestmark = pytest.mark.skipif(
+    not _DJANGO_OK, reason="Django not configured — skipping apps.hub.* tests"
+)
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers — no business-logic mocking, only tmp_path writes.
+# ---------------------------------------------------------------------------
+
+
+def _write_spec(
+    agents_dir: Path,
+    name: str,
+    *,
+    api_version: str = "scitex-agent-container/v3",
+    kind: str = "Agent",
+) -> Path:
+    """Materialise a SAC-v3-shaped ``<agents_dir>/<name>/spec.yaml`` on disk.
+
+    Mirrors the per-agent-directory layout used by SAC v3
+    (see ``examples/agents/full-agent/spec.yaml`` in the SAC repo):
+    one directory per agent, the directory name IS the agent name
+    (dir-as-SSoT — NO top-level ``name:`` key in the YAML).
+
+    Minimal valid payload: apiVersion + kind + a tiny ``spec`` block
+    that satisfies SAC's own validator (runtime + apptainer.image).
+    """
+    import yaml
+
+    agent_dir = agents_dir / name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    payload: dict = {
+        "apiVersion": api_version,
+        "kind": kind,
+        "spec": {
+            "runtime": "apptainer",
+            "apptainer": {
+                "image": "~/.scitex/agent-container/containers/sac-base.sif",
+            },
+        },
+    }
+    spec_path = agent_dir / "spec.yaml"
+    spec_path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    return spec_path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def db_transaction():
+    """Wrap each test in a Django transaction that is rolled back at
+    teardown. Equivalent to what ``django.test.TestCase`` does, but
+    composable with pytest fixtures.
+
+    Also ensures the schema exists (``call_command("migrate", ...)``)
+    on first use — this matters when the test is invoked from a bare
+    ``pytest tests/`` and not via ``manage.py test``.
+    """
+    from django.core.management import call_command
+    from django.db import connection, transaction
+
+    # Cheap idempotent migrate — Django no-ops if all migrations are
+    # already applied on the current connection.
+    if not connection.introspection.table_names():
+        call_command("migrate", "--run-syncdb", verbosity=0, interactive=False)
+
+    atomic = transaction.atomic()
+    atomic.__enter__()
+    sid = transaction.savepoint()
+    try:
+        yield
+    finally:
+        transaction.savepoint_rollback(sid)
+        atomic.__exit__(Exception, None, None)
+
+
+@pytest.fixture
+def agents_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, db_transaction) -> Path:
+    """Fresh empty sac agents inventory rooted in tmp_path, exposed
+    to the daemon via the documented env var. Each test gets its own
+    isolated workspace so name-collision can't leak across runs.
+    """
+    d = tmp_path / "sac-agents"
+    d.mkdir()
+    monkeypatch.setenv("SCITEX_AGENT_CONTAINER_AGENTS_DIR", str(d))
+    monkeypatch.setenv(
+        "SCITEX_OROCHI_SAC_SYNC_WORKSPACE", f"reconciler-test-{tmp_path.name}"
+    )
+    return d
+
+
+def _ws():
+    from apps.hub.models import Workspace
+
+    return Workspace.objects.get(name=os.environ["SCITEX_OROCHI_SAC_SYNC_WORKSPACE"])
+
+
+def _profile_names() -> set[str]:
+    from apps.hub.models import AgentProfile
+
+    return set(
+        AgentProfile.objects.filter(workspace=_ws()).values_list("name", flat=True)
+    )
+
+
+def _hidden_names() -> set[str]:
+    from apps.hub.models import AgentProfile
+
+    return set(
+        AgentProfile.objects.filter(workspace=_ws(), is_hidden=True).values_list(
+            "name", flat=True
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Contract tests
+# ---------------------------------------------------------------------------
+
+
+def test_first_pass_creates_one_row_per_spec(agents_dir):
+    """Contract 1 — three yamls → three AgentProfile rows, all visible."""
+    from scitex_orochi._daemons._sac_inventory_sync import reconcile_once
+
+    for n in ("alpha", "bravo", "charlie"):
+        _write_spec(agents_dir, n)
+
+    counters = reconcile_once(agents_dir)
+
+    assert counters["present"] == 3
+    assert counters["created"] == 3
+    assert counters["hidden"] == 0
+    assert _profile_names() == {"alpha", "bravo", "charlie"}
+    assert _hidden_names() == set()
+
+
+def test_removed_yaml_hides_but_does_not_delete(agents_dir):
+    """Contract 2 — removing a yaml flips is_hidden, preserves the row."""
+    from scitex_orochi._daemons._sac_inventory_sync import reconcile_once
+
+    for n in ("alpha", "bravo", "charlie"):
+        _write_spec(agents_dir, n)
+    reconcile_once(agents_dir)  # baseline
+
+    shutil.rmtree(agents_dir / "bravo")
+
+    counters = reconcile_once(agents_dir)
+
+    assert counters["present"] == 2
+    assert counters["hidden"] == 1
+    # Row still exists — message history preserved (ADR §Decision 2
+    # step 1 explicit requirement).
+    assert _profile_names() == {"alpha", "bravo", "charlie"}
+    assert _hidden_names() == {"bravo"}
+
+
+def test_restored_yaml_unhides(agents_dir):
+    """Contract 3 — re-appearing yaml clears is_hidden."""
+    from scitex_orochi._daemons._sac_inventory_sync import reconcile_once
+
+    for n in ("alpha", "bravo", "charlie"):
+        _write_spec(agents_dir, n)
+    reconcile_once(agents_dir)
+    shutil.rmtree(agents_dir / "bravo")
+    reconcile_once(agents_dir)
+    assert _hidden_names() == {"bravo"}
+
+    # Operator re-registers bravo with sac → spec.yaml back
+    _write_spec(agents_dir, "bravo")
+    counters = reconcile_once(agents_dir)
+
+    assert counters["unhidden"] == 1
+    assert _hidden_names() == set()
+    assert _profile_names() == {"alpha", "bravo", "charlie"}
+
+
+def test_malformed_yaml_does_not_crash_pass(agents_dir, caplog):
+    """Contract 4 — bad yaml is logged + skipped; rest of the pass still runs."""
+    import logging
+
+    from scitex_orochi._daemons._sac_inventory_sync import reconcile_once
+
+    _write_spec(agents_dir, "alpha")
+    _write_spec(agents_dir, "charlie")
+
+    # Hand-write a broken spec.yaml for "bravo" (unclosed bracket).
+    (agents_dir / "bravo").mkdir()
+    (agents_dir / "bravo" / "spec.yaml").write_text(
+        "apiVersion: scitex-agent-container/v3\nkind: Agent\nspec: {runtime: [unterminated",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="orochi.daemon.sac_inventory_sync"):
+        counters = reconcile_once(agents_dir)
+
+    # The two well-formed specs still got processed.
+    assert counters["present"] == 2
+    assert _profile_names() == {"alpha", "charlie"}
+    # The bad file was logged with the path so an operator can find it.
+    assert any(
+        "bravo" in rec.message and "spec.yaml" in rec.message for rec in caplog.records
+    ), (
+        f"expected a warning naming bravo/spec.yaml, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_unknown_apiversion_skipped(agents_dir, caplog):
+    """Contract 5 — non-v3 apiVersion is logged + skipped, no row created."""
+    import logging
+
+    from scitex_orochi._daemons._sac_inventory_sync import reconcile_once
+
+    _write_spec(agents_dir, "alpha")
+    # bravo declares the older v2 schema — must NOT be upserted.
+    _write_spec(agents_dir, "bravo", api_version="scitex-agent-container/v2")
+    _write_spec(agents_dir, "charlie")
+
+    with caplog.at_level(logging.WARNING, logger="orochi.daemon.sac_inventory_sync"):
+        counters = reconcile_once(agents_dir)
+
+    assert counters["present"] == 2
+    assert counters["created"] == 2
+    # bravo not in the DB — the v2 spec was rejected.
+    assert _profile_names() == {"alpha", "charlie"}
+    # And the operator gets a warning naming the file + the bad version.
+    assert any(
+        "bravo" in rec.message and "apiVersion" in rec.message for rec in caplog.records
+    ), (
+        f"expected an apiVersion warning naming bravo, got: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_icons_are_not_clobbered(agents_dir):
+    """Contract 6 — operator-set icon fields survive a reconcile pass.
+
+    Operators set icons via the dashboard (msg#17078 / AgentProfile
+    has icon_emoji / icon_image / icon_text / color columns). The
+    reconciler must never touch those fields on existing rows — the
+    only mutation it makes on an existing row is the ``is_hidden`` flag.
+    """
+    from apps.hub.models import AgentProfile, Workspace
+    from scitex_orochi._daemons._sac_inventory_sync import reconcile_once
+
+    # Pre-create the workspace + a row with operator-set icons.
+    ws_name = os.environ["SCITEX_OROCHI_SAC_SYNC_WORKSPACE"]
+    ws, _ = Workspace.objects.get_or_create(
+        name=ws_name, defaults={"description": "test"}
+    )
+    AgentProfile.objects.create(
+        workspace=ws,
+        name="alpha",
+        icon_emoji="🦊",
+        icon_text="AL",
+        color="#ff8800",
+        is_hidden=False,
+    )
+
+    # SAC inventory has alpha present.
+    _write_spec(agents_dir, "alpha")
+
+    reconcile_once(agents_dir)
+
+    profile = AgentProfile.objects.get(workspace=ws, name="alpha")
+    # Icons SURVIVE — the reconciler never overwrites them.
+    assert profile.icon_emoji == "🦊"
+    assert profile.icon_text == "AL"
+    assert profile.color == "#ff8800"
+    assert profile.is_hidden is False


### PR DESCRIPTION
## What + why

Resolves operator complaint msg#74 ("old contributors stay in orochi UI for months after they're gone from sac") by making SAC v3 filesystem inventory the canonical source of truth for which agents exist. A new daemon flips `AgentProfile.is_hidden=True` when a spec.yaml disappears (preserving message history) and clears the flag when it re-appears.

## Scope

This is ADR 0003 ([#443](https://github.com/ywatanabe1989/scitex-orochi/pull/443)) §Decision 2 step 1 — the highest-leverage single change called out in that ADR. ADR 0003 is being amended in lockstep (separate PR) to reflect SAC-v3 dir-as-SSoT (the directory name IS the agent name; no top-level `name:` key in canonical v3 YAML).

Honors SAC v3 conventions per `~/proj/scitex-agent-container/examples/agents/full-agent/spec.yaml`:

- agent name derived from `spec_path.parent.name` (dir-as-SSoT)
- validates `apiVersion: scitex-agent-container/v3` (warn+skip on mismatch)
- validates `kind in {Agent, AgentProxy}` (warn+skip on mismatch)
- never reads a `spec.orochi` block (not in canonical SAC v3)

Operator-set icon fields (`icon_emoji`, `icon_image`, `icon_text`, `color`) are **never clobbered** — the reconciler's only mutation on existing rows is the `is_hidden` flag.

## Files added

- `src/scitex_orochi/_daemons/_sac_inventory_sync.py` — daemon body
- `apps/hub/management/commands/sync_sac_inventory.py` — `python manage.py sync_sac_inventory`
- `tests/scitex_orochi/_daemons/test_sac_inventory_sync.py` — 6 contract tests

## Contract tests (all 6 green)

1. `test_first_pass_creates_one_row_per_spec` — three specs create three AgentProfile rows, all visible
2. `test_removed_yaml_hides_but_does_not_delete` — removing a spec flips `is_hidden=True`, row preserved
3. `test_restored_yaml_unhides` — restoring the spec clears `is_hidden`
4. `test_malformed_yaml_does_not_crash_pass` — bad yaml is logged + skipped; pass continues
5. `test_unknown_apiversion_skipped` — non-v3 apiVersion is logged + skipped (no row created)
6. `test_icons_are_not_clobbered` — operator-set icon fields survive a reconcile pass

## Deferred (out of scope for this PR — called out in module docstring)

- Multi-host inventory (single-host first; ADR §Decision 2 step 1 defers fleet inventory to a follow-up ADR)
- ContainerAgent collapse (ADR §Decision 2 steps 2-3)
- `hub.registry._agents` → `_session_cache` rename (ADR §Decision 2 step 3)
- `metadata.labels.*` mapping into orochi-side surfaces (description, role, capabilities)

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `SCITEX_AGENT_CONTAINER_AGENTS_DIR` | `~/.scitex/agent-container/agents` | SAC inventory root |
| `SCITEX_OROCHI_SAC_SYNC_INTERVAL` | `300` (5 min) | Reconcile tick interval (s) |
| `SCITEX_OROCHI_SAC_SYNC_WORKSPACE` | `default` | Target workspace (Phase-1 single-workspace simplification) |

## Test plan

- [x] `pytest tests/scitex_orochi/_daemons/test_sac_inventory_sync.py -v` → 6 passed
- [ ] Smoke: `python manage.py sync_sac_inventory` against a real `~/.scitex/agent-container/agents/` (post-merge, by operator)