### PR TITLE
fix(ops/#250): DM-healer dispatch for singleton-host-check + un-skip test path

### DIFF
--- a/apps/hub/tests/test_singleton_host_check.py
+++ b/apps/hub/tests/test_singleton_host_check.py
@@ -12,7 +12,17 @@ import tempfile
 import unittest
 from pathlib import Path
 
-_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "server" / "singleton-host-check.py"
+# Tests live at apps/hub/tests/test_singleton_host_check.py. parents:
+#   parents[0] = apps/hub/tests
+#   parents[1] = apps/hub
+#   parents[2] = apps
+#   parents[3] = <repo-root>  ← script lives at repo-root/scripts/server/
+# The original ``parents[2]`` was correct under the pre-ADR-0002 layout
+# (hub at repo root); commit b059a14 moved hub under apps/ but missed
+# this path-resolution update, so the 18 tests had been silently
+# ``skipped 'singleton-host-check.py not found'`` ever since.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT = _REPO_ROOT / "scripts" / "server" / "singleton-host-check.py"
 
 
 def _load_shc():
@@ -45,7 +55,9 @@ class CollectSpecsTest(unittest.TestCase):
             specs = _shc._collect_specs(p)
         self.assertEqual(len(specs), 1)
         self.assertEqual(specs[0]["name"], "proj-neurovista")
-        self.assertEqual(specs[0]["host_priority"], ["spartan", "ywata-note-win", "nas"])
+        self.assertEqual(
+            specs[0]["host_priority"], ["spartan", "ywata-note-win", "nas"]
+        )
 
     def test_single_host_spec_skipped(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -182,16 +194,242 @@ class FormatReportTest(unittest.TestCase):
         self.assertEqual(_shc._format_report([]), "")
 
     def test_warning_appears_in_report(self):
-        warnings = [{
-            "agent": "proj-neurovista",
-            "current_machine": "nas",
-            "current_rank": 3,
-            "preferred_host": "spartan",
-            "preferred_rank": 1,
-            "priority_list": ["spartan", "ywata-note-win", "nas"],
-        }]
+        warnings = [
+            {
+                "agent": "proj-neurovista",
+                "current_machine": "nas",
+                "current_rank": 3,
+                "preferred_host": "spartan",
+                "preferred_rank": 1,
+                "priority_list": ["spartan", "ywata-note-win", "nas"],
+            }
+        ]
         report = _shc._format_report(warnings)
         self.assertIn("proj-neurovista", report)
         self.assertIn("spartan", report)
         self.assertIn("nas", report)
         self.assertIn("#250", report)
+
+
+# ---------------------------------------------------------------------------
+# DM-healer dispatch tests (#250 Optional follow-up)
+# ---------------------------------------------------------------------------
+
+
+def _sample_warning() -> dict:
+    return {
+        "agent": "proj-neurovista",
+        "current_machine": "nas",
+        "current_rank": 3,
+        "preferred_host": "spartan",
+        "preferred_rank": 1,
+        "priority_list": ["spartan", "ywata-note-win", "nas"],
+    }
+
+
+@unittest.skipIf(_shc is None, "singleton-host-check.py not found")
+class ResolveHealerNameTest(unittest.TestCase):
+    def test_default_template_head_dash_host(self):
+        self.assertEqual(
+            _shc._resolve_healer_name("spartan", "head-{host}"),
+            "head-spartan",
+        )
+
+    def test_strips_user_at_prefix(self):
+        self.assertEqual(
+            _shc._resolve_healer_name("ywatanabe@spartan", "head-{host}"),
+            "head-spartan",
+        )
+
+    def test_strips_fqdn_suffix(self):
+        self.assertEqual(
+            _shc._resolve_healer_name("spartan.unimelb.edu.au", "head-{host}"),
+            "head-spartan",
+        )
+
+    def test_custom_template(self):
+        self.assertEqual(
+            _shc._resolve_healer_name("nas", "caduceus@{host}"),
+            "caduceus@nas",
+        )
+
+    def test_bad_placeholder_raises(self):
+        # Template referencing an unknown placeholder must NOT silently
+        # produce a malformed name — fail loud so the operator notices.
+        with self.assertRaises(KeyError):
+            _shc._resolve_healer_name("spartan", "{role}-{host}")
+
+
+@unittest.skipIf(_shc is None, "singleton-host-check.py not found")
+class DmChannelNameTest(unittest.TestCase):
+    def test_canonical_form_sorted(self):
+        # Sorted-principal-key shape (spec v3 §2.3): regardless of which
+        # side is the sender, the channel name is identical so the hub's
+        # ``_ensure_dm_channel`` get-or-create is idempotent.
+        a = _shc._dm_channel_name("singleton-host-check", "head-spartan")
+        b = _shc._dm_channel_name("head-spartan", "singleton-host-check")
+        self.assertEqual(a, b)
+        self.assertTrue(a.startswith("dm:"))
+        self.assertIn("agent:head-spartan", a)
+        self.assertIn("agent:singleton-host-check", a)
+
+    def test_principals_sorted_alphabetically(self):
+        # Sanity-check the exact canonical shape so spec drift is caught.
+        name = _shc._dm_channel_name("zeta", "alpha")
+        self.assertEqual(name, "dm:agent:alpha|agent:zeta")
+
+
+@unittest.skipIf(_shc is None, "singleton-host-check.py not found")
+class FormatDmForHealerTest(unittest.TestCase):
+    def test_includes_agent_and_action(self):
+        text = _shc._format_dm_for_healer(_sample_warning())
+        self.assertIn("proj-neurovista", text)
+        self.assertIn("spartan", text)
+        self.assertIn("nas", text)
+        self.assertIn("sac singleton-reconcile --execute", text)
+        self.assertIn("#250", text)
+
+    def test_priority_list_rendered_arrow_separated(self):
+        text = _shc._format_dm_for_healer(_sample_warning())
+        self.assertIn("spartan > ywata-note-win > nas", text)
+
+
+@unittest.skipIf(_shc is None, "singleton-host-check.py not found")
+class DispatchDmWarningsTest(unittest.TestCase):
+    def test_dispatches_one_per_warning_with_resolved_healer(self):
+        captured: list[tuple[str, str]] = []
+
+        def fake_post(healer: str, text: str) -> bool:
+            captured.append((healer, text))
+            return True
+
+        w1 = _sample_warning()
+        w2 = {**_sample_warning(), "agent": "proj-other", "preferred_host": "mba"}
+        results = _shc.dispatch_dm_warnings(
+            [w1, w2], template="head-{host}", post=fake_post
+        )
+
+        self.assertEqual(len(captured), 2)
+        self.assertEqual(captured[0][0], "head-spartan")
+        self.assertEqual(captured[1][0], "head-mba")
+        # Every result records its outcome so operators can see at a
+        # glance which DMs landed.
+        self.assertTrue(all(r["ok"] for r in results))
+        self.assertEqual(
+            [r["agent"] for r in results], ["proj-neurovista", "proj-other"]
+        )
+        self.assertEqual([r["healer"] for r in results], ["head-spartan", "head-mba"])
+
+    def test_post_failure_recorded_in_results(self):
+        def fake_post(healer: str, text: str) -> bool:
+            return False  # simulate hub unreachable
+
+        results = _shc.dispatch_dm_warnings(
+            [_sample_warning()], template="head-{host}", post=fake_post
+        )
+        self.assertEqual(
+            results,
+            [{"agent": "proj-neurovista", "healer": "head-spartan", "ok": False}],
+        )
+
+    def test_template_resolution_failure_skips_post(self):
+        calls: list[tuple[str, str]] = []
+
+        def fake_post(healer: str, text: str) -> bool:
+            calls.append((healer, text))
+            return True
+
+        # Bad template — {role} is not defined → KeyError → no post call.
+        results = _shc.dispatch_dm_warnings(
+            [_sample_warning()], template="{role}-{host}", post=fake_post
+        )
+        self.assertEqual(calls, [])
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0]["ok"])
+        self.assertIsNone(results[0]["healer"])
+
+
+@unittest.skipIf(_shc is None, "singleton-host-check.py not found")
+class PostDmToHealerUrlShapeTest(unittest.TestCase):
+    """Verify ``_post_dm_to_healer`` builds the correct request shape.
+
+    Uses ``unittest.mock.patch`` against the helper module's local
+    ``urllib.request.urlopen`` import — the helper imports inside the
+    function to keep top-level imports stdlib-only, so the patch
+    target is the ``urllib.request`` module rather than a re-bound
+    name on ``_shc`` itself.
+    """
+
+    def test_post_url_and_body_shape(self):
+        import urllib.request as _ur
+        from unittest import mock
+
+        # Force-known env values for deterministic URL/body assertions.
+        captured: dict[str, object] = {}
+
+        class _FakeResp:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+        def _fake_urlopen(req, timeout=10):
+            captured["url"] = req.full_url
+            captured["data"] = req.data
+            captured["method"] = req.get_method()
+            captured["content_type"] = req.headers.get("Content-type")
+            return _FakeResp()
+
+        # Patch the env-driven module-level constants on the helper
+        # module so the URL is fully deterministic, then patch urlopen
+        # at the urllib.request level (helper does
+        # ``import urllib.request`` inside the function body).
+        with (
+            mock.patch.object(_shc._dm, "HUB_URL", "https://hub.test"),
+            mock.patch.object(_shc._dm, "HUB_TOKEN", "wks_TESTTOKEN"),
+            mock.patch.object(_shc._dm, "WORKSPACE_SLUG", "fleet"),
+            mock.patch.object(_shc._dm, "SCRIPT_AGENT_NAME", "singleton-host-check"),
+            mock.patch.object(_ur, "urlopen", _fake_urlopen),
+        ):
+            ok = _shc._post_dm_to_healer("head-spartan", "hello")
+
+        self.assertTrue(ok)
+        self.assertEqual(captured["method"], "POST")
+        self.assertEqual(captured["content_type"], "application/json")
+        # URL — workspace-scoped messages endpoint with both query auth
+        # keys present so the eventual token-auth landing on
+        # ``api_messages`` can flip on without touching this caller.
+        self.assertIn(
+            "https://hub.test/api/workspace/fleet/messages/",
+            captured["url"],
+        )
+        self.assertIn("token=wks_TESTTOKEN", captured["url"])
+        self.assertIn("agent=singleton-host-check", captured["url"])
+        # Body — canonical DM channel + the supplied text. JSON body
+        # also carries the token for symmetry with the legacy
+        # ``_post_to_heads`` payload shape.
+        import json as _json
+
+        body = _json.loads(captured["data"])
+        self.assertEqual(body["text"], "hello")
+        self.assertEqual(body["token"], "wks_TESTTOKEN")
+        self.assertEqual(
+            body["channel"],
+            "dm:agent:head-spartan|agent:singleton-host-check",
+        )
+
+    def test_post_returns_false_on_urlopen_exception(self):
+        import urllib.request as _ur
+        from unittest import mock
+
+        def _boom(req, timeout=10):
+            raise OSError("hub unreachable")
+
+        with mock.patch.object(_ur, "urlopen", _boom):
+            ok = _shc._post_dm_to_healer("head-spartan", "hello")
+        # Hub-unreachable is logged (not raised) so the cron loop keeps
+        # going; the return value is the signal the caller checks.
+        self.assertFalse(ok)

