### PR TITLE
chore(release): bump version to 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.0] - 2026-06-20
+
+### 🚀 Features
+- feat(daemons): SAC inventory reconciler daemon (ADR-0003 Phase 1) —
+  reconciles the agent-container inventory into the hub.
+
+### 🐛 Bug Fixes
+- fix(bridge/dispatch): crash loud on remote-home / mkdir / scp failure
+  (no silent fallback).
+- fix(ops/#250): DM-healer dispatch for singleton-host-check + un-skip the
+  previously-skipped test path.
+
+### 🧹 Maintenance
+- ci: apply L1–L5 CI-speedup — canonical workflows replace the legacy
+  non-canonical CI; the audit job runs the canonical conformance gate
+  (`tests/develop/test_audit.py`) rather than raw `audit-all` (#449, #450).
+- ci: bundle `src/scitex_orochi/_sphinx_html/` into the wheel (PS-121) (#448).
+- ci(cla): owner-bypass for direct pushes; `cla.yml` uses the
+  `GH_PERSONAL_ACCESS_TOKEN` secret (PS-168) (#445).
+- docs(adr): ADR-0003 — agent identity, bridge shape, and ghost-channels;
+  clarify the sac/orochi cross-host boundary in the README.
+- test(bridge): cover the SoC seam (spec, mcp, dispatch); de-flake the
+  scheduler-thread teardown.
+
 ## [0.16.4] - 2026-05-31
 
 ### 🧹 Maintenance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "scitex-orochi"
-version = "0.16.4"
+version = "0.17.0"
 description = "Agent Communication Hub for the SciTeX ecosystem"
 readme = "README.md"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Release prep: scitex-orochi 0.16.4 → 0.17.0 (MINOR)

Version-only release-prep PR for the operator-authorized full-green release wave.

### Changes
- `pyproject.toml`: `[project].version` 0.16.4 → **0.17.0**
- `CHANGELOG.md`: add `[0.17.0]` entry

### Why MINOR
Since v0.16.4: new **SAC inventory reconciler daemon** (ADR-0003 Phase 1) plus
fail-loud bridge dispatch, CI canonicalization (#448/#449/#450), ADR/test hardening.

### DoD (verified locally)
- Full test suite: **749 passed**, 1 skipped, 1 xfailed (`pytest tests/ -m "not llm_eval"`).
- `audit-all` against a `scitex-orochi`-named checkout (CI-faithful, scitex-dev 0.18.0):
  `audit-project`, `audit-django`, `audit-python-apis`, `audit-skills` all **SUCC**.
  The lone `audit-cli: not-auditable` is the pre-existing, formally-deferred CLI noun-verb
  backlog (masked by `tests/develop/test_audit.py` skip_rules `§1…§10`), unchanged from develop.

No source/CLI/test changes — version + changelog only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)