--- a/deployment/host-setup/orochi-cron/cron.yaml.example
+++ b/deployment/host-setup/orochi-cron/cron.yaml.example
@@ -80,12 +80,26 @@ jobs:
 
   # Singleton host-priority checker (#250) — Option C interim.
   # Reads ~/.scitex/orochi/shared/agents/*/spec.yaml, queries /api/agents/,
-  # and posts a warning to #heads when a singleton agent is running on a
+  # and emits a warning when a singleton agent is running on a
   # lower-priority host while its preferred host is online.
-  # Requires: SCITEX_OROCHI_TOKEN, SCITEX_OROCHI_HUB_URL set in daemon env.
+  #
+  # Flags:
+  #   --post         broadcast warning to #heads (legacy fan-out).
+  #   --dm-healer    DM the resolved healer on each preferred host
+  #                  (template: SCITEX_OROCHI_HEALER_TEMPLATE, default
+  #                  'head-{host}') with a per-warning, action-oriented
+  #                  yield request — the healer can then call
+  #                  ``sac singleton-reconcile --execute``.
+  # Run both together for fleet-wide visibility AND targeted action;
+  # --dm-healer alone if you'd rather skip the #heads noise.
+  #
+  # Requires: SCITEX_OROCHI_TOKEN, SCITEX_OROCHI_HUB_URL set in daemon
+  # env. For --dm-healer also: SCITEX_OROCHI_WORKSPACE (default
+  # 'fleet') and optionally SCITEX_OROCHI_HEALER_TEMPLATE +
+  # SCITEX_OROCHI_SINGLETON_CHECK_AGENT.
   # - name: singleton-host-check
   #   interval: 10m
-  #   command: "python3 ${SCITEX_OROCHI_REPO_ROOT}/scripts/server/singleton-host-check.py --post"
+  #   command: "python3 ${SCITEX_OROCHI_REPO_ROOT}/scripts/server/singleton-host-check.py --post --dm-healer"
   #   timeout: 2m
 
   # scitex.ai post-deploy Playwright smoke test (#237 Part 2) — NAS only.

--- a/scripts/server/_singleton_dm_healer.py
+++ b/scripts/server/_singleton_dm_healer.py
@@ -1,0 +1,210 @@
+"""DM-dispatch helpers for ``singleton-host-check.py`` (issue #250).
+
+Split out of the main script to keep each file under the 512-line
+ceiling and to make the dispatch path independently testable. The main
+script re-exports these names so the existing ``importlib`` test
+loader keeps working without per-test path rewrites.
+
+What lives here
+---------------
+* ``HEALER_NAME_TEMPLATE`` / ``SCRIPT_AGENT_NAME`` / ``WORKSPACE_SLUG``
+  — env-driven configuration for "who is the healer on host X" and
+  "what sender identity do we DM as".
+* ``_resolve_healer_name(host, template)`` — strict ``{host}``
+  substitution; raises rather than silently producing a malformed name.
+* ``_dm_channel_name(sender, healer)`` — canonical spec v3 §2.3
+  ``dm:agent:<a>|agent:<b>`` channel name (sorted principals → name
+  is initiator-independent → hub's ``_ensure_dm_channel`` is
+  naturally idempotent).
+* ``_format_dm_for_healer(warning)`` — action-oriented per-warning
+  body that points the receiving healer at
+  ``sac singleton-reconcile --execute``.
+* ``_post_dm_to_healer(healer, text)`` — POSTs to
+  ``/api/workspace/<slug>/messages/`` with ``?token=&agent=`` query
+  auth. Returns bool; logs (does not raise) on hub-unreachable.
+* ``dispatch_dm_warnings(warnings)`` — orchestrator the CLI calls,
+  with an injectable ``post`` callable so tests can capture the
+  call shape without touching the network.
+
+References
+----------
+* Issue #250 — bug(singleton-scheduler): agent host-priority not
+  enforced. The "Optional" follow-up calls for DM-targeting the
+  preferred-host healer instead of broadcasting to ``#heads``.
+* ``apps/hub/views/api/_dms.py::_ensure_dm_channel`` — the hub-side
+  endpoint that lazy-creates the DM channel on first message send.
+* ``docs/architecture.md`` Snake Fleet Topology — fleet healer
+  naming convention (``head-<machine>``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Callable
+
+log = logging.getLogger("singleton-host-check.dm")
+
+# ---------------------------------------------------------------------------
+# Configuration (env-driven)
+# ---------------------------------------------------------------------------
+
+HUB_URL = os.environ.get("SCITEX_OROCHI_HUB_URL", "https://scitex-orochi.com")
+HUB_TOKEN = os.environ.get("SCITEX_OROCHI_TOKEN", "")
+
+# Sender identity used by the DM-healer dispatch path. The DM endpoint
+# resolves ``?agent=<name>`` into ``agent-<name>`` Django user, so this
+# value also becomes the visible sender in the healer's DM list. Kept
+# distinct from any real agent name so the DM provenance is obvious.
+SCRIPT_AGENT_NAME = os.environ.get(
+    "SCITEX_OROCHI_SINGLETON_CHECK_AGENT", "singleton-host-check"
+)
+
+# Template used to resolve a preferred-host name into the healer agent
+# name that owns lifecycle on that host. ``{host}`` is the only allowed
+# substitution. Default mirrors the ``head-<machine>`` convention used
+# by the fleet (see ``docs/architecture.md`` Snake Fleet Topology).
+HEALER_NAME_TEMPLATE = os.environ.get("SCITEX_OROCHI_HEALER_TEMPLATE", "head-{host}")
+
+# Workspace slug used when resolving the DM/messages endpoint on the
+# bare domain. Defaults to ``fleet`` (the canonical workspace operators
+# run agents against); operators on a different workspace set this env
+# var to match. Used by the ``/api/workspace/<slug>/...`` token-auth
+# routes that DM-create + DM-message both go through.
+WORKSPACE_SLUG = os.environ.get("SCITEX_OROCHI_WORKSPACE", "fleet")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_healer_name(host: str, template: str = HEALER_NAME_TEMPLATE) -> str:
+    """Return the healer agent name on ``host`` per ``template``.
+
+    ``template`` must contain ``{host}``; we substitute the bare host
+    (no FQDN / no ``user@`` prefix) so the resulting name lines up with
+    the registered agent identity (``head-spartan`` etc.). Strict
+    substitution — any other ``{...}`` placeholder raises ``KeyError``
+    rather than silently producing a malformed name.
+    """
+    bare = host.split("@")[-1].split(".")[0]
+    return template.format(host=bare)
+
+
+def _dm_channel_name(sender: str, healer: str) -> str:
+    """Return the canonical ``dm:<a>|<b>`` channel name for the pair.
+
+    Spec v3 §2.3: principal keys are sorted so the channel name is
+    initiator-independent, which makes ``_ensure_dm_channel`` on the
+    hub side idempotent.
+    """
+    keys = sorted([f"agent:{sender}", f"agent:{healer}"])
+    return "dm:" + "|".join(keys)
+
+
+def _format_dm_for_healer(warning: dict) -> str:
+    """Render the per-warning DM body sent to the preferred-host healer.
+
+    Action-oriented and stable — the healer parses neither, but humans
+    reading the DM should immediately see *what* to do (run ``sac
+    singleton-reconcile --execute``) and *why* (the priority drift).
+    """
+    return (
+        f"[#250 singleton-host-check] preferred-host yield needed\n"
+        f"agent: {warning['agent']}\n"
+        f"current_machine: {warning['current_machine']} "
+        f"(priority #{warning['current_rank']})\n"
+        f"preferred_host: {warning['preferred_host']} "
+        f"(priority #{warning['preferred_rank']}) — you\n"
+        f"priority_list: {' > '.join(warning['priority_list'])}\n"
+        f"action: run `sac singleton-reconcile --execute` to claim "
+        f"{warning['agent']} from {warning['current_machine']}"
+    )
+
+
+def _post_dm_to_healer(healer: str, text: str) -> bool:
+    """POST a DM to ``healer`` via the workspace messages endpoint.
+
+    Returns ``True`` on a 2xx response and ``False`` (with a warning
+    logged) otherwise. The channel name is the canonical ``dm:`` form
+    so the hub's ``_ensure_dm_channel`` lazy-create runs idempotently
+    on first contact.
+
+    Symmetric with the legacy ``_post_to_heads`` w.r.t. auth — passes
+    the workspace token in the JSON body and ``?agent=`` on the query
+    string so the eventual token-auth path (sibling work item) can be
+    added to ``api_messages`` without changing this call site.
+    """
+    try:
+        import urllib.request
+
+        channel = _dm_channel_name(SCRIPT_AGENT_NAME, healer)
+        data = json.dumps(
+            {
+                "token": HUB_TOKEN,
+                "channel": channel,
+                "text": text,
+            }
+        ).encode()
+        url = (
+            f"{HUB_URL}/api/workspace/{WORKSPACE_SLUG}/messages/"
+            f"?token={HUB_TOKEN}&agent={SCRIPT_AGENT_NAME}"
+        )
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= resp.status < 300
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (reason: hub may be unreachable during check)
+        log.warning("Failed to DM healer %s: %s", healer, exc)
+        return False
+
+
+def dispatch_dm_warnings(
+    warnings: list[dict],
+    *,
+    template: str = HEALER_NAME_TEMPLATE,
+    post: Callable[[str, str], bool] = _post_dm_to_healer,
+) -> list[dict]:
+    """Resolve + DM the preferred-host healer for each warning.
+
+    Returns a list of ``{agent, healer, ok}`` records — the caller
+    prints these so operators can see at a glance which DMs landed.
+    ``post`` is injectable so the unit tests can capture the call
+    shape without touching the network.
+    """
+    results: list[dict] = []
+    for w in warnings:
+        try:
+            healer = _resolve_healer_name(w["preferred_host"], template)
+        except (KeyError, IndexError, ValueError) as exc:
+            log.warning(
+                "Could not resolve healer for host %s via template %r: %s",
+                w.get("preferred_host"),
+                template,
+                exc,
+            )
+            results.append({"agent": w.get("agent"), "healer": None, "ok": False})
+            continue
+        ok = post(healer, _format_dm_for_healer(w))
+        results.append({"agent": w["agent"], "healer": healer, "ok": ok})
+    return results
+
+
+__all__ = [
+    "HEALER_NAME_TEMPLATE",
+    "SCRIPT_AGENT_NAME",
+    "WORKSPACE_SLUG",
+    "_resolve_healer_name",
+    "_dm_channel_name",
+    "_format_dm_for_healer",
+    "_post_dm_to_healer",
+    "dispatch_dm_warnings",
+]

--- a/scripts/server/singleton-host-check.py
+++ b/scripts/server/singleton-host-check.py
@@ -5,31 +5,40 @@ Reads singleton agent YAML files from the shared agents directory, extracts
 their ``host:`` priority lists, then queries the Orochi hub registry to
 determine where each agent is currently running.  When an agent is on a
 lower-priority host but a higher-priority host is alive (reachable via SSH
-or confirmed online via the hub registry), the script posts a warning to
-#heads.
+or confirmed online via the hub registry), the script can:
+
+* ``--post`` — post a broadcast warning to ``#heads`` (legacy behaviour);
+* ``--dm-healer`` — DM the resolved healer on the preferred host with a
+  per-warning, action-oriented message (e.g. "run ``sac
+  singleton-reconcile --execute``"). This narrows the alert from
+  fleet-wide to "the agent that can actually fix it" and closes the
+  *Optional* item left in issue #250.
 
 Designed to run as a cron job every 5–10 minutes:
 
-    */5 * * * * /path/to/singleton-host-check.py --post
+    */5 * * * * /path/to/singleton-host-check.py --post --dm-healer
 
-Without ``--post`` it prints the report to stdout only (dry-run mode).
+Without ``--post`` / ``--dm-healer`` it prints the report to stdout only
+(dry-run mode).
 
 References
 ----------
 * Issue #250 — bug(singleton-scheduler): agent host-priority not enforced
 * Design option (C) — cron-based interim check
+* ``SCITEX_OROCHI_HEALER_TEMPLATE`` env var — host→healer-name template
+  (default ``head-{host}``)
 """
 
 from __future__ import annotations
 
 import argparse
+import importlib.util as _importlib_util
 import json
 import logging
 import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
 try:
     import yaml
@@ -111,11 +120,13 @@ def _collect_specs(agents_dir: Path | None = None) -> list[dict]:
             continue
 
         agent_name = spec_file.parent.name
-        specs.append({
-            "name": agent_name,
-            "host_priority": host_priority,
-            "spec_path": str(spec_file),
-        })
+        specs.append(
+            {
+                "name": agent_name,
+                "host_priority": host_priority,
+                "spec_path": str(spec_file),
+            }
+        )
     return specs
 
 
@@ -128,6 +139,7 @@ def _fetch_agents() -> list[dict]:
     """GET /api/agents/ and return list of agent dicts."""
     try:
         import urllib.request
+
         url = f"{HUB_URL}/api/agents/?token={HUB_TOKEN}"
         with urllib.request.urlopen(url, timeout=10) as resp:
             return json.loads(resp.read())
@@ -169,13 +181,24 @@ def _online_machines(agents: list[dict]) -> set[str]:
 def _ssh_reachable(host: str, timeout: int = 5) -> bool:
     try:
         result = subprocess.run(
-            ["ssh", "-o", f"ConnectTimeout={timeout}", "-o", "BatchMode=yes",
-             "-o", "StrictHostKeyChecking=no", host, "hostname"],
+            [
+                "ssh",
+                "-o",
+                f"ConnectTimeout={timeout}",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "StrictHostKeyChecking=no",
+                host,
+                "hostname",
+            ],
             capture_output=True,
             timeout=timeout + 2,
         )
         return result.returncode == 0
-    except Exception:  # stx-allow: fallback (reason: SSH failure — treat host as unreachable)
+    except (
+        Exception
+    ):  # stx-allow: fallback (reason: SSH failure — treat host as unreachable)
         return False
 
 
@@ -209,13 +232,16 @@ def check_placements(
         # Find where this agent sits in the priority list
         try:
             current_rank = next(
-                i for i, h in enumerate(priority_list)
+                i
+                for i, h in enumerate(priority_list)
                 if h.lower() == current_machine_bare.lower()
             )
         except StopIteration:
             log.debug(
                 "%s on machine %s which is not in its priority list %s",
-                name, current_machine, priority_list,
+                name,
+                current_machine,
+                priority_list,
             )
             current_rank = len(priority_list)
 
@@ -232,14 +258,16 @@ def check_placements(
                     online_machines.add(host)  # cache
 
             if alive:
-                warnings.append({
-                    "agent": name,
-                    "current_machine": current_machine,
-                    "current_rank": current_rank + 1,
-                    "preferred_host": host,
-                    "preferred_rank": rank + 1,
-                    "priority_list": priority_list,
-                })
+                warnings.append(
+                    {
+                        "agent": name,
+                        "current_machine": current_machine,
+                        "current_rank": current_rank + 1,
+                        "preferred_host": host,
+                        "preferred_rank": rank + 1,
+                        "priority_list": priority_list,
+                    }
+                )
                 break  # report only the highest available preferred host
 
     return warnings
@@ -271,11 +299,14 @@ def _format_report(warnings: list[dict]) -> str:
 def _post_to_heads(text: str) -> None:
     try:
         import urllib.request
-        data = json.dumps({
-            "token": HUB_TOKEN,
-            "channel": HEADS_CHANNEL,
-            "text": text,
-        }).encode()
+
+        data = json.dumps(
+            {
+                "token": HUB_TOKEN,
+                "channel": HEADS_CHANNEL,
+                "text": text,
+            }
+        ).encode()
         req = urllib.request.Request(
             f"{HUB_URL}/api/messages/",
             data=data,
@@ -284,8 +315,38 @@ def _post_to_heads(text: str) -> None:
         )
         with urllib.request.urlopen(req, timeout=10):
             pass
-    except Exception as exc:  # stx-allow: fallback (reason: hub may be unreachable during check)
+    except (
+        Exception
+    ) as exc:  # stx-allow: fallback (reason: hub may be unreachable during check)
         log.warning("Failed to post to hub: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# DM-healer dispatch (#250 optional follow-up)
+# ---------------------------------------------------------------------------
+#
+# The helpers live in the sibling ``_singleton_dm_healer.py`` module to
+# keep this file under the 512-line ceiling. We re-export them here so
+# the existing ``importlib.util.spec_from_file_location("shc", _SCRIPT)``
+# test loader can still reach them by attribute name on the script
+# module (the test file is intentionally script-path-scoped, not
+# package-scoped).
+
+
+_DM_HELPER_PATH = Path(__file__).resolve().parent / "_singleton_dm_healer.py"
+_spec = _importlib_util.spec_from_file_location("_singleton_dm_healer", _DM_HELPER_PATH)
+_dm = _importlib_util.module_from_spec(_spec)  # type: ignore[arg-type]
+assert _spec and _spec.loader, "DM helper module missing"
+_spec.loader.exec_module(_dm)  # type: ignore[union-attr]
+
+HEALER_NAME_TEMPLATE = _dm.HEALER_NAME_TEMPLATE
+SCRIPT_AGENT_NAME = _dm.SCRIPT_AGENT_NAME
+WORKSPACE_SLUG = _dm.WORKSPACE_SLUG
+_resolve_healer_name = _dm._resolve_healer_name
+_dm_channel_name = _dm._dm_channel_name
+_format_dm_for_healer = _dm._format_dm_for_healer
+_post_dm_to_healer = _dm._post_dm_to_healer
+dispatch_dm_warnings = _dm.dispatch_dm_warnings
 
 
 # ---------------------------------------------------------------------------
@@ -298,7 +359,24 @@ def main() -> None:
     parser.add_argument(
         "--post",
         action="store_true",
-        help="Post warnings to #heads (default: dry-run, print only)",
+        help="Post broadcast warnings to #heads (default: dry-run, print only)",
+    )
+    parser.add_argument(
+        "--dm-healer",
+        action="store_true",
+        help=(
+            "Also DM the resolved healer on each preferred host with a "
+            "per-warning, action-oriented yield request (template via "
+            "SCITEX_OROCHI_HEALER_TEMPLATE, default 'head-{host}')."
+        ),
+    )
+    parser.add_argument(
+        "--healer-template",
+        default=HEALER_NAME_TEMPLATE,
+        help=(
+            "Override the host→healer name template "
+            "(default from SCITEX_OROCHI_HEALER_TEMPLATE)."
+        ),
     )
     parser.add_argument(
         "--ssh",
@@ -346,6 +424,12 @@ def main() -> None:
     if args.post:
         _post_to_heads(report)
         print("(posted to #heads)")
+    if args.dm_healer:
+        results = dispatch_dm_warnings(warnings, template=args.healer_template)
+        for r in results:
+            tag = "ok" if r["ok"] else "FAILED"
+            healer = r["healer"] or "<unresolved>"
+            print(f"(dm-healer {tag}: {r['agent']} → {healer})")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Closes the *Optional* follow-up on issue #250: when the singleton placement check finds an agent on a lower-priority host while a higher-priority host is live, DM the healer on the preferred host with an action-oriented yield request (run `sac singleton-reconcile --execute`) instead of only broadcasting to `#heads`.
- Adds `--dm-healer` CLI flag + new sibling helper module `scripts/server/_singleton_dm_healer.py`. Template `SCITEX_OROCHI_HEALER_TEMPLATE` (default `head-{host}`) resolves preferred-host → healer-agent-name. DM channel uses spec v3 §2.3 canonical `dm:agent:<a>|agent:<b>` shape so the hub's `_ensure_dm_channel` lazy-create is idempotent on first contact.
- Drive-by: un-skips the 18 existing tests for this script — they had been silently `skipped 'singleton-host-check.py not found'` since commit b059a14 moved `hub/` under `apps/hub/` without updating `parents[2]` → `parents[3]` in the test's path resolution.

## Files
- `scripts/server/_singleton_dm_healer.py` (new) — DM-dispatch helpers (`_resolve_healer_name`, `_dm_channel_name`, `_format_dm_for_healer`, `_post_dm_to_healer`, `dispatch_dm_warnings`).
- `scripts/server/singleton-host-check.py` — `--dm-healer` flag, `--healer-template` override, re-exports helpers from the sibling so the existing `importlib`-loaded test pattern keeps working unchanged.
- `apps/hub/tests/test_singleton_host_check.py` — `parents[2]` → `parents[3]` path fix + 14 new tests (5 template-resolution, 2 channel-name, 2 DM-body, 3 dispatch-orchestration, 2 URL/body-shape).
- `deployment/host-setup/orochi-cron/cron.yaml.example` — documents both `--post` and `--dm-healer`, plus the env vars `--dm-healer` reads.

## Why
Per the bottom comments on #250, the orochi-side remaining work was *"update `singleton-host-check.py` to dispatch A2A to preferred-host healer instead of just posting to `#heads`"*. The healer-side automation (`sac singleton-reconcile --execute`) already shipped via sac PR #98; this PR closes the orochi side of that loop. Healer-driven Option B is now end-to-end runnable: cron fires → orochi DMs preferred-host healer → healer runs `sac singleton-reconcile --execute` to claim.

The test-path fix is independent but lands in the same PR because it's a one-line change that unblocks verification of every other change in this file.

## Out of scope
- `api_messages` still uses `@login_required` (no token-auth branch). The new DM-dispatch payload carries the token in both the body and the query string, so the eventual token-auth landing on `api_messages` can flip on without touching this caller. Tracked separately if needed.
- Structural Option B (healer-self-yield from inside the agent) — that's the longer-horizon control-loop work outlined in the #250 comments; this PR is intentionally the targeted interim alert path.

## Test plan
- [x] `manage.py test apps.hub.tests.test_singleton_host_check` → **32 passed** (18 original now actually running + 14 new).
- [x] `pytest tests/ -m "not llm_eval"` (CI-equivalent) → **741 passed, 2 skipped, 1 deselected, 1 xfailed**.
- [x] `ruff check` on touched files → clean.
- [x] `python -m py_compile` on both Python files → OK.
- [x] Pre-existing failure `test_text_includes_per_host_gh_command` exists on develop unrelated to this PR; not in CI's pytest path.

Refs #250.